### PR TITLE
Report too large requests to the frontend

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,8 +4,10 @@ namespace App\Exceptions;
 
 use App\Exceptions\Handlers\AccessDBDenied;
 use App\Exceptions\Handlers\ApplyComposer;
+use App\Exceptions\Handlers\FileTooLarge;
 use App\Exceptions\Handlers\InvalidPayload;
 use App\Exceptions\Handlers\NoEncryptionKey;
+use App\Exceptions\Handlers\RequestTooLarge;
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Throwable;
@@ -64,6 +66,8 @@ class Handler extends ExceptionHandler
 		$checks[] = new InvalidPayload();
 		$checks[] = new AccessDBDenied();
 		$checks[] = new ApplyComposer();
+		$checks[] = new FileTooLarge();
+		$checks[] = new RequestTooLarge();
 
 		foreach ($checks as $check) {
 			if ($check->check($request, $exception)) {

--- a/app/Exceptions/Handlers/FileTooLarge.php
+++ b/app/Exceptions/Handlers/FileTooLarge.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Exceptions\Handlers;
+
+use Illuminate\Http\Response;
+use Illuminate\Validation\ValidationException;
+use Throwable;
+
+class FileTooLarge
+{
+	/**
+	 * Render an exception into an HTTP response.
+	 *
+	 * @param Illuminate\Http\Request $request
+	 * @param Throwable               $exception
+	 *
+	 * @return bool
+	 */
+	public function check($request, Throwable $exception)
+	{
+		return $exception instanceof ValidationException;
+	}
+
+	/**
+	 * @return \Illuminate\Http\Response
+	 */
+	// @codeCoverageIgnoreStart
+	public function go()
+	{
+		return response()->json('Error: Request invalid. If this happens during photo upload, consider increasing the PHP upload_max_filesize limit.');
+	}
+
+	// @codeCoverageIgnoreEnd
+}

--- a/app/Exceptions/Handlers/RequestTooLarge.php
+++ b/app/Exceptions/Handlers/RequestTooLarge.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Exceptions\Handlers;
+
+use Illuminate\Http\Exceptions\PostTooLargeException;
+use Illuminate\Http\Response;
+use Throwable;
+
+class RequestTooLarge
+{
+	/**
+	 * Render an exception into an HTTP response.
+	 *
+	 * @param Illuminate\Http\Request $request
+	 * @param Throwable               $exception
+	 *
+	 * @return bool
+	 */
+	public function check($request, Throwable $exception)
+	{
+		return $exception instanceof PostTooLargeException;
+	}
+
+	/**
+	 * @return \Illuminate\Http\Response
+	 */
+	// @codeCoverageIgnoreStart
+	public function go()
+	{
+		return response()->json('Error: Request too large. Consider increasing the PHP post_max_size limit.');
+	}
+
+	// @codeCoverageIgnoreEnd
+}


### PR DESCRIPTION
As suggested in #858, this adds additional diagnostics during failed photo uploads due to too small `upload_max_filesize` or `post_max_size`.