### PR TITLE
Make VideoHandler support optional

### DIFF
--- a/app/Actions/Photo/Strategies/AddStandaloneStrategy.php
+++ b/app/Actions/Photo/Strategies/AddStandaloneStrategy.php
@@ -94,10 +94,16 @@ class AddStandaloneStrategy extends AddBaseStrategy
 				$this->sourceImage = new ImageHandler();
 				$this->sourceImage->load($this->sourceFile);
 			} elseif ($this->photo->isVideo()) {
-				$videoHandler = new VideoHandler();
-				$videoHandler->load($this->sourceFile);
-				$position = is_numeric($this->photo->aperture) ? floatval($this->photo->aperture) / 2 : 0.0;
-				$this->sourceImage = $videoHandler->extractFrame($position);
+				// We try to extract a video frame using FFmpeg; however,
+				// that one's optional, so we need to be able to recover.
+				try {
+					$videoHandler = new VideoHandler();
+					$videoHandler->load($this->sourceFile);
+					$position = is_numeric($this->photo->aperture) ? floatval($this->photo->aperture) / 2 : 0.0;
+					$this->sourceImage = $videoHandler->extractFrame($position);
+				} catch (\Throwable) {
+					$this->sourceImage = null;
+				}
 			} else {
 				// If we have a raw file, we try to treat it as an image, as
 				// Imagick supports a lot of other image-like file types

--- a/tests/Feature/PhotosAddHandlerTestAbstract.php
+++ b/tests/Feature/PhotosAddHandlerTestAbstract.php
@@ -344,4 +344,37 @@ abstract class PhotosAddHandlerTestAbstract extends PhotoTestBase
 			],
 		]);
 	}
+
+	/**
+	 * Tests video upload with ffmpeg or exiftool.
+	 *
+	 * @return void
+	 */
+	public function testVideoUploadWithoutFFmpeg(): void
+	{
+		$hasExifTool = Configs::getValueAsInt(self::CONFIG_HAS_EXIF_TOOL);
+		Configs::set(self::CONFIG_HAS_EXIF_TOOL, 0);
+
+		$hasFFMpeg = Configs::getValueAsInt(TestCase::CONFIG_HAS_FFMPEG);
+		Configs::set(TestCase::CONFIG_HAS_FFMPEG, 0);
+
+		$response = $this->photos_tests->upload(
+			TestCase::createUploadedFile(TestCase::SAMPLE_FILE_GAMING_VIDEO)
+		);
+		$response->assertJson([
+			'album_id' => null,
+			'title' => 'gaming',
+			'type' => TestCase::MIME_TYPE_VID_MP4,
+			'size_variants' => [
+				'original' => [
+					'width' => 0,
+					'height' => 0,
+					'filesize' => 66781184,
+				],
+			],
+		]);
+
+		Configs::set(self::CONFIG_HAS_FFMPEG, $hasFFMpeg);
+		Configs::set(self::CONFIG_HAS_EXIF_TOOL, $hasExifTool);
+	}
 }

--- a/tests/Feature/PhotosAddHandlerTestAbstract.php
+++ b/tests/Feature/PhotosAddHandlerTestAbstract.php
@@ -12,6 +12,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Configs;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Tests\Feature\Base\PhotoTestBase;

--- a/tests/Feature/PhotosAddHandlerTestAbstract.php
+++ b/tests/Feature/PhotosAddHandlerTestAbstract.php
@@ -359,6 +359,8 @@ abstract class PhotosAddHandlerTestAbstract extends PhotoTestBase
 		$hasFFMpeg = Configs::getValueAsInt(TestCase::CONFIG_HAS_FFMPEG);
 		Configs::set(TestCase::CONFIG_HAS_FFMPEG, 0);
 
+		DB::table('logs')->delete();
+
 		$response = $this->photos_tests->upload(
 			TestCase::createUploadedFile(TestCase::SAMPLE_FILE_GAMING_VIDEO)
 		);
@@ -380,6 +382,18 @@ abstract class PhotosAddHandlerTestAbstract extends PhotoTestBase
 				'thumb' => null,
 			],
 		]);
+
+		// In the test suite we cannot really ensure that FFMpeg is not
+		// available, because the executable is still part of the test
+		// environment.
+		// Hence, we can only disable it (see above), but cannot be sure
+		// that it isn't called accidentally.
+		// As a second-best approach, we check at least for the existence
+		// of an error message in the log.
+		$logCount = DB::table('logs')
+			->where('text', 'like', '%FFmpeg%disabled%')
+			->count();
+		self::assertEquals(1, $logCount);
 
 		Configs::set(self::CONFIG_HAS_FFMPEG, $hasFFMpeg);
 		Configs::set(self::CONFIG_HAS_EXIF_TOOL, $hasExifTool);

--- a/tests/Feature/PhotosAddHandlerTestAbstract.php
+++ b/tests/Feature/PhotosAddHandlerTestAbstract.php
@@ -372,6 +372,12 @@ abstract class PhotosAddHandlerTestAbstract extends PhotoTestBase
 					'height' => 0,
 					'filesize' => 66781184,
 				],
+				'medium2x' => null,
+				'medium' => null,
+				'small2x' => null,
+				'small' => null,
+				'thumb2x' => null,
+				'thumb' => null,
 			],
 		]);
 

--- a/tests/Feature/PhotosAddHandlerTestAbstract.php
+++ b/tests/Feature/PhotosAddHandlerTestAbstract.php
@@ -347,7 +347,7 @@ abstract class PhotosAddHandlerTestAbstract extends PhotoTestBase
 	}
 
 	/**
-	 * Tests video upload with ffmpeg or exiftool.
+	 * Tests video upload without ffmpeg or exiftool.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
Fixes #1438 

This is a semi-draft PR:
* I fixed only the case of uploading a regular video file but I see that `VideoHandler` is also used for Google Motion Pictures. I left the latter as-is as I don't understand how that part works and what (if anything) we can do about it.
* By catching the exception, we prevent a message about missing FFmpeg from being generated in the logs. It seems like it would be useful to have it there though under these circumstances, but I wasn't sure what the "approved" way of doing it is these days. @nagmat84?