### PR TITLE
fix dropbox import: csp was a bit too tight

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -330,6 +330,7 @@ return [
 
 		'script-src' => [
 			'allow' => [
+				'https://www.dropbox.com/static/api/1/dropins.js',
 				// 'url',
 			],
 			'hashes' => [


### PR DESCRIPTION
fixes #565 

The CSP was a bit too tight, preventing the execution of the script from dropbox.