### PR TITLE
Exception-free wrapper for Laravel's `report` method.

### DIFF
--- a/app/Actions/Album/Archive.php
+++ b/app/Actions/Album/Archive.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Album;
 
 use App\Contracts\AbstractAlbum;
+use App\Exceptions\Handler;
 use App\Exceptions\Internal\FrameworkException;
 use App\Facades\AccessControl;
 use App\Facades\Helpers;
@@ -12,7 +13,6 @@ use App\Models\Extensions\BaseAlbum;
 use App\Models\Photo;
 use App\Models\TagAlbum;
 use App\SmartAlbums\BaseSmartAlbum;
-use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Collection;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -29,14 +29,6 @@ class Archive extends Action
 		"\x18", "\x19", "\x1a", "\x1b", "\x1c", "\x1d", "\x1e", "\x1f",
 		'<', '>', ':', '"', '/', '\\', '|', '?', '*',
 	];
-
-	protected ExceptionHandler $exceptionHandler;
-
-	public function __construct()
-	{
-		parent::__construct();
-		$this->exceptionHandler = resolve(ExceptionHandler::class);
-	}
 
 	/**
 	 * @param Collection<AbstractAlbum> $albums
@@ -195,7 +187,7 @@ class Archive extends Action
 				set_time_limit(ini_get('max_execution_time'));
 				$zip->addFileFromPath($fileName, $fullPath);
 			} catch (\Throwable $e) {
-				$this->exceptionHandler->report($e);
+				Handler::reportSafely($e);
 			}
 		}
 
@@ -208,7 +200,7 @@ class Archive extends Action
 				try {
 					$this->compressAlbum($subAlbum, $subDirs, $fullNameOfDirectory, $zip);
 				} catch (\Throwable $e) {
-					$this->exceptionHandler->report($e);
+					Handler::reportSafely($e);
 				}
 			}
 		}

--- a/app/Actions/Import/Exec.php
+++ b/app/Actions/Import/Exec.php
@@ -11,6 +11,7 @@ use App\DTO\ImportEventReport;
 use App\DTO\ImportProgressReport;
 use App\DTO\ImportReport;
 use App\Exceptions\FileOperationException;
+use App\Exceptions\Handler;
 use App\Exceptions\ImportCancelledException;
 use App\Exceptions\Internal\FrameworkException;
 use App\Exceptions\InvalidDirectoryException;
@@ -21,7 +22,6 @@ use App\Image\NativeLocalFile;
 use App\Models\Album;
 use App\Models\Configs;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Storage;
@@ -41,7 +41,6 @@ class Exec
 	protected bool $memWarningGiven = false;
 	private array $raw_formats;
 	private bool $firstReportGiven = false;
-	private ExceptionHandler $exceptionHandler;
 
 	/**
 	 * @param ImportMode $importMode          the import mode
@@ -57,7 +56,6 @@ class Exec
 		$this->enableCLIFormatting = $enableCLIFormatting;
 		$this->memLimit = $memLimit;
 		$this->raw_formats = explode('|', strtolower(Configs::get_value('raw_formats', '')));
-		$this->exceptionHandler = resolve(ExceptionHandler::class);
 	}
 
 	/**
@@ -102,7 +100,7 @@ class Exec
 		}
 
 		if ($report instanceof ImportEventReport && $report->getException()) {
-			$this->exceptionHandler->report($report->getException());
+			Handler::reportSafely($report->getException());
 		}
 	}
 

--- a/app/Actions/Import/FromUrl.php
+++ b/app/Actions/Import/FromUrl.php
@@ -7,6 +7,7 @@ use App\Actions\Photo\Create;
 use App\Actions\Photo\Extensions\Constants;
 use App\Actions\Photo\Extensions\SourceFileInfo;
 use App\Actions\Photo\Strategies\ImportMode;
+use App\Exceptions\Handler;
 use App\Exceptions\InsufficientFilesystemPermissions;
 use App\Exceptions\MassImportException;
 use App\Exceptions\MediaFileOperationException;
@@ -15,15 +16,12 @@ use App\Image\TemporaryLocalFile;
 use App\Models\Album;
 use App\Models\Configs;
 use App\Models\Photo;
-use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Collection;
 
 class FromUrl
 {
 	use Constants;
 	use Checks;
-
-	protected ExceptionHandler $exceptionHandler;
 
 	/**
 	 * @throws InsufficientFilesystemPermissions
@@ -34,7 +32,6 @@ class FromUrl
 		// Moreover, we do not even use the `import` folder which is checked by this method.
 		// There is similar odd test in {@link \App\Actions\Photo\Create::add()} which uses another "check" trait.
 		$this->checkPermissions();
-		$this->exceptionHandler = resolve(ExceptionHandler::class);
 	}
 
 	/**
@@ -97,7 +94,7 @@ class FromUrl
 				);
 			} catch (\Throwable $e) {
 				$exceptions[] = $e;
-				$this->exceptionHandler->report($e);
+				Handler::reportSafely($e);
 			}
 		}
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -370,7 +370,7 @@ class Handler extends ExceptionHandler
 	 * which documents an exception surprisingly is
 	 * {@link \Illuminate\Contracts\Debug\ExceptionHandler::report()}.
 	 * Unfortunately, it is an unspecific `\Throwable`.
-	 * Even worse, we now that our own implementation of that method
+	 * Even worse, we know that our own implementation of that method
 	 * {@link Handler::report()} does not even throw an exception.
 	 *
 	 * Here, we rectify this situation by provided an alternative function

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -357,4 +357,39 @@ class Handler extends ExceptionHandler
 
 		return $result;
 	}
+
+	/**
+	 * An exception-free replacement for Laravel's global `report` function.
+	 *
+	 * Normally, if one is inside a `catch`-block handling exceptions, one
+	 * does not like to deal with another (new) exception.
+	 * If `report` threw an exception, what should we do about it anyway?
+	 * Report it? ;-)
+	 * Even though the Laravel framework is very reluctant to document the
+	 * exceptions thrown by their methods, one of the few Laravel methods
+	 * which documents an exception surprisingly is
+	 * {@link \Illuminate\Contracts\Debug\ExceptionHandler::report()}.
+	 * Unfortunately, it is an unspecific `\Throwable`.
+	 * Even worse, we now that our own implementation of that method
+	 * {@link Handler::report()} does not even throw an exception.
+	 *
+	 * Here, we rectify this situation by provided an alternative function
+	 * which does not throw another exception.
+	 * This also makes the IDE happy again, because we don't use an
+	 * exception throwing method inside an exception handler.
+	 *
+	 * @param \Throwable $e
+	 *
+	 * @return void
+	 */
+	public static function reportSafely(\Throwable $e): void
+	{
+		try {
+			report($e);
+		} catch (\Throwable) {
+			// Simply do nothing.
+			// If even exception reporting does not work, we are lost anyway.
+			// There is nothing we could do, except maybe die.
+		}
+	}
 }

--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -4,6 +4,7 @@ namespace App\Metadata;
 
 use App\Exceptions\ExternalComponentFailedException;
 use App\Exceptions\ExternalComponentMissingException;
+use App\Exceptions\Handler;
 use App\Exceptions\MediaFileOperationException;
 use App\Facades\Helpers;
 use App\Models\Configs;
@@ -183,7 +184,7 @@ class Extractor
 		} catch (\RuntimeException $e) {
 			// thrown by $reader->read if EXIF could not be extracted,
 			// don't give up yet, only log the event
-			report($e);
+			Handler::reportSafely($e);
 			$exif = false;
 		}
 
@@ -213,7 +214,7 @@ class Extractor
 				// if readlink($filename) != False then $realFile = readlink($filename)
 				$realFile = readlink($fullPath) ?: $fullPath;
 			} catch (\Exception $e) {
-				report($e);
+				Handler::reportSafely($e);
 			}
 		}
 		if (Configs::hasExiftool() && file_exists($realFile . '.xmp')) {
@@ -231,7 +232,7 @@ class Extractor
 					$exif->setData(array_merge($sidecarData, $exif->getData()));
 				}
 			} catch (\Exception $e) {
-				report($e);
+				Handler::reportSafely($e);
 			}
 		}
 
@@ -520,7 +521,7 @@ class Extractor
 				$metadata['location'] = substr($metadata['location'], 0, 255);
 			}
 		} catch (ExternalComponentFailedException $e) {
-			report($e);
+			Handler::reportSafely($e);
 			$metadata['location'] = null;
 		}
 

--- a/app/Models/Configs.php
+++ b/app/Models/Configs.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Exceptions\Internal\InvalidConfigOption;
+use App\Exceptions\Internal\QueryBuilderException;
 use App\Exceptions\ModelDBException;
 use App\Facades\Helpers;
 use App\Models\Extensions\ConfigsHas;
@@ -178,6 +179,7 @@ class Configs extends Model
 	 * @return void
 	 *
 	 * @throws InvalidConfigOption
+	 * @throws QueryBuilderException
 	 */
 	public static function set(string $key, $value): void
 	{
@@ -214,6 +216,8 @@ class Configs extends Model
 	 * @param FixedQueryBuilder $query
 	 *
 	 * @return FixedQueryBuilder
+	 *
+	 * @throws QueryBuilderException
 	 */
 	public function scopePublic(FixedQueryBuilder $query): FixedQueryBuilder
 	{
@@ -226,6 +230,8 @@ class Configs extends Model
 	 * @param FixedQueryBuilder $query
 	 *
 	 * @return FixedQueryBuilder
+	 *
+	 * @throws QueryBuilderException
 	 */
 	public function scopeInfo(FixedQueryBuilder $query): FixedQueryBuilder
 	{
@@ -238,6 +244,8 @@ class Configs extends Model
 	 * @param FixedQueryBuilder $query
 	 *
 	 * @return FixedQueryBuilder
+	 *
+	 * @throws QueryBuilderException
 	 */
 	public function scopeAdmin(FixedQueryBuilder $query): FixedQueryBuilder
 	{

--- a/app/Models/Extensions/ConfigsHas.php
+++ b/app/Models/Extensions/ConfigsHas.php
@@ -2,8 +2,10 @@
 
 namespace App\Models\Extensions;
 
-use App\Models\Logs;
-use Exception;
+use App\Exceptions\ExternalComponentMissingException;
+use App\Exceptions\Handler;
+use App\Exceptions\Internal\InvalidConfigOption;
+use App\Exceptions\Internal\QueryBuilderException;
 
 trait ConfigsHas
 {
@@ -27,31 +29,26 @@ trait ConfigsHas
 		// 1: Exiftool is available
 		// 2: Not yet tested if exiftool is available
 
-		$has_exiftool = intval(self::get_value('has_exiftool'));
+		$has_exiftool = intval(self::get_value('has_exiftool', 2));
 
 		// value not yet set -> let's see if exiftool is available
-		if ($has_exiftool == 2) {
+		if ($has_exiftool === 2) {
 			try {
 				$path = exec('command -v exiftool');
-				if ($path == '') {
-					self::set('has_exiftool', 0);
-					$has_exiftool = false;
-				} else {
-					self::set('has_exiftool', 1);
-					$has_exiftool = true;
-				}
-			} catch (Exception $e) {
-				self::set('has_exiftool', 0);
-				$has_exiftool = false;
-				Logs::warning(__METHOD__, __LINE__, 'exec is disabled, has_exiftool has been set to 0.');
+			} catch (\Exception $e) {
+				$path = '';
+				Handler::reportSafely(new ExternalComponentMissingException('could not find exiftool, `has_exiftool` will be set to 0', $e));
 			}
-		} elseif ($has_exiftool == 1) {
-			$has_exiftool = true;
-		} else {
-			$has_exiftool = false;
+			$has_exiftool = empty($path) ? 0 : 1;
+			try {
+				self::set('has_exiftool', $has_exiftool);
+			} catch (InvalidConfigOption|QueryBuilderException $e) {
+				// If we could not save the detected setting, still proceed
+				Handler::reportSafely($e);
+			}
 		}
 
-		return $has_exiftool;
+		return $has_exiftool === 1;
 	}
 
 	/**
@@ -64,30 +61,25 @@ trait ConfigsHas
 		// 1: ffmpeg is available
 		// 2: Not yet tested if ffmpeg is available
 
-		$has_ffmpeg = intval(self::get_value('has_ffmpeg'));
+		$has_ffmpeg = intval(self::get_value('has_ffmpeg', 2));
 
 		// value not yet set -> let's see if ffmpeg is available
-		if ($has_ffmpeg == 2) {
+		if ($has_ffmpeg === 2) {
 			try {
 				$path = exec('command -v ffmpeg');
-				if ($path == '') {
-					self::set('has_ffmpeg', 0);
-					$has_ffmpeg = false;
-				} else {
-					self::set('has_ffmpeg', 1);
-					$has_ffmpeg = true;
-				}
-			} catch (Exception $e) {
-				self::set('has_ffmpeg', 0);
-				$has_ffmpeg = false;
-				Logs::warning(__METHOD__, __LINE__, 'exec is disabled, set_ffmpeg has been set to 0.');
+			} catch (\Exception $e) {
+				$path = '';
+				Handler::reportSafely(new ExternalComponentMissingException('could not find ffmpeg, `has_ffmpeg` will be set to 0', $e));
 			}
-		} elseif ($has_ffmpeg == 1) {
-			$has_ffmpeg = true;
-		} else {
-			$has_ffmpeg = false;
+			$has_ffmpeg = empty($path) ? 0 : 1;
+			try {
+				self::set('has_ffmpeg', $has_ffmpeg);
+			} catch (InvalidConfigOption|QueryBuilderException $e) {
+				// If we could not save the detected setting, still proceed
+				Handler::reportSafely($e);
+			}
 		}
 
-		return $has_ffmpeg;
+		return $has_ffmpeg === 1;
 	}
 }

--- a/app/Models/Extensions/ConfigsHas.php
+++ b/app/Models/Extensions/ConfigsHas.php
@@ -37,7 +37,7 @@ trait ConfigsHas
 				$path = exec('command -v exiftool');
 			} catch (\Exception $e) {
 				$path = '';
-				Handler::reportSafely(new ExternalComponentMissingException('could not find exiftool, `has_exiftool` will be set to 0', $e));
+				Handler::reportSafely(new ExternalComponentMissingException('could not find exiftool; `has_exiftool` will be set to 0', $e));
 			}
 			$has_exiftool = empty($path) ? 0 : 1;
 			try {

--- a/app/Models/Extensions/ConfigsHas.php
+++ b/app/Models/Extensions/ConfigsHas.php
@@ -69,7 +69,7 @@ trait ConfigsHas
 				$path = exec('command -v ffmpeg');
 			} catch (\Exception $e) {
 				$path = '';
-				Handler::reportSafely(new ExternalComponentMissingException('could not find ffmpeg, `has_ffmpeg` will be set to 0', $e));
+				Handler::reportSafely(new ExternalComponentMissingException('could not find ffmpeg; `has_ffmpeg` will be set to 0', $e));
 			}
 			$has_ffmpeg = empty($path) ? 0 : 1;
 			try {


### PR DESCRIPTION
While I have been working on my streaming branch, I was bugged out by the stupidity of the Laravel `report` function. It is my ultimate goal to get my Linter down to zero findings in the code. But this requires just another wrapper for another Laravel method (`report` in this case). In order to keep it out of the other PRs, I created this PR.

See https://github.com/LycheeOrg/Lychee/pull/1315/commits/648981f7fb5dcea5c9454770893d7fe12849b75f for background information first.