### PR TITLE
Mark update_min_max_takestamp as static.

### DIFF
--- a/app/ModelFunctions/AlbumActions/UpdateTakestamps.php
+++ b/app/ModelFunctions/AlbumActions/UpdateTakestamps.php
@@ -33,7 +33,7 @@ class UpdateTakestamps
 	 * Go through each sub album and update the minimum and maximum takestamp of the pictures.
 	 * This is expensive and not normally necessary so we only use it during migration.
 	 */
-	public function update_min_max_takestamp(Album $album)
+	public static function update_min_max_takestamp(Album $album)
 	{
 		$album_list = self::get_all_sub_albums_id($album, [$album->id]);
 


### PR DESCRIPTION
I encountered an issue while initially trying to migrate my Lychee v3 install to v4 that complained that `update_min_max_takestamp` should not be called statically. Looks like it actually is safe to call statically, it just wasn't marked `static`. Adding this made the error go away when I reran the migrations from scratch.