### PR TITLE
Fix geoposition types

### DIFF
--- a/app/Console/Commands/DecodeGpsLocations.php
+++ b/app/Console/Commands/DecodeGpsLocations.php
@@ -53,6 +53,7 @@ class DecodeGpsLocations extends Command
 		}
 
 		$cachedProvider = Geodecoder::getGeocoderProvider();
+		/** @var Photo $photo */
 		foreach ($photos as $photo) {
 			$this->line('Processing ' . $photo->title . '...');
 

--- a/app/Console/Commands/VideoData.php
+++ b/app/Console/Commands/VideoData.php
@@ -99,10 +99,10 @@ class VideoData extends Command
 					$photo->aperture = $info['aperture'];
 				}
 				if ($photo->latitude == null && $info['latitude'] !== null) {
-					$photo->latitude = $info['latitude'];
+					$photo->latitude = floatval($info['latitude']);
 				}
 				if ($photo->longitude == null && $info['longitude'] !== null) {
-					$photo->longitude = $info['longitude'];
+					$photo->longitude = floatval($info['longitude']);
 				}
 				if ($photo->isDirty()) {
 					$this->line('Updated metadata');

--- a/app/Metadata/Geodecoder.php
+++ b/app/Metadata/Geodecoder.php
@@ -42,15 +42,18 @@ class Geodecoder
 	/**
 	 * Decode GPS coordinates into location.
 	 *
-	 * @return string location
+	 * @param ?float $latitude
+	 * @param ?float $longitude
+	 *
+	 * @return ?string location
 	 */
-	public static function decodeLocation($latitude, $longitude)
+	public static function decodeLocation(?float $latitude, ?float $longitude): ?string
 	{
 		// User does not want to decode location data
 		if (Configs::get_value('location_decoding') == false) {
 			return null;
 		}
-		if ($latitude == null || $longitude == null) {
+		if ($latitude === null || $longitude === null) {
 			return null;
 		}
 
@@ -62,9 +65,13 @@ class Geodecoder
 	/**
 	 * Wrapper to decode GPS coordinates into location.
 	 *
-	 * @return string location
+	 * @param float         $latitude
+	 * @param float         $longitude
+	 * @param ProviderCache $cachedProvider
+	 *
+	 * @return ?string location
 	 */
-	public static function decodeLocation_core($latitude, $longitude, $cachedProvider)
+	public static function decodeLocation_core(float $latitude, float $longitude, ProviderCache $cachedProvider): ?string
 	{
 		$geocoder = new StatefulGeocoder($cachedProvider, Configs::get_value('lang'));
 		try {

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -96,6 +96,10 @@ class Photo extends Model implements HasRandomID
 		'owner_id' => 'integer',
 		'is_starred' => 'boolean',
 		'is_public' => 'boolean',
+		'latitude' => 'float',
+		'longitude' => 'float',
+		'altitude' => 'float',
+		'img_direction' => 'float',
 	];
 
 	/**

--- a/public/dist/main.js
+++ b/public/dist/main.js
@@ -8328,8 +8328,12 @@ _sidebar.createStructure.photo = function (data) {
 	if (data == null || data === "") return false;
 
 	var editable = typeof album !== "undefined" ? album.isUploadable() : false;
-	var exifHash = data.taken_at + data.make + data.model + data.shutter + data.aperture + data.focal + data.iso;
-	var locationHash = data.longitude + data.latitude + data.altitude;
+	var hasExif = !!data.taken_at || !!data.make || !!data.model || !!data.shutter || !!data.aperture || !!data.focal || !!data.iso;
+	// Attributes for geo-position are nullable floats.
+	// The geo-position 0°00'00'', 0°00'00'' at zero altitude is very unlikely
+	// but valid (it's south of the coast of Ghana in the Atlantic)
+	// So we must not calculate the sum and compare for zero.
+	var hasLocation = data.longitude !== null || data.latitude !== null || data.altitude !== null;
 	var structure = {};
 	var isPublic = "";
 	var isVideo = data.type && data.type.indexOf("video") > -1;
@@ -8411,7 +8415,7 @@ _sidebar.createStructure.photo = function (data) {
 	};
 
 	// Only create EXIF section when EXIF data available
-	if (exifHash !== "") {
+	if (hasExif !== "") {
 		structure.exif = {
 			title: lychee.locale["PHOTO_CAMERA"],
 			type: _sidebar.types.DEFAULT,
@@ -8433,7 +8437,7 @@ _sidebar.createStructure.photo = function (data) {
 		rows: [{ title: lychee.locale["PHOTO_LICENSE"], kind: "license", value: license, editable: editable }]
 	};
 
-	if (locationHash !== "" && locationHash !== 0) {
+	if (hasLocation) {
 		structure.location = {
 			title: lychee.locale["PHOTO_LOCATION"],
 			type: _sidebar.types.DEFAULT,
@@ -8453,7 +8457,7 @@ _sidebar.createStructure.photo = function (data) {
 				value: data.altitude ? (Math.round(parseFloat(data.altitude) * 10) / 10).toString() + "m" : ""
 			}, { title: lychee.locale["PHOTO_LOCATION"], kind: "location", value: data.location ? data.location : "" }]
 		};
-		if (data.img_direction) {
+		if (data.img_direction !== null) {
 			// No point in display sub-degree precision.
 			structure.location.rows.push({
 				title: lychee.locale["PHOTO_IMGDIRECTION"],

--- a/public/dist/main.js
+++ b/public/dist/main.js
@@ -8415,7 +8415,7 @@ _sidebar.createStructure.photo = function (data) {
 	};
 
 	// Only create EXIF section when EXIF data available
-	if (hasExif !== "") {
+	if (hasExif) {
 		structure.exif = {
 			title: lychee.locale["PHOTO_CAMERA"],
 			type: _sidebar.types.DEFAULT,

--- a/public/dist/view.js
+++ b/public/dist/view.js
@@ -1642,7 +1642,7 @@ sidebar.createStructure.photo = function (data) {
 	};
 
 	// Only create EXIF section when EXIF data available
-	if (hasExif !== "") {
+	if (hasExif) {
 		structure.exif = {
 			title: lychee.locale["PHOTO_CAMERA"],
 			type: sidebar.types.DEFAULT,

--- a/public/dist/view.js
+++ b/public/dist/view.js
@@ -1555,8 +1555,12 @@ sidebar.createStructure.photo = function (data) {
 	if (data == null || data === "") return false;
 
 	var editable = typeof album !== "undefined" ? album.isUploadable() : false;
-	var exifHash = data.taken_at + data.make + data.model + data.shutter + data.aperture + data.focal + data.iso;
-	var locationHash = data.longitude + data.latitude + data.altitude;
+	var hasExif = !!data.taken_at || !!data.make || !!data.model || !!data.shutter || !!data.aperture || !!data.focal || !!data.iso;
+	// Attributes for geo-position are nullable floats.
+	// The geo-position 0°00'00'', 0°00'00'' at zero altitude is very unlikely
+	// but valid (it's south of the coast of Ghana in the Atlantic)
+	// So we must not calculate the sum and compare for zero.
+	var hasLocation = data.longitude !== null || data.latitude !== null || data.altitude !== null;
 	var structure = {};
 	var isPublic = "";
 	var isVideo = data.type && data.type.indexOf("video") > -1;
@@ -1638,7 +1642,7 @@ sidebar.createStructure.photo = function (data) {
 	};
 
 	// Only create EXIF section when EXIF data available
-	if (exifHash !== "") {
+	if (hasExif !== "") {
 		structure.exif = {
 			title: lychee.locale["PHOTO_CAMERA"],
 			type: sidebar.types.DEFAULT,
@@ -1660,7 +1664,7 @@ sidebar.createStructure.photo = function (data) {
 		rows: [{ title: lychee.locale["PHOTO_LICENSE"], kind: "license", value: license, editable: editable }]
 	};
 
-	if (locationHash !== "" && locationHash !== 0) {
+	if (hasLocation) {
 		structure.location = {
 			title: lychee.locale["PHOTO_LOCATION"],
 			type: sidebar.types.DEFAULT,
@@ -1680,7 +1684,7 @@ sidebar.createStructure.photo = function (data) {
 				value: data.altitude ? (Math.round(parseFloat(data.altitude) * 10) / 10).toString() + "m" : ""
 			}, { title: lychee.locale["PHOTO_LOCATION"], kind: "location", value: data.location ? data.location : "" }]
 		};
-		if (data.img_direction) {
+		if (data.img_direction !== null) {
 			// No point in display sub-degree precision.
 			structure.location.rows.push({
 				title: lychee.locale["PHOTO_IMGDIRECTION"],


### PR DESCRIPTION
The front-end expects the attributes `latitude` and `longitude` to be JS numbers not strings. Otherwise the calculation of the wen frontend for the bounding box of the map view fails (the JS operator `+` erroneously concatenates strings, but does not add numbers)

If the DB engine is MySQL, Laraval converts the SQL type `decimal` to a PHP string by default. This causes the backend to eventually send strings to the frontend. This PR rectifies the issue.

Also see https://github.com/LycheeOrg/Lychee-front/pull/286 for the frontend.