### PR TITLE
Use Guzzle7 instead of Guzzle6. Fixes #998.

### DIFF
--- a/app/Metadata/Geodecoder.php
+++ b/app/Metadata/Geodecoder.php
@@ -32,7 +32,7 @@ class Geodecoder
 			'timeout' => Configs::get_value('location_decoding_timeout'),
 		]);
 
-		$httpAdapter = new \Http\Adapter\Guzzle6\Client($httpClient);
+		$httpAdapter = new \Http\Adapter\Guzzle7\Client($httpClient);
 
 		$provider = new Nominatim($httpAdapter, 'https://nominatim.openstreetmap.org', config('app.name'));
 


### PR DESCRIPTION
Fixes #998

We now install Guzzle7, not Guzzle6.

This is completely untested. If we could use an unversioned Guzzle call here it might save a repeat occurrence.