### PR TITLE
Fix import of video files and thumbnail generation

### DIFF
--- a/app/Actions/Photo/Extensions/SourceFileInfo.php
+++ b/app/Actions/Photo/Extensions/SourceFileInfo.php
@@ -74,7 +74,7 @@ class SourceFileInfo
 	{
 		return new self(
 			$file->getBasename(),
-			'.' . $file->getExtension(),
+			$file->getExtension(),
 			$file->getMimeType(),
 			$file
 		);

--- a/app/Image/SizeVariantDefaultFactory.php
+++ b/app/Image/SizeVariantDefaultFactory.php
@@ -4,7 +4,6 @@ namespace App\Image;
 
 use App\Contracts\SizeVariantFactory;
 use App\Contracts\SizeVariantNamingStrategy;
-use App\Facades\Helpers;
 use App\Models\Configs;
 use App\Models\Logs;
 use App\Models\Photo;
@@ -178,9 +177,7 @@ class SizeVariantDefaultFactory extends SizeVariantFactory
 	 */
 	protected function createTmpPathForReference(): void
 	{
-		$this->referenceFullPath = Helpers::createTemporaryFile(
-			$this->namingStrategy->getDefaultExtension()
-		);
+		$this->referenceFullPath = (new TemporaryLocalFile())->getAbsolutePath();
 		$this->needsCleanup = true;
 		Logs::notice(__METHOD__, __LINE__, 'Saving JPG of raw/video file to ' . $this->referenceFullPath);
 	}
@@ -237,6 +234,9 @@ class SizeVariantDefaultFactory extends SizeVariantFactory
 			throw new \InvalidArgumentException('createSizeVariantCond() must not be used to create original size, use createOriginal() instead');
 		}
 		if (!$this->isEnabledByConfiguration($sizeVariant)) {
+			return null;
+		}
+		if ($this->photo->isVideo() && ($sizeVariant === SizeVariant::MEDIUM || $sizeVariant === SizeVariant::MEDIUM2X)) {
 			return null;
 		}
 		if (empty($this->referenceFullPath)) {

--- a/app/Image/SizeVariantDefaultFactory.php
+++ b/app/Image/SizeVariantDefaultFactory.php
@@ -236,6 +236,7 @@ class SizeVariantDefaultFactory extends SizeVariantFactory
 		if (!$this->isEnabledByConfiguration($sizeVariant)) {
 			return null;
 		}
+		// Don't generate medium size variants for videos, because the current web front-end has no use for it. Let's save some storage space.
 		if ($this->photo->isVideo() && ($sizeVariant === SizeVariant::MEDIUM || $sizeVariant === SizeVariant::MEDIUM2X)) {
 			return null;
 		}


### PR DESCRIPTION
Fixes #1218

There were two separate bugs:
- Extra dot being added to file extensions on import
- Leftover invocation of `Helpers::createTemporaryFile` which doesn't exist as of #1203 

I also noticed that we were attempting to generate medium/medium2x variants for video files. They are not necessary because the front end can't use them (it displays the video file using the `video` tag, rather than displaying a medium image like it does for photos). Or was this change intentional? I'm guessing it dates back to #1055.