### PR TITLE
Fix password protection of albums

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -133,7 +133,8 @@ class SearchController extends Controller
 		 * from the top level.  This includes password-protected albums
 		 * (since they are visible) but not their content.
 		 */
-		$albumIDs = $this->albumsFunctions->getPublicAlbumsId();
+		$toplevel = $this->albumsFunctions->getToplevelAlbums();
+		$albumIDs = $this->albumsFunctions->getPublicAlbumsId($toplevel, null, true);
 
 		$query = Album::with([
 			'owner',
@@ -180,10 +181,11 @@ class SearchController extends Controller
 		/*
 		 * Photos.
 		 *
-		 * Begin by reusing the previously built list of albums.  We need to
-		 * eliminate password-protected albums and subalbums from it though,
-		 * since we can't access them.
+		 * We again begin by building a list of all albums and subalbums
+		 * accessible from the top level, only this time without
+		 * password-protected ones.
 		 */
+		$albumIDs = $this->albumsFunctions->getPublicAlbumsId($toplevel);
 		$query = Photo::with('album')->where(
 			function (Builder $query) use ($albumIDs) {
 				$query->whereIn('album_id', $albumIDs);

--- a/app/ModelFunctions/AlbumFunctions.php
+++ b/app/ModelFunctions/AlbumFunctions.php
@@ -147,6 +147,10 @@ class AlbumFunctions
 	public function get_thumbs(Album $album, BaseCollection $children): BaseCollection
 	{
 		$reduced = $children->reduce(function ($collection, $child) {
+			if (isset($child[0]->content_accessible) && $child[0]->content_accessible === false) {
+				return $collection;
+			}
+
 			$reduced_child = $this->get_thumbs($child[0], $child[1]);
 
 			return $collection->push($reduced_child);
@@ -348,9 +352,11 @@ class AlbumFunctions
 					if ($haveAccess === 1) {
 						$collected = $this->get_sub_albums($_album, $includePassProtected);
 					} else {
+						// when we generate the thumbs, we need to know whether that content is visible or not.
 						$_album->content_accessible = false;
+						$collected = new Collection();
 					}
-					// when we generate the thumbs, we need to know whether that content is visible or not.
+
 					return new Collection([$_album, $collected]);
 				}
 
@@ -405,6 +411,10 @@ class AlbumFunctions
 			if ($haveAccess === 1 || ($includePassProtected && $haveAccess === 3)) {
 				if ($haveAccess === 1) {
 					$collected = $this->get_sub_albums($_album, $includePassProtected);
+				} else {
+					// when we generate the thumbs, we need to know whether that content is visible or not.
+					$_album->content_accessible = false;
+					$collected = new BaseCollection();
 				}
 				$collect = $collect->push(new BaseCollection([$_album, $collected]));
 			}

--- a/app/SmartAlbums/SmartAlbum.php
+++ b/app/SmartAlbums/SmartAlbum.php
@@ -98,8 +98,7 @@ class SmartAlbum extends Album
 	public function filter($query)
 	{
 		if (!$this->sessionFunctions->is_admin()) {
-			$query = $query->whereIn('album_id', $this->albumIds)
-				->orWhere('public', '=', 1);
+			$query = $query->whereIn('album_id', $this->albumIds);
 		}
 
 		if ($this->sessionFunctions->is_logged_in() && $this->sessionFunctions->id() > 0) {


### PR DESCRIPTION
So we were leaking data behind password-protected albums like a sieve. It was leaking out through album thumbs, public search, public smart albums, and probably also the frame.

The most important fix is to `AlbumsFunctions->getPublicAlbumsId()`, which is used all over the place. It now, by default, does not return the IDs of password-protected albums, since we can't access them anyway. That closed most of the leaks.

Fixing the thumb leaking required additional checks in `AlbumFunctions->get_thumbs()` and `AlbumsFunctions->prepare_albums`. I also made use of `content_accessible` which was set but wasn't used.

`SearchController` then needed to be fixed so that it _would_ include password-protected albums (but not their contents). This required additions to `AlbumsFunctions->getPublicAlbumsId()` and `AlbumsFunctions->get_children()`.

Finally, I removed the pulling of unsorted public photos into public smart albums. In my opinion, it's a bit dangerous, as unsorted photos are effectively hidden so they should be accessible only to those who know the URL...