### PR TITLE
Make necessary configs available to the front end

### DIFF
--- a/database/migrations/2021_10_27_133121_fix_confidentiality.php
+++ b/database/migrations/2021_10_27_133121_fix_confidentiality.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Models\Configs;
+use Illuminate\Database\Migrations\Migration;
+
+class FixConfidentiality extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Configs::where('key', 'editor_enabled')->update(['confidentiality' => '0']);
+		Configs::where('key', 'upload_processing_limit')->update(['confidentiality' => '0']);
+		Configs::where('key', 'public_photos_hidden')->update(['confidentiality' => '0']);
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Configs::where('key', 'editor_enabled')->update(['confidentiality' => '2']);
+		Configs::where('key', 'upload_processing_limit')->update(['confidentiality' => '2']);
+		Configs::where('key', 'public_photos_hidden')->update(['confidentiality' => '2']);
+	}
+}


### PR DESCRIPTION
Fixes #1127

As it turns out, config variables with `confidentiality` set to `2` aren't actually available to the front end as part of `Session::init`. The server distinguishes only between _public_ and _admin_; there is no separate provision for logged in users.

This patch follows this model and changes the confidentiality of three variables that should be exposed to logged in users (`editor_enabled`, `upload_processing_limit`, and `public_photos_hidden`) to `0`.

An alternative implementation would be for `Session::init` to treat logged in users as a separate category. Feedback welcome...