### PR TITLE
Fixes 1280

### DIFF
--- a/database/migrations/2022_04_18_174417_fix_live_photo_short_path.php
+++ b/database/migrations/2022_04_18_174417_fix_live_photo_short_path.php
@@ -1,0 +1,64 @@
+<?php
+
+use Doctrine\DBAL\Exception as DBALException;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class FixLivePhotoShortPath extends Migration
+{
+	private string $driverName;
+
+	/**
+	 * @throws DBALException
+	 */
+	public function __construct()
+	{
+		$connection = Schema::connection(null)->getConnection();
+		$this->driverName = $connection->getDriverName();
+	}
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		// MySQL misuses the ANSI SQL concatenation operator `||` for
+		// a logical OR and provides the proprietary `CONCAT` statement
+		// instead.
+		$sqlConcatLivePhotoPath = match ($this->driverName) {
+			'mysql' => DB::raw('CONCAT(\'big/\', live_photo_short_path)'),
+			default => DB::raw('\'big/\' || live_photo_short_path'),
+		};
+
+		DB::table('photos')
+			->whereNotNull('live_photo_short_path')
+			->where('live_photo_short_path', 'not like', '%/%')
+			->update(['live_photo_short_path' => $sqlConcatLivePhotoPath]);
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		// In contrast to all other programming languages, the first character
+		// of a string has index 1 (not 0) in SQL.
+		// We want to remove `'big/'` or `'raw/'` from the string.
+		$sqlSubstringLivePhotoPath = match ($this->driverName) {
+			'mysql' => DB::raw('SUBSTRING(live_photo_short_path FROM 5'),
+			'pgsql' => DB::raw('SUBSTRING(live_photo_short_path FROM 5)'),
+			'sqlite' => DB::raw('SUBSTR(live_photo_short_path, 5)'),
+			default => throw new \RuntimeException('Unknown DBMS')
+		};
+
+		DB::table('photos')
+			->whereNotNull('live_photo_short_path')
+			->where('live_photo_short_path', 'like', '%/%')
+			->update(['live_photo_short_path' => $sqlSubstringLivePhotoPath]);
+	}
+}

--- a/database/migrations/2022_04_18_174417_fix_live_photo_short_path.php
+++ b/database/migrations/2022_04_18_174417_fix_live_photo_short_path.php
@@ -22,6 +22,8 @@ class FixLivePhotoShortPath extends Migration
 	 * Run the migrations.
 	 *
 	 * @return void
+	 *
+	 * @throws RuntimeException
 	 */
 	public function up()
 	{
@@ -30,7 +32,8 @@ class FixLivePhotoShortPath extends Migration
 		// instead.
 		$sqlConcatLivePhotoPath = match ($this->driverName) {
 			'mysql' => DB::raw('CONCAT(\'big/\', live_photo_short_path)'),
-			default => DB::raw('\'big/\' || live_photo_short_path'),
+			'pgsql', 'sqlite' => DB::raw('\'big/\' || live_photo_short_path'),
+			default => throw new \RuntimeException('Unknown DBMS')
 		};
 
 		DB::table('photos')
@@ -43,6 +46,8 @@ class FixLivePhotoShortPath extends Migration
 	 * Reverse the migrations.
 	 *
 	 * @return void
+	 *
+	 * @throws RuntimeException
 	 */
 	public function down()
 	{
@@ -50,8 +55,7 @@ class FixLivePhotoShortPath extends Migration
 		// of a string has index 1 (not 0) in SQL.
 		// We want to remove `'big/'` or `'raw/'` from the string.
 		$sqlSubstringLivePhotoPath = match ($this->driverName) {
-			'mysql' => DB::raw('SUBSTRING(live_photo_short_path FROM 5'),
-			'pgsql' => DB::raw('SUBSTRING(live_photo_short_path FROM 5)'),
+			'mysql', 'pgsql' => DB::raw('SUBSTRING(live_photo_short_path FROM 5)'),
 			'sqlite' => DB::raw('SUBSTR(live_photo_short_path, 5)'),
 			default => throw new \RuntimeException('Unknown DBMS')
 		};


### PR DESCRIPTION
Since the big refactoring the various columns which store paths store the complete, relative path of files to avoid hard-coding of prefixes in the Lychee source code. The original migration did not update the path for live photos accordingly. This belated migration rectifies the situation.