### PR TITLE
Invoke get_public in Cast::toArray()

### DIFF
--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -99,7 +99,6 @@ class PhotoController extends Controller
 
 		$return = Cast::toArray($photo);
 		Cast::urls($return, $photo);
-		$return['public'] = $photo->get_public();
 
 		$this->symLinkFunctions->getUrl($photo, $return);
 		if (!$this->sessionFunctions->is_current_user($photo->owner_id)) {

--- a/app/ModelFunctions/PhotoActions/Cast.php
+++ b/app/ModelFunctions/PhotoActions/Cast.php
@@ -25,6 +25,7 @@ class Cast
 			'description' => $photo->description == null ? '' : $photo->description,
 			'tags' => $photo->tags,
 			'star' => Helpers::str_of_bool($photo->star),
+			'public' => $photo->get_public(),
 			'album' => $photo->album_id !== null ? strval($photo->album_id) : null,
 			'width' => strval($photo->width),
 			'height' => strval($photo->height),


### PR DESCRIPTION
`public` wasn't being set for photos returned in `Album::get`. As a result, the front end could not display the orange visible-hidden eye badge for photos individually made public.

According to the Debugbar, the queries count is unchanged...