### PR TITLE
Ensure consistent sorting of albums in list of shares

### DIFF
--- a/app/Actions/Sharing/ListShare.php
+++ b/app/Actions/Sharing/ListShare.php
@@ -33,7 +33,8 @@ class ListShare
 
 			$albums_query = DB::table('base_albums')
 				->leftJoin('albums', 'albums.id', '=', 'base_albums.id')
-				->select(['base_albums.id', 'title', 'parent_id']);
+				->select(['base_albums.id', 'title', 'parent_id'])
+				->orderBy('title', 'ASC');
 
 			// apply filter
 			if ($userId !== 0) {


### PR DESCRIPTION
And another pick of cherries from #1414. This PR ensures that the list of available albums (i.e. those albums which aren't shared yet) in the list of shares is consistent and deterministic.