### PR TITLE
Fixes #1473

### DIFF
--- a/app/Actions/Import/Exec.php
+++ b/app/Actions/Import/Exec.php
@@ -128,10 +128,41 @@ class Exec
 			}
 
 			// Skip folders of Lychee
+			// Currently we must check for each directory which might be used
+			// by Lychee below `uploads/` individually, because the folder
+			// `uploads/import` is a potential source for imports and also
+			// placed below `uploads`.
+			// This is a design error and needs to be changed, at last when
+			// the media is stored remotely on a network storage such as
+			// AWS S3.
+			// A much better folder structure would be
+			//
+			// ```
+			//  |
+			//  +-- staging           // new directory which temporarily stores media which is not yet, but going to be added to Lychee
+			//  |     +-- imports     // replaces the current `uploads/import`
+			//  |     +-- uploads     // temporary storage location for images which have been uploaded via an HTTP POST request
+			//  |     +-- downloads   // temporary storage location for images which have been downloaded from a remote URL
+			//  +-- vault             // replaces the current `uploads/` and could be outsourced to a remote network storage
+			//        +-- original
+			//        +-- medium2x
+			//        +-- medium
+			//        +-- small2x
+			//        +-- small
+			//        +-- thumb2x
+			//        +-- thumb
+			// ```
+			//
+			// This way we could simply check if the path is anything below `vault`
 			if (
 				$realPath === Storage::path('big') ||
+				$realPath === Storage::path('raw') ||
+				$realPath === Storage::path('original') ||
+				$realPath === Storage::path('medium2x') ||
 				$realPath === Storage::path('medium') ||
+				$realPath === Storage::path('small2x') ||
 				$realPath === Storage::path('small') ||
+				$realPath === Storage::path('thumb2x') ||
 				$realPath === Storage::path('thumb')
 			) {
 				throw new ReservedDirectoryException('The given path is a reserved path of Lychee (' . $path . ')');

--- a/app/Actions/Install/DefaultConfig.php
+++ b/app/Actions/Install/DefaultConfig.php
@@ -64,12 +64,6 @@ class DefaultConfig
 			'public/img/' => 'file_exists|is_readable|is_writable|is_executable',
 			'public/sym/' => 'file_exists|is_readable|is_writable|is_executable',
 			'public/uploads/' => 'file_exists|is_readable|is_writable|is_executable',
-			'public/uploads/big/' => 'file_exists|is_readable|is_writable|is_executable',
-			'public/uploads/import/' => 'file_exists|is_readable|is_writable|is_executable',
-			'public/uploads/medium/' => 'file_exists|is_readable|is_writable|is_executable',
-			'public/uploads/raw/' => 'file_exists|is_readable|is_writable|is_executable',
-			'public/uploads/small/' => 'file_exists|is_readable|is_writable|is_executable',
-			'public/uploads/thumb/' => 'file_exists|is_readable|is_writable|is_executable',
 		],
 		// This is from https://github.com/rashidlaasri/LaravelInstaller
 		// We keep it so we can make the .env edition a bit more friendly (later).


### PR DESCRIPTION
I decided to remove the tests for the various sub-folders below `uploads/` completely, because if they do not exist, they are created on the fly via Flysystem.