### PR TITLE
Ensure innoDB

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -55,8 +55,7 @@ return [
 			'prefix' => '',
 			'prefix_indexes' => true,
 			'strict' => true,
-			'engine' => null,
-			// 'engine' => 'InnoDB ROW_FORMAT=DYNAMIC',
+			'engine' => 'InnoDB ROW_FORMAT=DYNAMIC',
 			'options' => extension_loaded('pdo_mysql') ? array_filter([
 				PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
 			]) : [],


### PR DESCRIPTION
It seems that on some MySQL DB, with previous settings they could set up in MyISAM which broke with the WebAuth update. This should be fixed now. Tested with @SerenaButler.