### PR TITLE
Restore code to fix image dimensions post-rotation

### DIFF
--- a/app/Actions/Photo/Strategies/AddStandaloneStrategy.php
+++ b/app/Actions/Photo/Strategies/AddStandaloneStrategy.php
@@ -193,11 +193,13 @@ class AddStandaloneStrategy extends AddBaseStrategy
 		$absolutePath = $this->sourceFile->getAbsolutePath();
 		// If we are importing via symlink, we don't actually overwrite
 		// the source, but we still need to fix the dimensions.
-		$this->imageHandler->autoRotate(
+		$rotation = $this->imageHandler->autoRotate(
 			$absolutePath,
 			$orientation,
 			$this->parameters->importMode->shallImportViaSymlink()
 		);
+		$this->parameters->exifInfo->width = $rotation['width'];
+		$this->parameters->exifInfo->height = $rotation['height'];
 
 		// stat info (filesize, access mode, etc.) are cached by PHP to avoid
 		// costly I/O calls.


### PR DESCRIPTION
Fixes #1388

This used to work; see e.g. this code in our latest public release: https://github.com/LycheeOrg/Lychee/blob/5b51765c7c66e6542ff2a6dcd3fb57393ff16717/app/Actions/Photo/Strategies/StrategyPhoto.php#L81-L85

But, during one of the many refactorings since, the code updating the metadata simply vanished. I can't be bothered to track down the actual commit, and I'm sure the code will be completely revamped again in #1351, but meanwhile, here we are with a nasty regression.