### PR TITLE
Added options for ZIP compression

### DIFF
--- a/app/Actions/Album/Archive.php
+++ b/app/Actions/Album/Archive.php
@@ -44,6 +44,9 @@ class Archive extends Action
 		$responseGenerator = function () use ($albums) {
 			$options = new \ZipStream\Option\Archive();
 			$options->setEnableZip64(Configs::getValueAsBool('zip64'));
+			$options->setLargeFileSize(Configs::getValueAsInt('zip_large_file_size'));
+			$options->setDeflateLevel(Configs::getValueAsInt('zip_deflate_level'));
+			$options->setZeroHeader(true);
 			$zip = new ZipStream(null, $options);
 
 			$usedDirNames = [];

--- a/app/Actions/Album/Archive.php
+++ b/app/Actions/Album/Archive.php
@@ -210,7 +210,9 @@ class Archive extends Action
 				$zipFileOption->setMethod($this->deflateLevel === -1 ? ZipMethod::STORE() : ZipMethod::DEFLATE());
 				$zipFileOption->setDeflateLevel($this->deflateLevel);
 				$zipFileOption->setComment($photo->title);
-				$zipFileOption->setTime($photo->taken_at);
+				if ($photo->taken_at !== null) {
+					$zipFileOption->setTime($photo->taken_at);
+				}
 				$zip->addFileFromStream($fileName, $file->read(), $zipFileOption);
 				$file->close();
 			} catch (\Throwable $e) {

--- a/app/Actions/Photo/Archive.php
+++ b/app/Actions/Photo/Archive.php
@@ -175,6 +175,9 @@ class Archive
 		$responseGenerator = function () use ($variant, $photos) {
 			$options = new \ZipStream\Option\Archive();
 			$options->setEnableZip64(Configs::getValueAsBool('zip64'));
+			$options->setLargeFileSize(Configs::getValueAsInt('zip_large_file_size'));
+			$options->setDeflateLevel(Configs::getValueAsInt('zip_deflate_level'));
+			$options->setZeroHeader(true);
 			$zip = new ZipStream(null, $options);
 
 			// We first need to scan the whole array of files to avoid

--- a/database/migrations/2022_08_03_184746_add_zip_options.php
+++ b/database/migrations/2022_08_03_184746_add_zip_options.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class AddZipOptions extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up(): void
+	{
+		DB::table('configs')->insert([
+			[
+				'key' => 'zip_large_file_size',
+				'value' => '30000000',
+				'confidentiality' => 0,
+				'cat' => 'config',
+				'type_range' => 'int',
+				'description' => 'Threshold in bytes above which files are not compressed but simply stored',
+			], [
+				'key' => 'zip_deflate_level',
+				'value' => '6',
+				'confidentiality' => 0,
+				'cat' => 'config',
+				'type_range' => '-1|0|1|2|3|4|5|6|7|8|9',
+				'description' => 'DEFLATE compression level: -1 = disable compression, 0 = no compression, 1 = minimal compression, ... 9 = maximum compression',
+			],
+		]);
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 * @throws InvalidArgumentException
+	 */
+	public function down(): void
+	{
+		DB::table('configs')
+			->whereIn('key', ['zip_large_file_size', 'zip_deflate_level'])
+			->delete();
+	}
+}

--- a/database/migrations/2022_08_03_184746_add_zip_options.php
+++ b/database/migrations/2022_08_03_184746_add_zip_options.php
@@ -14,19 +14,12 @@ class AddZipOptions extends Migration
 	{
 		DB::table('configs')->insert([
 			[
-				'key' => 'zip_large_file_size',
-				'value' => '30000000',
-				'confidentiality' => 0,
-				'cat' => 'config',
-				'type_range' => 'int',
-				'description' => 'Threshold in bytes above which files are not compressed but simply stored',
-			], [
 				'key' => 'zip_deflate_level',
 				'value' => '6',
 				'confidentiality' => 0,
 				'cat' => 'config',
 				'type_range' => '-1|0|1|2|3|4|5|6|7|8|9',
-				'description' => 'DEFLATE compression level: -1 = disable compression, 0 = no compression, 1 = minimal compression, ... 9 = maximum compression',
+				'description' => 'DEFLATE compression level: -1 = disable compression (use STORE method), 0 = no compression (use DEFLATE method), 1 = minimal compression (fast), ... 9 = maximum compression (slow)',
 			],
 		]);
 	}
@@ -41,7 +34,7 @@ class AddZipOptions extends Migration
 	public function down(): void
 	{
 		DB::table('configs')
-			->whereIn('key', ['zip_large_file_size', 'zip_deflate_level'])
+			->whereIn('key', ['zip_deflate_level'])
 			->delete();
 	}
 }

--- a/database/migrations/2022_08_03_184746_add_zip_options.php
+++ b/database/migrations/2022_08_03_184746_add_zip_options.php
@@ -35,6 +35,7 @@ class AddZipOptions extends Migration
 	 * Reverse the migrations.
 	 *
 	 * @return void
+	 *
 	 * @throws InvalidArgumentException
 	 */
 	public function down(): void

--- a/database/migrations/2022_08_03_184746_add_zip_options.php
+++ b/database/migrations/2022_08_03_184746_add_zip_options.php
@@ -34,7 +34,7 @@ class AddZipOptions extends Migration
 	public function down(): void
 	{
 		DB::table('configs')
-			->whereIn('key', ['zip_deflate_level'])
+			->where('key', '=', 'zip_deflate_level')
 			->delete();
 	}
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -53,3 +53,6 @@ parameters:
 
 		# False positive as stub code for PHP has not yet been updated to 2nd parameter, see https://github.com/php/doc-en/issues/1529 and https://www.php.net/imagick.writeimagefile
 		- '#Method Imagick::writeImageFile\(\) invoked with 2 parameters, 1 required#'
+
+		# False positive from maennchen/ZipStream
+		- '#Call to an undefined static method ZipStream\\Option\\Method::(STORE|DEFLATE)\(\)#'


### PR DESCRIPTION
Adds option to control compression of ZIP downloads.

And before anybody asks what the difference is between -1 = disable compression and 0 = no compression. I have no clue :grinning:  i only took it over from the docs.