### PR TITLE
Fix album unit tests

### DIFF
--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -290,8 +290,8 @@ class AlbumTest extends TestCase
 
 		$this->albums_tests->set_description('-1', 'new description', 422);
 		$this->albums_tests->set_description('abcdefghijklmnopqrstuvwx', 'new description', 404);
-		$this->albums_tests->set_protection_policy('-1', true, true, false, false, true, true, 422);
-		$this->albums_tests->set_protection_policy('abcdefghijklmnopqrstuvwx', true, true, false, false, true, true, 404);
+		$this->albums_tests->set_protection_policy('-1', true, true, false, false, true, true, null, 422);
+		$this->albums_tests->set_protection_policy('abcdefghijklmnopqrstuvwx', true, true, false, false, true, true, null, 404);
 
 		AccessControl::logout();
 	}

--- a/tests/Feature/Lib/AlbumsUnitTest.php
+++ b/tests/Feature/Lib/AlbumsUnitTest.php
@@ -259,6 +259,12 @@ class AlbumsUnitTest
 	 * @param bool        $nsfw
 	 * @param bool        $downloadable
 	 * @param bool        $share_button_visible
+	 * @param string|null $password             `null` does not change password
+	 *                                          settings;
+	 *                                          the empty string `''` removes
+	 *                                          a (potentially set) password;
+	 *                                          a non-empty string sets the
+	 *                                          password accordingly
 	 * @param int         $expectedStatusCode
 	 * @param string|null $assertSee
 	 */
@@ -270,10 +276,11 @@ class AlbumsUnitTest
 		bool $nsfw = false,
 		bool $downloadable = true,
 		bool $share_button_visible = true,
+		?string $password = null,
 		int $expectedStatusCode = 204,
 		?string $assertSee = null
 	): void {
-		$response = $this->testCase->postJson('/api/Album::setProtectionPolicy', [
+		$params = [
 			'grants_full_photo' => $full_photo,
 			'albumID' => $id,
 			'is_public' => $public,
@@ -281,7 +288,13 @@ class AlbumsUnitTest
 			'is_nsfw' => $nsfw,
 			'is_downloadable' => $downloadable,
 			'is_share_button_visible' => $share_button_visible,
-		]);
+		];
+
+		if ($password !== null) {
+			$params['password'] = $password;
+		}
+
+		$response = $this->testCase->postJson('/api/Album::setProtectionPolicy', $params);
 		$response->assertStatus($expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);

--- a/tests/Feature/Lib/AlbumsUnitTest.php
+++ b/tests/Feature/Lib/AlbumsUnitTest.php
@@ -139,7 +139,7 @@ class AlbumsUnitTest
 	public function unlock(
 		string $id,
 		string $password = '',
-		int $expectedStatusCode = 200,
+		int $expectedStatusCode = 204,
 		?string $assertSee = null
 	): void {
 		$response = $this->testCase->postJson(

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,6 +20,7 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Testing\TestResponse;
+use function Safe\json_decode;
 use function Safe\tempnam;
 
 abstract class TestCase extends BaseTestCase


### PR DESCRIPTION
This is another PR with cherry-picking from https://github.com/LycheeOrg/Lychee/pull/1414 in order to keep https://github.com/LycheeOrg/Lychee/pull/1414 lean. While working on https://github.com/LycheeOrg/Lychee/pull/1414 I discovered three unrelated issues:

- Wrong expected default return value (200 instead of 204) for `Album::unlock`. All our currently existing tests specify an explicit error code (401 or 403), hence this bug was never spotted.
- Missing `use \Safe\json_encode`
- `Album::setProtectionPoilcy` did not support setting a password