### PR TITLE
Cleanup download tests

### DIFF
--- a/tests/Feature/Lib/AlbumsUnitTest.php
+++ b/tests/Feature/Lib/AlbumsUnitTest.php
@@ -13,6 +13,7 @@
 namespace Tests\Feature\Lib;
 
 use Illuminate\Testing\TestResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Tests\TestCase;
 
 class AlbumsUnitTest
@@ -345,6 +346,12 @@ class AlbumsUnitTest
 			]
 		);
 		$response->assertOk();
+		if ($response->baseResponse instanceof StreamedResponse) {
+			// The content of a streamed response is not generated unless
+			// the content is fetched.
+			// This ensures that the generator of SUT is actually executed.
+			$response->streamedContent();
+		}
 
 		return $response;
 	}

--- a/tests/Feature/Lib/AssertableZipArchive.php
+++ b/tests/Feature/Lib/AssertableZipArchive.php
@@ -65,7 +65,7 @@ class AssertableZipArchive extends \ZipArchive
 	}
 
 	/**
-	 * Asserts that the ZIP archive exactly contains the given files and no more.
+	 * Asserts that the ZIP archive contains exactly the given files and no more.
 	 *
 	 * @param array<string, array{size?: ?int}> $expectedFiles a list of expected file names together with optional file attributes
 	 *

--- a/tests/Feature/Lib/AssertableZipArchive.php
+++ b/tests/Feature/Lib/AssertableZipArchive.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature\Lib;
+
+use App\Image\InMemoryBuffer;
+use App\Image\TemporaryLocalFile;
+use Illuminate\Testing\Assert as PHPUnit;
+use Illuminate\Testing\TestResponse;
+use function Safe\fwrite;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class AssertableZipArchive extends \ZipArchive
+{
+	public const ZIP_STAT_SIZE = 'size';
+
+	/**
+	 * Creates an assertable ZIP archive from the given response.
+	 *
+	 * @param TestResponse $response
+	 *
+	 * @return static
+	 */
+	public static function createFromResponse(TestResponse $response): self
+	{
+		$memoryBlob = new InMemoryBuffer();
+		fwrite(
+			$memoryBlob->stream(),
+			$response->baseResponse instanceof StreamedResponse ? $response->streamedContent() : $response->content()
+		);
+		$tmpZipFile = new TemporaryLocalFile('.zip', 'archive');
+		$tmpZipFile->write($memoryBlob->read());
+		$memoryBlob->close();
+
+		$zipArchive = new self();
+		$zipArchive->open($tmpZipFile->getRealPath());
+
+		return $zipArchive;
+	}
+
+	/**
+	 * Asserts that the ZIP archive contains a file of the given name and size.
+	 *
+	 * @param string   $fileName         the name of the expected file
+	 * @param int|null $expectedFileSize (optional) the expected file size of the uncompressed file
+	 *
+	 * @return void
+	 */
+	public function assertContainsFile(string $fileName, ?int $expectedFileSize): void
+	{
+		$stat = $this->statName($fileName);
+		PHPUnit::assertNotFalse($stat, 'Could not assert that ZIP archive contains ' . $fileName);
+		if ($expectedFileSize !== null) {
+			PHPUnit::assertEquals($expectedFileSize, $stat[self::ZIP_STAT_SIZE]);
+		}
+	}
+
+	/**
+	 * Asserts that the ZIP archive exactly contains the given files and no more.
+	 *
+	 * @param array<string, array{size?: ?int}> $expectedFiles a list of expected file names together with optional file attributes
+	 *
+	 * @return void
+	 */
+	public function assertContainsFilesExactly(array $expectedFiles): void
+	{
+		PHPUnit::assertCount(count($expectedFiles), $this);
+		foreach ($expectedFiles as $fileName => $fileStat) {
+			$this->assertContainsFile(
+				$fileName,
+				key_exists(self::ZIP_STAT_SIZE, $fileStat) ? $fileStat[self::ZIP_STAT_SIZE] : null
+			);
+		}
+	}
+}

--- a/tests/Feature/Lib/PhotosUnitTest.php
+++ b/tests/Feature/Lib/PhotosUnitTest.php
@@ -15,6 +15,7 @@ namespace Tests\Feature\Lib;
 use App\Actions\Photo\Archive;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Testing\TestResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Tests\TestCase;
 
 class PhotosUnitTest
@@ -349,6 +350,12 @@ class PhotosUnitTest
 			]
 		);
 		$response->assertOk();
+		if ($response->baseResponse instanceof StreamedResponse) {
+			// The content of a streamed response is not generated unless
+			// the content is fetched.
+			// This ensures that the generator of SUT is actually executed.
+			$response->streamedContent();
+		}
 
 		return $response;
 	}


### PR DESCRIPTION
This is a follow-up to #1453. I already wanted to do that yesterday, but wanted to keep the re-factoring out of #1453.

 1. It moves all download tests from the general `PhotosOperationsTest` to the new and specialized test class `PhotosDownloadTest` in order to keep them together.
 2. We test different ZIP archives in several tests. I moved the boiler-plate code to handle ZIP archives and make assertions about them into a new class `AssertableZIPArchive`