### PR TITLE
Various fixes

### DIFF
--- a/app/Actions/Album/Archive.php
+++ b/app/Actions/Album/Archive.php
@@ -141,12 +141,12 @@ class Archive extends Action
 		// cares in what order photos are zipped?
 
 		foreach ($photos as $photo) {
-			// For photos in public smart albums, skip the ones
-			// that are not downloadable based on their actual
-			// parent album.
+			// For photos in smart or tag albums, skip the ones that are not
+			// downloadable based on their actual parent album.  Photos from
+			// Unsorted are handled implicitly by the photo ownership test.
 			if (
-				$this->albumFactory->is_smart($albumID) && !AccessControl::is_logged_in() &&
-				$photo->album_id !== null && !$photo->album->is_downloadable()
+				$album->smart && !AccessControl::is_current_user($photo->owner_id) &&
+				!$photo->album->is_downloadable()
 			) {
 				continue;
 			}

--- a/app/Actions/Album/Archive.php
+++ b/app/Actions/Album/Archive.php
@@ -142,11 +142,12 @@ class Archive extends Action
 
 		foreach ($photos as $photo) {
 			// For photos in smart or tag albums, skip the ones that are not
-			// downloadable based on their actual parent album.  Photos from
-			// Unsorted are handled implicitly by the photo ownership test.
+			// downloadable based on their actual parent album.  The test for
+			// album_id == null shouldn't really be needed as all such photos
+			// in smart albums should be owned by the current user...
 			if (
 				$album->smart && !AccessControl::is_current_user($photo->owner_id) &&
-				!$photo->album->is_downloadable()
+				!($photo->album_id == null ? $album->is_downloadable() : $photo->album->is_downloadable())
 			) {
 				continue;
 			}

--- a/app/Actions/Album/Delete.php
+++ b/app/Actions/Album/Delete.php
@@ -18,8 +18,9 @@ class Delete
 	{
 		$no_error = true;
 		// root = unsorted
-		if ($albumIDs == '0') {
-			$photos = Photo::select_unsorted(Photo::OwnedBy(AccessControl::id()))->get();
+		if ($albumIDs == 'unsorted') {
+			$photos = Photo::OwnedBy(AccessControl::id())->where('album_id', '=', null)->get();
+
 			foreach ($photos as $photo) {
 				$no_error &= $photo->predelete();
 				$no_error &= $photo->delete();

--- a/app/Actions/Photo/Duplicate.php
+++ b/app/Actions/Photo/Duplicate.php
@@ -52,6 +52,9 @@ class Duplicate
 			$duplicate->thumbUrl = $photo->thumbUrl;
 			$duplicate->thumb2x = $photo->thumb2x;
 			$duplicate->album_id = $albumID ?? $photo->album_id;
+			if ($duplicate->album_id === '0') {
+				$duplicate->album_id = null;
+			}
 			$duplicate->checksum = $photo->checksum;
 			$duplicate->medium = $photo->medium;
 			$duplicate->medium2x = $photo->medium2x;


### PR DESCRIPTION
Various assorted fixes for old bugs discovered during the review of #832.

* Copying a photo to Unsorted didn't work (server hang).
* Deleting the (content of) Unsorted triggered server error due to missing `Photo::select_unsorted`. I tried to replace it with factories and such, but I couldn't figure it out, so I used the good old query builder. I'm sure @ildyria can do something better :smiley:.
* Album download has a custom filter that prevents the downloads of photos via smart albums if the actual album the photos are in is not downloadable. This needed to be expanded to handle tag albums, and to handle smart albums with multi-user content (e.g., Recent) correctly.