### PR TITLE
Remove use directive

### DIFF
--- a/app/ModelFunctions/ConfigFunctions.php
+++ b/app/ModelFunctions/ConfigFunctions.php
@@ -2,7 +2,7 @@
 
 namespace App\ModelFunctions;
 
-use App\Assets\Helpers;
+use App\Exceptions\ConfigurationKeyMissingException;
 use App\Exceptions\Internal\QueryBuilderException;
 use App\Facades\Lang;
 use App\Models\Configs;
@@ -14,6 +14,8 @@ class ConfigFunctions
 	 * return the basic information for a Page.
 	 *
 	 * @return array
+	 *
+	 * @throws ConfigurationKeyMissingException
 	 */
 	public function get_pages_infos(): array
 	{
@@ -101,7 +103,7 @@ class ConfigFunctions
 	 * However, the client knows by itself if it is a television or not.
 	 * Hence, these values should be part of the front-end code.
 	 *
-	 * See also {@link Helpers::getDeviceType()}.
+	 * See also {@link \App\Assets\Helpers::getDeviceType()}.
 	 *
 	 * @param string $device
 	 *


### PR DESCRIPTION
Might be fixing https://github.com/LycheeOrg/Lychee/issues/1536 (I don't know for sure).

Issue https://github.com/LycheeOrg/Lychee/issues/1536 is caused by Laravel trying to invoke the method `cacheBusting` on the wrong class. Laravel wrongly uses `\App\Assets\Helpers` instead of `\App\Facades\Helpers`.

I don't know why this happens, because I cannot reproduce it. The methods is called from within the Blade template

https://github.com/LycheeOrg/Lychee/blob/61b93a6d8b034c1f189fe2a3d9c5a739d1164b58/resources/views/gallery.blade.php#L7

And the Blade template is called in

https://github.com/LycheeOrg/Lychee/blob/61b93a6d8b034c1f189fe2a3d9c5a739d1164b58/app/Http/Controllers/IndexController.php#L94

Neither the Blade template nor the class `IndexController` explicitly import the class `\App\Facades\Helpers`. Hence the Laravel auto-loader should kick in. (I have told you how much I hate this "magic", haven't I?) and resolve the class `\App\Facades\Helpers`. But for some reason we end up with `\App\Assets\Helpers`. The only plausible explanation which I can conjuncture is that somehow the (wrong) class `\App\Assets\Helpers` gets loaded first. Hence, I looked around where this class is loaded explicitly, found a single occurrence and fixed that.

I don't know, if this PR will really fix the bug. It is more like an educated guess. However, this PR shouldn't do any harm either.