### PR TITLE
Fix files installation if no Git repo is available

### DIFF
--- a/scripts/install_files.php
+++ b/scripts/install_files.php
@@ -10,15 +10,17 @@ $GREEN = "\033[38;5;010m";
 $YELLOW = "\033[38;5;011m";
 $ORANGE = "\033[38;5;214m";
 
-echo "\n${YELLOW}creating file for CSS personalization$NO_COLOR" . PHP_EOL;
+echo "\n{$YELLOW}creating file for CSS personalization$NO_COLOR" . PHP_EOL;
 touch('public/dist/user.css');
 
-echo "\n${YELLOW}creating default SQLite database$NO_COLOR" . PHP_EOL;
+echo "\n{$YELLOW}creating default SQLite database$NO_COLOR" . PHP_EOL;
 touch('database/database.sqlite');
 
-echo "\n${YELLOW}setting up hooks for git pull and git commits$NO_COLOR" . PHP_EOL;
-copy('scripts/pre-commit', '.git/hooks/pre-commit');
-copy('scripts/post-merge', '.git/hooks/post-merge');
+if (is_dir('.git')) {
+	echo "\n{$YELLOW}setting up hooks for git pull and git commits$NO_COLOR" . PHP_EOL;
+	copy('scripts/pre-commit', '.git/hooks/pre-commit');
+	copy('scripts/post-merge', '.git/hooks/post-merge');
+}
 
-echo "\n${ORANGE}To disable the call of composer and migration on pull add$NO_COLOR" . PHP_EOL;
-echo "${ORANGE}a file named '.NO_AUTO_COMPOSER_MIGRATE' in this directory.$NO_COLOR" . PHP_EOL;
+echo "\n{$ORANGE}To disable the call of composer and migration on pull add$NO_COLOR" . PHP_EOL;
+echo "{$ORANGE}a file named '.NO_AUTO_COMPOSER_MIGRATE' in this directory.$NO_COLOR" . PHP_EOL;


### PR DESCRIPTION
If there is no Git repository and you try to run `scripts/install_files.php`, it fails because the directory does not exist. This just skips the hooks installation.

(Every other change was done by php-cs-fixer but everything still works.)