### PR TITLE
Fix album import

### DIFF
--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -68,9 +68,11 @@ class ImportController extends Controller
 				$res = false;
 				// @codeCoverageIgnoreEnd
 			}
+			// @codeCoverageIgnoreStart
 		} catch (Exception $e) {
 			$res = false;
 		}
+		// @codeCoverageIgnoreEnd
 
 		return $res;
 	}


### PR DESCRIPTION
Fixes #867 

* Invoke `create` on `Album\Create`, not `Photo\Create`

* Also catch exceptions from `Photo\Create->add`, such as when skipping a duplicate.