### PR TITLE
add CI on external PR

### DIFF
--- a/.github/workflows/Build-Dist.yml
+++ b/.github/workflows/Build-Dist.yml
@@ -3,6 +3,7 @@ name: Build-Dist
 # Run this workflow every time a new commit pushed to your repository
 on:
   push:
+  pull_request:
 
 jobs:
   tests:

--- a/.github/workflows/Build-Dist.yml
+++ b/.github/workflows/Build-Dist.yml
@@ -3,7 +3,11 @@ name: Build-Dist
 # Run this workflow every time a new commit pushed to your repository
 on:
   push:
+    paths-ignore:
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   tests:
@@ -44,6 +48,11 @@ jobs:
       key: cache-v1 # can be any string, change to clear the extension cache.
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.7.0
+        with:
+          access_token: ${{ github.token }}
+
       # Checks out a copy of your repository on the ubuntu machine
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/Build-Dist.yml
+++ b/.github/workflows/Build-Dist.yml
@@ -9,6 +9,8 @@ jobs:
   tests:
 
     runs-on: ${{ matrix.operating-system }}
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run by the push to the branch.
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
 
     # Service containers to run with `container-job`
     services:

--- a/.github/workflows/Build-Full-SQL.yml
+++ b/.github/workflows/Build-Full-SQL.yml
@@ -3,15 +3,19 @@ name: Build-Full-SQL
 # Run this workflow every time a new commit pushed to your repository
 on:
   push:
+    paths-ignore:
+      - '**/*.md'
   pull_request:
-    branches:
-        - master
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   tests:
 
     runs-on: ${{ matrix.operating-system }}
-
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run by the push to the branch.
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
+    
     # Service containers to run with `container-job`
     services:
       # Label used to access the service container
@@ -44,6 +48,11 @@ jobs:
       key: cache-v1 # can be any string, change to clear the extension cache.
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.7.0
+        with:
+          access_token: ${{ github.token }}
+
       # Checks out a copy of your repository on the ubuntu machine
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/Build-Full-SQL.yml
+++ b/.github/workflows/Build-Full-SQL.yml
@@ -3,6 +3,9 @@ name: Build-Full-SQL
 # Run this workflow every time a new commit pushed to your repository
 on:
   push:
+  pull_request:
+    branches:
+        - master
 
 jobs:
   tests:


### PR DESCRIPTION
Fixes the CI not being applied on external PR.
It was working for our PR due to the `on:push`  but this was not the case for external PR as they are not working on our repo but on the fork.