### PR TITLE
Fix for issue 1019

### DIFF
--- a/database/migrations/2021_05_02_174300_add_filesize_raw_col.php
+++ b/database/migrations/2021_05_02_174300_add_filesize_raw_col.php
@@ -20,7 +20,7 @@ class AddFileSizeRawCol extends Migration
 	public function up()
 	{
 		Schema::table(self::TABLE_NAME, function (Blueprint $table) {
-			$table->unsignedInteger(self::NEW_COL_NAME)->default(0)->after(self::OLD_COL_NAME);
+			$table->unsignedBigInteger(self::NEW_COL_NAME)->default(0)->after(self::OLD_COL_NAME);
 		});
 
 		DB::beginTransaction();

--- a/database/migrations/2021_05_31_201000_convert_filesize_to_bigint.php
+++ b/database/migrations/2021_05_31_201000_convert_filesize_to_bigint.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ConvertFileSizeToBigInt extends Migration
+{
+	/**
+	 * Converts the column `filesize` to a 64bit integer such that file sizes >= 4GB can be represented.
+	 */
+	public function up()
+	{
+		Schema::table('photos', function (Blueprint $table) {
+			$table->unsignedBigInteger('filesize')->nullable(false)->default(0)->change();
+		});
+	}
+
+	public function down()
+	{
+		// no-op by intention
+	}
+}


### PR DESCRIPTION
This bug fix solves to issue:

- For those users who haven't updated yet and are below version 4.3.1, the original migration file has been changed to create a `unsignedBigInt` right away in order to avoid migration errors for those who have files larger than >4GB in their database
- For those users who already have upgraded successfully, there is a new migration file which changes the column type from `integer` to `unsignedBigInt`such that those user won't experience errors in the future.