### PR TITLE
Add simple redirection system

### DIFF
--- a/app/Http/Controllers/RedirectController.php
+++ b/app/Http/Controllers/RedirectController.php
@@ -1,0 +1,24 @@
+<?php
+
+/** @noinspection PhpUndefinedClassInspection */
+
+namespace App\Http\Controllers;
+
+class RedirectController extends Controller
+{
+	/**
+	 * Trivial redirection.
+	 */
+	public function album($albumid)
+	{
+		return redirect('gallery#' . $albumid);
+	}
+
+	/**
+	 * Trivial redirection.
+	 */
+	public function photo($albumid, $photoid)
+	{
+		return redirect('gallery#' . $albumid . '/' . $photoid);
+	}
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,8 +31,8 @@ Route::get('/gallery', 'IndexController@gallery')->name('gallery')->middleware('
  *
  * Other ideas, redirection by album name, photo title...
  */
-Route::get('/redirect/{albumid}/{photoid}', 'RedirectController@photo');
-Route::get('/redirect/{albumid}', 'RedirectController@album');
+Route::get('/r/{albumid}/{photoid}', 'RedirectController@photo');
+Route::get('/r/{albumid}', 'RedirectController@album');
 
 Route::get('/view', 'ViewController@view');
 Route::get('/demo', 'DemoController@js');

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,16 @@ Route::get('/', 'IndexController@show')->name('home')->middleware('installed');
 Route::get('/phpinfo', 'IndexController@phpinfo')->middleware('admin');
 Route::get('/gallery', 'IndexController@gallery')->name('gallery')->middleware('installed');
 
+/*
+ * TODO see to add better redirection functionality later.
+ * This is to prevent instagram from taking control our # in url when sharing an album
+ * and not consider it as an hash-tag.
+ *
+ * Other ideas, redirection by album name, photo title...
+ */
+Route::get('/redirect/{albumid}/{photoid}', 'RedirectController@photo');
+Route::get('/redirect/{albumid}', 'RedirectController@album');
+
 Route::get('/view', 'ViewController@view');
 Route::get('/demo', 'DemoController@js');
 Route::get('/frame', 'FrameController@init')->name('frame');

--- a/tests/Feature/RedirectTest.php
+++ b/tests/Feature/RedirectTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class RedirectTest extends TestCase
+{
+	/**
+	 * A basic feature test example.
+	 *
+	 * @return void
+	 */
+	public function testRedirection()
+	{
+		$response = $this->get('redirect/12345');
+
+		$response->assertStatus(302);
+		$response->assertRedirect('gallery#12345');
+
+		$response = $this->get('redirect/12345/67890');
+
+		$response->assertStatus(302);
+		$response->assertRedirect('gallery#12345/67890');
+	}
+}

--- a/tests/Feature/RedirectTest.php
+++ b/tests/Feature/RedirectTest.php
@@ -13,12 +13,12 @@ class RedirectTest extends TestCase
 	 */
 	public function testRedirection()
 	{
-		$response = $this->get('redirect/12345');
+		$response = $this->get('r/12345');
 
 		$response->assertStatus(302);
 		$response->assertRedirect('gallery#12345');
 
-		$response = $this->get('redirect/12345/67890');
+		$response = $this->get('r/12345/67890');
 
 		$response->assertStatus(302);
 		$response->assertRedirect('gallery#12345/67890');


### PR DESCRIPTION
This is just a simple redirection.

Instead of sharing an album via https://example.com/gallery#12345 (respectively for a picture https://example.com/gallery#12345/67890) you can use https://example.com/r/12345 (respectively https://example.com/r/12345/67890). Lychee will take care of converting it back to our normal form.

Why is this useful ? If you ever wanted to share a link on instagram, they have this annoying design of hooking any # they find. This basically makes our link sharing not working in their app: user need to copy the url instead of just clicking on it...