### PR TITLE
Make Photo:add validation error easier to discern

### DIFF
--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -27,6 +27,7 @@ use App\Models\Photo;
 use App\Response;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class PhotoController extends Controller
@@ -79,9 +80,13 @@ class PhotoController extends Controller
 	 */
 	public function add(AlbumIDRequest $request, Create $create)
 	{
-		$request->validate([
-			'0' => 'required',
-		]);
+		try {
+			$request->validate([
+				'0' => 'required',
+			]);
+		} catch (ValidationException $e) {
+			return Response::error('validation failed');
+		}
 
 		if (!$request->hasfile('0')) {
 			return Response::error('missing files');

--- a/app/Locale/ChineseSimplified.php
+++ b/app/Locale/ChineseSimplified.php
@@ -402,6 +402,8 @@ final class ChineseSimplified implements Language
 			'UPLOAD_ERROR_CONSOLE' => '请查看浏览器控制台获取详细信息。',
 			'UPLOAD_UNKNOWN' => '服务器返回未知响应。请查看浏览器控制台获取详细信息。',
 			'UPLOAD_ERROR_UNKNOWN' => '上传失败。服务器返回了一个未知错误！',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => 'Lychee 当前正在上传！',
 			'UPLOAD_IMPORT_WARN_ERR' => '导入成功，但返回了的警告或错误。请查看日志（设置->显示日志）以获取详细信息。',
 			'UPLOAD_IMPORT_COMPLETE' => '导入完成',

--- a/app/Locale/ChineseTraditional.php
+++ b/app/Locale/ChineseTraditional.php
@@ -402,6 +402,8 @@ final class ChineseTraditional implements Language
 			'UPLOAD_ERROR_CONSOLE' => '請查看瀏覽器控制台獲取詳細信息。',
 			'UPLOAD_UNKNOWN' => '伺服器傳回了未知響應。請查看瀏覽器控制台獲取詳細信息。',
 			'UPLOAD_ERROR_UNKNOWN' => '上傳失敗。伺服器回傳了一個未知錯誤！',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => 'Lychee當前正在上傳！',
 			'UPLOAD_IMPORT_WARN_ERR' => '導入成功，但返回了的警告或錯誤。請查看日誌（設置->顯示日誌）以獲取詳細信息。',
 			'UPLOAD_IMPORT_COMPLETE' => '導入完成',

--- a/app/Locale/Czech.php
+++ b/app/Locale/Czech.php
@@ -409,6 +409,8 @@ final class Czech implements Language
 			'UPLOAD_ERROR_CONSOLE' => 'Podrobnosti získáte v konzoli svého prohlížeče.',
 			'UPLOAD_UNKNOWN' => 'Server vrátil neočkávanou dopověď. Podrobnosti získáte v konzoli svého prohlížeče.',
 			'UPLOAD_ERROR_UNKNOWN' => 'Upload selhal. Server vrátil neznámou chybu!',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => 'Právě probíhá upload na Lychee!',
 			'UPLOAD_IMPORT_WARN_ERR' => 'Import byl dokončen s upozorněními nebo chybami. Podrobnosti si prosím prohlédněte v protokolu (Nastavení -> Protokoly).',
 			'UPLOAD_IMPORT_COMPLETE' => 'Import dokončen',

--- a/app/Locale/Dutch.php
+++ b/app/Locale/Dutch.php
@@ -402,6 +402,8 @@ final class Dutch implements Language
 			'UPLOAD_ERROR_CONSOLE' => 'Kijk naar je browsers console voor meer informatie.',
 			'UPLOAD_UNKNOWN' => 'Server gaf een onbekende terugkoppeling, kijk naar je browsers console voor meer informatie.',
 			'UPLOAD_ERROR_UNKNOWN' => 'Upload mislukt. Server gaf een onbekende error!',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => 'Lychee is aan het uploaden!',
 			'UPLOAD_IMPORT_WARN_ERR' => 'De import is voltooid maar gaf waarschuwingen of errors terug. Kijk naar de logs (instellingen -> Show Log) for further details.',
 			'UPLOAD_IMPORT_COMPLETE' => 'Import complete',

--- a/app/Locale/English.php
+++ b/app/Locale/English.php
@@ -403,6 +403,8 @@ final class English implements Language
 			'UPLOAD_ERROR_CONSOLE' => 'Please take a look at the console of your browser for further details.',
 			'UPLOAD_UNKNOWN' => 'Server returned an unknown response. Please take a look at the console of your browser for further details.',
 			'UPLOAD_ERROR_UNKNOWN' => 'Upload failed. Server returned an unkown error!',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => 'Lychee is currently uploading!',
 			'UPLOAD_IMPORT_WARN_ERR' => 'The import has been finished, but returned warnings or errors. Please take a look at the log (Settings -> Show Log) for further details.',
 			'UPLOAD_IMPORT_COMPLETE' => 'Import complete',

--- a/app/Locale/French.php
+++ b/app/Locale/French.php
@@ -402,6 +402,8 @@ final class French implements Language
 			'UPLOAD_ERROR_CONSOLE' => 'Veuillez consulter la console de votre navigateur pour obtenir plus de détails.',
 			'UPLOAD_UNKNOWN' => 'Le serveur a retourné une reponse inconnue. Veuillez consulter la console de votre navigateur pour obtenir plus de détails.',
 			'UPLOAD_ERROR_UNKNOWN' => 'Échec de l\'upload. Le serveur a retourné une erreur inconnue !',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => 'Lychee est en cours de téléchargement !',
 			'UPLOAD_IMPORT_WARN_ERR' => 'L\'importation est terminée, mais des erreurs ou des avertissements ont été retournés. Veuillez consulter le fichier de Log (Paramètres -> Afficher les logs) pour obtenir plus de détails.',
 			'UPLOAD_IMPORT_COMPLETE' => 'Importation terminée',

--- a/app/Locale/German.php
+++ b/app/Locale/German.php
@@ -411,6 +411,8 @@ final class German implements Language
 			'UPLOAD_ERROR_CONSOLE' => 'Bitte schauen Sie in die Konsole Ihres Browsers, um weiter Details zu erfahren.',
 			'UPLOAD_UNKNOWN' => 'Der Server hat eine unbekannte Antwort gegeben. Bitte schauen Sie in die Konsole Ihres Browsers, um weiter Details zu erfahren.',
 			'UPLOAD_ERROR_UNKNOWN' => 'Hochladen fehlgeschlagen. Der Server hat einen unbekannten Fehler gemeldet!',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => 'Lychee ist gerade beim Hochladen!',
 			'UPLOAD_IMPORT_WARN_ERR' => 'Der Import ist fertig, hat aber Warnungen oder Fehler zurückgegeben. Schauen Sie bitte ins Protokoll (Einstellungen/Protokoll ansehen).',
 			'UPLOAD_IMPORT_COMPLETE' => 'Import abgeschlossen',

--- a/app/Locale/Greek.php
+++ b/app/Locale/Greek.php
@@ -402,6 +402,8 @@ final class Greek implements Language
 			'UPLOAD_ERROR_CONSOLE' => 'Παρακαλούμε ρίξτε μια ματιά στην κονσόλα του περιηγητή σας για περισσότερες λεπτομέρειες.',
 			'UPLOAD_UNKNOWN' => 'Ο εξυπηρετητής επέστρεψε μία άγνωστη απόκριση. Παρακαλούμε ρίξτε μια ματιά στην κονσόλα του περιηγητή σας για περισσότερες λεπτομέρειες.',
 			'UPLOAD_ERROR_UNKNOWN' => 'Η μεταφόρτωση απέτυχε. Ο εξυπηρετητής επέστρεψε ένα άγνωστο σφάλμα!',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => 'Το Lychee αυτή τη στιγμή μεταφορτώνει!',
 			'UPLOAD_IMPORT_WARN_ERR' => 'Η εισαγωγή ολοκληρώθηκε, αλλά επέστρεψε προειδοποιήσεις ή σφάλματα. Παρακαλούμε ρίξτε μια ματία στις καταγραφές (Ρυθμίσεις -> Εμφάνιση Καταγραφών) για περισσότερες λεπτομέρειες.',
 			'UPLOAD_IMPORT_COMPLETE' => 'Η εισαγωγή ολοκληρώθηκε',

--- a/app/Locale/Italian.php
+++ b/app/Locale/Italian.php
@@ -408,6 +408,8 @@ final class Italian implements Language
 			'UPLOAD_ERROR_CONSOLE' => 'Per favore controlla la console del tuo browser per ulteriori dettagli.',
 			'UPLOAD_UNKNOWN' => 'Il server ha restituito una risposta sconosciuta. Per favore controlla la console del tuo browser per ulteriori dettagli.',
 			'UPLOAD_ERROR_UNKNOWN' => 'Caricamneto fallito. Il server ha restituito un errore sconosciuto!',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => 'Lychee sta momentaneamente caricando!',
 			'UPLOAD_IMPORT_WARN_ERR' => 'L\'importazione è finita, ma ha restituito errori o avvisi. Per favore controlla il log (Impostazioni -> Visualizza Log) per ulteriori dettagli.',
 			'UPLOAD_IMPORT_COMPLETE' => 'Importazione completata',

--- a/app/Locale/NorwegianBokmal.php
+++ b/app/Locale/NorwegianBokmal.php
@@ -403,6 +403,8 @@ final class NorwegianBokmal implements Language
 			'UPLOAD_ERROR_CONSOLE' => 'Vennligst se konsollen i nettleseren for mer informasjon.',
 			'UPLOAD_UNKNOWN' => 'Serveren svarte med en ukjent feilmelding. Vennlist se konsollen i nettleseren for mer informasjon.',
 			'UPLOAD_ERROR_UNKNOWN' => 'Opplasting feilet. Serveren svarte med en ukjent feil!',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => 'Lychee laster for tiden opp!',
 			'UPLOAD_IMPORT_WARN_ERR' => 'Importeringen er ferdig, men advarsler eller feil ble returnert. Vennligst see loggen (Innstilinger -> Vis Logg) for mer informasjon.',
 			'UPLOAD_IMPORT_COMPLETE' => 'Importering fullført',

--- a/app/Locale/Russian.php
+++ b/app/Locale/Russian.php
@@ -403,6 +403,8 @@ final class Russian implements Language
 			'UPLOAD_ERROR_CONSOLE' => 'Подробности смотрите в консоли браузера.',
 			'UPLOAD_UNKNOWN' => 'Сервер вернул непонятный ответ. Проверьте консоль браузера.',
 			'UPLOAD_ERROR_UNKNOWN' => 'Загрузка не удалась: сервер вернул что-то непонятное!',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => 'Lychee выполняет выгрузку.',
 			'UPLOAD_IMPORT_WARN_ERR' => 'Импорт был завершён, но обнаружены ошибки или предупреждения. Пожалуйста, проверьте лог (Settings -> Логи).',
 			'UPLOAD_IMPORT_COMPLETE' => 'Импорт завершён',

--- a/app/Locale/Slovak.php
+++ b/app/Locale/Slovak.php
@@ -409,6 +409,8 @@ final class Slovak implements Language
 			'UPLOAD_ERROR_CONSOLE' => 'Skontrolujte konzolu prehliadača, pre zistenie ďalších podrobností.',
 			'UPLOAD_UNKNOWN' => 'Server vrátil neznámu odpoveď.Skontrolujte konzolu prehliadača, pre zistenie ďalších podrobností.',
 			'UPLOAD_ERROR_UNKNOWN' => 'Nahrávanie zlyhalo. Server ohlásil neznámu chybu!',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => 'Lychee práve nahráva!',
 			'UPLOAD_IMPORT_WARN_ERR' => 'Import je hotový, vyskytli sa ale chyby alebo varovania. Skontrolujte protokoly (Nastavenia/ Protokoly).',
 			'UPLOAD_IMPORT_COMPLETE' => 'Import hotový',

--- a/app/Locale/Spanish.php
+++ b/app/Locale/Spanish.php
@@ -402,6 +402,8 @@ final class Spanish implements Language
 			'UPLOAD_ERROR_CONSOLE' => 'Por favor, eche un vistazo a la consola de su navegador para más detalles.',
 			'UPLOAD_UNKNOWN' => 'El servidor devolvió una respuesta desconocida. Por favor, eche un vistazo a la consola de su navegador para más detalles.',
 			'UPLOAD_ERROR_UNKNOWN' => 'Subida fallida. ¡El servidor devolvió un error desconocido!',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => '¡Lychee está subiendo actualmente!',
 			'UPLOAD_IMPORT_WARN_ERR' => 'La importación ha finalizado, pero devolvió advertencias o errores. Por favor, eche un vistazo al registro (Configuración -> Mostrar registro) para obtener más detalles.',
 			'UPLOAD_IMPORT_COMPLETE' => 'Importación completa',

--- a/app/Locale/Swedish.php
+++ b/app/Locale/Swedish.php
@@ -402,6 +402,8 @@ final class Swedish implements Language
 			'UPLOAD_ERROR_CONSOLE' => 'Kontrollera din webbläsares konsoll för ytterligare information.',
 			'UPLOAD_UNKNOWN' => 'Servern returnerade ett oklart svar. Kontrollera din webbläsares konsoll för ytterligare information.',
 			'UPLOAD_ERROR_UNKNOWN' => 'Uppladdning misslyckades. Servern returnerade ett oklart fel!',
+			'UPLOAD_ERROR_POSTSIZE' => 'Upload failed. The PHP post_max_size limit is too small!',
+			'UPLOAD_ERROR_FILESIZE' => 'Upload failed. The PHP upload_max_filesize limit is too small!',
 			'UPLOAD_IN_PROGRESS' => 'Lychee laddar för tillfället upp material!',
 			'UPLOAD_IMPORT_WARN_ERR' => 'Importeringen är avslutad, men processen gav felmeddelanden. Kontrollera logfilen (Inställningar -> Visa logfilen) för ytterligare detaljer.',
 			'UPLOAD_IMPORT_COMPLETE' => 'Importeringen klar',

--- a/tests/Feature/Lib/PhotosUnitTest.php
+++ b/tests/Feature/Lib/PhotosUnitTest.php
@@ -65,7 +65,8 @@ class PhotosUnitTest
 				'albumID' => '0',
 			]
 		);
-		$response->assertStatus(302);
+		$response->assertStatus(200);
+		$response->assertSee('"Error: validation failed"', false);
 	}
 
 	/**


### PR DESCRIPTION
This is a second try, once I realized that most of the problem is in the frontend.

As suggested in #858, this adds additional diagnostics during failed photo uploads due to too small `upload_max_filesize` or `post_max_size`.

The server needs a tweak because by default a failed validation (which is what happens if a file size exceeds `upload_max_filesize`) results in a redirect so normally we never even see the error code in the frontend.