### PR TITLE
bigfix - unset mimetype from the sidecar so we don't overwrite the actual mimetype

### DIFF
--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -110,6 +110,9 @@ class Extractor
 				// Don't use the same reader as the file in case it's a video
 				$sidecarReader = Reader::factory(Reader::TYPE_EXIFTOOL);
 				$sidecarData = $sidecarReader->read($realFile . '.xmp')->getData();
+
+				// We don't want to overwrite the media's type with the mimetype of the sidecar file
+				unset($sidecarData['type']);
 			}
 		} catch (\Exception $e) {
 			// Use Php native tools


### PR DESCRIPTION
There is a bug when reading in side files - the mimetype is overwritten and set to that of the sidecar file which is XML. This unset's that array key so that it doesn't overwrite what was pulled from the media.