### PR TITLE
Fix return value for empty array of photos

### DIFF
--- a/app/Actions/Album/Prepare.php
+++ b/app/Actions/Album/Prepare.php
@@ -42,11 +42,6 @@ class Prepare
 		$return['id'] = strval($album->id);
 		$return['num'] = strval(count($return['photos']));
 
-		// finalize the loop
-		if ($return['num'] === '0') {
-			$return['photos'] = false;
-		}
-
 		return $return;
 	}
 }

--- a/tests/Feature/PhotosTest.php
+++ b/tests/Feature/PhotosTest.php
@@ -168,7 +168,7 @@ class PhotosTest extends TestCase
 		$response = $albums_tests->get($albumID, '', 'true');
 		$content = $response->getContent();
 		$array_content = json_decode($content);
-		$this->assertEquals(0, $array_content->photos);
+		$this->assertEquals(0, count($array_content->photos));
 
 		// save initial value
 		$init_config_value = Configs::get_value('gen_demo_js');


### PR DESCRIPTION
The response type for an empty array of photos should not artificially set to "false" because it breaks type correctness for clients which use strong typing.