### PR TITLE
Fixes #1330

### DIFF
--- a/app/Actions/Album/Delete.php
+++ b/app/Actions/Album/Delete.php
@@ -101,18 +101,49 @@ class Delete extends Action
 			// \Kalnoy\Nestedset\NodeTrait
 			// I really liked the code of master@0199212 ways better, but it was
 			// simply too inefficient
+
+			// This code also fixes a bug when more than one album with
+			// sub-albums is deleted, i.e. if we delete a "sub-forest".
+			// The original code (of the nested set model) updates the
+			// (lft,rgt)-indices on the DB level for every single deletion.
+			// However, this way deletion of the second albums fails, if the
+			// second album has already been hydrated earlier, because the
+			// indices of the already hydrated models and the indices in the
+			// DB are out-of-sync.
+			// Either all remaining models needs to be re-hydrated aka
+			// "refreshed" from the (already updated) DB after every single
+			// deletion or the update of the DB needs to be postponed until
+			// all models have been deleted.
+			// The latter is more efficient, because we do not reload models
+			// from the DB.
+
+			/** @var array<array{lft: int, rgt:int}> $pendingGapsToMake */
+			$pendingGapsToMake = [];
+			$deleteQuery = Album::query();
+			// First collect all albums to delete in a single query and
+			// memorize which indices need to be updated later.
 			foreach ($albums as $album) {
-				$lft = $album->getLft();
-				$rgt = $album->getRgt();
-				$album
-					->descendants()
-					->orderBy($album->getLftName(), 'desc')
-					->delete();
-				$height = $rgt - $lft + 1;
-				$album->newNestedSetQuery()->makeGap($rgt + 1, -$height);
+				$pendingGapsToMake[] = [
+					'lft' => $album->getLft(),
+					'rgt' => $album->getRgt(),
+				];
+				$deleteQuery->whereDescendantOf($album, 'or', false, true);
+			}
+			// For MySQL deletion must be done in correct order otherwise the
+			// foreign key constraint to `parent_id` fails.
+			$deleteQuery->orderBy('_lft', 'desc')->delete();
+			// _After all_ albums have been deleted, remove the gaps which
+			// have been created by the removed albums.
+			// Note, the gaps must be removed beginning with the highest
+			// values first otherwise the later indices won't be correct.
+			// To save some DB queries, we could implement a "makeMultiGap".
+			usort($pendingGapsToMake, fn ($a, $b) => $b['lft'] <=> $a['lft']);
+			foreach ($pendingGapsToMake as $pendingGap) {
+				$height = $pendingGap['rgt'] - $pendingGap['lft'] + 1;
+				$album->newNestedSetQuery()->makeGap($pendingGap['rgt'] + 1, -$height);
 				Album::$actionsPerformed++;
 			}
-			Album::query()->whereIn('id', $albumIDs)->delete();
+
 			TagAlbum::query()->whereIn('id', $albumIDs)->delete();
 
 			// Note, we may need to delete more base albums than those whose

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -175,108 +175,110 @@ class AlbumTest extends TestCase
 	 */
 	public function testMultiDelete(): void
 	{
-		// In order check the (_lft,_rgt)-indices we need deterministic
-		// indices.
-		// Hence, we must ensure that there are no left-overs from previous
-		// tests.
-		static::assertDatabaseCount('base_albums', 0);
+		try {
+			// In order check the (_lft,_rgt)-indices we need deterministic
+			// indices.
+			// Hence, we must ensure that there are no left-overs from previous
+			// tests.
+			static::assertDatabaseCount('base_albums', 0);
 
-		AccessControl::log_as_id(0);
+			AccessControl::log_as_id(0);
 
-		// Create the test layout
-		$albumID1 = $this->albums_tests->add(null, 'Album 1')->offsetGet('id');
-		$albumID11 = $this->albums_tests->add($albumID1, 'Album 1.1')->offsetGet('id');
-		$albumID12 = $this->albums_tests->add($albumID1, 'Album 1.2')->offsetGet('id');
-		$albumID13 = $this->albums_tests->add($albumID1, 'Album 1.3')->offsetGet('id');
-		$albumID111 = $this->albums_tests->add($albumID11, 'Album 1.1.1')->offsetGet('id');
-		$albumID121 = $this->albums_tests->add($albumID12, 'Album 1.2.1')->offsetGet('id');
-		$albumID131 = $this->albums_tests->add($albumID13, 'Album 1.3.1')->offsetGet('id');
+			// Create the test layout
+			$albumID1 = $this->albums_tests->add(null, 'Album 1')->offsetGet('id');
+			$albumID11 = $this->albums_tests->add($albumID1, 'Album 1.1')->offsetGet('id');
+			$albumID12 = $this->albums_tests->add($albumID1, 'Album 1.2')->offsetGet('id');
+			$albumID13 = $this->albums_tests->add($albumID1, 'Album 1.3')->offsetGet('id');
+			$albumID111 = $this->albums_tests->add($albumID11, 'Album 1.1.1')->offsetGet('id');
+			$albumID121 = $this->albums_tests->add($albumID12, 'Album 1.2.1')->offsetGet('id');
+			$albumID131 = $this->albums_tests->add($albumID13, 'Album 1.3.1')->offsetGet('id');
 
-		// Low-level tests on the DB layer to check of nested-set IDs are as expected
-		$albumStat = DB::table('albums')
-			->get(['id', 'parent_id', '_lft', '_rgt'])
-			->map(fn ($row) => get_object_vars($row))
-			->keyBy('id')
-			->toArray();
-		static::assertEquals([
-			$albumID1 => [
-				'id' => $albumID1,
-				'parent_id' => null,
-				'_lft' => 1,
-				'_rgt' => 14,
-			],
-			$albumID11 => [
-				'id' => $albumID11,
-				'parent_id' => $albumID1,
-				'_lft' => 2,
-				'_rgt' => 5,
-			],
-			$albumID12 => [
-				'id' => $albumID12,
-				'parent_id' => $albumID1,
-				'_lft' => 6,
-				'_rgt' => 9,
-			],
-			$albumID13 => [
-				'id' => $albumID13,
-				'parent_id' => $albumID1,
-				'_lft' => 10,
-				'_rgt' => 13,
-			],
-			$albumID111 => [
-				'id' => $albumID111,
-				'parent_id' => $albumID11,
-				'_lft' => 3,
-				'_rgt' => 4,
-			],
-			$albumID121 => [
-				'id' => $albumID121,
-				'parent_id' => $albumID12,
-				'_lft' => 7,
-				'_rgt' => 8,
-			],
-			$albumID131 => [
-				'id' => $albumID131,
-				'parent_id' => $albumID13,
-				'_lft' => 11,
-				'_rgt' => 12,
-			],
-		], $albumStat);
+			// Low-level tests on the DB layer to check of nested-set IDs are as expected
+			$albumStat = DB::table('albums')
+				->get(['id', 'parent_id', '_lft', '_rgt'])
+				->map(fn ($row) => get_object_vars($row))
+				->keyBy('id')
+				->toArray();
+			static::assertEquals([
+				$albumID1 => [
+					'id' => $albumID1,
+					'parent_id' => null,
+					'_lft' => 1,
+					'_rgt' => 14,
+				],
+				$albumID11 => [
+					'id' => $albumID11,
+					'parent_id' => $albumID1,
+					'_lft' => 2,
+					'_rgt' => 5,
+				],
+				$albumID12 => [
+					'id' => $albumID12,
+					'parent_id' => $albumID1,
+					'_lft' => 6,
+					'_rgt' => 9,
+				],
+				$albumID13 => [
+					'id' => $albumID13,
+					'parent_id' => $albumID1,
+					'_lft' => 10,
+					'_rgt' => 13,
+				],
+				$albumID111 => [
+					'id' => $albumID111,
+					'parent_id' => $albumID11,
+					'_lft' => 3,
+					'_rgt' => 4,
+				],
+				$albumID121 => [
+					'id' => $albumID121,
+					'parent_id' => $albumID12,
+					'_lft' => 7,
+					'_rgt' => 8,
+				],
+				$albumID131 => [
+					'id' => $albumID131,
+					'parent_id' => $albumID13,
+					'_lft' => 11,
+					'_rgt' => 12,
+				],
+			], $albumStat);
 
-		// Now let's do the multi-delete of a sub-forest
-		$this->albums_tests->delete([$albumID11, $albumID13]);
+			// Now let's do the multi-delete of a sub-forest
+			$this->albums_tests->delete([$albumID11, $albumID13]);
 
-		// Re-check on the lowest level
-		$albumStat = DB::table('albums')
-			->get(['id', 'parent_id', '_lft', '_rgt'])
-			->map(fn ($row) => get_object_vars($row))
-			->keyBy('id')
-			->toArray();
-		static::assertEquals([
-			$albumID1 => [
-				'id' => $albumID1,
-				'parent_id' => null,
-				'_lft' => 1,
-				'_rgt' => 6,
-			],
-			$albumID12 => [
-				'id' => $albumID12,
-				'parent_id' => $albumID1,
-				'_lft' => 2,
-				'_rgt' => 5,
-			],
-			$albumID121 => [
-				'id' => $albumID121,
-				'parent_id' => $albumID12,
-				'_lft' => 3,
-				'_rgt' => 4,
-			],
-		], $albumStat);
-
-		// Clean-up the remaining albums
-		$this->albums_tests->delete([$albumID1]);
-
-		AccessControl::logout();
+			// Re-check on the lowest level
+			$albumStat = DB::table('albums')
+				->get(['id', 'parent_id', '_lft', '_rgt'])
+				->map(fn ($row) => get_object_vars($row))
+				->keyBy('id')
+				->toArray();
+			static::assertEquals([
+				$albumID1 => [
+					'id' => $albumID1,
+					'parent_id' => null,
+					'_lft' => 1,
+					'_rgt' => 6,
+				],
+				$albumID12 => [
+					'id' => $albumID12,
+					'parent_id' => $albumID1,
+					'_lft' => 2,
+					'_rgt' => 5,
+				],
+				$albumID121 => [
+					'id' => $albumID121,
+					'parent_id' => $albumID12,
+					'_lft' => 3,
+					'_rgt' => 4,
+				],
+			], $albumStat);
+		} finally {
+			// Clean-up any left-overs
+			DB::table('albums')->orderBy('_lft', 'desc')->delete();
+			DB::table('base_albums')->delete();
+			AccessControl::logout();
+		}
 	}
 
 	public function testTrueNegative(): void

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -14,11 +14,18 @@ namespace Tests\Feature;
 
 use App\Facades\AccessControl;
 use Tests\Feature\Lib\AlbumsUnitTest;
-use Tests\Feature\Lib\SessionUnitTest;
 use Tests\TestCase;
 
 class AlbumTest extends TestCase
 {
+	protected AlbumsUnitTest $albums_tests;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->albums_tests = new AlbumsUnitTest($this);
+	}
+
 	/**
 	 * Test album functions.
 	 *
@@ -26,125 +33,119 @@ class AlbumTest extends TestCase
 	 */
 	public function testAddNotLogged(): void
 	{
-		$albums_tests = new AlbumsUnitTest($this);
-		$albums_tests->add(null, 'test_album', 401);
+		$this->albums_tests->add(null, 'test_album', 401);
 
-		$albums_tests->get('recent', 401);
-		$albums_tests->get('starred', 401);
-		$albums_tests->get('public', 401);
-		$albums_tests->get('unsorted', 401);
+		$this->albums_tests->get('recent', 401);
+		$this->albums_tests->get('starred', 401);
+		$this->albums_tests->get('public', 401);
+		$this->albums_tests->get('unsorted', 401);
 
 		// Ensure that we get proper 404 (not found) response for a
 		// non-existing album, not a false 403 (forbidden) response
-		$albums_tests->get('abcdefghijklmnopqrstuvwx', 404);
+		$this->albums_tests->get('abcdefghijklmnopqrstuvwx', 404);
 	}
 
 	public function testAddReadLogged(): void
 	{
-		$albums_tests = new AlbumsUnitTest($this);
-		$session_tests = new SessionUnitTest($this);
-
 		AccessControl::log_as_id(0);
 
-		$albums_tests->get('recent');
-		$albums_tests->get('starred');
-		$albums_tests->get('public');
-		$albums_tests->get('unsorted');
+		$this->albums_tests->get('recent');
+		$this->albums_tests->get('starred');
+		$this->albums_tests->get('public');
+		$this->albums_tests->get('unsorted');
 
-		$albumID = $albums_tests->add(null, 'test_album')->offsetGet('id');
-		$albumID2 = $albums_tests->add(null, 'test_album2')->offsetGet('id');
-		$albumID3 = $albums_tests->add(null, 'test_album3')->offsetGet('id');
-		$albumTagID1 = $albums_tests->addByTags('test_tag_album1', ['test'])->offsetGet('id');
+		$albumID1 = $this->albums_tests->add(null, 'test_album')->offsetGet('id');
+		$albumID2 = $this->albums_tests->add(null, 'test_album2')->offsetGet('id');
+		$albumID3 = $this->albums_tests->add(null, 'test_album3')->offsetGet('id');
+		$albumTagID1 = $this->albums_tests->addByTags('test_tag_album1', ['test'])->offsetGet('id');
 
-		$albums_tests->set_tags($albumTagID1, ['test', 'coolnewtag', 'secondnewtag']);
-		$response = $albums_tests->get($albumTagID1);
+		$this->albums_tests->set_tags($albumTagID1, ['test', 'cool_new_tag', 'second_new_tag']);
+		$response = $this->albums_tests->get($albumTagID1);
 		$response->assertJson([
-			'show_tags' => ['test', 'coolnewtag', 'secondnewtag'],
+			'show_tags' => ['test', 'cool_new_tag', 'second_new_tag'],
 		]);
 
-		$albums_tests->see_in_albums($albumID);
-		$albums_tests->see_in_albums($albumID2);
-		$albums_tests->see_in_albums($albumID3);
-		$albums_tests->see_in_albums($albumTagID1);
+		$this->albums_tests->see_in_albums($albumID1);
+		$this->albums_tests->see_in_albums($albumID2);
+		$this->albums_tests->see_in_albums($albumID3);
+		$this->albums_tests->see_in_albums($albumTagID1);
 
-		$albums_tests->move([$albumTagID1], $albumID3, 404);
-		$albums_tests->move([$albumID3], $albumID2);
-		$albums_tests->move([$albumID2], $albumID);
-		$albums_tests->move([$albumID3], null);
+		$this->albums_tests->move([$albumTagID1], $albumID3, 404);
+		$this->albums_tests->move([$albumID3], $albumID2);
+		$this->albums_tests->move([$albumID2], $albumID1);
+		$this->albums_tests->move([$albumID3], null);
 
 		/*
 		 * try to get a non-existing album
 		 */
-		$albums_tests->get('abcdefghijklmnopqrstuvwx', 404);
+		$this->albums_tests->get('abcdefghijklmnopqrstuvwx', 404);
 
-		$response = $albums_tests->get($albumID);
+		$response = $this->albums_tests->get($albumID1);
 		$response->assertJson([
-			'id' => $albumID,
+			'id' => $albumID1,
 			'description' => null,
 			'title' => 'test_album',
 			'albums' => [['id' => $albumID2]],
 		]);
 
-		$albums_tests->set_title($albumID, 'NEW_TEST');
-		$albums_tests->set_description($albumID, 'new description');
-		$albums_tests->set_license($albumID, 'WTFPL', 422);
-		$albums_tests->set_license($albumID, 'reserved');
-		$albums_tests->set_sorting($albumID, 'title', 'ASC');
+		$this->albums_tests->set_title($albumID1, 'NEW_TEST');
+		$this->albums_tests->set_description($albumID1, 'new description');
+		$this->albums_tests->set_license($albumID1, 'WTFPL', 422);
+		$this->albums_tests->set_license($albumID1, 'reserved');
+		$this->albums_tests->set_sorting($albumID1, 'title', 'ASC');
 
 		/**
 		 * Let's see if the info changed.
 		 */
-		$response = $albums_tests->get($albumID);
+		$response = $this->albums_tests->get($albumID1);
 		$response->assertJson([
-			'id' => $albumID,
+			'id' => $albumID1,
 			'description' => 'new description',
 			'title' => 'NEW_TEST',
 		]);
 
-		$albums_tests->set_sorting($albumID, '', 'ASC');
+		$this->albums_tests->set_sorting($albumID1, '', 'ASC');
 
 		/*
 		 * Flush the session to see if we can access the album
 		 */
-		$session_tests->logout();
+		AccessControl::logout();
 
 		/*
 		 * Let's try to get the info of the album we just created.
 		 */
-		$albums_tests->unlock($albumID, '', 422);
-		$albums_tests->unlock($albumID, 'wrong-password', 403);
-		$albums_tests->get($albumID, 401);
+		$this->albums_tests->unlock($albumID1, '', 422);
+		$this->albums_tests->unlock($albumID1, 'wrong-password', 403);
+		$this->albums_tests->get($albumID1, 401);
 
-		/*
-		 * Because we don't know login and password we are just going to assumed we are logged in.
-		 */
 		AccessControl::log_as_id(0);
 
 		/*
 		 * Let's try to delete this album.
 		 */
-		$albums_tests->delete([$albumID]);
+		$this->albums_tests->delete([$albumID1]);
+		$this->albums_tests->delete([$albumID3]);
+		$this->albums_tests->delete([$albumTagID1]);
 
 		/*
 		 * Because we deleted the album, we should not see it anymore.
 		 */
-		$albums_tests->dont_see_in_albums($albumID);
+		$this->albums_tests->dont_see_in_albums($albumID1);
+		$this->albums_tests->dont_see_in_albums($albumID3);
+		$this->albums_tests->dont_see_in_albums($albumTagID1);
 
-		$session_tests->logout();
+		AccessControl::logout();
 	}
 
 	public function testTrueNegative(): void
 	{
-		$albums_tests = new AlbumsUnitTest($this);
-		$session_tests = new SessionUnitTest($this);
-
 		AccessControl::log_as_id(0);
 
-		$albums_tests->set_description('-1', 'new description', 422);
-		$albums_tests->set_description('abcdefghijklmnopqrstuvwx', 'new description', 404);
-		$albums_tests->set_protection_policy('-1', true, true, false, false, true, true, 422);
-		$albums_tests->set_protection_policy('abcdefghijklmnopqrstuvwx', true, true, false, false, true, true, 404);
+		$this->albums_tests->set_description('-1', 'new description', 422);
+		$this->albums_tests->set_description('abcdefghijklmnopqrstuvwx', 'new description', 404);
+		$this->albums_tests->set_protection_policy('-1', true, true, false, false, true, true, 422);
+		$this->albums_tests->set_protection_policy('abcdefghijklmnopqrstuvwx', true, true, false, false, true, true, 404);
 
-		$session_tests->logout();
+		AccessControl::logout();
 	}
 }

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -13,6 +13,7 @@
 namespace Tests\Feature;
 
 use App\Facades\AccessControl;
+use Illuminate\Support\Facades\DB;
 use Tests\Feature\Lib\AlbumsUnitTest;
 use Tests\TestCase;
 
@@ -133,6 +134,147 @@ class AlbumTest extends TestCase
 		$this->albums_tests->dont_see_in_albums($albumID1);
 		$this->albums_tests->dont_see_in_albums($albumID3);
 		$this->albums_tests->dont_see_in_albums($albumTagID1);
+
+		AccessControl::logout();
+	}
+
+	/**
+	 * Tests that the nested-set model remains consistent for a multi-delete of a forest.
+	 *
+	 * This tests considers the following album layout (the `_lft`, `_rgt`
+	 * indices of the nested set model are illustrated):
+	 *
+	 *                             (root)
+	 *                               |
+	 *                            Album 1
+	 *                            ( 1,14)
+	 *                               |
+	 *            +------------------+------------------+
+	 *            |                  |                  |
+	 *      Sub-Album 1.1      Sub-Album 1.2      Sub-Album 1.3
+	 *          (2,5)              (6,9)             (10,13)
+	 *            |                  |                  |
+	 *     Sub-Album 1.1.1    Sub-Album 1.2.1    Sub-Album 1.3.1
+	 *          (3,4)              (7,8)             (11,12)
+	 *
+	 * We then do a _simultaneous_ multi-delete for album 1.1 and 1.3
+	 * and expect the nested-set model to be updated like
+	 *
+	 *                             (root)
+	 *                               |
+	 *                            Album 1
+	 *                             (1,6)
+	 *                               |
+	 *                         Sub-Album 1.2
+	 *                             (2,5)
+	 *                               |
+	 *                        Sub-Album 1.2.1
+	 *                             (3,4)
+	 *
+	 * @return void
+	 */
+	public function testMultiDelete(): void
+	{
+		// In order check the (_lft,_rgt)-indices we need deterministic
+		// indices.
+		// Hence, we must ensure that there are no left-overs from previous
+		// tests.
+		static::assertDatabaseCount('base_albums', 0);
+
+		AccessControl::log_as_id(0);
+
+		// Create the test layout
+		$albumID1 = $this->albums_tests->add(null, 'Album 1')->offsetGet('id');
+		$albumID11 = $this->albums_tests->add($albumID1, 'Album 1.1')->offsetGet('id');
+		$albumID12 = $this->albums_tests->add($albumID1, 'Album 1.2')->offsetGet('id');
+		$albumID13 = $this->albums_tests->add($albumID1, 'Album 1.3')->offsetGet('id');
+		$albumID111 = $this->albums_tests->add($albumID11, 'Album 1.1.1')->offsetGet('id');
+		$albumID121 = $this->albums_tests->add($albumID12, 'Album 1.2.1')->offsetGet('id');
+		$albumID131 = $this->albums_tests->add($albumID13, 'Album 1.3.1')->offsetGet('id');
+
+		// Low-level tests on the DB layer to check of nested-set IDs are as expected
+		$albumStat = DB::table('albums')
+			->get(['id', 'parent_id', '_lft', '_rgt'])
+			->map(fn ($row) => get_object_vars($row))
+			->keyBy('id')
+			->toArray();
+		static::assertEquals([
+			$albumID1 => [
+				'id' => $albumID1,
+				'parent_id' => null,
+				'_lft' => 1,
+				'_rgt' => 14,
+			],
+			$albumID11 => [
+				'id' => $albumID11,
+				'parent_id' => $albumID1,
+				'_lft' => 2,
+				'_rgt' => 5,
+			],
+			$albumID12 => [
+				'id' => $albumID12,
+				'parent_id' => $albumID1,
+				'_lft' => 6,
+				'_rgt' => 9,
+			],
+			$albumID13 => [
+				'id' => $albumID13,
+				'parent_id' => $albumID1,
+				'_lft' => 10,
+				'_rgt' => 13,
+			],
+			$albumID111 => [
+				'id' => $albumID111,
+				'parent_id' => $albumID11,
+				'_lft' => 3,
+				'_rgt' => 4,
+			],
+			$albumID121 => [
+				'id' => $albumID121,
+				'parent_id' => $albumID12,
+				'_lft' => 7,
+				'_rgt' => 8,
+			],
+			$albumID131 => [
+				'id' => $albumID131,
+				'parent_id' => $albumID13,
+				'_lft' => 11,
+				'_rgt' => 12,
+			],
+		], $albumStat);
+
+		// Now let's do the multi-delete of a sub-forest
+		$this->albums_tests->delete([$albumID11, $albumID13]);
+
+		// Re-check on the lowest level
+		$albumStat = DB::table('albums')
+			->get(['id', 'parent_id', '_lft', '_rgt'])
+			->map(fn ($row) => get_object_vars($row))
+			->keyBy('id')
+			->toArray();
+		static::assertEquals([
+			$albumID1 => [
+				'id' => $albumID1,
+				'parent_id' => null,
+				'_lft' => 1,
+				'_rgt' => 6,
+			],
+			$albumID12 => [
+				'id' => $albumID12,
+				'parent_id' => $albumID1,
+				'_lft' => 2,
+				'_rgt' => 5,
+			],
+			$albumID121 => [
+				'id' => $albumID121,
+				'parent_id' => $albumID12,
+				'_lft' => 3,
+				'_rgt' => 4,
+			],
+		], $albumStat);
+
+		// Clean-up the remaining albums
+		$this->albums_tests->delete([$albumID1]);
 
 		AccessControl::logout();
 	}


### PR DESCRIPTION
Fixes a wrong update of the `_lft`, `_rgt` indices if multiple albums are deleted within the same request. The PR also includes a new test `testMultiDelete` which triggers the bug.