### PR TITLE
remove last references to PhotoFunctions.php

### DIFF
--- a/app/Console/Commands/ExifLens.php
+++ b/app/Console/Commands/ExifLens.php
@@ -36,8 +36,7 @@ class ExifLens extends Command
 	/**
 	 * Create a new command instance.
 	 *
-	 * @param PhotoFunctions $photoFunctions
-	 * @param Extractor      $metadataExtractor
+	 * @param Extractor $metadataExtractor
 	 */
 	public function __construct(Extractor $metadataExtractor)
 	{

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,7 +13,6 @@ use App\Metadata\GitHubFunctions;
 use App\Metadata\GitRequest;
 use App\Metadata\LycheeVersion;
 use App\ModelFunctions\ConfigFunctions;
-use App\ModelFunctions\PhotoFunctions;
 use App\ModelFunctions\SessionFunctions;
 use App\ModelFunctions\SymLinkFunctions;
 use App\Models\Configs;
@@ -27,7 +26,6 @@ class AppServiceProvider extends ServiceProvider
 	public $singletons
 	= [
 		SymLinkFunctions::class => SymLinkFunctions::class,
-		PhotoFunctions::class => PhotoFunctions::class,
 		ConfigFunctions::class => ConfigFunctions::class,
 		LangFactory::class => LangFactory::class,
 		Lang::class => Lang::class,


### PR DESCRIPTION
Fixes following complaint.

On Gitter:
> ABLomas @ABLomas 12:40
> trying to update from earlier (~2 months old) version - web update failed, doing from console. Did "git pull", then composer update, but fails at missing file: https://p.defau.lt/?Q_RA_UNWpJTk8sjkh8fs7Q