### PR TITLE
Fix some potential null references

### DIFF
--- a/app/Console/Commands/PhotosAddedNotification.php
+++ b/app/Console/Commands/PhotosAddedNotification.php
@@ -68,7 +68,7 @@ class PhotosAddedNotification extends Command
 						];
 					}
 
-					$thumbUrl = $photo->size_variants->getThumb()->url;
+					$thumbUrl = $photo->size_variants->getThumb()?->url;
 					logger($thumbUrl);
 
 					// If the url config doesn't contain a trailing slash then add it

--- a/app/Models/Extensions/Thumb.php
+++ b/app/Models/Extensions/Thumb.php
@@ -14,10 +14,10 @@ class Thumb implements Arrayable, JsonSerializable
 {
 	protected string $id;
 	protected string $type;
-	protected ?string $thumbUrl;
+	protected string $thumbUrl;
 	protected ?string $thumb2xUrl;
 
-	protected function __construct(string $id, string $type, ?string $thumbUrl, ?string $thumb2xUrl = null)
+	protected function __construct(string $id, string $type, string $thumbUrl, ?string $thumb2xUrl = null)
 	{
 		$this->id = $id;
 		$this->type = $type;
@@ -76,12 +76,15 @@ class Thumb implements Arrayable, JsonSerializable
 			return null;
 		}
 		$thumb = $photo->size_variants->getThumb();
+		if (!$thumb) {
+			return null;
+		}
 		$thumb2x = $photo->size_variants->getThumb2x();
 
 		return new self(
 			$photo->id,
 			$photo->type,
-			$thumb?->url,
+			$thumb->url,
 			$thumb2x?->url
 		);
 	}


### PR DESCRIPTION
As a side result of the discussion on the annotated front-end, @kamil4 pointed out that a photo might not have a thumbnail, if the photo is a video and FFmpeg is not installed (probably there are some other cases, too, but this is the most prominent one).

Hence, I checked with the back-end if there is any code which wrongly assumes that thumbnails always exists. Luckily, the situation has not been as bad as I initially feared, but I found to issues nonetheless. 