### PR TITLE
Fix user test

### DIFF
--- a/tests/Feature/UsersTest.php
+++ b/tests/Feature/UsersTest.php
@@ -28,7 +28,7 @@ class UsersTest extends TestCase
 {
 	use InteractWithSmartAlbums;
 
-	public function testSetAminLoginIfAdminUnconfigured(): void
+	public function testSetAdminLoginIfAdminUnconfigured(): void
 	{
 		/**
 		 * because there is no dependency injection in test cases.

--- a/tests/Feature/UsersTest.php
+++ b/tests/Feature/UsersTest.php
@@ -28,49 +28,30 @@ class UsersTest extends TestCase
 {
 	use InteractWithSmartAlbums;
 
-	public function testSetLogin(): void
+	public function testSetAminLoginIfAdminUnconfigured(): void
 	{
 		/**
 		 * because there is no dependency injection in test cases.
 		 */
 		$sessions_test = new SessionUnitTest($this);
 
-		$clear = false;
-		$configs = Configs::get();
-
-		/*
-		 * Check if password and username are set
-		 */
-		if ($configs['password'] === '' && $configs['username'] === '') {
-			$clear = true;
-
-			$sessions_test->set_admin('lychee', 'password');
-			$sessions_test->logout();
-
-			$sessions_test->set_admin('lychee', 'password', 403, 'Admin user is already registered');
-
-			$sessions_test->login('lychee', 'password');
-			$sessions_test->logout();
-		} else {
-			static::markTestSkipped('Username and Password are set. We do not bother testing further.');
+		if (!AdminAuthentication::isAdminNotRegistered()) {
+			static::markTestSkipped('Admin user is registered; test skipped.');
 		}
 
-		/*
-		 * We check that there are username and password set in the database
-		 */
+		static::assertTrue(AdminAuthentication::loginAsAdminIfNotRegistered());
+		$sessions_test->set_admin('lychee', 'password');
+		$sessions_test->logout();
 		static::assertFalse(AdminAuthentication::isAdminNotRegistered());
+
+		$sessions_test->set_admin('lychee', 'password', 403, 'Admin user is already registered');
+
+		$sessions_test->login('lychee', 'password');
+		$sessions_test->logout();
 
 		$sessions_test->login('foo', 'bar', 401);
 		$sessions_test->login('lychee', 'bar', 401);
 		$sessions_test->login('foo', 'password', 401);
-
-		/*
-		 * If we did set login and password we clear them
-		 */
-		if ($clear) {
-			Configs::set('username', '');
-			Configs::set('password', '');
-		}
 	}
 
 	public function testUsers(): void


### PR DESCRIPTION
You might remember the sometimes failing test suite in the CI. As this problem just hit me locally, I guess I found the problem. This PR fixes it.

Currently, the test `UsersTest::testSetLogin` tried to set the admin login without ensuring that it has authenticated before. This sometimes works, if the test suite is till being authenticated as admin from a previous test, but it is not reliable, of course.

I also changed the pre-condition of the test to be more consistent and I renamed the test.