### PR TITLE
Fix rotation

### DIFF
--- a/app/Actions/Photo/Create.php
+++ b/app/Actions/Photo/Create.php
@@ -52,6 +52,8 @@ class Create
 	/** @var array */
 	public $info;
 	public $livePhotoPartner;
+	/** @var bool */
+	public $is_uploaded;
 
 	public function add(
 		array $file,
@@ -80,6 +82,7 @@ class Create
 
 		// Set paths
 		$this->tmp_name = $file['tmp_name'];
+		$this->is_uploaded = is_uploaded_file($file['tmp_name']);
 		$this->photo_Url = md5(microtime()) . $this->extension;
 		$this->path_prefix = ($this->kind != 'raw') ? 'big/' : 'raw/';
 		$this->path = Storage::path($this->path_prefix . $this->photo_Url);
@@ -126,7 +129,7 @@ class Create
 			$res = $this->save($this->photo);
 		}
 
-		if ($delete_imported && !is_uploaded_file($this->tmp_name) && ($exists || Configs::get_value('import_via_symlink', '0') !== '1')) {
+		if ($delete_imported && !$this->is_uploaded && ($exists || Configs::get_value('import_via_symlink', '0') !== '1')) {
 			@unlink($this->tmp_name);
 		}
 

--- a/app/Actions/Photo/Extensions/ImageEditing.php
+++ b/app/Actions/Photo/Extensions/ImageEditing.php
@@ -65,7 +65,13 @@ trait ImageEditing
 			return '';
 		}
 
-		$tmp_file = tempnam(sys_get_temp_dir(), 'lychee') . '.jpeg';
+		if (!($tmp_file = tempnam(sys_get_temp_dir(), 'lychee')) ||
+			!rename($tmp_file, $tmp_file . '.jpeg')) {
+			Logs::notice(__METHOD__, __LINE__, 'Could not create a temporary file.');
+
+			return '';
+		}
+		$tmp_file .= '.jpeg';
 		Logs::notice(__METHOD__, __LINE__, 'Saving JPG of raw file to ' . $tmp_file);
 
 		$resWidth = $resHeight = 0;

--- a/app/Actions/Photo/Extensions/VideoEditing.php
+++ b/app/Actions/Photo/Extensions/VideoEditing.php
@@ -48,7 +48,13 @@ trait VideoEditing
 		$ffmpeg = FFMpeg::create();
 		/** @var Video */
 		$video = $ffmpeg->open(Storage::path('big/' . $photo->url));
-		$tmp = tempnam(sys_get_temp_dir(), 'lychee') . '.jpeg';
+		if (!($tmp = tempnam(sys_get_temp_dir(), 'lychee')) ||
+			!rename($tmp, $tmp . '.jpeg')) {
+			Logs::notice(__METHOD__, __LINE__, 'Could not create a temporary file.');
+
+			return '';
+		}
+		$tmp .= '.jpeg';
 		Logs::notice(__METHOD__, __LINE__, 'Saving frame to ' . $tmp);
 
 		try {

--- a/app/Actions/Photo/Strategies/StrategyDuplicate.php
+++ b/app/Actions/Photo/Strategies/StrategyDuplicate.php
@@ -74,7 +74,7 @@ class StrategyDuplicate extends StrategyPhotoBase
 				$res = new JsonWarning('This photo has been skipped because it\'s already in your library.');
 			}
 
-			if ($this->delete_imported && !is_uploaded_file($create->tmp_name)) {
+			if ($this->delete_imported && !$create->is_uploaded) {
 				@unlink($create->tmp_name);
 			}
 

--- a/app/Http/Controllers/PhotoEditorController.php
+++ b/app/Http/Controllers/PhotoEditorController.php
@@ -4,6 +4,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\Photo\Prepare;
 use App\Actions\Photo\Rotate;
 use App\Http\Requests\PhotoRequests\PhotoIDRequest;
 use App\Models\Configs;
@@ -16,9 +17,9 @@ class PhotoEditorController extends Controller
 	 *
 	 * @param PhotoIDRequest $request
 	 *
-	 * @return tring
+	 * @return array|string
 	 */
-	public function rotate(PhotoIDRequest $request, Rotate $rotate)
+	public function rotate(PhotoIDRequest $request, Rotate $rotate, Prepare $prepare)
 	{
 		if (!Configs::get_value('editor_enabled', '0')) {
 			return 'false';
@@ -28,6 +29,10 @@ class PhotoEditorController extends Controller
 
 		$photo = Photo::findOrFail($request['photoID']);
 
-		return $rotate->do($photo, intval($request['direction'])) ? 'true' : 'false';
+		if ($rotate->do($photo, intval($request['direction'])) == false) {
+			return 'false';
+		}
+
+		return $prepare->do($photo);
 	}
 }

--- a/app/Http/Controllers/PhotoEditorController.php
+++ b/app/Http/Controllers/PhotoEditorController.php
@@ -29,7 +29,7 @@ class PhotoEditorController extends Controller
 
 		$photo = Photo::findOrFail($request['photoID']);
 
-		if ($rotate->do($photo, intval($request['direction'])) == false) {
+		if (!$rotate->do($photo, intval($request['direction']))) {
 			return 'false';
 		}
 

--- a/app/Image/GdHandler.php
+++ b/app/Image/GdHandler.php
@@ -137,7 +137,7 @@ class GdHandler implements ImageHandlerInterface
 		if ($res === false) {
 			return false;
 		}
-		list($sourceImg, $mime, $width, $height) = $res;
+		list($sourceImg, , $width, $height) = $res;
 
 		if ($width < $height) {
 			$newSize = $width;

--- a/app/Image/ImageHandler.php
+++ b/app/Image/ImageHandler.php
@@ -68,11 +68,39 @@ class ImageHandler implements ImageHandlerInterface
 	 *
 	 * @param string $path
 	 * @param array  $info
+	 * @param bool   $pretend
 	 *
 	 * @return array
 	 */
-	public function autoRotate(string $path, array $info): array
+	public function autoRotate(string $path, array $info, bool $pretend = false): array
 	{
-		return $this->engines[0]->autoRotate($path, $info);
+		$i = 0;
+		$ret = [false, false];
+		while ($i < count($this->engines) && ($ret = $this->engines[$i]->autoRotate($path, $info, $pretend)) == [false, false]) {
+			$i++;
+		}
+
+		return $ret;
+	}
+
+	/**
+	 * @param string $source
+	 * @param int    $angle
+	 * @param string $destination
+	 *
+	 * @return bool
+	 */
+	public function rotate(string $source, int $angle, string $destination = null): bool
+	{
+		if ($angle != 90 && $angle != -90) {
+			return false;
+		}
+
+		$i = 0;
+		while ($i < count($this->engines) && !$this->engines[$i]->rotate($source, $angle, $destination)) {
+			$i++;
+		}
+
+		return $i != count($this->engines);
 	}
 }

--- a/app/Image/ImageHandlerInterface.php
+++ b/app/Image/ImageHandlerInterface.php
@@ -48,8 +48,18 @@ interface ImageHandlerInterface
 	 *
 	 * @param string $path
 	 * @param array  $info
+	 * @param boo    $pretend
 	 *
 	 * @return array
 	 */
-	public function autoRotate(string $path, array $info): array;
+	public function autoRotate(string $path, array $info, bool $pretend = false): array;
+
+	/**
+	 * @param string $source
+	 * @param int    $angle
+	 * @param string $destination
+	 *
+	 * @return bool
+	 */
+	public function rotate(string $source, int $angle, string $destination = null): bool;
 }

--- a/app/Models/SymLink.php
+++ b/app/Models/SymLink.php
@@ -66,7 +66,7 @@ class SymLink extends Model
 	];
 
 	/**
-	 * Generate a sim link.
+	 * Generate a sym link.
 	 * The salt is important in order to remove the deterministic side of the address.
 	 *
 	 * @param Photo  $photo
@@ -76,14 +76,13 @@ class SymLink extends Model
 	 */
 	private function create(Photo $photo, string $kind, string $salt, $field)
 	{
-		$urls = explode('.', $photo->$field);
 		if (substr($kind, -2, 2) == '2x') {
-			$url = $urls[0] . '@2x.' . $urls[1];
+			$url = Helpers::ex2x($photo->$field);
 		} else {
-			$url = $urls[0] . '.' . $urls[1];
+			$url = $photo->$field;
 		}
 
-		if ($photo->type == 'raw') {
+		if ($photo->type == 'raw' && $kind == 'url') {
 			$original = Storage::path('raw/' . $url);
 		} else {
 			$original = Storage::path($this->kinds_dir[$kind] . '/' . $url);
@@ -121,12 +120,12 @@ class SymLink extends Model
 			$this->create($photo, 'url', strval($now), 'url');
 		}
 
-		// in case of video we need to use thumbUrl instead
 		$kinds = [
 			'medium', 'medium2x', 'small', 'small2x', 'thumbUrl', 'thumb2x',
 		];
 
-		if (strpos($photo->type, 'video') === 0) {
+		if ($photo->isVideo() || $photo->type == 'raw') {
+			// in case of video and raw we need to use thumbUrl instead
 			foreach ($kinds as $kind) {
 				if ($photo->$kind != '' && $photo->$kind != '0') {
 					$this->create($photo, $kind, strval($now), 'thumbUrl');

--- a/database/migrations/2021_01_24_231904_fix-rotation.php
+++ b/database/migrations/2021_01_24_231904_fix-rotation.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\Photo;
+use Illuminate\Database\Migrations\Migration;
+
+class FixRotation extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Photo::where('small', 'x')->update(['small' => '']);
+		Photo::where('small2x', 'x')->update(['small2x' => '']);
+		Photo::where('medium', 'x')->update(['medium' => '']);
+		Photo::where('medium2x', 'x')->update(['medium2x' => '']);
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		// There is no undo
+	}
+}

--- a/public/dist/main.js
+++ b/public/dist/main.js
@@ -347,7 +347,7 @@ var _templateObject = _taggedTemplateLiteral(["<p>", " <input class='text' name=
     _templateObject49 = _taggedTemplateLiteral(["\n\t\t\t\t<h1>Lychee ", "</h1>\n\t\t\t\t<div class='version'><span><a target='_blank' href='", "'>", "</a></span></div>\n\t\t\t\t<h1>", "</h1>\n\t\t\t\t<p><a target='_blank' href='", "'>Lychee</a> ", "</p>\n\t\t\t  "], ["\n\t\t\t\t<h1>Lychee ", "</h1>\n\t\t\t\t<div class='version'><span><a target='_blank' href='", "'>", "</a></span></div>\n\t\t\t\t<h1>", "</h1>\n\t\t\t\t<p><a target='_blank' href='", "'>Lychee</a> ", "</p>\n\t\t\t  "]),
     _templateObject50 = _taggedTemplateLiteral(["\n\t\t\t<a class='signInKeyLess' id='signInKeyLess'>", "</a>\n\t\t\t<form>\n\t\t\t\t<p class='signIn'>\n\t\t\t\t\t<input class='text' name='username' autocomplete='on' type='text' placeholder='$", "' autocapitalize='off' data-tabindex='", "'>\n\t\t\t\t\t<input class='text' name='password' autocomplete='current-password' type='password' placeholder='$", "' data-tabindex='", "'>\n\t\t\t\t</p>\n\t\t\t\t<p class='version'>Lychee ", "<span> &#8211; <a target='_blank' href='", "' data-tabindex='-1'>", "</a><span></p>\n\t\t\t</form>\n\t\t\t"], ["\n\t\t\t<a class='signInKeyLess' id='signInKeyLess'>", "</a>\n\t\t\t<form>\n\t\t\t\t<p class='signIn'>\n\t\t\t\t\t<input class='text' name='username' autocomplete='on' type='text' placeholder='$", "' autocapitalize='off' data-tabindex='", "'>\n\t\t\t\t\t<input class='text' name='password' autocomplete='current-password' type='password' placeholder='$", "' data-tabindex='", "'>\n\t\t\t\t</p>\n\t\t\t\t<p class='version'>Lychee ", "<span> &#8211; <a target='_blank' href='", "' data-tabindex='-1'>", "</a><span></p>\n\t\t\t</form>\n\t\t\t"]),
     _templateObject51 = _taggedTemplateLiteral(["<link data-prefetch rel=\"prefetch\" href=\"", "\">"], ["<link data-prefetch rel=\"prefetch\" href=\"", "\">"]),
-    _templateObject52 = _taggedTemplateLiteral(["<p>", " '", "' ", "</p>"], ["<p>", " '", "' ", "</p>"]),
+    _templateObject52 = _taggedTemplateLiteral(["<p>", " '", "'", "</p>"], ["<p>", " '", "'", "</p>"]),
     _templateObject53 = _taggedTemplateLiteral(["<p>", " ", " ", "</p>"], ["<p>", " ", " ", "</p>"]),
     _templateObject54 = _taggedTemplateLiteral(["<input class='text' name='title' type='text' maxlength='100' placeholder='Title' value='$", "'>"], ["<input class='text' name='title' type='text' maxlength='100' placeholder='Title' value='$", "'>"]),
     _templateObject55 = _taggedTemplateLiteral(["<p>", " ", " ", " ", "</p>"], ["<p>", " ", " ", " ", "</p>"]),
@@ -1755,6 +1755,35 @@ album.isUploadable = function () {
 	}
 
 	return album.json.owner === lychee.username;
+};
+
+album.updatePhoto = function (data) {
+	if (album.json) {
+		$.each(album.json.photos, function () {
+			if (this.id === data.id) {
+				this.width = data.width;
+				this.height = data.height;
+				this.small = data.small;
+				this.small_dim = data.small_dim;
+				this.small2x = data.small2x;
+				this.small2x_dim = data.small2x_dim;
+				this.medium = data.medium;
+				this.medium_dim = data.medium_dim;
+				this.medium2x = data.medium2x;
+				this.medium2x_dim = data.medium2x_dim;
+				this.thumbUrl = data.thumbUrl;
+				this.thumb2x = data.thumb2x;
+				this.url = data.url;
+				this.size = data.size;
+
+				view.album.content.updatePhoto(this);
+				albums.refresh();
+
+				return false;
+			}
+			return true;
+		});
+	}
 };
 
 album.reload = function () {
@@ -7064,14 +7093,6 @@ _photo.showDirectLinks = function (photoID) {
 photoeditor = {};
 
 photoeditor.rotate = function (photoID, direction) {
-	var swapDims = function swapDims(d) {
-		var p = d.indexOf("x");
-		if (p !== -1) {
-			return d.substr(0, p) + "x" + d.substr(p + 1);
-		}
-		return d;
-	};
-
 	if (!photoID) return false;
 	if (!direction) return false;
 
@@ -7081,39 +7102,26 @@ photoeditor.rotate = function (photoID, direction) {
 	};
 
 	api.post("PhotoEditor::rotate", params, function (data) {
-		if (data !== true) {
+		if (data === false) {
 			lychee.error(null, params, data);
 		} else {
-			var mr = "?" + Math.random();
-			var sel_big = "img#image";
-			var sel_thumb = "div[data-id=" + photoID + "] > span > img";
-			var sel_div = "div[data-id=" + photoID + "]";
-			$(sel_big).prop("src", $(sel_big).attr("src") + mr);
-			$(sel_big).prop("srcset", $(sel_big).attr("src"));
-			$(sel_thumb).prop("src", $(sel_thumb).attr("src") + mr);
-			$(sel_thumb).prop("srcset", $(sel_thumb).attr("src"));
-			var arrayLength = album.json.photos.length;
-			for (var i = 0; i < arrayLength; i++) {
-				if (album.json.photos[i].id === photoID) {
-					var w = album.json.photos[i].width;
-					var h = album.json.photos[i].height;
-					album.json.photos[i].height = w;
-					album.json.photos[i].width = h;
-					album.json.photos[i].small += mr;
-					album.json.photos[i].small_dim = swapDims(album.json.photos[i].small_dim);
-					album.json.photos[i].small2x += mr;
-					album.json.photos[i].small2x_dim = swapDims(album.json.photos[i].small2x_dim);
-					album.json.photos[i].medium += mr;
-					album.json.photos[i].medium_dim = swapDims(album.json.photos[i].medium_dim);
-					album.json.photos[i].medium2x += mr;
-					album.json.photos[i].medium2x_dim = swapDims(album.json.photos[i].medium2x_dim);
-					album.json.photos[i].thumb2x += mr;
-					album.json.photos[i].thumbUrl += mr;
-					album.json.photos[i].url += mr;
-					view.album.content.justify();
-					break;
-				}
+			_photo.json = data;
+			_photo.json.original_album = _photo.json.album;
+			if (album.json) {
+				_photo.json.album = album.json.id;
 			}
+
+			var image = $("img#image");
+			if (_photo.json.hasOwnProperty("medium2x") && _photo.json.medium2x !== "") {
+				image.prop("srcset", _photo.json.medium + " " + parseInt(_photo.json.medium_dim, 10) + "w, " + _photo.json.medium2x + " " + parseInt(_photo.json.medium2x_dim, 10) + "w");
+			} else {
+				image.prop("srcset", "");
+			}
+			image.prop("src", _photo.json.medium !== "" ? _photo.json.medium : _photo.json.url);
+			view.photo.onresize();
+			view.photo.sidebar();
+
+			album.updatePhoto(data);
 		}
 	});
 };
@@ -9655,8 +9663,8 @@ view.album = {
 		},
 
 		cover: function cover(photoID) {
-			$('.album .icn-cover').removeClass("badge--cover");
-			$('.photo .icn-cover').removeClass("badge--cover");
+			$(".album .icn-cover").removeClass("badge--cover");
+			$(".photo .icn-cover").removeClass("badge--cover");
 
 			if (album.json.cover_id === photoID) {
 				var badge = $('.photo[data-id="' + photoID + '"] .icn-cover');
@@ -9671,6 +9679,42 @@ view.album = {
 					});
 				}
 			}
+		},
+
+		updatePhoto: function updatePhoto(data) {
+			var src = void 0,
+			    srcset = "";
+
+			// This mimicks the structure of build.photo
+			if (lychee.layout === "0") {
+				src = data.thumbUrl;
+				if (data.hasOwnProperty("thumb2x") && data.thumb2x !== "") {
+					srcset = data.thumb2x + " 2x";
+				}
+			} else {
+				if (data.small !== "") {
+					src = data.small;
+					if (data.hasOwnProperty("small2x") && data.small2x !== "") {
+						srcset = data.small + " " + parseInt(data.small_dim, 10) + "w, " + data.small2x + " " + parseInt(data.small2x_dim, 10) + "w";
+					}
+				} else if (data.medium !== "") {
+					src = data.medium;
+					if (data.hasOwnProperty("medium2x") && data.medium2x !== "") {
+						srcset = data.medium + " " + parseInt(data.medium_dim, 10) + "w, " + data.medium2x + " " + parseInt(data.medium2x_dim, 10) + "w";
+					}
+				} else if (!data.type || data.type.indexOf("video") !== 0) {
+					src = data.url;
+				} else {
+					src = data.thumbUrl;
+					if (data.hasOwnProperty("thumb2x") && data.thumb2x !== "") {
+						srcset = data.thumbUrl + " 200w, " + data.thumb2x + " 400w";
+					}
+				}
+			}
+
+			$('.photo[data-id="' + data.id + '"] > span.thumbimg > img').attr("data-src", src).attr("data-srcset", srcset).addClass("lazyload");
+
+			view.album.content.justify();
 		},
 
 		delete: function _delete(photoID) {
@@ -9917,6 +9961,7 @@ view.photo = {
 		view.photo.title();
 		view.photo.star();
 		view.photo.public();
+		view.photo.header();
 		view.photo.photo(autoplay);
 
 		_photo.json.init = 1;
@@ -10148,6 +10193,14 @@ view.photo = {
 				var marker = L.marker([_photo.json.latitude, _photo.json.longitude], { icon: viewDirectionIcon }).addTo(mymap);
 				marker.setRotationAngle(_photo.json.imgDirection);
 			}
+		}
+	},
+
+	header: function header() {
+		if (_photo.json.type && (_photo.json.type.indexOf("video") === 0 || _photo.json.type === "raw") || _photo.json.livePhotoUrl !== "" && _photo.json.livePhotoUrl !== null) {
+			$("#button_rotate_cwise, #button_rotate_ccwise").hide();
+		} else {
+			$("#button_rotate_cwise, #button_rotate_ccwise").show();
 		}
 	},
 

--- a/tests/Feature/Lib/PhotosUnitTest.php
+++ b/tests/Feature/Lib/PhotosUnitTest.php
@@ -482,10 +482,8 @@ class PhotosUnitTest
 			'direction' => $direction,
 		]);
 		$response->assertStatus($code);
-		if ($code == 200) {
-			if ($result != 'true') {
-				$response->assertSee($result, false);
-			}
+		if ($code == 200 && $result != 'true') {
+			$response->assertSee($result, false);
 		}
 
 		return $response;

--- a/tests/Feature/Lib/PhotosUnitTest.php
+++ b/tests/Feature/Lib/PhotosUnitTest.php
@@ -461,6 +461,16 @@ class PhotosUnitTest
 		return $response->streamedContent();
 	}
 
+	/**
+	 * Rotate a picture.
+	 *
+	 * @param TestCase $testCase
+	 * @param string   $id
+	 * @param          $direction
+	 * @param string   $result
+	 *
+	 * @return TestResponse
+	 */
 	protected function rotate(
 		string $id,
 		$direction,
@@ -473,7 +483,11 @@ class PhotosUnitTest
 		]);
 		$response->assertStatus($code);
 		if ($code == 200) {
-			$response->assertSee($result, false);
+			if ($result != 'true') {
+				$response->assertSee($result, false);
+			}
 		}
+
+		return $response;
 	}
 }

--- a/tests/Feature/PhotosRotateTest.php
+++ b/tests/Feature/PhotosRotateTest.php
@@ -29,7 +29,7 @@ class PhotosRotateTest extends TestCase
 		$file = new UploadedFile(
 			'public/uploads/import/night.jpg',
 			'night.jpg',
-			'image/jpg',
+			'image/jpeg',
 			null,
 			true
 		);
@@ -64,18 +64,17 @@ class PhotosRotateTest extends TestCase
 		$photos_tests->rotate('-1', 1, 'false');
 		$photos_tests->rotate($id, 'asdq', 'false', 422);
 		$photos_tests->rotate($id, '2', 'false');
-		$photos_tests->rotate($id, 1);
 
+		$response = $photos_tests->rotate($id, 1);
 		/*
 		* Check some Exif data
 		*/
-		$response = $photos_tests->get($id, 'true');
 		$response->assertJson([
 			'height' => '6720',
 			'id' => $id,
 			// 'size' => '20.1 MB', // This changes during the image manipulation sadly.
-			'small_dim' => '360x540',
-			'medium_dim' => '1080x1620',
+			'small_dim' => '240x360',
+			'medium_dim' => '720x1620',
 			'width' => '4480',
 		]);
 

--- a/tests/Feature/PhotosRotateTest.php
+++ b/tests/Feature/PhotosRotateTest.php
@@ -74,7 +74,7 @@ class PhotosRotateTest extends TestCase
 			'id' => $id,
 			// 'size' => '20.1 MB', // This changes during the image manipulation sadly.
 			'small_dim' => '240x360',
-			'medium_dim' => '720x1620',
+			'medium_dim' => '720x1080',
 			'width' => '4480',
 		]);
 

--- a/tests/Feature/PhotosTest.php
+++ b/tests/Feature/PhotosTest.php
@@ -35,7 +35,7 @@ class PhotosTest extends TestCase
 		$file = new UploadedFile(
 			'public/uploads/import/night.jpg',
 			'night.jpg',
-			'image/jpg',
+			'image/jpeg',
 			null,
 			true
 		);

--- a/tests/Feature/RSSTest.php
+++ b/tests/Feature/RSSTest.php
@@ -58,7 +58,7 @@ class RSSTest extends TestCase
 		$file = new UploadedFile(
 			'public/uploads/import/night.jpg',
 			'night.jpg',
-			'image/jpg',
+			'image/jpeg',
 			null,
 			true
 		);


### PR DESCRIPTION
Fixes #741.

The corresponding frontend changes are in https://github.com/LycheeOrg/Lychee-front/pull/244.

This ended up being much larger and more complex than I anticipated (and it took like a week :disappointed:). Once I started fixing that part of the code I kept uncovering small bugs and inconsistencies. I like to think that I fixed all of them or that I didn't expose any additional ones that I didn't fix but I wouldn't bet my money on it...

Here are the main fixes to the image rotation code:
* The rotated images are written under new file names, to avoid any inconsistencies due to client caching.  This requires API changes as we now need to return a full updated photo
description to the caller.
* The bug that left an `x` in database columns for missing intermediate image sizes is fixed and there's a migration in place that fixes the database as well.
* Intermediate image sizes are not rotated but instead are regenerated from the rotated original. Rotating intermediate images was incorrect as it results in wrong image sizes (e.g., a `180x240` `medium` image will be `240x180` after rotation instead of the expected `320x240`).
* Fixed the hard dependency on imagick.  Instead implemented a generic image rotation capability that also works with GD.
* Added checks for live photos and raw files, which rotation does not support.
* The photo file size is updated after the rotation as it may have changed.
* Duplicates are updated as well.

Other fixes:
* `import_via_symlink` had a number of problems with image auto-rotation, mainly having to do with the same incorrect assumption about rotating intermediate image sizes post-generation.  Even though the original is not rotated, we still need to flip `width` and `height` in `Photo` as the front end uses those for layout.  Enabling it would also unnecessarily prevent auto-rotation during regular uploads
* `is_uploaded_file` stops working correctly after the file is moved so it's best to invoke it once and cache the result in `Create`.
* We were using `tempnam` incorrectly, resulting in leftover empty temporary files after video and raw imports.
* `autoRotate` was only using the first engine for some reason, unlike the other image handling methods.
* Symlinking was broken for raw files.