### PR TITLE
Fix top-level edits for non-admin users

### DIFF
--- a/app/Http/Middleware/UploadCheck.php
+++ b/app/Http/Middleware/UploadCheck.php
@@ -104,7 +104,7 @@ class UploadCheck
 
 		// Remove smart albums (they get a pass).
 		for ($i = 0; $i < count($albumIDs);) {
-			if ($this->albumFunctions->is_smart_album($albumIDs[$i])) {
+			if ($this->albumFunctions->is_smart_album($albumIDs[$i]) || $albumIDs[$i] === '0') {
 				array_splice($albumIDs, $i, 1);
 			} else {
 				$i++;


### PR DESCRIPTION
Fix #669.

I left the smart album test for now but given the discussion we had recently, that should eventually probably go away; I just don't want to deal with any collateral damage it might cause right now.