### PR TITLE
fixes #646

### DIFF
--- a/app/Console/Commands/Sync.php
+++ b/app/Console/Commands/Sync.php
@@ -81,7 +81,7 @@ class Sync extends Command
 		$import_controller->disableMemCheck();
 
 		Session::put('UserID', $owner_id);
-
+		Session::put('login', true);
 		try {
 			$import_controller->server_exec($directory, $album_id, $delete_imported, $force_skip_duplicates, null, $resync_metadata);
 		} catch (Exception $e) {


### PR DESCRIPTION
Trivial.

fixes #646

in `$import_controller->server_exec()` there is a call to `$this->sessionFunctions->id()` and well :

```php
	public function id()
	{
		if (!Session::get('login')) {
			throw new NotLoggedInException();
		}

		return Session::get('UserID');
	}
```

As we only set 
```php
		Session::put('UserID', $owner_id);
```
but not:
```php
		Session::put('login', true);
```

It was complaining.