### PR TITLE
also support Caps on size format

### DIFF
--- a/app/Actions/Diagnostics/Checks/IniSettingsCheck.php
+++ b/app/Actions/Diagnostics/Checks/IniSettingsCheck.php
@@ -17,12 +17,15 @@ class IniSettingsCheck implements DiagnosticCheckInterface
 		$size = intval($size);
 
 		switch ($last) {
+			case 'G':
 			case 'g':
 				$size *= 1024;
 				// no break
+			case 'M':
 			case 'm':
 				$size *= 1024;
 				// no break
+			case 'K':
 			case 'k':
 				$size *= 1024;
 		}


### PR DESCRIPTION
Just found out that if we have
`Max uploaded file size:          500M`
Then this will still raise the warning:
`Warning: You may experience problems when uploading a large amount of photos. Take a look in the FAQ for details.`

