### PR TITLE
Excluded '/api/Session::init' from CSRF protection

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -15,8 +15,9 @@ class VerifyCsrfToken extends Middleware
 	 * @var array
 	 */
 	protected $except = [
-		// entry point...
+		// entry points...
 		'/php/index.php',
+		'/api/Session::init',
 	];
 
 	/**


### PR DESCRIPTION
Fix for issue #959