### PR TITLE
Feature/ghostbust dead symlinks

### DIFF
--- a/app/Console/Commands/Ghostbuster.php
+++ b/app/Console/Commands/Ghostbuster.php
@@ -123,8 +123,8 @@ class Ghostbuster extends Command
 						if ($dryrun) {
 							$this->line(str_pad($photo->url, 50) . $this->col->red(' photo will be removed') . '.');
 						} else {
-							// Laravel apparently doesn't thing dead symlinks 'exist', so manually remove the original here.
-							unlink("$path/$url");
+							// Laravel apparently doesn't think dead symlinks 'exist', so manually remove the original here.
+							unlink($path . '/' . $url);
 
 							$photo->predelete();
 							$photo->delete();

--- a/app/Console/Commands/Ghostbuster.php
+++ b/app/Console/Commands/Ghostbuster.php
@@ -70,7 +70,7 @@ class Ghostbuster extends Command
 				continue;
 			}
 
-			$isDeadSymlink = is_link("$path/$url") && !file_exists(readlink("$path/$url"));
+			$isDeadSymlink = is_link($path . '/' . $url) && !file_exists(readlink($path . '/' . $url));
 
 			$photos = Photo::where('url', '=', $url)->get();
 			if (count($photos) === 0 || $isDeadSymlink) {


### PR DESCRIPTION
Resolves https://github.com/LycheeOrg/Lychee/issues/578

A couple of caveats here: I had to manually delete the 'big' file path even though we are calling `->delete()` on the photo because inside the `predelete` method, `Storage::exists` actually returns `false` if you pass in a dead symlink. So a predelete and delete is not enough here, have to manually unlink the dead symlink itself.

Something to consider: should this be an additional flag we pass into the ghostbuster command? I'm thinking in the event that images are mounted on an external drive, NFS, whatever and are 'temporarily' unavailable. Just something to keep in mind.