### PR TITLE
Synchronize/update the list of PHP extensions

### DIFF
--- a/app/Actions/Diagnostics/Checks/PHPVersionCheck.php
+++ b/app/Actions/Diagnostics/Checks/PHPVersionCheck.php
@@ -44,7 +44,26 @@ class PHPVersionCheck implements DiagnosticCheckInterface
 		}
 
 		// Extensions
-		$extensions = ['session', 'exif', 'mbstring', 'gd', 'PDO', 'json', 'zip'];
+		$extensions = [
+			'bcmath', // Required by Laravel
+			'ctype', // Required by Laravel
+			'dom', // Required by dependencies
+			'exif',
+			'fileinfo', // Required by Laravel
+			'filter', // Required by dependencies
+			'gd',
+			'json', // Required by Laravel
+			'libxml', // Required by dependencies
+			'mbstring', // Required by Laravel
+			'openssl', // Required by Laravel
+			'pcre', // Required by dependencies
+			'PDO', // Required by Laravel
+			'Phar', // Required by dependencies
+			'SimpleXML', // Required by dependencies
+			'tokenizer', // Required by Laravel
+			'xml', // Required by Laravel
+			'xmlwriter', // Required by dependencies
+		];
 
 		foreach ($extensions as $extension) {
 			if (!extension_loaded($extension)) {

--- a/app/Actions/Install/DefaultConfig.php
+++ b/app/Actions/Install/DefaultConfig.php
@@ -22,13 +22,24 @@ class DefaultConfig
 
 		'requirements' => [
 			'php' => [
-				'openssl',
-				'pdo',
-				'mbstring',
-				'tokenizer',
-				'JSON',
+				'bcmath', // Required by Laravel
+				'ctype', // Required by Laravel
+				'dom', // Required by dependencies
 				'exif',
+				'fileinfo', // Required by Laravel
+				'filter', // Required by dependencies
 				'gd',
+				'json', // Required by Laravel
+				'libxml', // Required by dependencies
+				'mbstring', // Required by Laravel
+				'openssl', // Required by Laravel
+				'pcre', // Required by dependencies
+				'PDO', // Required by Laravel
+				'Phar', // Required by dependencies
+				'SimpleXML', // Required by dependencies
+				'tokenizer', // Required by Laravel
+				'xml', // Required by Laravel
+				'xmlwriter', // Required by dependencies
 			],
 			'apache' => ['mod_rewrite'],
 		],

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "ext-pdo": "*",
         "ext-tokenizer": "*",
         "ext-xml": "*",
-        "ext-zip": "*",
         "bepsvpt/secure-headers": "^7.1",
         "darkghosthunter/larapass": "dev-LycheeSpecial",
         "doctrine/dbal": "^3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48235c98ce615f01ac9f50a4a36ff832",
+    "content-hash": "6b63e514ff9e6ac9b457b66f361261df",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -11974,11 +11974,10 @@
         "ext-openssl": "*",
         "ext-pdo": "*",
         "ext-tokenizer": "*",
-        "ext-xml": "*",
-        "ext-zip": "*"
+        "ext-xml": "*"
     },
     "platform-dev": {
         "ext-imagick": "*"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
I went through the `composer.lock` and I actually extracted the list of PHP extensions that are required, plus what Laravel claims to need at https://laravel.com/docs/8.x/deployment#server-requirements.

Overall, the list in `composer.json` was close (other than the not actually required ZIP). The lists in the installer and the Diagnostics page were a lot further from complete, and I also added the requirements of our various dependencies (which don't need to be listed in `composer.json` since composer obviously takes care of them automatically). I duplicated those lists across two source files which is admittedly ugly but I know that @nagmat84 intends to rewrite the installer so I saw no point in refactoring this code at this point.

There will be a separate PR to our online docs, which contain yet another list...