### PR TITLE
fixing default license display

### DIFF
--- a/app/Actions/Photo/Prepare.php
+++ b/app/Actions/Photo/Prepare.php
@@ -47,6 +47,8 @@ class Prepare extends SymLinker
 			$return['share_button_visible'] = '1';
 		}
 
+		$return['license'] = $photo->get_license();
+
 		return $return;
 	}
 }

--- a/app/Models/Extensions/PhotoCast.php
+++ b/app/Models/Extensions/PhotoCast.php
@@ -43,7 +43,7 @@ trait PhotoCast
 
 			'sysdate' => $this->created_at->format('d F Y \a\t H:i'),
 			'takedate' => isset($this->takestamp) ? $this->takestamp->format('d F Y \a\t H:i') : '',
-			'license' => $this->license,
+			'license' => $this->get_license(),
 		];
 	}
 

--- a/app/Models/Extensions/PhotoCast.php
+++ b/app/Models/Extensions/PhotoCast.php
@@ -43,7 +43,7 @@ trait PhotoCast
 
 			'sysdate' => $this->created_at->format('d F Y \a\t H:i'),
 			'takedate' => isset($this->takestamp) ? $this->takestamp->format('d F Y \a\t H:i') : '',
-			'license' => $this->get_license(),
+			'license' => $this->license,
 		];
 	}
 


### PR DESCRIPTION
Looks like this was just an oversight or maybe some copy-paste casualty. Just need to make sure the `get_license()` function is getting called like it is for the albums, and not just using the straight property. 