### PR TITLE
fixes #1059 - Add Cache busting.

### DIFF
--- a/app/Actions/Install/ApplyMigration.php
+++ b/app/Actions/Install/ApplyMigration.php
@@ -31,6 +31,7 @@ class ApplyMigration
 	 */
 	public function migrate(array &$output)
 	{
+		Artisan::call('view:clear');
 		Artisan::call('migrate', ['--force' => true]);
 		$this->str_to_array(Artisan::output(), $output);
 


### PR DESCRIPTION
Fixes #1059

ERROR: Non-static method App\Assets\Helpers::cacheBusting() should not be called statically

Adding below line works 

```php
Artisan::call('view:clear');
```