### PR TITLE
skip live video files from cleanup

### DIFF
--- a/app/Console/Commands/Ghostbuster.php
+++ b/app/Console/Commands/Ghostbuster.php
@@ -81,7 +81,9 @@ class Ghostbuster extends Command
 			}
 
 			$isDeadSymlink = is_link($path . '/' . $url) && !file_exists(readlink($path . '/' . $url));
-			$photos = Photo::where('url', '=', $url)->get();
+			$photos = Photo::where(function ($query) use ($url) {
+				return $query->where('url', '=', $url)->orWhere('livePhotoUrl', '=', $url);
+			})->get();
 
 			if (count($photos) === 0 || ($isDeadSymlink && $removeDeadSymLinks)) {
 				$photoName = explode('.', $url);


### PR DESCRIPTION
I noticed that after running `lychee:ghostbuster` command, my live images would no longer play and their download link would 404. Ensure that we skip them if they exist in the db as a valid file for live photos.