### PR TITLE
Fix missing photos var and add photo title

### DIFF
--- a/app/Console/Commands/PhotosAddedNotification.php
+++ b/app/Console/Commands/PhotosAddedNotification.php
@@ -69,7 +69,6 @@ class PhotosAddedNotification extends Command
 					}
 
 					$thumbUrl = $photo->size_variants->getThumb()?->url;
-					logger($thumbUrl);
 
 					// If the url config doesn't contain a trailing slash then add it
 					if (str_ends_with(config('app.url'), '/')) {

--- a/app/Console/Commands/PhotosAddedNotification.php
+++ b/app/Console/Commands/PhotosAddedNotification.php
@@ -79,6 +79,7 @@ class PhotosAddedNotification extends Command
 					}
 
 					$photos[$photo->album_id]['photos'][$photo->id] = [
+						'title' => $photo->title,
 						'thumb' => $thumbUrl,
 						// TODO: Clean this up. There should be a better way to get the URL of a photo than constructing it manually
 						'link' => config('app.url') . $trailing_slash . 'r/' . $photo->album_id . '/' . $photo->id,

--- a/app/Mail/PhotosAdded.php
+++ b/app/Mail/PhotosAdded.php
@@ -35,6 +35,7 @@ class PhotosAdded extends Mailable
 	{
 		return $this->markdown('emails.photos-added', [
 			'title' => $this->title,
+			'photos' => $this->photos,
 		]);
 	}
 }

--- a/resources/views/emails/photos-added.blade.php
+++ b/resources/views/emails/photos-added.blade.php
@@ -17,7 +17,7 @@
 
 @foreach($album['photos'] as $key => $photo)
 <div class="" style="display:inline-block;margin-right: 3px; margin-bottom: 3px;">
-    <a href="{{ $photo['link'] }}"><img src="{{ asset($photo['thumb']) }}" alt="{{ $photo['title'] }}" style="max-width: 60px;" /></a>
+    <a href="{{ $photo['link'] }}"><img src="{{ $photo['thumb'] }}" alt="{{ $photo['title'] }}" style="max-width: 60px;" /></a>
 </div>
 @endforeach
 

--- a/resources/views/emails/photos-added.blade.php
+++ b/resources/views/emails/photos-added.blade.php
@@ -17,7 +17,7 @@
 
 @foreach($album['photos'] as $key => $photo)
 <div class="" style="display:inline-block;margin-right: 3px; margin-bottom: 3px;">
-    <a href="{{ $photo['link'] }}"><img src="{{ asset($photo['thumb']) }}" alt="" style="max-width: 60px;" /></a>
+    <a href="{{ $photo['link'] }}"><img src="{{ asset($photo['thumb']) }}" alt="{{ $photo['title'] }}" style="max-width: 60px;" /></a>
 </div>
 @endforeach
 

--- a/resources/views/view.blade.php
+++ b/resources/views/view.blade.php
@@ -5,8 +5,8 @@
     <link type="text/css" rel="stylesheet" href="{{ Helpers::cacheBusting('dist/main.css') }}">
 
     <link rel="shortcut icon" href="favicon.ico">
-    <link rel="apple-touch-icon" href="Lychee-front/images/apple-touch-icon-iphone.png" sizes="120x120">
-    <link rel="apple-touch-icon" href="Lychee-front/images/apple-touch-icon-ipad.png" sizes="152x152">
+    <link rel="apple-touch-icon" href="img/apple-touch-icon-iphone.png" sizes="120x120">
+    <link rel="apple-touch-icon" href="img/apple-touch-icon-ipad.png" sizes="152x152">
 @endsection
 
 @section('head-meta')


### PR DESCRIPTION
Just add the variable `photos` to fix https://github.com/LycheeOrg/Lychee/issues/1354. Also adds a var `title` with the photo's title set a alt text for the image.