### PR TITLE
[Bug][Regression] Fix dir permissions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,16 +45,6 @@ DB_LOG_SQL=false
 # Some rare setups may require directories and files to be world writeable.
 # In this case, use "world" here.
 # USE WITH PRECAUTIONS: world writeable files and folders may be a SECURITY RISK.
-# Note at the time of writing, the Flysystem package v1 has a bug which
-# prevents the "world" preset from working.
-# This is a temporary problem and will be solved after
-# https://github.com/thephpleague/flysystem/pull/1523 will have been merged
-# upstream or after Lychee will have migrated to Laravel 9.
-# Until then, if you need to use world-writable directories, please edit
-# `config/filesystems.php` and re-define the values for
-# `disks.images.permissions.(file|dir).public` such that they equal
-# `disks.images.permissions.(file|dir).world` and use the preset `public`
-# instead.
 # LYCHEE_IMAGE_VISIBILITY=public
 
 # folders in which the files will be stored
@@ -91,4 +81,4 @@ MAIL_FROM_ADDRESS=
 TRUSTED_PROXIES=null
 
 # Comma-separated list of class names of diagnostics checks that should be skipped.
-#SKIP_DIAGNOSTICS_CHECKS= 
+#SKIP_DIAGNOSTICS_CHECKS=

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -47,6 +47,7 @@ return [
 			'root' => env('LYCHEE_UPLOADS', public_path('uploads/')),
 			'url' => env('LYCHEE_UPLOADS_URL', 'uploads/'),
 			'visibility' => env('LYCHEE_IMAGE_VISIBILITY', 'public'),
+			'directory_visibility' => env('LYCHEE_IMAGE_VISIBILITY', 'public'),
 			'permissions' => [
 				'file' => [
 					'world' => 00666,


### PR DESCRIPTION
The upgrade from Laravel 8 to 9 and the implicit upgrade from Flystem 1 to 3, introduced a regression regarding file permissions. There are two independent problems: one is ultimately fixed by this PR for the other this PR contains a workaround.

 * Besides the configuration parameter `visibility` Flysystem 3 requires a new parameter `directory_visibility` which - nomen est omen - defines the permissions for newly created directories. If this option is not set (or equals `null`), Flysystem does not fall back to `visibility` (as one could expect) but uses an internal default value.
 * The second problem is an upstream regression between Flysystem 1 and 3 (actually between 2 and 3) which makes Flysystem behave inconsistent with respect to the umask value. The upstream bug is reported at https://github.com/thephpleague/flysystem/issues/1584. As a workaround this bugfix temporarily sets the umask value to zero.