### PR TITLE
Some fixes

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,7 @@
 <?php
 
+ini_set('user_agent', 'Lychee/4 (https://lycheeorg.github.io/)');
+
 /*
 |--------------------------------------------------------------------------
 | Create The Application

--- a/bootstrap/initialize.php
+++ b/bootstrap/initialize.php
@@ -1,7 +1,5 @@
 <?php
 
-ini_set('user_agent', 'Lychee/4 (https://lycheeorg.github.io/)');
-
 /*
  |--------------------------------------------------------------------------
  | If we are running Apache, mod_rewrite needs to be available


### PR DESCRIPTION
**Enforce consistent SQL modes for MySQL/MariaDB**

I stumbled across this bug in combination with our admin user. By default, MySQL does not like primary IDs which equal 0.

**Config option `user_agent` is also set for CLI commands now**

Another bug I found while testing and playing around with my huge PR.