### PR TITLE
adding backend setting to disable display of GPS direction on map

### DIFF
--- a/app/Http/Controllers/Administration/SettingsController.php
+++ b/app/Http/Controllers/Administration/SettingsController.php
@@ -224,24 +224,6 @@ class SettingsController extends Controller
 	}
 
 	/**
-	 * Enable display of photos on map for public albums.
-	 *
-	 * @param Request $request
-	 *
-	 * @return string
-	 */
-	public function setMapDisplayPublic(Request $request)
-	{
-		$request->validate(['map_display_public' => 'required|string']);
-
-		if ($request['map_display_public'] == '1') {
-			return Configs::set('map_display_public', '1') ? 'true' : 'false';
-		}
-
-		return Configs::set('map_display_public', '0') ? 'true' : 'false';
-	}
-
-	/**
 	 * Enable display of photo direction on map.
 	 *
 	 * @param Request $request

--- a/app/Http/Controllers/Administration/SettingsController.php
+++ b/app/Http/Controllers/Administration/SettingsController.php
@@ -224,21 +224,21 @@ class SettingsController extends Controller
 	}
 
 	/**
-	 * Enable display of photo direction on map.
+	 * Enable display of photos on map for public albums.
 	 *
 	 * @param Request $request
 	 *
 	 * @return string
 	 */
-	public function setMapDisplayDirection(Request $request)
+	public function setMapDisplayPublic(Request $request)
 	{
-		$request->validate(['map_display_direction' => 'required|string']);
+		$request->validate(['map_display_public' => 'required|string']);
 
-		if ($request['map_display_direction'] == '1') {
-			return Configs::set('map_display_direction', '1') ? 'true' : 'false';
+		if ($request['map_display_public'] == '1') {
+			return Configs::set('map_display_public', '1') ? 'true' : 'false';
 		}
 
-		return Configs::set('map_display_direction', '0') ? 'true' : 'false';
+		return Configs::set('map_display_public', '0') ? 'true' : 'false';
 	}
 
 	/**

--- a/app/Http/Controllers/Administration/SettingsController.php
+++ b/app/Http/Controllers/Administration/SettingsController.php
@@ -242,6 +242,24 @@ class SettingsController extends Controller
 	}
 
 	/**
+	 * Enable display of photo direction on map.
+	 *
+	 * @param Request $request
+	 *
+	 * @return string
+	 */
+	public function setMapDisplayDirection(Request $request)
+	{
+		$request->validate(['map_display_direction' => 'required|string']);
+
+		if ($request['map_display_direction'] == '1') {
+			return Configs::set('map_display_direction', '1') ? 'true' : 'false';
+		}
+
+		return Configs::set('map_display_direction', '0') ? 'true' : 'false';
+	}
+
+	/**
 	 * Set provider of OSM map tiles.
 	 *
 	 * @param Request $request

--- a/database/migrations/2021_01_27_085903_config_map_display_direction.php
+++ b/database/migrations/2021_01_27_085903_config_map_display_direction.php
@@ -1,0 +1,40 @@
+<?php
+
+/** @noinspection PhpUndefinedClassInspection */
+
+use App\Models\Configs;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class ConfigMapDisplayDirection extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		defined('BOOL') or define('BOOL', '0|1');
+
+		DB::table('configs')->insert([
+			[
+				'key' => 'map_display_direction',
+				'value' => '1',
+				'confidentiality' => 1,
+				'cat' => 'Mod Map',
+				'type_range' => BOOL,
+			],
+		]);
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Configs::where('key', '=', 'map_display_direction')->delete();
+	}
+}

--- a/database/migrations/2021_01_27_085903_config_map_display_direction.php
+++ b/database/migrations/2021_01_27_085903_config_map_display_direction.php
@@ -21,7 +21,7 @@ class ConfigMapDisplayDirection extends Migration
 			[
 				'key' => 'map_display_direction',
 				'value' => '1',
-				'confidentiality' => 1,
+				'confidentiality' => 0,
 				'cat' => 'Mod Map',
 				'type_range' => BOOL,
 			],

--- a/public/dist/main.js
+++ b/public/dist/main.js
@@ -347,7 +347,7 @@ var _templateObject = _taggedTemplateLiteral(["<p>", " <input class='text' name=
     _templateObject49 = _taggedTemplateLiteral(["\n\t\t\t\t<h1>Lychee ", "</h1>\n\t\t\t\t<div class='version'><span><a target='_blank' href='", "'>", "</a></span></div>\n\t\t\t\t<h1>", "</h1>\n\t\t\t\t<p><a target='_blank' href='", "'>Lychee</a> ", "</p>\n\t\t\t  "], ["\n\t\t\t\t<h1>Lychee ", "</h1>\n\t\t\t\t<div class='version'><span><a target='_blank' href='", "'>", "</a></span></div>\n\t\t\t\t<h1>", "</h1>\n\t\t\t\t<p><a target='_blank' href='", "'>Lychee</a> ", "</p>\n\t\t\t  "]),
     _templateObject50 = _taggedTemplateLiteral(["\n\t\t\t<a class='signInKeyLess' id='signInKeyLess'>", "</a>\n\t\t\t<form>\n\t\t\t\t<p class='signIn'>\n\t\t\t\t\t<input class='text' name='username' autocomplete='on' type='text' placeholder='$", "' autocapitalize='off' data-tabindex='", "'>\n\t\t\t\t\t<input class='text' name='password' autocomplete='current-password' type='password' placeholder='$", "' data-tabindex='", "'>\n\t\t\t\t</p>\n\t\t\t\t<p class='version'>Lychee ", "<span> &#8211; <a target='_blank' href='", "' data-tabindex='-1'>", "</a><span></p>\n\t\t\t</form>\n\t\t\t"], ["\n\t\t\t<a class='signInKeyLess' id='signInKeyLess'>", "</a>\n\t\t\t<form>\n\t\t\t\t<p class='signIn'>\n\t\t\t\t\t<input class='text' name='username' autocomplete='on' type='text' placeholder='$", "' autocapitalize='off' data-tabindex='", "'>\n\t\t\t\t\t<input class='text' name='password' autocomplete='current-password' type='password' placeholder='$", "' data-tabindex='", "'>\n\t\t\t\t</p>\n\t\t\t\t<p class='version'>Lychee ", "<span> &#8211; <a target='_blank' href='", "' data-tabindex='-1'>", "</a><span></p>\n\t\t\t</form>\n\t\t\t"]),
     _templateObject51 = _taggedTemplateLiteral(["<link data-prefetch rel=\"prefetch\" href=\"", "\">"], ["<link data-prefetch rel=\"prefetch\" href=\"", "\">"]),
-    _templateObject52 = _taggedTemplateLiteral(["<p>", " '", "' ", "</p>"], ["<p>", " '", "' ", "</p>"]),
+    _templateObject52 = _taggedTemplateLiteral(["<p>", " '", "'", "</p>"], ["<p>", " '", "'", "</p>"]),
     _templateObject53 = _taggedTemplateLiteral(["<p>", " ", " ", "</p>"], ["<p>", " ", " ", "</p>"]),
     _templateObject54 = _taggedTemplateLiteral(["<input class='text' name='title' type='text' maxlength='100' placeholder='Title' value='$", "'>"], ["<input class='text' name='title' type='text' maxlength='100' placeholder='Title' value='$", "'>"]),
     _templateObject55 = _taggedTemplateLiteral(["<p>", " ", " ", " ", "</p>"], ["<p>", " ", " ", " ", "</p>"]),
@@ -1755,6 +1755,35 @@ album.isUploadable = function () {
 	}
 
 	return album.json.owner === lychee.username;
+};
+
+album.updatePhoto = function (data) {
+	if (album.json) {
+		$.each(album.json.photos, function () {
+			if (this.id === data.id) {
+				this.width = data.width;
+				this.height = data.height;
+				this.small = data.small;
+				this.small_dim = data.small_dim;
+				this.small2x = data.small2x;
+				this.small2x_dim = data.small2x_dim;
+				this.medium = data.medium;
+				this.medium_dim = data.medium_dim;
+				this.medium2x = data.medium2x;
+				this.medium2x_dim = data.medium2x_dim;
+				this.thumbUrl = data.thumbUrl;
+				this.thumb2x = data.thumb2x;
+				this.url = data.url;
+				this.size = data.size;
+
+				view.album.content.updatePhoto(this);
+				albums.refresh();
+
+				return false;
+			}
+			return true;
+		});
+	}
 };
 
 album.reload = function () {
@@ -4035,6 +4064,7 @@ var lychee = {
 	image_overlay_type_default: "exif", // image overlay type default type
 	map_display: false, // display photo coordinates on map
 	map_display_public: false, // display photos of public album on map (user not logged in)
+	map_display_direction: true, // use the GPS direction data on displayed maps
 	map_provider: "Wikimedia", // Provider of OSM Tiles
 	map_include_subalbums: false, // include photos of subalbums on map
 	location_decoding: false, // retrieve location name from GPS data
@@ -4197,6 +4227,7 @@ lychee.init = function () {
 			lychee.image_overlay_type_default = lychee.image_overlay_type;
 			lychee.map_display = data.config.map_display && data.config.map_display === "1" || false;
 			lychee.map_display_public = data.config.map_display_public && data.config.map_display_public === "1" || false;
+			lychee.map_display_direction = data.config.map_display_direction && data.config.map_display_direction === "1" || false;
 			lychee.map_provider = !data.config.map_provider ? "Wikimedia" : data.config.map_provider;
 			lychee.map_include_subalbums = data.config.map_include_subalbums && data.config.map_include_subalbums === "1" || false;
 			lychee.location_decoding = data.config.location_decoding && data.config.location_decoding === "1" || false;
@@ -4269,6 +4300,7 @@ lychee.init = function () {
 			lychee.image_overlay_type_default = lychee.image_overlay_type;
 			lychee.map_display = data.config.map_display && data.config.map_display === "1" || false;
 			lychee.map_display_public = data.config.map_display_public && data.config.map_display_public === "1" || false;
+			lychee.map_display_direction = data.config.map_display_direction && data.config.map_display_direction === "1" || false;
 			lychee.map_provider = !data.config.map_provider ? "Wikimedia" : data.config.map_provider;
 			lychee.map_include_subalbums = data.config.map_include_subalbums && data.config.map_include_subalbums === "1" || false;
 			lychee.location_show = data.config.location_show && data.config.location_show === "1" || false;
@@ -7064,14 +7096,6 @@ _photo.showDirectLinks = function (photoID) {
 photoeditor = {};
 
 photoeditor.rotate = function (photoID, direction) {
-	var swapDims = function swapDims(d) {
-		var p = d.indexOf("x");
-		if (p !== -1) {
-			return d.substr(0, p) + "x" + d.substr(p + 1);
-		}
-		return d;
-	};
-
 	if (!photoID) return false;
 	if (!direction) return false;
 
@@ -7081,39 +7105,26 @@ photoeditor.rotate = function (photoID, direction) {
 	};
 
 	api.post("PhotoEditor::rotate", params, function (data) {
-		if (data !== true) {
+		if (data === false) {
 			lychee.error(null, params, data);
 		} else {
-			var mr = "?" + Math.random();
-			var sel_big = "img#image";
-			var sel_thumb = "div[data-id=" + photoID + "] > span > img";
-			var sel_div = "div[data-id=" + photoID + "]";
-			$(sel_big).prop("src", $(sel_big).attr("src") + mr);
-			$(sel_big).prop("srcset", $(sel_big).attr("src"));
-			$(sel_thumb).prop("src", $(sel_thumb).attr("src") + mr);
-			$(sel_thumb).prop("srcset", $(sel_thumb).attr("src"));
-			var arrayLength = album.json.photos.length;
-			for (var i = 0; i < arrayLength; i++) {
-				if (album.json.photos[i].id === photoID) {
-					var w = album.json.photos[i].width;
-					var h = album.json.photos[i].height;
-					album.json.photos[i].height = w;
-					album.json.photos[i].width = h;
-					album.json.photos[i].small += mr;
-					album.json.photos[i].small_dim = swapDims(album.json.photos[i].small_dim);
-					album.json.photos[i].small2x += mr;
-					album.json.photos[i].small2x_dim = swapDims(album.json.photos[i].small2x_dim);
-					album.json.photos[i].medium += mr;
-					album.json.photos[i].medium_dim = swapDims(album.json.photos[i].medium_dim);
-					album.json.photos[i].medium2x += mr;
-					album.json.photos[i].medium2x_dim = swapDims(album.json.photos[i].medium2x_dim);
-					album.json.photos[i].thumb2x += mr;
-					album.json.photos[i].thumbUrl += mr;
-					album.json.photos[i].url += mr;
-					view.album.content.justify();
-					break;
-				}
+			_photo.json = data;
+			_photo.json.original_album = _photo.json.album;
+			if (album.json) {
+				_photo.json.album = album.json.id;
 			}
+
+			var image = $("img#image");
+			if (_photo.json.hasOwnProperty("medium2x") && _photo.json.medium2x !== "") {
+				image.prop("srcset", _photo.json.medium + " " + parseInt(_photo.json.medium_dim, 10) + "w, " + _photo.json.medium2x + " " + parseInt(_photo.json.medium2x_dim, 10) + "w");
+			} else {
+				image.prop("srcset", "");
+			}
+			image.prop("src", _photo.json.medium !== "" ? _photo.json.medium : _photo.json.url);
+			view.photo.onresize();
+			view.photo.sidebar();
+
+			album.updatePhoto(data);
 		}
 	});
 };
@@ -9655,8 +9666,8 @@ view.album = {
 		},
 
 		cover: function cover(photoID) {
-			$('.album .icn-cover').removeClass("badge--cover");
-			$('.photo .icn-cover').removeClass("badge--cover");
+			$(".album .icn-cover").removeClass("badge--cover");
+			$(".photo .icn-cover").removeClass("badge--cover");
 
 			if (album.json.cover_id === photoID) {
 				var badge = $('.photo[data-id="' + photoID + '"] .icn-cover');
@@ -9671,6 +9682,42 @@ view.album = {
 					});
 				}
 			}
+		},
+
+		updatePhoto: function updatePhoto(data) {
+			var src = void 0,
+			    srcset = "";
+
+			// This mimicks the structure of build.photo
+			if (lychee.layout === "0") {
+				src = data.thumbUrl;
+				if (data.hasOwnProperty("thumb2x") && data.thumb2x !== "") {
+					srcset = data.thumb2x + " 2x";
+				}
+			} else {
+				if (data.small !== "") {
+					src = data.small;
+					if (data.hasOwnProperty("small2x") && data.small2x !== "") {
+						srcset = data.small + " " + parseInt(data.small_dim, 10) + "w, " + data.small2x + " " + parseInt(data.small2x_dim, 10) + "w";
+					}
+				} else if (data.medium !== "") {
+					src = data.medium;
+					if (data.hasOwnProperty("medium2x") && data.medium2x !== "") {
+						srcset = data.medium + " " + parseInt(data.medium_dim, 10) + "w, " + data.medium2x + " " + parseInt(data.medium2x_dim, 10) + "w";
+					}
+				} else if (!data.type || data.type.indexOf("video") !== 0) {
+					src = data.url;
+				} else {
+					src = data.thumbUrl;
+					if (data.hasOwnProperty("thumb2x") && data.thumb2x !== "") {
+						srcset = data.thumbUrl + " 200w, " + data.thumb2x + " 400w";
+					}
+				}
+			}
+
+			$('.photo[data-id="' + data.id + '"] > span.thumbimg > img').attr("data-src", src).attr("data-srcset", srcset).addClass("lazyload");
+
+			view.album.content.justify();
 		},
 
 		delete: function _delete(photoID) {
@@ -9917,6 +9964,7 @@ view.photo = {
 		view.photo.title();
 		view.photo.star();
 		view.photo.public();
+		view.photo.header();
 		view.photo.photo(autoplay);
 
 		_photo.json.init = 1;
@@ -10134,7 +10182,7 @@ view.photo = {
 				attribution: map_provider_layer_attribution[lychee.map_provider].attribution
 			}).addTo(mymap);
 
-			if (!_photo.json.imgDirection || _photo.json.imgDirection === "") {
+			if (!lychee.map_display_direction || !_photo.json.imgDirection || _photo.json.imgDirection === "") {
 				// Add Marker to map, direction is not set
 				L.marker([_photo.json.latitude, _photo.json.longitude]).addTo(mymap);
 			} else {
@@ -10148,6 +10196,14 @@ view.photo = {
 				var marker = L.marker([_photo.json.latitude, _photo.json.longitude], { icon: viewDirectionIcon }).addTo(mymap);
 				marker.setRotationAngle(_photo.json.imgDirection);
 			}
+		}
+	},
+
+	header: function header() {
+		if (_photo.json.type && (_photo.json.type.indexOf("video") === 0 || _photo.json.type === "raw") || _photo.json.livePhotoUrl !== "" && _photo.json.livePhotoUrl !== null) {
+			$("#button_rotate_cwise, #button_rotate_ccwise").hide();
+		} else {
+			$("#button_rotate_cwise, #button_rotate_ccwise").show();
 		}
 	},
 


### PR DESCRIPTION
This is the backend PR for issue #886. Adds a new configuration setting to control whether the embedded maps use the GPS direction data to display a facing cone. It's set to `true` by default so upgrades won't cause unexpected breaks to existing behavior. 

(Paired with LycheeOrg/Lychee-front#243)