### PR TITLE
Fix dead Installation/Build link in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ Sign in and click the gear in the top left corner to change your settings. [Sett
 
 ### Build
 
-Lychee is ready to use, right out of the box. If you want to contribute and edit CSS or JS files, you need to rebuild [Lychee-front](https://github.com/LycheeOrg/Lychee-front). [Build &#187;](https://lycheeorg.github.io/docs/node.html)
+Lychee is ready to use, right out of the box. If you want to contribute and edit CSS or JS files, you need to rebuild [Lychee-front](https://github.com/LycheeOrg/Lychee-front). [Build &#187;](https://lycheeorg.github.io/docs/frontend.html)
 
 ## Advanced Features
 


### PR DESCRIPTION
`node` was moved/renamed to `frontend` in the pull request below:

- https://github.com/LycheeOrg/LycheeOrg.github.io/pull/64/files
