### PR TITLE
Move original deletion to later in the function

### DIFF
--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -374,7 +374,7 @@ class ImportController extends Controller
 					continue;
 				}
 			} else {
-				$this->status_update('Problem: Unsupported file type (' . $file . ')');
+				$this->status_update('Problem: ' . $file . ': Unsupported file type');
 				Logs::error(__METHOD__, __LINE__, 'Unsupported file type (' . $file . ')');
 				continue;
 			}


### PR DESCRIPTION
Fixes #733.

There was a race condition between the original being deleted early and the photo being saved in the database much later; if for some reason the photo didn't get saved (timeout, etc), an image would go missing.

In the process I undid what I believe was an unnecessary  change from #574 to `ImportController` which resulted in a notification string that was not following the required formatting.