### PR TITLE
fix Installation

### DIFF
--- a/app/Actions/Install/ApplyMigration.php
+++ b/app/Actions/Install/ApplyMigration.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Artisan;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use function Safe\unlink;
 
 class ApplyMigration
 {

--- a/app/Actions/Install/ApplyMigration.php
+++ b/app/Actions/Install/ApplyMigration.php
@@ -6,6 +6,8 @@ use App\Exceptions\InstallationFailedException;
 use App\Exceptions\Internal\FrameworkException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Artisan;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use function Safe\unlink;
 
 class ApplyMigration
@@ -73,26 +75,14 @@ class ApplyMigration
 		try {
 			Artisan::call('key:generate', ['--force' => true]);
 			$this->str_to_array(Artisan::output(), $output);
-			if (!str_contains(end($output), 'Application key set successfully')) {
+			if (
+				!str_contains(end($output), 'Application key set successfully') ||
+				config('app.key') === null
+			) {
 				$output[] = 'We could not generate the encryption key.';
 				throw new InstallationFailedException('Could not generate encryption key');
 			}
-
-			// key is generated, we can safely remove that file (in theory)
-			$filename = base_path('.NO_SECURE_KEY');
-			if (file_exists($filename)) {
-				if (is_file($filename)) {
-					unlink($filename);
-				} else {
-					throw new InstallationFailedException('A filesystem object . ' . $filename . ' exists, but is not an ordinary file.');
-				}
-			}
-		} catch (\ErrorException $e) {
-			// possibly thrown by `unlink`
-			$output[] = $e->getMessage();
-			$output[] = 'Could not remove file `.NO_SECURE_KEY`.';
-			throw new InstallationFailedException('Could not remove file `.NO_SECURE_KEY`', $e);
-		} catch (BindingResolutionException $e) {
+		} catch (BindingResolutionException|NotFoundExceptionInterface|ContainerExceptionInterface $e) {
 			throw new FrameworkException('Laravel\'s container component', $e);
 		}
 	}

--- a/app/Actions/Install/DefaultConfig.php
+++ b/app/Actions/Install/DefaultConfig.php
@@ -62,7 +62,6 @@ class DefaultConfig
 			'storage/logs/' => 'file_exists|is_readable|is_writable|is_executable',
 			'bootstrap/cache/' => 'file_exists|is_readable|is_writable|is_executable',
 			'public/dist/' => 'file_exists|is_readable|is_writable|is_executable',
-			'public/img/' => 'file_exists|is_readable|is_writable|is_executable',
 			'public/sym/' => 'file_exists|is_readable|is_writable|is_executable',
 			'public/uploads/' => 'file_exists|is_readable|is_writable|is_executable',
 		],

--- a/app/Actions/Install/DefaultConfig.php
+++ b/app/Actions/Install/DefaultConfig.php
@@ -54,6 +54,7 @@ class DefaultConfig
 			*/
 		'permissions' => [
 			'.' => 'file_exists|is_readable|is_writable|is_executable',
+			'database/' => 'file_exists|is_readable|is_writable|is_executable',
 			'database/database.sqlite' => 'file_exists|is_readable|is_writable',
 			'storage/framework/' => 'file_exists|is_readable|is_writable|is_executable',
 			'storage/framework/views/' => 'file_exists|is_readable|is_writable|is_executable',

--- a/app/Actions/Install/DefaultConfig.php
+++ b/app/Actions/Install/DefaultConfig.php
@@ -54,6 +54,7 @@ class DefaultConfig
 			*/
 		'permissions' => [
 			'.' => 'file_exists|is_readable|is_writable|is_executable',
+			'database/database.sqlite' => 'file_exists|is_readable|is_writable',
 			'storage/framework/' => 'file_exists|is_readable|is_writable|is_executable',
 			'storage/framework/views/' => 'file_exists|is_readable|is_writable|is_executable',
 			'storage/framework/cache/' => 'file_exists|is_readable|is_writable|is_executable',

--- a/app/Console/Commands/FixPermissions.php
+++ b/app/Console/Commands/FixPermissions.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Actions\Diagnostics\Checks\BasicPermissionCheck;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
 use function Safe\chmod;
 use function Safe\fileowner;
 use function Safe\sprintf;
@@ -11,11 +12,6 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
 
 class FixPermissions extends Command
 {
-	public const DIRECTORIES = [
-		'public/uploads',
-		'public/sym',
-	];
-
 	/**
 	 * The name and signature of the console command.
 	 *
@@ -52,6 +48,11 @@ class FixPermissions extends Command
 	 */
 	public function handle(): int
 	{
+		$directories = [
+			Storage::disk('images')->path(''),
+			Storage::disk('symbolic')->path(''),
+		];
+
 		if (!extension_loaded('posix')) {
 			$this->error('Non-POSIX OS detected: Command unsupported');
 
@@ -63,7 +64,7 @@ class FixPermissions extends Command
 		clearstatcache(true);
 		$this->effUserId = posix_geteuid();
 
-		foreach (self::DIRECTORIES as $directory) {
+		foreach ($directories as $directory) {
 			$this->line(sprintf('Scanning: <info>%s</info>', $directory));
 			$this->fixPermissionsRecursively($directory);
 		}

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -222,7 +222,7 @@ class Handler extends ExceptionHandler
 	 */
 	protected function prepareResponse($request, \Throwable $e): SymfonyResponse
 	{
-		if (!$this->isHttpException($e) && config('app.debug') !== null) {
+		if (!$this->isHttpException($e) && config('app.debug') === true) {
 			return $this->toIlluminateResponse($this->convertExceptionToResponse($e), $e);
 		}
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -206,7 +206,7 @@ class Handler extends ExceptionHandler
 	 * decided that the client expects a HTML response, but _before_ the
 	 * actual work horse {@link Handler::renderHttpException} is called.
 	 *
-	 * This method is 99% identical to the parent method expects for a tiny
+	 * This method is 99% identical to the parent method except for a tiny
 	 * bug fix which adds the original exception to the encapsulating
 	 * `HttpException`.
 	 *

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -10,13 +10,60 @@ use App\Exceptions\Handlers\MigrationHandler;
 use App\Exceptions\Handlers\NoEncryptionKey;
 use App\Models\Logs;
 use Illuminate\Auth\AuthenticationException;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\Request;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\Arr;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
+/**
+ * Lychee's custom exception handler.
+ *
+ * While the overall architectural approach of the original exception handler
+ * of the framework is fine, the original exception handler is mostly broken
+ * when it comes to the details.
+ *
+ * The overall architectural approach is as follows:
+ *
+ *  1. Substitute or wrap certain exceptions by or into other exceptions
+ *     (i.e. via `mapException`)
+ *  2. Decide whether the client expects an HTML or JSON response
+ *  3. Convert (or "render") the exception into a response with said content
+ *     type
+ *
+ * However, there are two major issues with the original exception handler:
+ *
+ *  - Substitution of exception is not limited to `mapException` but happens
+ *    all the time which makes it hard to reliably predict what happens to
+ *    an exception when a method (other than `mapException`) is called.
+ *    One might end up with a different exception.
+ *    Moreover, not all of these substitution are sensible enough to add the
+ *    original exception as a predecessor to the new exception.
+ *  - A constant mix-up of the terms "HTTP" and "HTML".
+ *    The framework frequently uses the term "HTTP" as an antonym to "JSON"
+ *    when "HTML" would be rather appropriate.
+ *    For example like in `renderJsonResponse($e)` vs. `renderHttpResponse($e)`.
+ *    The latter is called, when an exception shall be converted into HTML.
+ *    But of course, a JSON response is also an HTTP response.
+ *    It seems as if the framework is not even aware of this confusion.
+ *
+ * 90% of this handler are bug fixes.
+ * This means, parent methods are not overwritten, because we need a special
+ * non-standard behaviour, but simply the _right_ behaviour.
+ * Unfortunately, this class cannot solve the unfortunate naming of some
+ * methods, but must stick to the names used by the parent class.
+ * Alternatively, this class could overwrite the entry method `render($e)`,
+ * re-implement everything which comes after that (even using better names)
+ * and let the rest of the parent class go down the drain.
+ * However, this bears the risk that some 3rd-party calls unfixed methods of
+ * the original exception handler.
+ */
 class Handler extends ExceptionHandler
 {
 	/**
@@ -153,11 +200,57 @@ class Handler extends ExceptionHandler
 	}
 
 	/**
-	 * Renders the given HttpException.
+	 * Prepare a response for the given exception.
+	 *
+	 * This method is called by the framework, _after_ the framework has
+	 * decided that the client expects a HTML response, but _before_ the
+	 * actual work horse {@link Handler::renderHttpException} is called.
+	 *
+	 * This method is 99% identical to the parent method expects for a tiny
+	 * bug fix which adds the original exception to the encapsulating
+	 * `HttpException`.
+	 *
+	 * @param Request    $request
+	 * @param \Throwable $e
+	 *
+	 * @return SymfonyResponse
+	 *
+	 * @throws BindingResolutionException
+	 * @throws \InvalidArgumentException
+	 * @throws ContainerExceptionInterface
+	 * @throws NotFoundExceptionInterface
+	 */
+	protected function prepareResponse($request, \Throwable $e): SymfonyResponse
+	{
+		if (!$this->isHttpException($e) && config('app.debug')) {
+			return $this->toIlluminateResponse($this->convertExceptionToResponse($e), $e);
+		}
+
+		if (!$this->isHttpException($e)) {
+			$e = new HttpException(500, $e->getMessage(), $e);
+		}
+
+		return $this->toIlluminateResponse(
+			$this->renderHttpException($e), $e
+		);
+	}
+
+	/**
+	 * Renders the given HttpException into HTML.
 	 *
 	 * This method is called by the framework if
 	 *  1. `config('app.debug')` is not set, i.e. the application is not in debug mode
 	 *  2. the client expects an HTML response
+	 *
+	 * **Attention:**
+	 * This method is a misnomer caused by the framework.
+	 * The framework provides two methods `renderHttpException` and
+	 * `renderJsonException` with the former being called if the client
+	 * expects HTML.
+	 * Hence, the method should rather be named `renderHtmlException`.
+	 * That current name of the method, if meant as an antonym to
+	 * `renderJsonException` is obviously nonsense as JSON is also transported
+	 * over HTTP.
 	 *
 	 * @param HttpExceptionInterface $e
 	 *

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -222,7 +222,7 @@ class Handler extends ExceptionHandler
 	 */
 	protected function prepareResponse($request, \Throwable $e): SymfonyResponse
 	{
-		if (!$this->isHttpException($e) && config('app.debug')) {
+		if (!$this->isHttpException($e) && config('app.debug') !== null) {
 			return $this->toIlluminateResponse($this->convertExceptionToResponse($e), $e);
 		}
 
@@ -230,9 +230,12 @@ class Handler extends ExceptionHandler
 			$e = new HttpException(500, $e->getMessage(), $e);
 		}
 
-		return $this->toIlluminateResponse(
-			$this->renderHttpException($e), $e
-		);
+		// `renderHttpException` expects `$e` to be an instance of
+		// `HttpExceptionInterface`.
+		// This is ensured by `isHttpException` above, but PHPStan does not
+		// understand that.
+		// @phpstan-ignore-next-line
+		return $this->toIlluminateResponse($this->renderHttpException($e), $e);
 	}
 
 	/**

--- a/app/Exceptions/Handlers/NoEncryptionKey.php
+++ b/app/Exceptions/Handlers/NoEncryptionKey.php
@@ -26,9 +26,6 @@ class NoEncryptionKey implements HttpExceptionHandler
 			if ($e instanceof MissingAppKeyException) {
 				return true;
 			}
-			if ($e->getMessage() === 'No application encryption key has been specified.') {
-				return true;
-			}
 		} while ($e = $e->getPrevious());
 
 		return false;

--- a/app/Exceptions/Handlers/NoEncryptionKey.php
+++ b/app/Exceptions/Handlers/NoEncryptionKey.php
@@ -43,7 +43,13 @@ class NoEncryptionKey implements HttpExceptionHandler
 			try {
 				touch(base_path('.NO_SECURE_KEY'));
 			} catch (Throwable) {
-				// do nothing
+				// We do nothing. Does it matter? Not really.
+				// .NO_SECURE_KEY is just used in the IsInstalled check for the middleware
+				// to guarantee a redirection to install when coming back to `lychee.org/`
+				// e.g. when reloading a page.
+				//
+				// Also here we directly redirect to /install
+				// During installation, the file is removed if it exists.
 			}
 			$redirectResponse = ToInstall::go();
 			$contentType = $defaultResponse->headers->get('Content-Type');

--- a/app/Exceptions/Handlers/NoEncryptionKey.php
+++ b/app/Exceptions/Handlers/NoEncryptionKey.php
@@ -26,6 +26,9 @@ class NoEncryptionKey implements HttpExceptionHandler
 			if ($e instanceof MissingAppKeyException) {
 				return true;
 			}
+			if ($e->getMessage() === 'No application encryption key has been specified.') {
+				return true;
+			}
 		} while ($e = $e->getPrevious());
 
 		return false;
@@ -37,7 +40,11 @@ class NoEncryptionKey implements HttpExceptionHandler
 	public function renderHttpException(SymfonyResponse $defaultResponse, HttpException $e): SymfonyResponse
 	{
 		try {
-			touch(base_path('.NO_SECURE_KEY'));
+			try {
+				touch(base_path('.NO_SECURE_KEY'));
+			} catch (Throwable) {
+				// do nothing
+			}
 			$redirectResponse = ToInstall::go();
 			$contentType = $defaultResponse->headers->get('Content-Type');
 			if ($contentType !== null && $contentType !== '') {

--- a/app/Exceptions/Handlers/NoEncryptionKey.php
+++ b/app/Exceptions/Handlers/NoEncryptionKey.php
@@ -37,17 +37,6 @@ class NoEncryptionKey implements HttpExceptionHandler
 	public function renderHttpException(SymfonyResponse $defaultResponse, HttpException $e): SymfonyResponse
 	{
 		try {
-			try {
-				touch(base_path('.NO_SECURE_KEY'));
-			} catch (Throwable) {
-				// We do nothing. Does it matter? Not really.
-				// .NO_SECURE_KEY is just used in the IsInstalled check for the middleware
-				// to guarantee a redirection to install when coming back to `lychee.org/`
-				// e.g. when reloading a page.
-				//
-				// Also here we directly redirect to /install
-				// During installation, the file is removed if it exists.
-			}
 			$redirectResponse = ToInstall::go();
 			$contentType = $defaultResponse->headers->get('Content-Type');
 			if ($contentType !== null && $contentType !== '') {

--- a/app/Exceptions/Handlers/NoEncryptionKey.php
+++ b/app/Exceptions/Handlers/NoEncryptionKey.php
@@ -5,7 +5,6 @@ namespace App\Exceptions\Handlers;
 use App\Contracts\HttpExceptionHandler;
 use App\Redirections\ToInstall;
 use Illuminate\Encryption\MissingAppKeyException;
-use function Safe\touch;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface as HttpException;
 use Throwable;

--- a/app/Http/Middleware/Checks/IsInstalled.php
+++ b/app/Http/Middleware/Checks/IsInstalled.php
@@ -29,6 +29,9 @@ class IsInstalled implements MiddlewareCheck
 			// This can only happen if:
 			// - Connection with DB is broken (firewall?)
 			// - Connection with DB is not set (MySql without credentials)
+			//
+			// We only check Authentication to DB failled and just skip in
+			// the other cases to get a proper message error.
 			return !Str::contains($e->getMessage(), 'SQLSTATE[HY000] [1045]');
 		} catch (BindingResolutionException $e) {
 			throw new FrameworkException('Laravel\'s container component', $e);

--- a/app/Http/Middleware/Checks/IsInstalled.php
+++ b/app/Http/Middleware/Checks/IsInstalled.php
@@ -32,8 +32,8 @@ class IsInstalled implements MiddlewareCheck
 			//
 			// We only check Authentication to DB failled and just skip in
 			// the other cases to get a proper message error.
-			if (!Str::contains($e->getMessage(), 'SQLSTATE[HY000] [1045]')) {
-				return true;
+			if (Str::contains($e->getMessage(), 'SQLSTATE[HY000] [1045]')) {
+				return false;
 			}
 			throw $e;
 		} catch (BindingResolutionException $e) {

--- a/app/Http/Middleware/Checks/IsInstalled.php
+++ b/app/Http/Middleware/Checks/IsInstalled.php
@@ -9,6 +9,8 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 class IsInstalled implements MiddlewareCheck
 {
@@ -19,7 +21,7 @@ class IsInstalled implements MiddlewareCheck
 	{
 		try {
 			return
-				!file_exists(base_path('.NO_SECURE_KEY')) &&
+				config('app.key') !== null &&
 				Schema::hasTable('configs');
 		} catch (QueryException $e) {
 			// Authentication to DB failled.
@@ -36,7 +38,7 @@ class IsInstalled implements MiddlewareCheck
 				return false;
 			}
 			throw $e;
-		} catch (BindingResolutionException $e) {
+		} catch (BindingResolutionException|NotFoundExceptionInterface|ContainerExceptionInterface $e) {
 			throw new FrameworkException('Laravel\'s container component', $e);
 		}
 	}

--- a/app/Http/Middleware/Checks/IsInstalled.php
+++ b/app/Http/Middleware/Checks/IsInstalled.php
@@ -1,4 +1,4 @@
- <?php
+<?php
 
 namespace App\Http\Middleware\Checks;
 

--- a/app/Http/Middleware/Checks/IsInstalled.php
+++ b/app/Http/Middleware/Checks/IsInstalled.php
@@ -32,7 +32,10 @@ class IsInstalled implements MiddlewareCheck
 			//
 			// We only check Authentication to DB failled and just skip in
 			// the other cases to get a proper message error.
-			return !Str::contains($e->getMessage(), 'SQLSTATE[HY000] [1045]');
+			if (!Str::contains($e->getMessage(), 'SQLSTATE[HY000] [1045]')) {
+				return true;
+			}
+			throw $e;
 		} catch (BindingResolutionException $e) {
 			throw new FrameworkException('Laravel\'s container component', $e);
 		}

--- a/app/Http/Middleware/Checks/IsInstalled.php
+++ b/app/Http/Middleware/Checks/IsInstalled.php
@@ -6,7 +6,9 @@ use App\Contracts\InternalLycheeException;
 use App\Contracts\MiddlewareCheck;
 use App\Exceptions\Internal\FrameworkException;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 
 class IsInstalled implements MiddlewareCheck
 {
@@ -19,6 +21,8 @@ class IsInstalled implements MiddlewareCheck
 			return
 				!file_exists(base_path('.NO_SECURE_KEY')) &&
 				Schema::hasTable('configs');
+		} catch (QueryException $e) {
+			return !Str::contains($e->getMessage(), 'SQLSTATE[HY000] [1045]');
 		} catch (BindingResolutionException $e) {
 			throw new FrameworkException('Laravel\'s container component', $e);
 		}

--- a/app/Http/Middleware/Checks/IsInstalled.php
+++ b/app/Http/Middleware/Checks/IsInstalled.php
@@ -1,4 +1,4 @@
-<?php
+ <?php
 
 namespace App\Http\Middleware\Checks;
 
@@ -22,6 +22,13 @@ class IsInstalled implements MiddlewareCheck
 				!file_exists(base_path('.NO_SECURE_KEY')) &&
 				Schema::hasTable('configs');
 		} catch (QueryException $e) {
+			// Authentication to DB failled.
+			// This means that we cannot even check that `configs` is present,
+			// therefore we will just assume it is not.
+			//
+			// This can only happen if:
+			// - Connection with DB is broken (firewall?)
+			// - Connection with DB is not set (MySql without credentials)
 			return !Str::contains($e->getMessage(), 'SQLSTATE[HY000] [1045]');
 		} catch (BindingResolutionException $e) {
 			throw new FrameworkException('Laravel\'s container component', $e);

--- a/database/migrations/2022_07_13_174800_permission_test.php
+++ b/database/migrations/2022_07_13_174800_permission_test.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Str;
 
 class PermissionTest extends Migration
 {
@@ -13,14 +12,7 @@ class PermissionTest extends Migration
 	 */
 	public function up(): void
 	{
-		$is_public = Str::endsWith(getcwd(), 'public');
-		if ($is_public) {
-			chdir('..');
-		}
 		Artisan::call('lychee:fix-permissions', ['--dry-run' => 1]);
-		if ($is_public) {
-			chdir('public');
-		}
 	}
 
 	/**

--- a/database/migrations/2022_07_13_174800_permission_test.php
+++ b/database/migrations/2022_07_13_174800_permission_test.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
 
 class PermissionTest extends Migration
 {
@@ -12,7 +13,14 @@ class PermissionTest extends Migration
 	 */
 	public function up(): void
 	{
+		$is_public = Str::endsWith(getcwd(), 'public');
+		if ($is_public) {
+			chdir('..');
+		}
 		Artisan::call('lychee:fix-permissions', ['--dry-run' => 1]);
+		if ($is_public) {
+			chdir('public');
+		}
 	}
 
 	/**

--- a/resources/views/install/permission-line.blade.php
+++ b/resources/views/install/permission-line.blade.php
@@ -1,7 +1,0 @@
-<span class="perm float-right">
-@if($perm[1] & 1)
-    <i class="fa fa-fw fa-exclamation-circle error"></i>
-@else
-    <i class="fa fa-fw fa-check-circle-o success"></i>
-@endif
-{{ $perm[0] }}</span>

--- a/resources/views/install/permissions.blade.php
+++ b/resources/views/install/permissions.blade.php
@@ -17,8 +17,21 @@
     @foreach ($permissions as $permission)
         <li class="list__item list__item--permissions">
         <span>{{ $permission['folder'] }}</span>
+        @if (count($permission['permission']) < 4)
+            @for ($i = 0;$i < 4 - count($permission['permission']); $i++)
+                <span class="perm float-right">
+                    &nbsp;
+                </span>
+            @endfor
+        @endif
         @foreach ($permission['permission'] as $perm)
-            @include('install.permission-line')
+            <span class="perm float-right">
+            @if($perm[1] & 1)
+                <i class="fa fa-fw fa-exclamation-circle error"></i>
+            @else
+                <i class="fa fa-fw fa-check-circle-o success"></i>
+            @endif
+            {{ $perm[0] }}</span>
         @endforeach
     @endforeach
     </ul>

--- a/tests/Feature/InstallTest.php
+++ b/tests/Feature/InstallTest.php
@@ -32,13 +32,16 @@ class InstallTest extends TestCase
 		/** @var User $admin */
 		$admin = User::query()->find(0);
 
-		touch(base_path('.NO_SECURE_KEY'));
+		$prevAppKey = config('app.key');
+		config(['app.key' => null]);
 		$response = $this->get('install/');
 		$response->assertOk();
-		unlink(base_path('.NO_SECURE_KEY'));
+		config(['app.key' => $prevAppKey]);
 
 		// TODO: Why does a `git pull` delete `installed.log`? This test needs to be discussed with @ildyria
-		unlink(base_path('installed.log'));
+		if (file_exists(base_path('installed.log'))) {
+			unlink(base_path('installed.log'));
+		}
 		/**
 		 * No installed.log: we should not be redirected to install (case where we have not done the last migration).
 		 */


### PR DESCRIPTION
- The Exception handling of Laravel changed with regard to the Encryption key... We now also look at the content of the message.
- When `.` write access was not present, `touch` was failing, preventing the redirection to install.
- Added a `QueryException` catch on the Installation check "config exists in DB" to ensure that this does not fail even if we don't have access to any DB.
- Require `database/database.sqlite` to be writable (makes it easier to used out of the box too).