### PR TITLE
Assume that application/octet-stream are videos

### DIFF
--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -52,7 +52,7 @@ class PhotoFunctions
 	public $validVideoTypes = [
 		'video/mp4',
 		'video/mpeg',
-		'image/x-tga', // mpg
+		'image/x-tga', // mpg; will be corrected by the metadata extractor
 		'video/ogg',
 		'video/webm',
 		'video/quicktime',
@@ -60,6 +60,7 @@ class PhotoFunctions
 		'video/x-ms-wmv', // wmv file
 		'video/x-msvideo', // Avi
 		'video/x-m4v', // Avi
+		'application/octet-stream', // Some mp4 files; will be corrected by the metadata extractor
 	];
 
 	/**


### PR DESCRIPTION
Fixes #846.

We know that some `.mp4` files show up as having an `application/octet-stream` MIME type. We have a partial fix in place in php-exif via https://github.com/LycheeOrg/php-exif/pull/28, but that fix turns out to only work if exiftool is in use. https://github.com/LycheeOrg/php-exif/pull/30, once merged, will expand the fix in php-exif to the native adapter as well, but for a more robust solution, it's best to assume in Lychee early on that `application/octet-stream` are video files.