### PR TITLE
Feature/orientation

### DIFF
--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -498,6 +498,7 @@ class PhotoController extends Controller
 			$duplicate->make = $photo->make;
 			$duplicate->model = $photo->model;
 			$duplicate->lens = $photo->lens;
+			$duplicate->orientation = $photo->orientation;
 			$duplicate->shutter = $photo->shutter;
 			$duplicate->focal = $photo->focal;
 			$duplicate->latitude = $photo->latitude;

--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -30,6 +30,7 @@ class Extractor
 			'focal' => '',
 			'takestamp' => null,
 			'lens' => '',
+			'orientation' => 1,
 			'tags' => '',
 			'position' => '',
 			'latitude' => null,
@@ -118,6 +119,7 @@ class Extractor
 		$metadata['shutter'] = ($exif->getExposure() !== false) ? $exif->getExposure() : '';
 		$metadata['takestamp'] = ($exif->getCreationDate() !== false) ? $exif->getCreationDate()->format('Y-m-d H:i:s') : null;
 		$metadata['lens'] = ($exif->getLens() !== false) ? $exif->getLens() : '';
+		$metadata['orientation'] = ($exif->getOrientation() !== false) ? $exif->getOrientation() : '';
 		$metadata['tags'] = ($exif->getKeywords() !== false) ? (is_array($exif->getKeywords()) ? implode(',', $exif->getKeywords()) : $exif->getKeywords()) : '';
 		$metadata['latitude'] = ($exif->getLatitude() !== false) ? $exif->getLatitude() : null;
 		$metadata['longitude'] = ($exif->getLongitude() !== false) ? $exif->getLongitude() : null;

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -381,13 +381,6 @@ class PhotoFunctions
 						$photo->height = $rotation['height'];
 					} else {
 						$photo->orientation = $info['orientation'];
-
-						if ($photo->orientation >= 5) {
-							$tempWidth = $photo->width;
-							$tempHeight = $photo->height;
-							$photo->width = $tempHeight;
-							$photo->height = $tempWidth;
-						}
 					}
 				}
 

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -311,6 +311,7 @@ class PhotoFunctions
 		$photo->make = $info['make'];
 		$photo->model = $info['model'];
 		$photo->lens = $info['lens'];
+		$photo->orientation = $info['orientation'];
 		$photo->shutter = $info['shutter'];
 		$photo->focal = $info['focal'];
 		$photo->takestamp = $info['takestamp'];
@@ -481,7 +482,7 @@ class PhotoFunctions
 		$frame = $video->frame(FFMpeg\Coordinate\TimeCode::fromSeconds($photo->aperture / 2));
 
 		$tmp = tempnam(sys_get_temp_dir(), 'lychee');
-		Logs::notice(__METHOD__, __LINE__, 'Saving frame to ' . $tmp);
+		Nnotice(__METHOD__, __LINE__, 'Saving frame to ' . $tmp);
 		$frame->save($tmp);
 
 		return $tmp;

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -484,7 +484,7 @@ class PhotoFunctions
 		$frame = $video->frame(FFMpeg\Coordinate\TimeCode::fromSeconds($photo->aperture / 2));
 
 		$tmp = tempnam(sys_get_temp_dir(), 'lychee');
-		Nnotice(__METHOD__, __LINE__, 'Saving frame to ' . $tmp);
+		Logs::notice(__METHOD__, __LINE__, 'Saving frame to ' . $tmp);
 		$frame->save($tmp);
 
 		return $tmp;

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -381,6 +381,13 @@ class PhotoFunctions
 						$photo->height = $rotation['height'];
 					} else {
 						$photo->orientation = $info['orientation'];
+
+						if ($photo->orientation >= 5) {
+							$tempWidth = $photo->width;
+							$tempHeight = $photo->height;
+							$photo->width = $tempWidth;
+							$photo->height = $tempHeight;
+						}
 					}
 				}
 

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -379,6 +379,8 @@ class PhotoFunctions
 					if ($rotation !== [false, false]) {
 						$photo->width = $rotation['width'];
 						$photo->height = $rotation['height'];
+					} else {
+						$photo->orientation = $info['orientation'];
 					}
 				}
 

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -385,8 +385,8 @@ class PhotoFunctions
 						if ($photo->orientation >= 5) {
 							$tempWidth = $photo->width;
 							$tempHeight = $photo->height;
-							$photo->width = $tempWidth;
-							$photo->height = $tempHeight;
+							$photo->width = $tempHeight;
+							$photo->height = $tempWidth;
 						}
 					}
 				}

--- a/app/Photo.php
+++ b/app/Photo.php
@@ -32,6 +32,7 @@ use Storage;
  * @property string      $make
  * @property string      $model
  * @property string      $lens
+ * @property int|null 	 $orientation
  * @property string      $shutter
  * @property string      $focal
  * @property float|null  $latitude
@@ -80,6 +81,7 @@ use Storage;
  * @method static Builder|Photo whereIso($value)
  * @method static Builder|Photo whereLatitude($value)
  * @method static Builder|Photo whereLens($value)
+ * @method static Builder|Photo whereOrientation($value)
  * @method static Builder|Photo whereLicense($value)
  * @method static Builder|Photo wherelivePhotoChecksum($value)
  * @method static Builder|Photo wherelivePhotoContentID($value)
@@ -219,6 +221,7 @@ class Photo extends Model
 		$photo['shutter'] = $this->shutter;
 		$photo['focal'] = $this->focal;
 		$photo['lens'] = $this->lens;
+		$photo['orientation'] = $this->orientation;
 		$photo['latitude'] = $this->latitude;
 		$photo['longitude'] = $this->longitude;
 		$photo['altitude'] = $this->altitude;

--- a/database/migrations/2020_05_03_165315_add_exif_orientation.php
+++ b/database/migrations/2020_05_03_165315_add_exif_orientation.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddExifOrientation extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('photos', function ($table) {
+			$table->integer('orientation')->default(1)->after('thumbURL')->nullable();
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('photos', function (Blueprint $table) {
+			$table->dropColumn('orientation');
+		});
+	}
+}

--- a/tests/Feature/PhotosTest.php
+++ b/tests/Feature/PhotosTest.php
@@ -75,6 +75,7 @@ class PhotosTest extends TestCase
 			'id' => $id,
 			'iso' => '1250',
 			'lens' => 'EF16-35mm f/2.8L USM',
+			'orientation' => 1,
 			'license' => 'reserved',
 			'make' => 'Canon',
 			'model' => 'Canon EOS R',


### PR DESCRIPTION
Goes with matching PR in the Lychee-front repo.

If we fail to auto-rotate an image (read-only filesystem, example: when syncing with symlinks from a read-only mount), we need to store the orientation EXIF data so that the frontend can account for it. Otherwise images are displayed sideways.