### PR TITLE
Distinguish UTC vs local video takestamps

### DIFF
--- a/database/migrations/2020_07_29_132731_config_local_takestamp.php
+++ b/database/migrations/2020_07_29_132731_config_local_takestamp.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Configs;
+use Illuminate\Database\Migrations\Migration;
+
+class ConfigLocalTakestamp extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		defined('DISABLED') or define('DISABLED', '');
+
+		DB::table('configs')->insert([
+			[
+				'key' => 'local_takestamp_video_formats',
+				'value' => '.avi|.mov',
+				'confidentiality' => '2',
+				'cat' => 'Image Processing',
+				'type_range' => DISABLED,
+			],
+		]);
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Configs::where('key', '=', 'local_takestamp_video_formats')->delete();
+	}
+}


### PR DESCRIPTION
Fixes #675.

This adds a heuristic to determine whether the takestamp embedded in a video file is in UTC or in local time. The heuristic is based on the filename extension. There is a new config variable, `local_takestamp_video_formats`, that provides a list the extensions for files that should be treated as having a takestamp in the local time zone. It defaults to AVI and MOV, as those are the two most commonly used in digital cameras, which typically use the local time zone. For files that don't match (such as MP4 files from Android phones) the takestamp is considered to be in UTC and is converted at import time to the local time zone of the server.

While working on this I noticed several bugs that this PR also fixes. In particular:
* MPG files were treated as image files because at least on my system that's what the MIME says (`image/x-tga`)?!

* `file_type` method in `PhotoFunctions` was fundamentally broken; it would return `photo` for video files. Fixing its twisted logic required a complete refactoring.

* With that fixed, I was able to replace all the ad-hoc tests for video files based on MIME, which didn't work for MPG files (see above).

* WMV videos misbehaved when using the Exiftool metadata extractor because of conflicting MIME data (Exiftool identifies them as `video/x-ms-wmv`). There were many other issues when using Exiftool instead of FFmpeg for video files' metadata, which were addressed in https://github.com/LycheeOrg/php-exif/pull/22 (now merged).

* If FFmpeg is disabled in the config, we shouldn't try to use it to for anything, including extracting a video frame for the thumb. I fixed that particular use case but it appears that there may be more left in the new live photos support? I'm not familiar with that feature so I didn't touch it. @tmp-hallenser?