### PR TITLE
Added shortcuts via `RewriteRule` to .htaccess

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -14,6 +14,15 @@
     RewriteCond %{REQUEST_URI} (.+)/$
     RewriteRule ^ %1 [L,R=301]
 
+	# Any request to the public folders can be served directly.
+	# There is no need to direct them to the front-controller.
+	# Hence, we take a short-cut here, [L] means last rule.
+	# This also avoids some unneccessary execptions and exception logging
+	# inside Lychee, if a non-existing file is requested.
+	# Also disable compression for already highly compressed media files.
+	RewriteRule ^(css|dist|img|installer|js|src)/ - [L]
+	RewriteRule ^(sym|uploads)/ - [L,E=no-gzip:1]
+
     # Send Requests To Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
While I was looking for a solution to https://github.com/LycheeOrg/Lychee/pull/1217#discussion_r836552854, I discovered that our `.htaccess` could be improved.

As there is a lot (I mean really A LOT) requests for the `upload` directory, we can take a shortcut there. The new rules also avoid some unnecessary exceptions and logging, if a browser requests a non-existing file.