### PR TITLE
autorotate small/medium separately for import_via_symlink (Fixes #460)

### DIFF
--- a/app/Image/GdHandler.php
+++ b/app/Image/GdHandler.php
@@ -15,9 +15,11 @@ class GdHandler implements ImageHandlerInterface
 
 	/**
 	 * Rotates a given image resource based on the given orientation.
-	 * @param resource $image The image reference to rotate.
-	 * @param int $orientation The orientation of the original image.
-	 * @return array A dictionary of width and height of the rotated image.
+	 *
+	 * @param resource $image       the image reference to rotate
+	 * @param int      $orientation the orientation of the original image
+	 *
+	 * @return array a dictionary of width and height of the rotated image
 	 */
 	private function autoRotateInternal(&$image, int $orientation): array
 	{
@@ -53,6 +55,9 @@ class GdHandler implements ImageHandlerInterface
 
 			case 8:
 				$image = imagerotate($image, 90, 0);
+				break;
+
+			default:
 				break;
 		}
 

--- a/app/Image/GdHandler.php
+++ b/app/Image/GdHandler.php
@@ -14,6 +14,52 @@ class GdHandler implements ImageHandlerInterface
 	private $compressionQuality;
 
 	/**
+	 * Rotates a given image resource based on the given orientation.
+	 * @param resource $image The image reference to rotate.
+	 * @param int $orientation The orientation of the original image.
+	 * @return array A dictionary of width and height of the rotated image.
+	 */
+	private function autoRotateInternal(&$image, int $orientation): array
+	{
+		switch ($orientation) {
+			case 1:
+				// nothing to do
+				break;
+			case 2:
+				imageflip($image, IMG_FLIP_HORIZONTAL);
+				break;
+
+			case 3:
+				$image = imagerotate($image, -180, 0);
+				break;
+
+			case 4:
+				imageflip($image, IMG_FLIP_VERTICAL);
+				break;
+
+			case 5:
+				$image = imagerotate($image, -90, 0);
+				imageflip($image, IMG_FLIP_HORIZONTAL);
+				break;
+
+			case 6:
+				$image = imagerotate($image, -90, 0);
+				break;
+
+			case 7:
+				$image = imagerotate($image, 90, 0);
+				imageflip($image, IMG_FLIP_HORIZONTAL);
+				break;
+
+			case 8:
+				$image = imagerotate($image, 90, 0);
+				break;
+		}
+
+		return ['width' => imagesx($image), 'height' => imagesy($image)];
+	}
+
+	/**
 	 * {@inheritdoc}
 	 */
 	public function __construct(int $compressionQuality)
@@ -54,6 +100,11 @@ class GdHandler implements ImageHandlerInterface
 
 		imagecopyresampled($image, $sourceImg, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
 
+		// the image may need to be rotated prior saving
+		$exif = exif_read_data($source);
+		$orientation = isset($exif['Orientation']) && $exif['Orientation'] !== '' ? $exif['Orientation'] : 1;
+		$dimensions = $this->autoRotateInternal($image, $orientation);
+
 		switch ($mime) {
 			case IMAGETYPE_JPEG:
 			case IMAGETYPE_JPEG2000:
@@ -71,8 +122,8 @@ class GdHandler implements ImageHandlerInterface
 		imagedestroy($image);
 		imagedestroy($sourceImg);
 
-		$resWidth = $newWidth;
-		$resHeight = $newHeight;
+		$resWidth = $dimensions['width'];
+		$resHeight = $dimensions['height'];
 
 		return true;
 	}
@@ -106,6 +157,12 @@ class GdHandler implements ImageHandlerInterface
 		}
 
 		$this->fastImageCopyResampled($image, $sourceImg, 0, 0, $startWidth, $startHeight, $newWidth, $newHeight, $newSize, $newSize);
+
+		// the image may need to be rotated prior saving
+		$exif = exif_read_data($source);
+		$orientation = isset($exif['Orientation']) && $exif['Orientation'] !== '' ? $exif['Orientation'] : 1;
+		$this->autoRotateInternal($image, $orientation);
+
 		imagejpeg($image, $destination, $this->compressionQuality);
 
 		imagedestroy($image);
@@ -121,51 +178,18 @@ class GdHandler implements ImageHandlerInterface
 	{
 		$image = imagecreatefromjpeg($path);
 
-		$rotate = true;
-		switch ($info['orientation']) {
-			case 1:
-				$rotate = false;
-				break;
-			case 2:
-				imageflip($image, IMG_FLIP_HORIZONTAL);
-				break;
+		$orientation = isset($info['orientation']) && $info['orientation'] !== '' ? $info['orientation'] : 1;
+		$rotate = $orientation !== 1;
 
-			case 3:
-				$image = imagerotate($image, -180, 0);
-				break;
+		$dimensions = $this->autoRotateInternal($image, $orientation);
 
-			case 4:
-				imageflip($image, IMG_FLIP_VERTICAL);
-				break;
-
-			case 5:
-				$image = imagerotate($image, -90, 0);
-				imageflip($image, IMG_FLIP_HORIZONTAL);
-				break;
-
-			case 6:
-				$image = imagerotate($image, -90, 0);
-				break;
-
-			case 7:
-				$image = imagerotate($image, 90, 0);
-				imageflip($image, IMG_FLIP_HORIZONTAL);
-				break;
-
-			case 8:
-				$image = imagerotate($image, 90, 0);
-				break;
-		}
-
-		if ($rotate) { // we only rotate if there is a need. Fixes #111
+		if ($rotate) {
 			imagejpeg($image, $path, 100);
 		}
 
 		imagedestroy($image);
 
-		list($width, $height) = getimagesize($path);
-
-		return ['width' => $width, 'height' => $height];
+		return $dimensions;
 	}
 
 	/**

--- a/app/Image/ImagickHandler.php
+++ b/app/Image/ImagickHandler.php
@@ -14,8 +14,10 @@ class ImagickHandler implements ImageHandlerInterface
 
 	/**
 	 * Rotates a given image based on the given orientation.
-	 * @param \Imagick $image The image reference to rotate.
-	 * @return array A dictionary of width and height of the rotated image.
+	 *
+	 * @param \Imagick $image the image reference to rotate
+	 *
+	 * @return array a dictionary of width and height of the rotated image
 	 */
 	private function autoRotateInternal(\Imagick &$image): array
 	{

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -372,7 +372,9 @@ class PhotoFunctions
 			// (2) There is a partner and we're uploading a photo
 			if (($livePhotoPartner === false) || !(in_array($photo->type, $this->validVideoTypes, true))) {
 				// Set orientation based on EXIF data
-				if ($photo->type === 'image/jpeg' && isset($info['orientation']) && $info['orientation'] !== '') {
+				// but do not rotate if the image shall not be modified
+				if ($photo->type === 'image/jpeg' && isset($info['orientation']) && $info['orientation'] !== ''
+						&& Configs::get_value('import_via_symlink', '0') === '0') {
 					$rotation = $this->imageHandler->autoRotate($path, $info);
 
 					if ($rotation !== [false, false]) {


### PR DESCRIPTION
Fixes the possibly wrong rotation when using the import_via_symlink option. See https://github.com/LycheeOrg/Lychee/issues/460#issuecomment-622592371 for the explanation of the issue and how it was solved here.