### PR TITLE
fix fopen for symlinked files

### DIFF
--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -656,7 +656,7 @@ class PhotoFunctions
 
 		try {
 			// 1. Extract the video part
-			$fp = fopen($uploadFolder . $photo->url, 'r+');
+			$fp = fopen($uploadFolder . $photo->url, 'r');
 			$fp_video = tmpfile(); // use a temporary file, will be delted once closed
 
 			// The MP4 file is located in the last bytes of the file


### PR DESCRIPTION
No need to open as `r+` (reading AND writing) if we're just reading / seeking in the existing file and storing the data in another location. This causes creating live photos to fail when you've synced your library via symlinks.