### PR TITLE
PHP based basic install script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,12 +81,24 @@
             "@php artisan key:generate"
         ],
         "post-autoload-dump": [
-            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover",
+            "@autoload_dump",
+            "@package_discover",
             "@install_files"
         ],
+        "autoload_dump": [
+            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump"
+        ],
+        "package_discover": [
+            "@php artisan package:discover"
+        ],
         "install_files": [
-            "sh scripts/install_files.sh"
+            "@php -r \"touch('public/dist/user.css');\"",
+            "@php -r \"touch('database/database.sqlite');\"",
+            "@php -r \"file_exists('.git/hooks') || copy('scripts/pre-commit', '.git/hooks/pre-commit');\"",
+            "@php -r \"file_exists('.git/hooks') || copy('scripts/pre-merge', '.git/hooks/pre-merge');\""
+        ],
+        "disable_auto_composer_upgrade": [
+            "@php -r \"touch('.NO_AUTO_COMPOSER_MIGRATE');\""
         ]
     },
     "config": {

--- a/install.php
+++ b/install.php
@@ -1,5 +1,5 @@
 <?php
-COMPOSER_INSTALLER='https://getcomposer.org/installer';
+define('COMPOSER_INSTALLER','https://getcomposer.org/installer');
 
 chdir('..');
 $OK=true;

--- a/install.php
+++ b/install.php
@@ -10,18 +10,22 @@ function print_o($A) {
     foreach ($A as $a) {
       echo $a."<br/>\n";
     }
+    return true;
 }
 
 function H($a,$l=1) { 
     echo "<h$l>".$a."</h$l>";
+    return true;
 }
 
 function T($a) { 
     echo $a."<br/>\n";
+    return true;
 }
 
 function CL($a) { 
     echo "<li><code>".$a."</code></li>\n";
+    return true;
 }
 
 function RUN($cmd,$get=false) { 

--- a/install.php
+++ b/install.php
@@ -1,4 +1,6 @@
 <?php
+COMPOSER_INSTALLER='https://getcomposer.org/installer';
+
 chdir('..');
 $OK=true;
 if (!file_exists('.env')) {
@@ -40,7 +42,7 @@ function RUN($cmd,$get=false) {
 }
 
 H('Installing Composer.phar');
-copy('https://getcomposer.org/installer', 'composer-setup.php');
+copy(COMPOSER_INSTALLER, 'composer-setup.php');
 if (hash_file('sha384', 'composer-setup.php') === '55ce33d7678c5a611085589f1f3ddf8b3c52d662cd01d4ba75c0ee0459970c2200a51f492d557530c71c15d8dba01eae') { 
     T('Installer verified');
     exec('php composer-setup.php');
@@ -70,9 +72,6 @@ if ($OK) {
         H('Generate key');
         echo print_o(RUN('php artisan key:generate --force'))."<br/>\n";
     }
-}
-
-if ($OK) {
     H('Migrate database');
     echo print_o(RUN('php artisan migrate --force'));
 }

--- a/install.php
+++ b/install.php
@@ -1,0 +1,97 @@
+<?php
+chdir('..');
+$OK=true;
+if (!file_exists('.env')) {
+    exec("cp .env.example .env");
+    H('Copy .env.example to .env');
+}
+
+function print_o($A) {
+    foreach ($A as $a) {
+      echo $a."<br/>\n";
+    }
+}
+
+function H($a,$l=1) { 
+    echo "<h$l>".$a."</h$l>";
+}
+
+function T($a) { 
+    echo $a."<br/>\n";
+}
+
+function CL($a) { 
+    echo "<li><code>".$a."</code></li>\n";
+}
+
+function RUN($cmd,$get=false) { 
+    $output='';
+    $retval=null;
+    $ret=exec($cmd,$output,$retval);
+    if ($get) {
+        return $ret;
+    } else {
+        return $output;
+    }
+}
+
+H('Installing Composer.phar');
+copy('https://getcomposer.org/installer', 'composer-setup.php');
+if (hash_file('sha384', 'composer-setup.php') === '55ce33d7678c5a611085589f1f3ddf8b3c52d662cd01d4ba75c0ee0459970c2200a51f492d557530c71c15d8dba01eae') { 
+    T('Installer verified');
+    exec('php composer-setup.php');
+    unlink('composer-setup.php');
+} else {
+    T('Installer corrupt'); 
+    unlink('composer-setup.php'); 
+    $OK=false;
+}
+
+if ($OK) {
+    H('Update composer.lock');
+    echo print_o(RUN('php ./composer.phar update'));
+}
+
+if ($OK) {
+    H('Install composer.json (no-dev)');
+    echo print_o(RUN('php ./composer.phar install --no-dev'));
+    H('Creating user.css',2);
+    touch('public/dist/user.css');
+    H('Creating the sqlite database',2);
+    touch('database/database.sqlite');
+}
+
+if ($OK) {
+    if (RUN("grep '^APP_KEY=' .env|sed -e 's/APP_KEY=//ig'",true)=='') {
+        H('Generate key');
+        echo print_o(RUN('php artisan key:generate --force'))."<br/>\n";
+    }
+}
+
+if ($OK) {
+    H('Migrate database');
+    echo print_o(RUN('php artisan migrate --force'));
+}
+
+if (RUN("grep '^APP_KEY=' .env|sed -e 's/APP_KEY=//ig'",true)=='') {$OK=false;}
+
+if ($OK) {
+    T("The installation is complete.");
+    T('<a href="/">Continue here.</a>');
+    chdir('public');
+    rename("install.php","../install.php");
+} else {
+    T("Installation error. Run thr following steps manually in the installtion directory:");
+    T('<ol dir="auto">');
+    CL('php -r "'."copy('https://getcomposer.org/installer', 'composer-setup.php'".');\"');
+    CL('php -r "'."if (hash_file('sha384', 'composer-setup.php') === '55ce33d7678c5a611085589f1f3ddf8b3c52d662cd01d4ba75c0ee0459970c2200a51f492d557530c71c15d8dba01eae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;".'"');
+    CL('php composer-setup.php');
+    CL('php -r "'."unlink('composer-setup.php');".'"');
+    CL("cp .env.example .env");
+    CL("./composer.phar update");
+    CL("./composer.phar install --no-dev --prefer-dist");
+    CL("php artisan key:generate");
+    CL("php artisan migrate");
+    T("<li><code>mv public/install.php .</code></li>");
+    T('</ol>');
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,4 +1,6 @@
 <?php
+/* Run install.php, if present*/
+if (file_exists('install.php')) {header("Location: /install.php"); die();}
 
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;


### PR DESCRIPTION
Lychee requires some command line installation steps.

This is not only ugly but nor error proof.

So idea of this PR is to simply run these steps from PHP to make the process more reliable.

The script install.php can be simply moved to the public folder after cloning the repository or unpacking the zip-archive.

If the browser is pointed to the lychee url the install script will be executed exactly once. At the end it will be moved back to the project root.

If an installation does not have the public/index.php modified, the script can still be used. After moving install.php has been moved in place one needs to point the browser to <lychee-domain>/install.php once.

The idea is not to have a beauty queen but something which works out of the box.