### PR TITLE
Security fix: Unsorted photos

### DIFF
--- a/app/Actions/PhotoAuthorisationProvider.php
+++ b/app/Actions/PhotoAuthorisationProvider.php
@@ -82,11 +82,18 @@ class PhotoAuthorisationProvider
 	 */
 	public function isVisible(?Photo $photo): bool
 	{
+		// We must explicitly check that the photo is not unsorted before
+		// checking whether the parent album is accessible, because the root
+		// album always is accessible and gets a pass.
+		// However, we do not want every unsorted photo to be publicly
+		// visible.
 		return
 			$photo === null ||
 			AccessControl::is_current_user_or_admin($photo->owner_id) ||
-			$photo->is_public ||
-			$this->albumAuthorisationProvider->isAccessible($photo->album);
+			$photo->is_public || (
+				$photo->album !== null &&
+				$this->albumAuthorisationProvider->isAccessible($photo->album)
+			);
 	}
 
 	/**


### PR DESCRIPTION
Another finding of #1414. :warning: **This is a severe one and security related.** :warning:

Currently any unsorted photo can be fetched by direct link even if it is not public.

Luckily, the photo does not show up in the smart albums, because the photo is not searchable unless someone activates the option `public_search`. The problem is that all unsorted photos are considered to be public. Oh, oh, ...

@ildyria This fix must also be applied to your Gate for `PhotoPolicy::visible`.