### PR TITLE
Fix #584

### DIFF
--- a/app/Http/Controllers/RSSController.php
+++ b/app/Http/Controllers/RSSController.php
@@ -71,6 +71,8 @@ class RSSController extends Controller
 				$id = 'view?p=' . $photo_model->id;
 			}
 
+			$photo['url'] = $photo['url'] ?: $photo['medium2x'] ?: $photo['medium'];
+
 			$length = \File::size($photo['url']);
 			$mime_type = \File::mimeType($photo['url']);
 

--- a/app/Http/Controllers/RSSController.php
+++ b/app/Http/Controllers/RSSController.php
@@ -71,12 +71,17 @@ class RSSController extends Controller
 				$id = 'view?p=' . $photo_model->id;
 			}
 
+			$length = \File::size($photo['url']);
+			$mime_type = \File::mimeType($photo['url']);
+
 			return FeedItem::create([
 				'id' => url('/' . $id),
 				'title' => $photo_model->title,
 				'summary' => $photo_model->description,
 				'updated' => $photo_model->created_at,
 				'link' => $photo['url'],
+				'enclosureLength' => $length,
+				'enclosureMime' => $mime_type,
 				'author' => $photo_model->owner->username, ]);
 		});
 

--- a/app/Http/Controllers/RSSController.php
+++ b/app/Http/Controllers/RSSController.php
@@ -4,13 +4,16 @@
 
 namespace App\Http\Controllers;
 
+use App;
 use App\Configs;
 use App\ModelFunctions\AlbumFunctions;
 use App\ModelFunctions\SymLinkFunctions;
 use App\Photo;
+use File;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Spatie\Feed\FeedItem;
+use Storage;
 
 class RSSController extends Controller
 {
@@ -54,7 +57,7 @@ class RSSController extends Controller
 			->limit(Configs::get_Value('rss_max_items', '100'))
 			->get();
 
-		$photos = $photos->map(function ($photo_model) {
+		$photos = $photos->map(function (Photo $photo_model) {
 			$photo = $photo_model->prepareData();
 			$this->symLinkFunctions->getUrl($photo_model, $photo);
 			$id = null;
@@ -72,9 +75,14 @@ class RSSController extends Controller
 			}
 
 			$photo['url'] = $photo['url'] ?: $photo['medium2x'] ?: $photo['medium'];
-
-			$length = \File::size($photo['url']);
-			$mime_type = \File::mimeType($photo['url']);
+			// TODO: this will need to be fixed for s3 and when the upload folder is NOT the Lychee folder.
+			if (App::runningUnitTests()) {
+				$path = Storage::path('../' . $photo['url']);
+			} else {
+				$path = Storage::path($photo['url']);
+			}
+			$length = File::size($path);
+			$mime_type = File::mimeType($path);
 
 			return FeedItem::create([
 				'id' => url('/' . $id),

--- a/config/feed.php
+++ b/config/feed.php
@@ -16,7 +16,7 @@ return [
 			/*
 			 * The feed will be available on this url.
 			 */
-			'url' => '/rss',
+			'url' => '/feed',
 
 			'title' => 'Latest pictures',
 			'description' => 'Latest added pictures.',
@@ -25,12 +25,7 @@ return [
 			/*
 			 * The view that will render the feed.
 			 */
-			'view' => 'feed::atom',
-
-			/*
-			 * The type to be used in the <link> tag
-			 */
-			'type' => 'application/atom+xml',
+			'view' => 'feed::rss',
 		],
 	],
 ];

--- a/resources/views/vendor/feed/atom.blade.php
+++ b/resources/views/vendor/feed/atom.blade.php
@@ -1,0 +1,35 @@
+<?=
+	/* Using an echo tag here so the `<? ... ?>` won't get parsed as short tags */
+	'<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL;
+?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    @foreach($meta as $key => $metaItem)
+        @if($key === 'link')
+            <{{ $key }} href="{{ url($metaItem) }}"></{{ $key }}>
+        @elseif($key === 'title')
+            <{{ $key }}><![CDATA[{{ $metaItem }}]]></{{ $key }}>
+        @else
+            <{{ $key }}>{{ $metaItem }}</{{ $key }}>
+        @endif
+    @endforeach
+    @foreach($items as $item)
+        <entry>
+            <title><![CDATA[{{ $item->title }}]]></title>
+            <link rel="alternate" href="{{ url($item->link) }}" />
+            <id>{{ url($item->id) }}</id>
+            <author>
+                <name> <![CDATA[{{ $item->author }}]]></name>
+            </author>
+            <summary type="html">
+                <![CDATA[{!! $item->summary !!}]]>
+            </summary>
+            @if($item->__isset('enclosure'))
+              <enclosure url="{{ url($item->enclosure) }}" length="{{ $item->enclosureLength }}" type="{{ $item->enclosureType }}" />
+            @endif
+            <category type="html">
+                <![CDATA[{!! $item->category ?? '' !!}]]>
+            </category>
+            <updated>{{ $item->updated->toRssString() }}</updated>
+        </entry>
+    @endforeach
+</feed>

--- a/resources/views/vendor/feed/feed.blade.php
+++ b/resources/views/vendor/feed/feed.blade.php
@@ -1,0 +1,1 @@
+@include('feed::atom')

--- a/resources/views/vendor/feed/links.blade.php
+++ b/resources/views/vendor/feed/links.blade.php
@@ -1,0 +1,3 @@
+@foreach($feeds as $name => $feed)
+    <link rel="alternate" type="{{ $feed['type'] ?? 'application/atom+xml' }}" href="{{ route("feeds.{$name}") }}" title="{{ $feed['title'] }}">
+@endforeach

--- a/resources/views/vendor/feed/rss.blade.php
+++ b/resources/views/vendor/feed/rss.blade.php
@@ -1,0 +1,25 @@
+<?=
+/* Using an echo tag here so the `<? ... ?>` won't get parsed as short tags */
+'<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL;
+?>
+<rss version="2.0">
+    <channel>
+        <title><![CDATA[{{ $meta['title'] }}]]></title>
+        <link><![CDATA[{{ url($meta['link']) }}]]></link>
+        <description><![CDATA[{{ $meta['description'] }}]]></description>
+        <language>{{ $meta['language'] }}</language>
+        <pubDate>{{ $meta['updated'] }}</pubDate>
+
+        @foreach($items as $item)
+            <item>
+                <title><![CDATA[{{ $item->title }}]]></title>
+                <link>{{ url($item->link) }}</link>
+                <description><![CDATA[{!! $item->summary !!}]]></description>
+                <author><![CDATA[{{ $item->author }}]]></author>
+                <guid>{{ url($item->id) }}</guid>
+                <enclosure url="{{ url($item->link)}}" type="{{ $item->enclosureMime }}" length="{{ $item->enclosureLength  }}" />
+                <pubDate>{{ $item->updated->toRssString() }}</pubDate>
+            </item>
+        @endforeach
+    </channel>
+</rss>

--- a/tests/Feature/RSSTest.php
+++ b/tests/Feature/RSSTest.php
@@ -21,7 +21,7 @@ class RSSTest extends TestCase
 		$this->assertEquals(Configs::get_value('rss_enable'), '0');
 
 		// check redirection
-		$response = $this->get('/rss');
+		$response = $this->get('/feed');
 		$response->assertStatus(404);
 
 		Configs::set('Mod_Frame', $init_config_value);
@@ -39,7 +39,7 @@ class RSSTest extends TestCase
 		$this->assertEquals(Configs::get_value('rss_enable'), '1');
 
 		// check redirection
-		$response = $this->get('/rss');
+		$response = $this->get('/feed');
 		$response->assertStatus(200);
 
 		// now we start adding some stuff
@@ -74,7 +74,7 @@ class RSSTest extends TestCase
 		$albums_tests->set_public($this, $albumID, 1, 1, 1, 1, 1, 'true');
 
 		// try to get the RSS feed.
-		$response = $this->get('/rss');
+		$response = $this->get('/feed');
 		$response->assertStatus(200);
 
 		$albums_tests->delete($this, $albumID);

--- a/tests/Feature/RSSTest.php
+++ b/tests/Feature/RSSTest.php
@@ -63,7 +63,7 @@ class RSSTest extends TestCase
 		$photos_tests->set_public($this, $photoID);
 
 		// try to get the RSS feed.
-		$response = $this->get('/rss');
+		$response = $this->get('/feed');
 		$response->assertStatus(200);
 
 		// set picture to private


### PR DESCRIPTION
`laravel-feed` defaults to Atom 1.0 feeds, which do not support media attachments. Since this is a feed for photos, switching to RSS 2.0 as the default allows items in the feed to have an `enclosure` tag which sends the photo to RSS aggregators.

This update creates local versions of the feed templates from the vendor folder. Users could modify these further, adding more metadata (icons, etc).

The `enclosure` tag requires length and mime parameters which are retrieved using Laravel's built-in file information methods.