### PR TITLE
Moved unit tests for root album into separate class

### DIFF
--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -15,16 +15,19 @@ namespace Tests\Feature;
 use App\Facades\AccessControl;
 use Illuminate\Support\Facades\DB;
 use Tests\Feature\Lib\AlbumsUnitTest;
+use Tests\Feature\Lib\RootAlbumUnitTest;
 use Tests\TestCase;
 
 class AlbumTest extends TestCase
 {
 	protected AlbumsUnitTest $albums_tests;
+	protected RootAlbumUnitTest $root_album_tests;
 
 	public function setUp(): void
 	{
 		parent::setUp();
 		$this->albums_tests = new AlbumsUnitTest($this);
+		$this->root_album_tests = new RootAlbumUnitTest($this);
 	}
 
 	/**
@@ -66,10 +69,10 @@ class AlbumTest extends TestCase
 			'show_tags' => ['test', 'cool_new_tag', 'second_new_tag'],
 		]);
 
-		$this->albums_tests->see_in_albums($albumID1);
-		$this->albums_tests->see_in_albums($albumID2);
-		$this->albums_tests->see_in_albums($albumID3);
-		$this->albums_tests->see_in_albums($albumTagID1);
+		$this->root_album_tests->get(200, $albumID1);
+		$this->root_album_tests->get(200, $albumID2);
+		$this->root_album_tests->get(200, $albumID3);
+		$this->root_album_tests->get(200, $albumTagID1);
 
 		$this->albums_tests->move([$albumTagID1], $albumID3, 404);
 		$this->albums_tests->move([$albumID3], $albumID2);
@@ -131,9 +134,9 @@ class AlbumTest extends TestCase
 		/*
 		 * Because we deleted the album, we should not see it anymore.
 		 */
-		$this->albums_tests->dont_see_in_albums($albumID1);
-		$this->albums_tests->dont_see_in_albums($albumID3);
-		$this->albums_tests->dont_see_in_albums($albumTagID1);
+		$this->root_album_tests->get(200, null, $albumID1);
+		$this->root_album_tests->get(200, null, $albumID3);
+		$this->root_album_tests->get(200, null, $albumTagID1);
 
 		AccessControl::logout();
 	}

--- a/tests/Feature/Lib/AlbumsUnitTest.php
+++ b/tests/Feature/Lib/AlbumsUnitTest.php
@@ -153,34 +153,6 @@ class AlbumsUnitTest
 	}
 
 	/**
-	 * Check if we see `id` in the list of all visible albums.
-	 *
-	 * Result varies depending on login state.
-	 *
-	 * @param string $id
-	 */
-	public function see_in_albums(string $id): void
-	{
-		$response = $this->testCase->postJson('/api/Albums::get');
-		$response->assertOk();
-		$response->assertSee($id, false);
-	}
-
-	/**
-	 * Check if we don't see id in the list of all visible albums.
-	 *
-	 * Result varies depending on login state!
-	 *
-	 * @param string $id
-	 */
-	public function dont_see_in_albums(string $id): void
-	{
-		$response = $this->testCase->postJson('/api/Albums::get');
-		$response->assertOk();
-		$response->assertDontSee($id, false);
-	}
-
-	/**
 	 * Change title.
 	 *
 	 * @param string      $id

--- a/tests/Feature/Lib/RootAlbumUnitTest.php
+++ b/tests/Feature/Lib/RootAlbumUnitTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature\Lib;
+
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+class RootAlbumUnitTest
+{
+	private TestCase $testCase;
+
+	public function __construct(TestCase $testCase)
+	{
+		$this->testCase = $testCase;
+	}
+
+	/**
+	 * Gets the root album.
+	 *
+	 * @param int         $expectedStatusCode
+	 * @param string|null $assertSee
+	 * @param string|null $assertDontSee
+	 *
+	 * @return TestResponse
+	 */
+	public function get(
+		int $expectedStatusCode = 200,
+		?string $assertSee = null,
+		?string $assertDontSee = null
+	): TestResponse {
+		$response = $this->testCase->postJson('/api/Albums::get');
+		$response->assertStatus($expectedStatusCode);
+		if ($assertSee) {
+			$response->assertSee($assertSee, false);
+		}
+		if ($assertDontSee) {
+			$response->assertDontSee($assertDontSee, false);
+		}
+
+		return $response;
+	}
+}


### PR DESCRIPTION
While working on https://github.com/LycheeOrg/Lychee/pull/1414 I noticed that we do not have a test class which collects all API calls to the root album in the same way as we have for albums and photos. So far we only have had a method to call `Albums::get` as part of the (normal) albums test, but it also has been quite different in style from the typical methods we have. As I am going to need more API calls to the root album in https://github.com/LycheeOrg/Lychee/pull/1414, I first want to remedy this situation.