### PR TITLE
Fix rollback code for mysql

### DIFF
--- a/database/migrations/2022_04_16_170724_add_missing_indices.php
+++ b/database/migrations/2022_04_16_170724_add_missing_indices.php
@@ -43,9 +43,14 @@ class AddMissingIndices extends Migration
 
 	public function down()
 	{
-		Schema::table('photos', function (Blueprint $table) {
+		$descriptionSQL = match ($this->driverName) {
+			'mysql' => DB::raw('description(128)'),
+			default => 'description',
+		};
+
+		Schema::table('photos', function (Blueprint $table) use ($descriptionSQL) {
 			$this->dropIndexIfExists($table, 'photos_album_id_is_starred_title_index');
-			$this->dropIndexIfExists($table, 'photos_album_id_is_starred_description_index');
+			$this->dropIndexIfExists($table, 'photos_album_id_is_starred_' . $descriptionSQL . '_index');
 		});
 	}
 


### PR DESCRIPTION
Fixes rollback code from #1278

The regular migration code special-cases mysql but the same is missing from the rollback code, resulting in one index not being deleted, so a subsequent forward migration fails.