### PR TITLE
Fix type issues related to thumbs

### DIFF
--- a/app/Models/Extensions/PhotoCast.php
+++ b/app/Models/Extensions/PhotoCast.php
@@ -25,7 +25,7 @@ trait PhotoCast
 			$filename = $this->url;
 		}
 		$filename2x = ($filename !== '') ? Helpers::ex2x($filename) : '';
-		$thumbFileName2x = $this->thumb2x === '1' ? Helpers::ex2x($this->thumbUrl) : null;
+		$thumbFileName2x = $this->thumb2x === 1 ? Helpers::ex2x($this->thumbUrl) : null;
 
 		// The original size is not stored in this sub-array but on the root level of the JSON response
 		// TODO: Maybe harmonize and put original variant into this array, too? This would also avoid an ugly if branch in SymLink#override.
@@ -130,7 +130,7 @@ trait PhotoCast
 			$thumb->thumb = Storage::url(
 				Photo::VARIANT_2_PATH_PREFIX[Photo::VARIANT_THUMB] . '/' . $this->thumbUrl
 			);
-			if ($this->thumb2x == '1') {
+			if ($this->thumb2x === 1) {
 				$thumb->set_thumb2x();
 			}
 		}

--- a/app/Models/SymLink.php
+++ b/app/Models/SymLink.php
@@ -142,7 +142,7 @@ class SymLink extends Model
 		$this->updated_at = $now;
 
 		foreach (self::VARIANT_2_INDICATOR_FIELD as $variant => $indicator_field) {
-			if ($photo->{$indicator_field} != null && $photo->{$indicator_field} != 0 && $photo->{$indicator_field} != '') {
+			if ($photo->{$indicator_field} !== null && $photo->{$indicator_field} !== 0 && $photo->{$indicator_field} !== '') {
 				$this->create($photo, $variant, strval($now));
 			}
 		}


### PR DESCRIPTION
Fixes the issues with thumbs reported on gitter, which trigger primarily with symlinking enabled.

The change to `SymLink.php` is needed because in PHP `'a4995077a769bf97d0fc352083407df8.jpeg' == 0` evaluates to true...