### PR TITLE
Fixing artisan lychee:decode_GPS_locations 

### DIFF
--- a/app/Console/Commands/DecodeGpsLocations.php
+++ b/app/Console/Commands/DecodeGpsLocations.php
@@ -41,8 +41,8 @@ class DecodeGpsLocations extends Command
 	{
 		// Update location if field 'location' is null or empty
 		$photos = Photo::whereNotNull('latitude')->whereNotNull('longitude')->where(
-			function($query) {
-			    $query->where('location','=','')->orWhereNull('location');
+			function ($query) {
+			        $query->where('location', '=', '')->orWhereNull('location');
 			})
 			->get();
 

--- a/app/Console/Commands/DecodeGpsLocations.php
+++ b/app/Console/Commands/DecodeGpsLocations.php
@@ -39,7 +39,11 @@ class DecodeGpsLocations extends Command
 	 */
 	public function handle()
 	{
-		$photos = Photo::whereNotNull('latitude')->whereNotNull('longitude')->whereNull('location')
+		// Update location if field 'location' is null or empty
+		$photos = Photo::whereNotNull('latitude')->whereNotNull('longitude')->where(
+			function($query) {
+			    $query->where('location','=','')->orWhereNull('location');
+			})
 			->get();
 
 		if (count($photos) == 0) {

--- a/app/Console/Commands/DecodeGpsLocations.php
+++ b/app/Console/Commands/DecodeGpsLocations.php
@@ -42,7 +42,7 @@ class DecodeGpsLocations extends Command
 		// Update location if field 'location' is null or empty
 		$photos = Photo::whereNotNull('latitude')->whereNotNull('longitude')->where(
 			function ($query) {
-			        $query->where('location', '=', '')->orWhereNull('location');
+				$query->where('location', '=', '')->orWhereNull('location');
 			})
 			->get();
 

--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -317,7 +317,7 @@ class Extractor
 		// but only if return value is not null (= function has been disabled)
 		$metadata['location'] = Geodecoder::decodeLocation($metadata['latitude'], $metadata['longitude']);
 		if (is_null($metadata['location']) == false) {
-			$metadata['location'] = substr($metadata['location'] , 0, 100);
+			$metadata['location'] = substr($metadata['location'] , 0, 255);
 		}
         
 		return $metadata;

--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -313,13 +313,13 @@ class Extractor
 			}
 		}
 
-		// Decode location data, it can be longer than is acceptable for DB that's the reason for substr 
+		// Decode location data, it can be longer than is acceptable for DB that's the reason for substr
 		// but only if return value is not null (= function has been disabled)
 		$metadata['location'] = Geodecoder::decodeLocation($metadata['latitude'], $metadata['longitude']);
 		if (is_null($metadata['location']) == false) {
-			$metadata['location'] = substr($metadata['location'] , 0, 255);
+			$metadata['location'] = substr($metadata['location'], 0, 255);
 		}
-        
+
 		return $metadata;
 	}
 }

--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -313,9 +313,13 @@ class Extractor
 			}
 		}
 
-		// Decode location data, it can be longer than is acceptable for DB that's the reason for substr
-		$metadata['location'] = substr(Geodecoder::decodeLocation($metadata['latitude'], $metadata['longitude']), 0, 100);
-
+		// Decode location data, it can be longer than is acceptable for DB that's the reason for substr 
+		// but only if return value is not null (= function has been disabled)
+		$metadata['location'] = Geodecoder::decodeLocation($metadata['latitude'], $metadata['longitude']);
+		if (is_null($metadata['location']) == false) {
+			$metadata['location'] = substr($metadata['location'] , 0, 100);
+		}
+        
 		return $metadata;
 	}
 }


### PR DESCRIPTION
Function decode_GPS_locations was only selection photos with `location=null` and omitting empty string ones