### PR TITLE
fix 500 stack log manager error while running dev

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -32,7 +32,8 @@ return [
 	'channels' => [
 		'log' => [
 			'path' => storage_path('logs/laravel.log'),
-			'driver' => 'log',
+			'driver' => 'single',
+			'level' => 'debug',
 		],
 	],
 ];

--- a/config/logging.php
+++ b/config/logging.php
@@ -32,6 +32,7 @@ return [
 	'channels' => [
 		'log' => [
 			'path' => storage_path('logs/laravel.log'),
+			'driver' => 'log',
 		],
 	],
 ];


### PR DESCRIPTION
On 500 crash during tests (hopefully only applicable in development), instead of having nice error message, a stack trace is produced complaining about missing "driver" in config. 

This is due to https://github.com/LycheeOrg/Lychee/pull/1366