### PR TITLE
Added more file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,6 @@ npm-debug.log
 yarn-error.log
 .env
 .env.*
-!.env.example
-!.env.homestead
 
 public/dist/user.css
 aliases

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,9 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 .env
-.env.bck
+.env.*
+!.env.example
+!.env.homestead
 
 public/dist/user.css
 aliases


### PR DESCRIPTION
For developing and testing my number of `.env`-files has increased significantly over the last month. I use these different `.env`-files as a symlink target and I iterate over them to check the effect of changes for different setups. I always fear to accidentally commit them some day. So I decided it has been time to exclude them.

If anybody has a better idea, I am open to ideas. I don't mind if this PR is rejected.

FYI, my collection of `.env`-files look like that

 - `.env.debug.mysql.empty`
 - `.env.debug.mysql.geeklihui`
 - `.env.debug.mysql.ildyria`
 - `.env.debug.mysql.own`
 - `.env.production.mysql.empty`
 - `.env.production.mysql.geeklihui`
 - `.env.production.mysql.ildyria`
 - `.env.production.mysql.own`
 - `.env.testing.mysql.empty`
 - `.env.debug.psql.empty`
 - `.env.debug.psql.own`
 - `.env.production.psql.empty`
 - `.env.production.psql.own`
 - `.env.testing.psql.empty`
 - `.env.debug.sqlite.empty`
 - `.env.production.sqlite.empty`
 - `.env.testing.sqlite.empty`
