### PR TITLE
Don't use locale

### DIFF
--- a/resources/views/view.blade.php
+++ b/resources/views/view.blade.php
@@ -58,7 +58,7 @@
 <!-- Infobox -->
 <div class="sidebar">
     <div class="sidebar__header">
-        <h1>{{ $locale['PHOTO_ABOUT'] }}</h1>
+        <h1>About</h1>
     </div>
     <div class="sidebar__wrapper"></div>
 </div>


### PR DESCRIPTION
Undoes one change from #1270: the view mode didn't work because it does not support the localization of the blade.