### PR TITLE
Fixes #1514

### DIFF
--- a/app/Models/Extensions/HasRandomIDAndLegacyTimeBasedID.php
+++ b/app/Models/Extensions/HasRandomIDAndLegacyTimeBasedID.php
@@ -107,7 +107,7 @@ trait HasRandomIDAndLegacyTimeBasedID
 			} catch (QueryException $e) {
 				$lastException = $e;
 				$errorCode = $e->getCode();
-				if ($errorCode === 23000 || $errorCode === 23505) {
+				if ($errorCode === 23000 || $errorCode === 23505 || $errorCode === '23000' || $errorCode === '23505') {
 					// houston, we have a duplicate entry problem
 					// Our ids are based on current system time, so
 					// wait randomly up to 1s before retrying.


### PR DESCRIPTION
Fixes #1514.

For 32bit systems and time-based, legacy IDs we must catch failing inserts due to duplicate legacy ID when insertions is running to fast. In the path it was sufficient to check for MySQL error codes 23000 and 23005 as integers and then pause for a short period of time.

"Something" has changed (probably inside Laravel) such that MySQL errors codes are not reliably reported as integers but also as strings. This fix makes the comparison more robust.