### PR TITLE
fix(rss): avoid display feed link in HTML if RSS option is disabled

### DIFF
--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -58,12 +58,13 @@ class IndexController extends Controller
 			$menus = Page::menu()->get();
 
 			$title = Configs::get_value('site_title', Config::get('defines.defaults.SITE_TITLE'));
+			$rss_enable = (Configs::get_value('rss_enable', '0') == '1') ? true : false;
 
 			$page_config = [];
 			$page_config['show_hosted_by'] = false;
 			$page_config['display_socials'] = false;
 
-			return view('landing', ['locale' => $lang, 'title' => $title, 'infos' => $infos, 'menus' => $menus, 'page_config' => $page_config]);
+			return view('landing', ['locale' => $lang, 'title' => $title, 'infos' => $infos, 'menus' => $menus, 'page_config' => $page_config, 'rss_enable' => $rss_enable]);
 		}
 
 		return $this->gallery();
@@ -103,10 +104,11 @@ class IndexController extends Controller
 		$lang['language'] = Configs::get_value('lang');
 
 		$title = Configs::get_value('site_title', Config::get('defines.defaults.SITE_TITLE'));
+		$rss_enable = (Configs::get_value('rss_enable', '0') == '1') ? true : false;
 		$page_config = [];
 		$page_config['show_hosted_by'] = true;
 		$page_config['display_socials'] = Configs::get_value('display_social_in_gallery', '0') == '1';
 
-		return view('gallery', ['locale' => $lang, 'title' => $title, 'infos' => $infos,  'page_config' => $page_config]);
+		return view('gallery', ['locale' => $lang, 'title' => $title, 'infos' => $infos,  'page_config' => $page_config, 'rss_enable' => $rss_enable]);
 	}
 }

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -50,6 +50,7 @@ class PageController extends Controller
 
 		$infos = $this->configFunctions->get_pages_infos();
 		$title = Configs::get_value('site_title', Config::get('defines.defaults.SITE_TITLE'));
+		$rss_enable = (Configs::get_value('rss_enable', '0') == '1') ? true : false;
 		$menus = Page::menu()->get();
 
 		$contents = $page->content;
@@ -57,7 +58,7 @@ class PageController extends Controller
 		$page_config['show_hosted_by'] = false;
 		$page_config['display_socials'] = false;
 
-		return view('page', ['locale' => $lang, 'title' => $title, 'infos' => $infos, 'menus' => $menus, 'contents' => $contents, 'page_config' => $page_config]);
+		return view('page', ['locale' => $lang, 'title' => $title, 'infos' => $infos, 'menus' => $menus, 'contents' => $contents, 'page_config' => $page_config, 'rss_enable' => $rss_enable]);
 	}
 
 	/**

--- a/app/Http/Controllers/ViewController.php
+++ b/app/Http/Controllers/ViewController.php
@@ -64,6 +64,7 @@ class ViewController extends Controller
 		}
 
 		$title = Configs::get_value('site_title', Config::get('defines.defaults.SITE_TITLE'));
+		$rss_enable = (Configs::get_value('rss_enable', '0') == '1') ? true : false;
 
 		$url = config('app.url') . $request->server->get('REQUEST_URI');
 		$picture = config('app.url') . '/uploads/' . $dir . '/' . $photo->url;
@@ -73,6 +74,7 @@ class ViewController extends Controller
 			'photo' => $photo,
 			'picture' => $picture,
 			'title' => $title,
+			'rss_enable' => $rss_enable
 		]);
 	}
 }

--- a/resources/views/includes/head.blade.php
+++ b/resources/views/includes/head.blade.php
@@ -13,6 +13,8 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black">
 <meta name="apple-mobile-web-app-capable" content="yes">
 
-@include('feed::links')
+@if($rss_enable)
+  @include('feed::links')
+@endif
 
 @yield('head-meta')


### PR DESCRIPTION
Hi, I found the title issue :)

## Description

Currently, lychee always displays a link for feed on HTML even if `rss_enable` option is false.

```
<link rel="alternate" type="application/atom+xml" href="http://localhsot:90/feed" title="Latest pictures">
```

## Implementation

*  IndexController, PageController, and ViewController checks the `rss_enable` setting and return `true/false` to `head.blade.php`.
* `head.blade.php` receive `true/false` from them.
    * if true, displays a link feed.
    * if false, does not display a link feed.
