### PR TITLE
Added method to get the full path of albums

### DIFF
--- a/app/Album.php
+++ b/app/Album.php
@@ -414,10 +414,10 @@ class Album extends Model
 	 *
 	 * @return string
 	 */
-	public function getFullPath()
+	public static function getFullPath($album)
 	{
-		$title = [$this->title];
-		$parentId = $this->parent_id;
+		$title = [$album->title];
+		$parentId = $album->parent_id;
 		while ($parentId) {
 			$parent = Album::find($parentId);
 			array_unshift($title, $parent->title);

--- a/app/Album.php
+++ b/app/Album.php
@@ -408,4 +408,22 @@ class Album extends Model
 
 		return $no_error;
 	}
+
+	/**
+	 * Return the full path of the album consisting of all its parents' titles.
+	 *
+	 * @return string
+	 */
+	public function getFullPath()
+	{
+		$title = [$this->title];
+		$parentId = $this->parent_id;
+		while ($parentId) {
+			$parent = Album::find($parentId);
+			array_unshift($title, $parent->title);
+			$parentId = $parent->parent_id;
+		}
+
+		return implode('/', $title);
+	}
 }

--- a/app/Http/Controllers/SharingController.php
+++ b/app/Http/Controllers/SharingController.php
@@ -41,10 +41,17 @@ class SharingController extends Controller
 				->join('albums', 'album_id', 'albums.id')
 				->orderBy('title', 'ASC')
 				->orderBy('username', 'ASC')
-				->get();
+				->get()
+				->each(function (&$s) {
+					$album = Album::find($s->album_id);
+					$s->title = $album->getFullPath();
+				});
 
-			$albums = Album::select(['id', 'title'])->orderBy('title', 'ASC')
-				->get();
+			$albums = Album::select(['id', 'title', 'parent_id'])->orderBy('title', 'ASC')
+				->get()->each(function (&$album) {
+					$album->title = $album->getFullPath();
+				});
+
 			$users = User::select(['id', 'username'])
 				->orderBy('username', 'ASC')->get();
 		} else {
@@ -56,10 +63,17 @@ class SharingController extends Controller
 				->where('albums.owner_id', '=', $UserId)
 				->orderBy('title', 'ASC')
 				->orderBy('username', 'ASC')
-				->get();
+				->get()
+				->each(function (&$s) {
+					$album = Album::find($s->album_id);
+					$s->title = $album->getFullPath();
+				});
 
-			$albums = Album::select(['id', 'title'])
-				->where('owner_id', '=', $UserId)->orderBy('title', 'ASC')->get();
+			$albums = Album::select(['id', 'title', 'parent_id'])
+				->where('owner_id', '=', $UserId)->orderBy('title', 'ASC')->get()->each(function ($album) {
+					$album->title = $album->getFullPath();
+				});
+
 			$users = User::select(['id', 'username'])
 				->orderBy('username', 'ASC')->get();
 		}

--- a/app/Http/Controllers/SharingController.php
+++ b/app/Http/Controllers/SharingController.php
@@ -36,20 +36,19 @@ class SharingController extends Controller
 		if ($UserId == 0) {
 			$shared = DB::table('user_album')
 				->select('user_album.id', 'user_id', 'album_id', 'username',
-					'title')
+					'title', 'parent_id')
 				->join('users', 'user_id', 'users.id')
 				->join('albums', 'album_id', 'albums.id')
 				->orderBy('title', 'ASC')
 				->orderBy('username', 'ASC')
 				->get()
 				->each(function (&$s) {
-					$album = Album::find($s->album_id);
-					$s->title = $album->getFullPath();
+					$s->title = Album::getFullPath($s);
 				});
 
 			$albums = Album::select(['id', 'title', 'parent_id'])->orderBy('title', 'ASC')
 				->get()->each(function (&$album) {
-					$album->title = $album->getFullPath();
+					$album->title = Album::getFullPath($album);
 				});
 
 			$users = User::select(['id', 'username'])
@@ -65,13 +64,12 @@ class SharingController extends Controller
 				->orderBy('username', 'ASC')
 				->get()
 				->each(function (&$s) {
-					$album = Album::find($s->album_id);
-					$s->title = $album->getFullPath();
+					$s->title = Album::getFullPath($s);
 				});
 
 			$albums = Album::select(['id', 'title', 'parent_id'])
 				->where('owner_id', '=', $UserId)->orderBy('title', 'ASC')->get()->each(function ($album) {
-					$album->title = $album->getFullPath();
+					$album->title = Album::getFullPath($album);
 				});
 
 			$users = User::select(['id', 'username'])


### PR DESCRIPTION
Specifically in the sharing screen, when albums are sometimes named the same (if they are organized by Year and Month), then it is impossible to tell which album you are actually sharing. This adds the ability to get the album's "full path" and sends it down for the sharing settings.

This is fast in my library, but I don't have a large amount of nested albums. This may be inefficient and I'm open to alternatives. I also thought about adding a new column on the database for "full_path" but am unsure of how best to approach it so it is backwards compatible. Can a migration be created to retroactively alter existing records in the database?