### PR TITLE
Improved file handling

### DIFF
--- a/app/Actions/Import/Exec.php
+++ b/app/Actions/Import/Exec.php
@@ -231,8 +231,10 @@ class Exec
 			}
 
 			$filesCount++;
+
 			// It is possible to move a file because of directory permissions but
 			// the file may still be unreadable by the user
+			// TODO: This check will be unnecessary, after we have proper exception handling, because we try to read streams
 			if (!is_readable($file)) {
 				$this->status_error($file, 'Could not read file');
 				Logs::error(__METHOD__, __LINE__, 'Could not read file or directory (' . $file . ')');
@@ -240,6 +242,9 @@ class Exec
 			}
 			$extension = Helpers::getExtension($file, true);
 			$is_raw = in_array(strtolower($extension), $this->raw_formats, true);
+			// TODO: Consolidate all mimetype/extension handling in one place; here we have another test whether the source file is supported which is inconsistent with tests elsewhere
+			// TODO: Probably the best place is \App\Image\MediaFile.
+			// TODO: Consider to make this test a general part of \App\Actions\Photo\Create::add. Then we don't need those tests at multiple places.
 			if (@exif_imagetype($file) !== false || in_array(strtolower($extension), $this->validExtensions, true) || $is_raw) {
 				// Photo or Video
 				try {
@@ -257,7 +262,7 @@ class Exec
 						$this->resync_metadata
 					));
 					if (
-						$photoCreate->add(SourceFileInfo::createForLocalFile($file), $albumID) == null
+						$photoCreate->add(SourceFileInfo::createByLocalFile($file), $albumID) == null
 					) {
 						$this->status_error($file, 'Could not import file');
 						Logs::error(__METHOD__, __LINE__, 'Could not import file (' . $file . ')');

--- a/app/Actions/Import/Exec.php
+++ b/app/Actions/Import/Exec.php
@@ -250,7 +250,7 @@ class Exec
 				Logs::error(__METHOD__, __LINE__, 'Could not read file or directory (' . $file . ')');
 				continue;
 			}
-			$extension = Helpers::getExtension($file, true);
+			$extension = Helpers::getExtension($file, false);
 			$is_raw = in_array(strtolower($extension), $this->raw_formats, true);
 			// TODO: Consolidate all mimetype/extension handling in one place; here we have another test whether the source file is supported which is inconsistent with tests elsewhere
 			// TODO: Probably the best place is \App\Image\MediaFile.
@@ -283,7 +283,7 @@ class Exec
 					$this->status_error($file, 'Skipped duplicate (resynced metadata)');
 				} catch (Exception $e) {
 					$this->status_error($file, 'Could not import file');
-					Logs::error(__METHOD__, __LINE__, 'Could not import file (' . $file . ')');
+					Logs::error(__METHOD__, __LINE__, 'Could not import file (' . $file . '): ' . $e->getMessage());
 				}
 			} else {
 				$this->status_error($file, 'Unsupported file type');

--- a/app/Actions/Import/FromUrl.php
+++ b/app/Actions/Import/FromUrl.php
@@ -7,7 +7,6 @@ use App\Actions\Photo\Create;
 use App\Actions\Photo\Extensions\Constants;
 use App\Actions\Photo\Extensions\SourceFileInfo;
 use App\Actions\Photo\Strategies\ImportMode;
-use App\Facades\Helpers;
 use App\Image\TemporaryLocalFile;
 use App\Models\Configs;
 use App\Models\Logs;
@@ -34,10 +33,13 @@ class FromUrl
 			// Reset the execution timeout for every iteration.
 			set_time_limit(ini_get('max_execution_time'));
 
+			$path = parse_url($url, PHP_URL_PATH);
+			$basename = pathinfo($path, PATHINFO_FILENAME);
+			$extension = '.' . pathinfo($path, PATHINFO_EXTENSION);
+
 			// Validate photo type and extension even when $this->photo (=> $photo->add) will do the same.
 			// This prevents us from downloading invalid photos.
 			// Verify extension
-			$extension = Helpers::getExtension($url, true);
 			if (!$this->isValidExtension($extension)) {
 				$error = true;
 				Logs::error(__METHOD__, __LINE__, 'Photo format not supported (' . $url . ')');
@@ -66,7 +68,7 @@ class FromUrl
 			}
 
 			// Import photo
-			if ($create->add(SourceFileInfo::createByTempFile($extension, $tmpFile), $albumId) == null) {
+			if ($create->add(SourceFileInfo::createByTempFile($basename, $extension, $tmpFile), $albumId) == null) {
 				$error = true;
 				Logs::error(__METHOD__, __LINE__, 'Could not import file (' . $tmpFile->getAbsolutePath() . ')');
 			}

--- a/app/Actions/Import/FromUrl.php
+++ b/app/Actions/Import/FromUrl.php
@@ -8,9 +8,9 @@ use App\Actions\Photo\Extensions\Constants;
 use App\Actions\Photo\Extensions\SourceFileInfo;
 use App\Actions\Photo\Strategies\ImportMode;
 use App\Facades\Helpers;
+use App\Image\TemporaryLocalFile;
 use App\Models\Configs;
 use App\Models\Logs;
-use Illuminate\Support\Facades\Storage;
 
 class FromUrl
 {
@@ -44,26 +44,31 @@ class FromUrl
 				continue;
 			}
 
+			// Download file, before exif checks the mimetype, otherwise we download it twice
+			$tmpFile = new TemporaryLocalFile();
+			try {
+				$downloadStream = fopen($url, 'r');
+				$tmpFile->write($downloadStream);
+				fclose($downloadStream);
+			} catch (\Exception $e) {
+				$error = true;
+				Logs::error(__METHOD__, __LINE__, 'Could not download (' . $url . ') to (' . $tmpFile->getAbsolutePath() . ') due to ' . $e->getMessage());
+				continue;
+			}
+
 			// Verify image
-			$type = @exif_imagetype($url);
+			// TODO: Consider to make this test a general part of \App\Actions\Photo\Create::add. Then we don't need those tests at multiple places.
+			$type = @exif_imagetype($tmpFile->getAbsolutePath());
 			if (!$this->isValidImageType($type) && !in_array(strtolower($extension), $this->validExtensions, true)) {
 				$error = true;
 				Logs::error(__METHOD__, __LINE__, 'Photo type not supported (' . $url . ')');
 				continue;
 			}
 
-			$filename = pathinfo($url, PATHINFO_FILENAME) . $extension;
-			$tmp_name = Storage::path('import/' . $filename);
-			if (@copy($url, $tmp_name) === false) {
-				$error = true;
-				Logs::error(__METHOD__, __LINE__, 'Could not copy file (' . $url . ') to temp-folder (' . $tmp_name . ')');
-				continue;
-			}
-
 			// Import photo
-			if ($create->add(SourceFileInfo::createForLocalFile($tmp_name), $albumId) == null) {
+			if ($create->add(SourceFileInfo::createByTempFile($extension, $tmpFile), $albumId) == null) {
 				$error = true;
-				Logs::error(__METHOD__, __LINE__, 'Could not import file (' . $tmp_name . ')');
+				Logs::error(__METHOD__, __LINE__, 'Could not import file (' . $tmpFile->getAbsolutePath() . ')');
 			}
 		}
 

--- a/app/Actions/Photo/Create.php
+++ b/app/Actions/Photo/Create.php
@@ -134,7 +134,7 @@ class Create
 
 		// Use title of file if IPTC title missing
 		if ($this->strategyParameters->info['title'] === '') {
-			$this->strategyParameters->info['title'] = $sourceFileInfo->getOriginalName();
+			$this->strategyParameters->info['title'] = substr($sourceFileInfo->getOriginalName(), 0, 98);
 		}
 	}
 

--- a/app/Actions/Photo/Create.php
+++ b/app/Actions/Photo/Create.php
@@ -124,7 +124,7 @@ class Create
 		/* @var  Extractor $metadataExtractor */
 		$metadataExtractor = resolve(Extractor::class);
 
-		$this->strategyParameters->info = $metadataExtractor->extract($sourceFileInfo->getTmpFullPath(), $this->strategyParameters->kind);
+		$this->strategyParameters->info = $metadataExtractor->extract($sourceFileInfo->getFile()->getAbsolutePath(), $this->strategyParameters->kind);
 		if ($this->strategyParameters->kind == 'raw') {
 			$this->strategyParameters->info['type'] = 'raw';
 		}
@@ -134,11 +134,7 @@ class Create
 
 		// Use title of file if IPTC title missing
 		if ($this->strategyParameters->info['title'] === '') {
-			if ($this->strategyParameters->kind == 'raw') {
-				$this->strategyParameters->info['title'] = substr(basename($sourceFileInfo->getOriginalFilename()), 0, 98);
-			} else {
-				$this->strategyParameters->info['title'] = substr(basename($sourceFileInfo->getOriginalFilename(), $sourceFileInfo->getOriginalFileExtension()), 0, 98);
-			}
+			$this->strategyParameters->info['title'] = $sourceFileInfo->getOriginalName();
 		}
 	}
 

--- a/app/Actions/Photo/Extensions/Checks.php
+++ b/app/Actions/Photo/Extensions/Checks.php
@@ -82,7 +82,7 @@ trait Checks
 	 */
 	public function file_kind(SourceFileInfo $sourceFileInfo): string
 	{
-		$extension = $sourceFileInfo->getOriginalFileExtension();
+		$extension = $sourceFileInfo->getOriginalExtension();
 		// check raw files
 		$raw_formats = strtolower(Configs::get_value('raw_formats', ''));
 		if (in_array(strtolower($extension), explode('|', $raw_formats), true)) {
@@ -105,12 +105,12 @@ trait Checks
 			throw new JsonError('EXIF library not loaded on the server!');
 		}
 
-		$type = @exif_imagetype($sourceFileInfo->getTmpFullPath());
+		$type = @exif_imagetype($sourceFileInfo->getFile()->getAbsolutePath());
 		if (in_array($type, $this->validTypes, true)) {
 			return 'photo';
 		}
 
-		Logs::error(__METHOD__, __LINE__, 'Photo type not supported: ' . $sourceFileInfo->getOriginalFilename());
+		Logs::error(__METHOD__, __LINE__, 'Photo type not supported: ' . $sourceFileInfo->getOriginalExtension());
 		throw new JsonError('Photo type not supported!');
 	}
 }

--- a/app/Actions/Photo/Extensions/SourceFileInfo.php
+++ b/app/Actions/Photo/Extensions/SourceFileInfo.php
@@ -2,50 +2,102 @@
 
 namespace App\Actions\Photo\Extensions;
 
-use App\Facades\Helpers;
+use App\Image\MediaFile;
+use App\Image\NativeLocalFile;
+use App\Image\TemporaryLocalFile;
+use App\Models\Photo;
 use Illuminate\Http\UploadedFile;
-use phpDocumentor\Reflection\DocBlock\Tags\Source;
 
 /**
  * Class SourceFileInfo.
  */
 class SourceFileInfo
 {
-	protected string $originalFilename;
+	/** @var string the original name of the media file or title of the media */
+	protected string $originalName;
+	/** @var string the original extension incl. a preceding dot */
+	protected string $originalExtension;
 	protected string $originalMimeType;
-	protected string $tmpFullPath;
+	protected MediaFile $file;
 
 	/**
 	 * SourceFileInfo constructor.
 	 *
-	 * @param string $originalFilename the original filename as reported by
-	 *                                 the client (in case of an upload) or by
-	 *                                 the (remote) server (in case of an
-	 *                                 import)
-	 * @param string $originalMimeType the original mime-type as reported by
-	 *                                 the client or by the (remote) server
-	 * @param string $tmpFullPath      the temporary location of the file
-	 *                                 after upload from the client or
-	 *                                 fetching from the (remote) server
+	 * @param string    $originalName      the name of the original media file
+	 *                                     or title of the media
+	 * @param string    $originalExtension the extension of the original file
+	 *                                     incl. a preceding dot as reported
+	 *                                     by the client (in case of an
+	 *                                     upload) or by the (remote) server
+	 *                                     (in case of an import)
+	 * @param string    $originalMimeType  the original mime-type as reported
+	 *                                     by the client or by the (remote)
+	 *                                     server
+	 * @param MediaFile $file              the media file
 	 */
-	public function __construct(string $originalFilename, string $originalMimeType, string $tmpFullPath)
+	protected function __construct(string $originalName, string $originalExtension, string $originalMimeType, MediaFile $file)
 	{
-		$this->originalFilename = $originalFilename;
+		$this->originalName = $originalName;
+		$this->originalExtension = $originalExtension;
 		$this->originalMimeType = $originalMimeType;
-		$this->tmpFullPath = $tmpFullPath;
+		$this->file = $file;
 	}
 
 	/**
 	 * Creates a new instance which is suitable, if the source file is a
-	 * local file on the server.
+	 * temporary file.
 	 *
-	 * @param string $path the absolute path of the source file on the same server as Lychee is running on
+	 * @param string             $originalName      the name of the original
+	 *                                              media file or title of the
+	 *                                              media
+	 * @param string             $originalExtension the extension of the
+	 *                                              original file incl. a
+	 *                                              preceding dot
+	 * @param TemporaryLocalFile $file              the temporary file
 	 *
 	 * @return SourceFileInfo the new instance
 	 */
-	public static function createForLocalFile(string $path): SourceFileInfo
+	public static function createByTempFile(string $originalName, string $originalExtension, TemporaryLocalFile $file): SourceFileInfo
 	{
-		return new self($path, mime_content_type($path), $path);
+		return new self($originalName, $originalExtension, $file->getMimeType(), $file);
+	}
+
+	/**
+	 * Creates a new instance which is suitable, if the source file is a
+	 * local file.
+	 *
+	 * @param NativeLocalFile $file the local source file
+	 *
+	 * @return SourceFileInfo the new instance
+	 */
+	public static function createByLocalFile(NativeLocalFile $file): SourceFileInfo
+	{
+		return new self(
+			$file->getBasename(),
+			'.' . $file->getExtension(),
+			$file->getMimeType(),
+			$file
+		);
+	}
+
+	/**
+	 * Creates a new instance which is suitable, if the source file is a
+	 * native file on the server.
+	 *
+	 * @param Photo $photo the photo
+	 *
+	 * @return SourceFileInfo the new instance
+	 */
+	public static function createByPhoto(Photo $photo): SourceFileInfo
+	{
+		$file = $photo->size_variants->getOriginal()->getFile();
+
+		return new self(
+			$photo->title,
+			$file->getExtension(),
+			$photo->type,
+			$file
+		);
 	}
 
 	/**
@@ -56,24 +108,50 @@ class SourceFileInfo
 	 *
 	 * @return SourceFileInfo the new instance
 	 */
-	public static function createForUploadedFile(UploadedFile $file): SourceFileInfo
+	public static function createByUploadedFile(UploadedFile $file): SourceFileInfo
 	{
-		return new self($file->getClientOriginalName(), $file->getMimeType(), $file->getPathName());
+		$fallbackTitle = pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME);
+
+		return new self(
+			$fallbackTitle,
+			'.' . $file->getClientOriginalExtension(),
+			$file->getMimeType(),
+			NativeLocalFile::createFromUploadedFile($file)
+		);
 	}
 
 	/**
-	 * Returns the original filename of the source file.
+	 * Returns the original name of the source file or its title.
 	 *
-	 * Note that this filename differs from the final filename which Lychee
-	 * uses to store the file in the image storage.
+	 * The original name is either the basename of the originally
+	 * uploaded/downloaded file or - if the source file is already provided
+	 * by a photo in the DB - the user-defined title of the source photo.
 	 *
-	 * This attribute has previously been called `name` in an anonymous array.
+	 * The original name is used as a fallback title for the imported photo
+	 * in case the media file does not provide a title via EXIF data.
 	 *
-	 * @return string the original filename from the client side before upload
+	 * @return string the original name of the media file or the title of the media
 	 */
-	public function getOriginalFilename(): string
+	public function getOriginalName(): string
 	{
-		return $this->originalFilename;
+		return $this->originalName;
+	}
+
+	/**
+	 * Returns the original extension of the source file.
+	 *
+	 * The original file extension is provided as part of the client-side
+	 * file name during upload or by the filename when downloaded from a
+	 * remote server.
+	 * This file extension is used as a fallback to determine the type of
+	 * file, if no better information (i.e. mimetype) can be provided or
+	 * extracted from the file.
+	 *
+	 * @return string the original extension of the file
+	 */
+	public function getOriginalExtension(): string
+	{
+		return $this->originalExtension;
 	}
 
 	/**
@@ -96,26 +174,12 @@ class SourceFileInfo
 	}
 
 	/**
-	 * Returns the path at which Lychee has temporarily stored
-	 * the uploaded or fetched file.
+	 * Returns the media file.
 	 *
-	 * This attribute has previously been called `tmp_name` in an anonymous
-	 * array.
-	 *
-	 * @return string the mime type
+	 * @return MediaFile the media file
 	 */
-	public function getTmpFullPath(): string
+	public function getFile(): MediaFile
 	{
-		return $this->tmpFullPath;
-	}
-
-	/**
-	 * Returns the file extension of the original source file.
-	 *
-	 * @return string the original file extension with a preceding dot
-	 */
-	public function getOriginalFileExtension(): string
-	{
-		return Helpers::getExtension($this->originalFilename, false);
+		return $this->file;
 	}
 }

--- a/app/Actions/Photo/Strategies/AddPhotoPartnerStrategy.php
+++ b/app/Actions/Photo/Strategies/AddPhotoPartnerStrategy.php
@@ -30,11 +30,7 @@ class AddPhotoPartnerStrategy extends AddStandaloneStrategy
 		// and moves it to the correct destination of a live partner for the
 		// photo.
 		$parameters = new AddStrategyParameters(new ImportMode(true));
-		$parameters->sourceFileInfo = new SourceFileInfo(
-			$this->existingVideo->title,
-			$this->existingVideo->type,
-			$this->existingVideo->size_variants->getOriginal()->full_path
-		);
+		$parameters->sourceFileInfo = SourceFileInfo::createByPhoto($this->existingVideo);
 		$videoStrategy = new AddVideoPartnerStrategy($parameters, $this->photo);
 		$videoStrategy->do();
 

--- a/app/Actions/Photo/Strategies/AddStandaloneStrategy.php
+++ b/app/Actions/Photo/Strategies/AddStandaloneStrategy.php
@@ -61,7 +61,18 @@ class AddStandaloneStrategy extends AddBaseStrategy
 			$this->parameters->info['width'],
 			$this->parameters->info['height']
 		);
-		$this->putSourceIntoFinalDestination($original->short_path);
+		try {
+			$this->putSourceIntoFinalDestination($original->short_path);
+		} catch (\Exception $e) {
+			// If source file could not be put into final destination, remove
+			// freshly created photo from DB to avoid having "zombie" entries.
+			try {
+				$this->photo->delete();
+			} catch (\Throwable) {
+				// Sic! If anything goes wrong here, we still throw the original exception
+			}
+			throw $e;
+		}
 
 		// Create remaining size variants
 		try {

--- a/app/Actions/Photo/Strategies/AddVideoPartnerStrategy.php
+++ b/app/Actions/Photo/Strategies/AddVideoPartnerStrategy.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Photo\Strategies;
 
+use App\Facades\Helpers;
 use App\Models\Photo;
 
 class AddVideoPartnerStrategy extends AddBaseStrategy
@@ -13,12 +14,12 @@ class AddVideoPartnerStrategy extends AddBaseStrategy
 
 	public function do(): Photo
 	{
-		$original = $this->photo->size_variants->getOriginal();
-		$ext = $this->parameters->sourceFileInfo->getOriginalFileExtension();
-		$dstShortPath = substr($original->short_path, 0, -strlen($ext)) . $ext;
-		$dstFullPath = substr($original->full_path, 0, -strlen($ext)) . $ext;
-		$this->putSourceIntoFinalDestination($dstFullPath);
-		$this->photo->live_photo_short_path = $dstShortPath;
+		$photoPath = $this->photo->size_variants->getOriginal()->short_path;
+		$photoExt = Helpers::getExtension($photoPath);
+		$videoExt = $this->parameters->sourceFileInfo->getOriginalExtension();
+		$videoPath = substr($photoPath, 0, -strlen($photoExt)) . $videoExt;
+		$this->putSourceIntoFinalDestination($videoPath);
+		$this->photo->live_photo_short_path = $videoPath;
 		$this->photo->save();
 
 		return $this->photo;

--- a/app/Actions/Photo/Strategies/AddVideoPartnerStrategy.php
+++ b/app/Actions/Photo/Strategies/AddVideoPartnerStrategy.php
@@ -2,7 +2,6 @@
 
 namespace App\Actions\Photo\Strategies;
 
-use App\Facades\Helpers;
 use App\Models\Photo;
 
 class AddVideoPartnerStrategy extends AddBaseStrategy
@@ -14,8 +13,9 @@ class AddVideoPartnerStrategy extends AddBaseStrategy
 
 	public function do(): Photo
 	{
-		$photoPath = $this->photo->size_variants->getOriginal()->short_path;
-		$photoExt = Helpers::getExtension($photoPath);
+		$photoFile = $this->photo->size_variants->getOriginal()->getFile();
+		$photoPath = $photoFile->getRelativePath();
+		$photoExt = $photoFile->getExtension();
 		$videoExt = $this->parameters->sourceFileInfo->getOriginalExtension();
 		$videoPath = substr($photoPath, 0, -strlen($photoExt)) . $videoExt;
 		$this->putSourceIntoFinalDestination($videoPath);

--- a/app/Actions/Photo/Strategies/RotateStrategy.php
+++ b/app/Actions/Photo/Strategies/RotateStrategy.php
@@ -5,8 +5,8 @@ namespace App\Actions\Photo\Strategies;
 use App\Actions\Photo\Extensions\SourceFileInfo;
 use App\Contracts\SizeVariantFactory;
 use App\Contracts\SizeVariantNamingStrategy;
-use App\Facades\Helpers;
 use App\Image\ImageHandlerInterface;
+use App\Image\TemporaryLocalFile;
 use App\Metadata\Extractor;
 use App\Models\Logs;
 use App\Models\Photo;
@@ -74,18 +74,18 @@ class RotateStrategy extends AddBaseStrategy
 	{
 		// Generate a temporary name for the rotated file.
 		$oldOriginalSizeVariant = $this->photo->size_variants->getOriginal();
-		$oldOriginalFullPath = $oldOriginalSizeVariant->full_path;
 		$oldOriginalWidth = $oldOriginalSizeVariant->width;
 		$oldOriginalHeight = $oldOriginalSizeVariant->height;
 		$oldChecksum = $this->photo->checksum;
-		$oldExtension = Helpers::getExtension($oldOriginalFullPath);
-		$tmpFullPath = Helpers::createTemporaryFile($oldExtension);
+		$origFile = $oldOriginalSizeVariant->getFile();
+		$tmpFile = new TemporaryLocalFile();
 
 		// Rotate the image and save result as the temporary file
 		/** @var ImageHandlerInterface $imageHandler */
 		$imageHandler = resolve(ImageHandlerInterface::class);
-		if ($imageHandler->rotate($oldOriginalFullPath, ($this->direction == 1) ? 90 : -90, $tmpFullPath) === false) {
-			$msg = 'Failed to rotate ' . $oldOriginalFullPath;
+		// TODO: If we ever wish to support something else than local files, ImageHandler must work on resource streams, not absolute file names (see ImageHandlerInterface)
+		if ($imageHandler->rotate($origFile->getAbsolutePath(), ($this->direction == 1) ? 90 : -90, $tmpFile->getAbsolutePath()) === false) {
+			$msg = 'Failed to rotate ' . $origFile->getRelativePath();
 			Logs::error(__METHOD__, __LINE__, $msg);
 			throw new \RuntimeException($msg);
 		}
@@ -93,8 +93,9 @@ class RotateStrategy extends AddBaseStrategy
 		// The file size and checksum may have changed after the rotation.
 		/* @var Extractor $metadataExtractor */
 		$metadataExtractor = resolve(Extractor::class);
-		$this->photo->filesize = $metadataExtractor->filesize($tmpFullPath);
-		$this->photo->checksum = $metadataExtractor->checksum($tmpFullPath);
+		// TODO: See above, we must stop using absolute paths
+		$this->photo->filesize = $metadataExtractor->filesize($tmpFile->getAbsolutePath());
+		$this->photo->checksum = $metadataExtractor->checksum($tmpFile->getAbsolutePath());
 		$this->photo->save();
 
 		// Delete all size variants from current photo, this will also take
@@ -105,14 +106,13 @@ class RotateStrategy extends AddBaseStrategy
 		$this->photo->size_variants->deleteAll();
 
 		// Initialize factory for size variants
-		$this->parameters->sourceFileInfo = new SourceFileInfo(
-			pathinfo($oldOriginalFullPath, PATHINFO_BASENAME),
-			$this->photo->type,
-			$tmpFullPath
+		$this->parameters->sourceFileInfo = SourceFileInfo::createByTempFile(
+			$this->photo->title, $origFile->getExtension(), $tmpFile
 		);
+
 		/** @var SizeVariantNamingStrategy $namingStrategy */
 		$namingStrategy = resolve(SizeVariantNamingStrategy::class);
-		$namingStrategy->setFallbackExtension($this->parameters->sourceFileInfo->getOriginalFileExtension());
+		$namingStrategy->setFallbackExtension($this->parameters->sourceFileInfo->getOriginalExtension());
 		/** @var SizeVariantFactory $sizeVariantFactory */
 		$sizeVariantFactory = resolve(SizeVariantFactory::class);
 		$sizeVariantFactory->init($this->photo, $namingStrategy);
@@ -123,7 +123,7 @@ class RotateStrategy extends AddBaseStrategy
 		// Using a different filename allows to avoid caching effects.
 		// Sic! Swap width and height here, because the image has been rotated
 		$newOriginalSizeVariant = $sizeVariantFactory->createOriginal($oldOriginalHeight, $oldOriginalWidth);
-		$this->putSourceIntoFinalDestination($newOriginalSizeVariant->full_path);
+		$this->putSourceIntoFinalDestination($newOriginalSizeVariant->short_path);
 
 		// Create remaining size variants
 		$newSizeVariants = null;

--- a/app/Assets/Helpers.php
+++ b/app/Assets/Helpers.php
@@ -3,7 +3,6 @@
 namespace App\Assets;
 
 use App\Exceptions\DivideByZeroException;
-use App\Models\Logs;
 use Illuminate\Support\Facades\File;
 use WhichBrowser\Parser as BrowserParser;
 
@@ -147,29 +146,6 @@ class Helpers
 		}
 
 		return false;
-	}
-
-	/**
-	 * Creates a temporary file in the local system's temporary directory with
-	 * a random name and the designated extension.
-	 *
-	 * The caller is responsible to move/delete the temporary file after it is
-	 * not needed anymore.
-	 *
-	 * @param string $extension the desired file extension, must include a starting dot
-	 *
-	 * @return string the path to the newly created file
-	 */
-	public function createTemporaryFile(string $extension): string
-	{
-		if (!($result = tempnam(sys_get_temp_dir(), 'lychee')) ||
-			!rename($result, $result . $extension)) {
-			$msg = 'Could not create a temporary file.';
-			Logs::notice(__METHOD__, __LINE__, $msg);
-			throw new \RuntimeException($msg);
-		}
-
-		return $result . $extension;
 	}
 
 	/**

--- a/app/Assets/SizeVariantLegacyNamingStrategy.php
+++ b/app/Assets/SizeVariantLegacyNamingStrategy.php
@@ -3,7 +3,6 @@
 namespace App\Assets;
 
 use App\Contracts\SizeVariantNamingStrategy;
-use App\Facades\Helpers;
 use App\Models\Photo;
 use App\Models\SizeVariant;
 
@@ -37,13 +36,8 @@ class SizeVariantLegacyNamingStrategy extends SizeVariantNamingStrategy
 	{
 		parent::setPhoto($photo);
 		$this->originalExtension = '';
-		if ($this->photo) {
-			$sv = $this->photo->size_variants->getOriginal();
-			if ($sv) {
-				if (!empty($sv->short_path)) {
-					$this->originalExtension = Helpers::getExtension($sv->short_path, false);
-				}
-			}
+		if ($this->photo && $sv = $this->photo->size_variants->getOriginal()) {
+			$this->originalExtension = $sv->getFile()->getExtension();
 		}
 	}
 

--- a/app/Console/Commands/Takedate.php
+++ b/app/Console/Commands/Takedate.php
@@ -4,7 +4,9 @@ namespace App\Console\Commands;
 
 use App\Metadata\Extractor;
 use App\Models\Photo;
+use App\Models\SizeVariant;
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Takedate extends Command
 {
@@ -44,10 +46,13 @@ class Takedate extends Command
 		if ($argument == 0) {
 			$argument = PHP_INT_MAX;
 		}
+		$photoQuery = Photo::with(['size_variants' => function (HasMany $r) {
+			$r->where('type', '=', SizeVariant::ORIGINAL);
+		}]);
 		if ($force) {
-			$photos = Photo::offset($from)->limit($argument)->get();
+			$photos = $photoQuery->offset($from)->limit($argument)->get();
 		} else {
-			$photos = Photo::whereNull('taken_at')->offset($from)->limit($argument)->get();
+			$photos = $photoQuery->whereNull('taken_at')->offset($from)->limit($argument)->get();
 		}
 		if (count($photos) == 0) {
 			$this->line('No pictures require takedate updates.');

--- a/app/Facades/Helpers.php
+++ b/app/Facades/Helpers.php
@@ -18,7 +18,6 @@ use Illuminate\Support\Facades\Facade;
  * @method static string getExtension(string $filename, bool $isURI = false)
  * @method static bool hasPermissions(string $path)
  * @method static bool hasFullPermissions(string $path)
- * @method static string createTemporaryFile(string $extension)
  * @method static int gcd(int $a, int $b)
  * @method static string str_of_bool(bool $b)
  * @method static int data_index()

--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -92,13 +92,13 @@ class PhotoController extends Controller
 		// Only process the first photo in the array
 		/** @var UploadedFile $file */
 		$file = $request->file('0');
-		$sourceFileInfo = SourceFileInfo::createForUploadedFile($file);
+		$sourceFileInfo = SourceFileInfo::createByUploadedFile($file);
 		$albumID = $request['albumID'];
 
-		// If the file has been uploaded, the (temporary) source file shall be
+		// As the file has been uploaded, the (temporary) source file shall be
 		// deleted
 		$create = new Create(new ImportMode(
-			is_uploaded_file($sourceFileInfo->getTmpFullPath()),
+			true,
 			Configs::get_value('skip_duplicates', '0') === '1'
 		));
 

--- a/app/Image/FlysystemFile.php
+++ b/app/Image/FlysystemFile.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Image;
+
+use Illuminate\Contracts\Filesystem\Filesystem;
+use League\Flysystem\AdapterInterface;
+
+/**
+ * Class FlysystemFile.
+ *
+ * This class is based on legacy Flysystem v1 which ships with Laravel 8.
+ * Laravel 9 will migrate to Flysystem v2 which provides a different and
+ * more consistent API.
+ *
+ * For v1, this documentation is relevant:
+ * https://flysystem.thephpleague.com/v1/docs/usage/filesystem-api/
+ */
+class FlysystemFile extends MediaFile
+{
+	protected Filesystem $disk;
+	protected string $relativePath;
+	/** @var ?resource */
+	protected $stream = null;
+
+	public function __construct(Filesystem $disk, string $relativePath)
+	{
+		$this->disk = $disk;
+		$this->relativePath = $relativePath;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function read()
+	{
+		$this->stream = $this->disk->readStream($this->relativePath);
+		if ($this->stream === false || !is_resource($this->stream)) {
+			$this->stream = null;
+			throw new \RuntimeException('Could not read from file ' . $this->relativePath);
+		}
+
+		return $this->stream;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function write($stream): void
+	{
+		if (is_resource($this->stream)) {
+			throw new \LogicException('Cannot write to a file which is opened for read');
+		}
+		// TODO: `put` must be replaced by `writeStream` when Flysystem 2 is shipped with Laravel 9
+		// This will also be more consistent with `readStream`.
+		// Note that v1 also provides a method `writeStream`, but this is a misnomer.
+		// See: https://flysystem.thephpleague.com/v2/docs/what-is-new/
+		if (!$this->disk->put($this->relativePath, $stream)) {
+			throw new \RuntimeException('Could not write to file ' . $this->relativePath);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function delete(): void
+	{
+		if (!$this->disk->delete($this->relativePath)) {
+			throw new \RuntimeException('Could not delete file ' . $this->relativePath);
+		}
+	}
+
+	/**
+	 * Returns the relative path of the file wrt. the underlying Flysystem disk.
+	 *
+	 * @return string the relative path
+	 */
+	public function getRelativePath(): string
+	{
+		return $this->relativePath;
+	}
+
+	/**
+	 * Returns the absolute (aka "full") path of the Flysystem file.
+	 *
+	 * Note, the syntax of the absolute path depends on the adapter of the
+	 * underlying Flysystem disk.
+	 * For example, for a disk which uses the "Local" adapter, the absolute
+	 * path starts with a slash `/`.
+	 *
+	 * Optimally, this method should not be used at all, because it exposes
+	 * internal implementation details of the Flysystem adapter.
+	 * However, it is a last resort to implement features which Flysystem does
+	 * not provide using low-level functions.
+	 *
+	 * See also: {@link FlysystemFile::getStorageAdapter()}.
+	 *
+	 * @return string
+	 */
+	public function getAbsolutePath(): string
+	{
+		return $this->disk->path($this->relativePath);
+	}
+
+	/**
+	 * Returns the adapter which drives the Flysystem disk of the file.
+	 *
+	 * Correct interpretation of the absolute path of the file requires to
+	 * know the "type" of the disk on which the file is located on.
+	 *
+	 * See also: {@link FlysystemFile::getAbsolutePath()}.
+	 *
+	 * @return AdapterInterface
+	 */
+	public function getStorageAdapter(): AdapterInterface
+	{
+		return $this->disk->getDriver()->getAdapter();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getExtension(): string
+	{
+		$ext = pathinfo($this->relativePath, PATHINFO_EXTENSION);
+
+		return $ext ? '.' . $ext : '';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getBasename(): string
+	{
+		return pathinfo($this->relativePath, PATHINFO_FILENAME);
+	}
+}

--- a/app/Image/ImageHandlerInterface.php
+++ b/app/Image/ImageHandlerInterface.php
@@ -2,6 +2,31 @@
 
 namespace App\Image;
 
+/**
+ * Interface ImageHandlerInterface.
+ *
+ * TODO: If we ever plan to support other than the local filesystem this interface must be heavily refactored.
+ *
+ * In particular, the interface must not use strings which represent paths of
+ * image file, but must entirely work on streams or resources in PHP
+ * terminology.
+ * These streams are provided by Flysystem and may represent local or
+ * remote files (it doesn't really matter).
+ *
+ * This is the idea:
+ * The interface should represent a image (not an image handler).
+ * The interface should provide a `read`-method which reads from a stream
+ * and creates the image in memory.
+ * All methods which are currently defined by this interface operate on this
+ * memory representation.
+ * In particular, the methods don't receive any paths.
+ * The interface should provide a `write`-method which write the current
+ * in-memory image to the stream.
+ * This works for both child classes {@link GdHandler} and
+ * {@link ImagickHandler}.
+ * Both libraries provide classes and methods to read from/write to streams
+ * in an object-oriented fashion.
+ */
 interface ImageHandlerInterface
 {
 	/**
@@ -10,6 +35,8 @@ interface ImageHandlerInterface
 	public function __construct(int $compressionQuality);
 
 	/**
+	 * TODO: Get rid of the parameters `$source` and `$destination`. See comment on the interface.
+	 *
 	 * @param string $source
 	 * @param string $destination
 	 * @param int    $newWidth
@@ -29,6 +56,8 @@ interface ImageHandlerInterface
 	): bool;
 
 	/**
+	 * TODO: Get rid of the parameters `$source` and `$destination`. See comment on the interface.
+	 *
 	 * @param string $source
 	 * @param string $destination
 	 * @param int    $newWidth
@@ -46,6 +75,8 @@ interface ImageHandlerInterface
 	/**
 	 * Rotates and flips a photo based on its EXIF orientation.
 	 *
+	 * TODO: Get rid of the parameters `$source` and `$destination`. See comment on the interface.
+	 *
 	 * @param string $path
 	 * @param int    $orientation the orientation value (1..8) as defined by EXIF specification, default is 1 (means up-right and not mirrored/flipped)
 	 * @param bool   $pretend
@@ -55,9 +86,11 @@ interface ImageHandlerInterface
 	public function autoRotate(string $path, int $orientation = 1, bool $pretend = false): array;
 
 	/**
+	 * TODO: Get rid of the parameters `$source` and `$destination`. See comment on the interface.
+	 *
 	 * @param string $source
 	 * @param int    $angle
-	 * @param string $destination
+	 * @param string $destination if `null`, the image is rotated in place
 	 *
 	 * @return bool
 	 */

--- a/app/Image/MediaFile.php
+++ b/app/Image/MediaFile.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Image;
+
+/**
+ * Interface MediaFile.
+ *
+ * This interface abstracts from the differences of files which are provided
+ * through a Flysystem adapter and files outside Flysystem.
+ */
+abstract class MediaFile
+{
+	/** @var ?resource */
+	protected $stream = null;
+
+	/**
+	 * Returns a resource from which can be read.
+	 *
+	 * To free the resource after use, call {@link MediaFile::close()}.
+	 *
+	 * @return resource
+	 */
+	abstract public function read();
+
+	/**
+	 * Writes the content of the provided resource into the file.
+	 *
+	 * Note, you must not write into a file which has been opened for
+	 * reading via {@link MediaFile::read()} and not yet been closed again.
+	 *
+	 * @param resource $stream
+	 *
+	 * @return void
+	 */
+	abstract public function write($stream): void;
+
+	/**
+	 * @return void
+	 */
+	public function close(): void
+	{
+		if (is_resource($this->stream)) {
+			fclose($this->stream);
+			$this->stream = null;
+		}
+	}
+
+	/**
+	 * Deletes the file.
+	 *
+	 * @return void
+	 */
+	abstract public function delete(): void;
+
+	/**
+	 * Returns the absolute path of the file.
+	 *
+	 * @return string
+	 */
+	abstract public function getAbsolutePath(): string;
+
+	/**
+	 * Returns the extension of the file incl. a preceding dot.
+	 *
+	 * @return string
+	 */
+	abstract public function getExtension(): string;
+
+	/**
+	 * Returns the basename of the file.
+	 *
+	 * The basename of a file is the name of the file without any
+	 * preceding path and without a file extension.
+	 * For example, the basename of the file `/path/to/my-image.jpg` is
+	 * `my-image`.
+	 * Note, this terminology conflicts how the term "basename" is used in
+	 * the PHP documentation.
+	 *
+	 * @return string
+	 */
+	abstract public function getBasename(): string;
+}

--- a/app/Image/NativeLocalFile.php
+++ b/app/Image/NativeLocalFile.php
@@ -107,4 +107,9 @@ class NativeLocalFile extends MediaFile
 	{
 		return pathinfo($this->absolutePath, PATHINFO_FILENAME);
 	}
+
+	public function getMimeType(): string
+	{
+		return mime_content_type($this->absolutePath);
+	}
 }

--- a/app/Image/NativeLocalFile.php
+++ b/app/Image/NativeLocalFile.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Image;
+
+use Illuminate\Http\UploadedFile;
+
+/**
+ * Class NativeLocalFile.
+ *
+ * Represents a file which must be handled with native PHP methods
+ * like `fopen`, etc.
+ * This mostly applies to files which are uploaded to the server or
+ * imported from the server and thus are located outside any Flysystem disk.
+ */
+class NativeLocalFile extends MediaFile
+{
+	protected string $absolutePath;
+
+	public function __construct(string $path)
+	{
+		$absolutePath = realpath($path);
+		if ($absolutePath === false || !is_file($absolutePath)) {
+			throw new \RuntimeException('The path "' . $path . '" does not point to a local file');
+		}
+		$this->absolutePath = $absolutePath;
+	}
+
+	public static function createFromUploadedFile(UploadedFile $file): self
+	{
+		$path = $file->getRealPath();
+		if ($path === false) {
+			throw new \RuntimeException('The uploaded file does not exist');
+		}
+
+		return new self($path);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function read()
+	{
+		if (is_resource($this->stream)) {
+			throw new \LogicException('Cannot read from a file which is already opened for read');
+		}
+		$this->stream = fopen($this->absolutePath, 'rb');
+		if ($this->stream === false || !is_resource($this->stream)) {
+			$this->stream = null;
+			throw new \RuntimeException('Could not read from file ' . $this->absolutePath);
+		}
+
+		return $this->stream;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function write($stream): void
+	{
+		if (is_resource($this->stream)) {
+			throw new \LogicException('Cannot write to a file which is opened for read');
+		}
+		// inspired from \League\Flysystem\Adapter\Local
+		$this->stream = fopen($this->absolutePath, 'wb');
+		if (
+			!is_resource($this->stream) ||
+			stream_copy_to_stream($stream, $this->stream) === false ||
+			!fclose($this->stream)
+		) {
+			throw new \RuntimeException('Could not write file ' . $this->absolutePath);
+		}
+		$this->stream = null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function delete(): void
+	{
+		if (!unlink($this->absolutePath)) {
+			throw new \RuntimeException('Could not delete file ' . $this->absolutePath);
+		}
+	}
+
+	/**
+	 * @return string the absolute path of the file
+	 */
+	public function getAbsolutePath(): string
+	{
+		return $this->absolutePath;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getExtension(): string
+	{
+		$ext = pathinfo($this->absolutePath, PATHINFO_EXTENSION);
+
+		return $ext ? '.' . $ext : '';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getBasename(): string
+	{
+		return pathinfo($this->absolutePath, PATHINFO_FILENAME);
+	}
+}

--- a/app/Image/TemporaryLocalFile.php
+++ b/app/Image/TemporaryLocalFile.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Image;
+
+/**
+ * Class TemporaryLocalFile.
+ *
+ * Represents a local file with a automatically chosen, unique name intended
+ * to be used temporarily.
+ */
+class TemporaryLocalFile extends NativeLocalFile
+{
+	public function __construct()
+	{
+		$tempFilePath = tempnam(sys_get_temp_dir(), 'lychee');
+		if ($tempFilePath === false) {
+			throw new \RuntimeException('Could not create temporary file');
+		}
+		parent::__construct($tempFilePath);
+	}
+
+	public function getMimeType(): string
+	{
+		return mime_content_type($this->absolutePath);
+	}
+}

--- a/app/Image/TemporaryLocalFile.php
+++ b/app/Image/TemporaryLocalFile.php
@@ -18,9 +18,4 @@ class TemporaryLocalFile extends NativeLocalFile
 		}
 		parent::__construct($tempFilePath);
 	}
-
-	public function getMimeType(): string
-	{
-		return mime_content_type($this->absolutePath);
-	}
 }

--- a/app/Models/SizeVariant.php
+++ b/app/Models/SizeVariant.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Casts\MustNotSetCast;
 use App\Facades\AccessControl;
+use App\Image\FlysystemFile;
 use App\Models\Extensions\HasAttributesPatch;
 use App\Models\Extensions\HasBidirectionalRelationships;
 use App\Models\Extensions\UTCBasedTimes;
@@ -178,6 +179,11 @@ class SizeVariant extends Model
 	public function getFullPathAttribute(): string
 	{
 		return Storage::path($this->short_path);
+	}
+
+	public function getFile(): FlysystemFile
+	{
+		return new FlysystemFile(Storage::disk(), $this->short_path);
 	}
 
 	/**

--- a/app/Models/SymLink.php
+++ b/app/Models/SymLink.php
@@ -3,7 +3,6 @@
 namespace App\Models;
 
 use App\Casts\MustNotSetCast;
-use App\Facades\Helpers;
 use App\Models\Extensions\HasAttributesPatch;
 use App\Models\Extensions\UTCBasedTimes;
 use Illuminate\Database\Eloquent\Builder;
@@ -112,8 +111,9 @@ class SymLink extends Model
 	 */
 	protected function performInsert(Builder $query): bool
 	{
-		$origFullPath = $this->size_variant->full_path;
-		$extension = Helpers::getExtension($origFullPath);
+		$file = $this->size_variant->getFile();
+		$origFullPath = $file->getAbsolutePath();
+		$extension = $file->getExtension();
 		$symShortPath = hash('sha256', random_bytes(32) . '|' . $origFullPath) . $extension;
 		$symFullPath = Storage::disk(SymLink::DISK_NAME)->path($symShortPath);
 		if (is_link($symFullPath)) {

--- a/app/Models/SymLink.php
+++ b/app/Models/SymLink.php
@@ -18,7 +18,6 @@ use Illuminate\Support\Facades\Storage;
  * @property int $size_variant_id
  * @property SizeVariant size_variant
  * @property string $short_path
- * @property string $full_path
  * @property string $url
  * @property Carbon $created_at
  * @property Carbon $updated_at
@@ -84,21 +83,6 @@ class SymLink extends Model
 	}
 
 	/**
-	 * Accessor for the "virtual" attribute {@link SymLink::$full_path}.
-	 *
-	 * Returns the full path of the symbolic link as it needs to be input into
-	 * some low-level PHP functions like `unlink`.
-	 * This is a convenient method and wraps {@link SymLink::$short_path}
-	 * into {@link \Illuminate\Support\Facades\Storage::path()}.
-	 *
-	 * @return string the full path of the symbolic link
-	 */
-	protected function getFullPathAttribute(): string
-	{
-		return Storage::disk(self::DISK_NAME)->path($this->short_path);
-	}
-
-	/**
 	 * Performs the `INSERT` operation of the model and creates an actual
 	 * symbolic link on disk.
 	 *
@@ -137,7 +121,7 @@ class SymLink extends Model
 	 */
 	public function delete(): bool
 	{
-		$fullPath = $this->full_path;
+		$fullPath = Storage::disk(self::DISK_NAME)->path($this->short_path);
 		// Laravel and Flysystem does not support symbolic links.
 		// So we must use low-level methods here.
 		if ((is_link($fullPath) && !unlink($fullPath)) || (file_exists($fullPath)) && !is_link($fullPath)) {

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -41,6 +41,9 @@ return [
 	*/
 
 	'disks' => [
+		/*
+		 * TODO: Is this disk referenced anywhere? Probably, this can be deleted.
+		 */
 		'local' => [
 			'driver' => 'local',
 			'root' => storage_path('app'),
@@ -67,13 +70,20 @@ return [
 			'visibility' => 'public',
 		],
 
+		/*
+		 * TODO: Is this disk referenced anywhere? Probably, this can be deleted.
+		 */
 		'public' => [
 			'driver' => 'local',
+			// TODO: If we keep this at all, then the `root` should probably be `public_path('')`.
 			'root' => storage_path('app/public'),
 			'url' => env('APP_URL') . '/storage',
 			'visibility' => 'public',
 		],
 
+		/*
+		 * TODO: Is this disk referenced anywhere? Probably, this can be deleted.
+		 */
 		's3' => [
 			'driver' => 's3',
 			'key' => env('AWS_ACCESS_KEY_ID'),

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -41,14 +41,7 @@ return [
 	*/
 
 	'disks' => [
-		/*
-		 * TODO: Is this disk referenced anywhere? Probably, this can be deleted.
-		 */
-		'local' => [
-			'driver' => 'local',
-			'root' => storage_path('app'),
-		],
-
+		// Lychee uses the disk "images" to store the media files
 		'images' => [
 			'driver' => 'local',
 			'root' => env('LYCHEE_UPLOADS', public_path('uploads/')),
@@ -56,35 +49,11 @@ return [
 			'visibility' => 'public',
 		],
 
-		'dist' => [
-			'driver' => 'local',
-			'root' => env('LYCHEE_DIST', public_path('dist/')),
-			'url' => env('LYCHEE_DIST_URL', 'dist/'),
-			'visibility' => 'public',
-		],
-
-		'symbolic' => [
-			'driver' => 'local',
-			'root' => public_path('sym'),
-			'url' => 'sym',
-			'visibility' => 'public',
-		],
-
+		// This is an example how the "images" disk can be hosted on an AWS S3
+		// ATTENTION: This is NOT supported yet!!!
+		// This is only a placeholder/reminder for the future
 		/*
-		 * TODO: Is this disk referenced anywhere? Probably, this can be deleted.
-		 */
-		'public' => [
-			'driver' => 'local',
-			// TODO: If we keep this at all, then the `root` should probably be `public_path('')`.
-			'root' => storage_path('app/public'),
-			'url' => env('APP_URL') . '/storage',
-			'visibility' => 'public',
-		],
-
-		/*
-		 * TODO: Is this disk referenced anywhere? Probably, this can be deleted.
-		 */
-		's3' => [
+		'images' => [
 			'driver' => 's3',
 			'key' => env('AWS_ACCESS_KEY_ID'),
 			'secret' => env('AWS_SECRET_ACCESS_KEY'),
@@ -92,6 +61,27 @@ return [
 			'bucket' => env('AWS_BUCKET'),
 			'url' => env('AWS_URL'),
 			'endpoint' => env('AWS_ENDPOINT'),
+		],*/
+
+		// Lychee uses this disk to store the customized CSS file provided by the user
+		// ATTENTION: This disk MUST ALWAYS point to the local `./public/dist` directory.
+		// TODO: Maybe we should drop this Flysystem disk, because neither the driver nor the root must be changed and hence the whole point of using the Flysystem abstraction is gone.
+		'dist' => [
+			'driver' => 'local',
+			'root' => env('LYCHEE_DIST', public_path('dist/')),
+			'url' => env('LYCHEE_DIST_URL', 'dist/'),
+			'visibility' => 'public',
+		],
+
+		// Lychee uses this disk to create ephemeral, symbolic links to photos,
+		// if the feature is enabled.
+		// ATTENTION: This disk MUST ALWAYS use the "local" driver, because
+		// Flysystem does not support symbolic links.
+		'symbolic' => [
+			'driver' => 'local',
+			'root' => public_path('sym'),
+			'url' => 'sym',
+			'visibility' => 'public',
 		],
 	],
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -75,6 +75,7 @@ return [
 
 		// Lychee uses this disk to create ephemeral, symbolic links to photos,
 		// if the feature is enabled.
+		// For this feature to work, the "images" disk must use the "local" driver.
 		// ATTENTION: This disk MUST ALWAYS use the "local" driver, because
 		// Flysystem does not support symbolic links.
 		'symbolic' => [

--- a/database/migrations/2022_01_16_181337_optimize_tables.php
+++ b/database/migrations/2022_01_16_181337_optimize_tables.php
@@ -34,7 +34,7 @@ class OptimizeTables extends Migration
 				$this->msgSection->writeln('<info>Info:</info> MySql/MariaDB detected.');
 				$sql = 'ANALYZE TABLE ';
 				break;
-			case 'posgresql':
+			case 'pgsql':
 				$this->msgSection->writeln('<info>Info:</info> PostgreSQL detected.');
 				$sql = 'ANALYZE ';
 				break;


### PR DESCRIPTION
This PR

 * aims at fixing #1198 by copying file via streams
 * is a small step forward to allow other Flysystem adapters than the local adapter to be used for image storage (e.g. AWS S3)
 * fixes a regression spotted by @kamil4 that the filename of uploaded photos is based on the checksum before auto-rotation

This PR also fixes a totally unrelated, tiny bug in the latest migration (`optimize_tables`).

At its heart, this PR introduces four new classes which abstracts away the differences between (media) files stored on a Flysystem disk and files outside of Flysystem:

                MediaFile
                «abstract»
                    |
         +----------+---------+
         |                    |
    FlysystemFile      NativeLocalFile
                              |
                      TemporaryLocalFile

In particular, these abstractions allow a unified copy mechanism based on streams between all kind of files. This

 1. will allow to use other Flysystem adapters than the local adapter for the "image" disk in the future
 2. avoids problems with native PHP methods like `rename`, `move` and `copy` and thereby fixes #1198

**Hint for review:** Start reviewing these new classes first. The remaining changes only adopt the existing code to these new classes.

_Note:_ Regarding goal 1, there is still a long way to go. Currently, Lychee still uses absolute files paths and low-level file routines ubiquitously. I only adopted existing code to the extend necessary to achieve goal 2 and added many comments otherwise.