### PR TITLE
Improve Locale check

### DIFF
--- a/app/Locale/French.php
+++ b/app/Locale/French.php
@@ -26,9 +26,6 @@ final class French implements Language
 			'SEARCH' => 'Rechercher…',
 			'MORE' => 'Plus',
 			'DEFAULT' => 'Valeur par défaut',
-			'ALBUM_SET_ORDER' => 'Changer l’ordre',
-			'ALBUM_ORDERING' => 'Trier par',
-			'ALBUM_OWNER' => 'Propriétaire',
 			'GALLERY' => 'Gallery',
 
 			'USERS' => 'Utilisateurs',

--- a/tests/Feature/LangTest.php
+++ b/tests/Feature/LangTest.php
@@ -16,6 +16,7 @@ use App\Facades\Lang;
 use App\Factories\LangFactory;
 use App\Models\Configs;
 use Illuminate\Support\Facades\DB;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Tests\TestCase;
 
 class LangTest extends TestCase
@@ -25,22 +26,32 @@ class LangTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testLang(): void
+	public function testLanguageConsistency(): void
 	{
-		$lang_available = Lang::get_lang_available();
-		$keys = array_keys(Lang::get_lang());
-
-		foreach ($lang_available as $code) {
-			$lang_test = Lang::factory()->make($code);
-			$locale = $lang_test->get_locale();
-
-			foreach ($keys as $key) {
-				static::assertArrayHasKey($key, $locale, 'Language ' . $lang_test->code() . ' is incomplete.');
-			}
-		}
-
 		static::assertEquals('en', Lang::get_code());
 		static::assertEquals('OK', Lang::get('SUCCESS'));
+
+		$msgSection = (new ConsoleOutput())->section();
+
+		$englishDictionary = Lang::get_lang();
+		$availableDictionaries = Lang::get_lang_available();
+		$failed = false;
+
+		foreach ($availableDictionaries as $locale) {
+			$dictionary = Lang::factory()->make($locale)->get_locale();
+			$missingKeys = array_diff_key($englishDictionary, $dictionary);
+			foreach ($missingKeys as $key => $value) {
+				$msgSection->writeln(sprintf('<comment>Error:</comment> Locale %s misses the following key: %s', str_pad($locale, 8), $key));
+				$failed = true;
+			}
+
+			$extraKeys = array_diff_key($dictionary, $englishDictionary);
+			foreach ($extraKeys as $key => $value) {
+				$msgSection->writeln(sprintf('<comment>Error:</comment> Locale %s has the following extra key: %s', str_pad($locale, 8), $key));
+				$failed = true;
+			}
+		}
+		static::assertFalse($failed);
 	}
 
 	public function testEnglishAsFallbackIfLangConfigIsMissing(): void


### PR DESCRIPTION
Rewrite the tests for locale:
- check if English keys are contained in other languages
- check if other languages do not contains extra keys compared to English.

Tested by inserting extra keys in both languages - Works as expected.

Rather than doing `implode()` I used a `foreach` loop which improves the console readability of the failing test.

`str_pad()` is used to align the text properly:
```
▶ vendor/bin/phpunit --filter testLang tests/Feature/LangTest.php
PHPUnit 9.5.25 #StandWithUkraine

Runtime:       PHP 8.1.5
Configuration: ~/Documents/Lychee/phpunit.xml
Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set

Error: Locale 简体中文 misses the following key: TEST
Error: Locale 繁體中文 misses the following key: TEST
Error: Locale cz       misses the following key: TEST
Error: Locale nl       misses the following key: TEST
Error: Locale fr       misses the following key: TEST
Error: Locale de       misses the following key: TEST
Error: Locale el       misses the following key: TEST
Error: Locale el       has the following extra key: TEST2
Error: Locale it       misses the following key: TEST
Error: Locale nb-no    misses the following key: TEST
Error: Locale pl       misses the following key: TEST
Error: Locale pt       misses the following key: TEST
Error: Locale ru       misses the following key: TEST
Error: Locale sk       misses the following key: TEST
Error: Locale es       misses the following key: TEST
Error: Locale sv       misses the following key: TEST
Error: Locale vi       misses the following key: TEST
F                                                                   1 / 1 (100%)
```