### PR TITLE
Fixes #1311

### DIFF
--- a/app/Actions/Import/Exec.php
+++ b/app/Actions/Import/Exec.php
@@ -230,10 +230,7 @@ class Exec
 
 			// TODO: Consider to use a modern OO-approach using [`DirectoryIterator`](https://www.php.net/manual/en/class.directoryiterator.php) and [`SplFileInfo`](https://www.php.net/manual/en/class.splfileinfo.php)
 			/** @var string[] $files */
-			$files = glob($path . '/*');
-			if ($files === false) {
-				throw new FileOperationException('Could not list directory entries (' . $path . ')');
-			}
+			$files = \Safe\glob($path . '/*');
 
 			$filesTotal = count($files);
 			$filesCount = 0;
@@ -308,7 +305,7 @@ class Exec
 					Album::query()
 						->select(['albums.*'])
 						->join('base_albums', 'base_albums.id', '=', 'albums.id')
-						->where('albums.parent_id', '=', $parentAlbum->id)
+						->where('albums.parent_id', '=', $parentAlbum?->id)
 						->where('base_albums.title', '=', basename($dir))
 						->get()
 						->first() :


### PR DESCRIPTION
Recursive import from the server into the root albums failed with

```
2022-05-08 20:42:24 UTC -- error -- App\Actions\Import\Exec::do -- 313 -- Attempt to read property "id" on null 
```

due to this line

```php
->​where​(​'albums.parent_id'​, ​'='​, ​$​parentAlbum​->​id​)
```

which should have been

```php
->​where​(​'albums.parent_id'​, ​'='​, ​$​parentAlbum​?->​id​)
```

This fixes #1311. The OP already confirmed that the fix works.