### PR TITLE
enable strict mode in Laravel

### DIFF
--- a/app/Actions/Album/Delete.php
+++ b/app/Actions/Album/Delete.php
@@ -96,7 +96,7 @@ class Delete extends Action
 			/** @var Album $album */
 			foreach ($albums as $album) {
 				// Collect all (aka recursive) sub-albums in each album
-				$subAlbums = $album->descendants()->select(['id', 'track_short_path'])->get();
+				$subAlbums = $album->descendants()->without(['cover', 'thumb'])->select(['id', 'track_short_path'])->get();
 				$recursiveAlbumIDs = array_merge($recursiveAlbumIDs, $subAlbums->pluck('id')->all());
 				$recursiveAlbumTracks = $recursiveAlbumTracks->merge($subAlbums->pluck('track_short_path'));
 			}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -20,6 +20,7 @@ use App\ModelFunctions\ConfigFunctions;
 use App\ModelFunctions\SymLinkFunctions;
 use App\Policies\AlbumQueryPolicy;
 use App\Policies\PhotoQueryPolicy;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
@@ -58,6 +59,15 @@ class AppServiceProvider extends ServiceProvider
 				Log::info($msg);
 			});
 		}
+
+		/**
+		 * We enforce strict mode
+		 * this has the following effect:
+		 * - lazy loading is disabled
+		 * - non-fillable attributes on creation of model are not discarded but throw an error
+		 * - prevents accessing missing attributes.
+		 */
+		Model::shouldBeStrict();
 
 		try {
 			stream_filter_register(

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -53,7 +53,7 @@ parameters:
 		- '#Parameter \#1 \$key of method .*::partition\(\) expects \(callable\(.*\): bool\)\|Illuminate\\Database\\Eloquent\\Model\|string, Closure\(.*\): bool given.#'
 
 
-		- '#Call to an undefined( static)? method Kalnoy\\Nestedset\\.*::(whereIn|select|join|leftJoin|orderBy|addSelect)\(\)#'
+		- '#Call to an undefined( static)? method Kalnoy\\Nestedset\\.*::(whereIn|select|join|leftJoin|orderBy|addSelect|without)\(\)#'
 		- '#Parameter .* of method .*::newEloquentBuilder\(\) should be contravariant with parameter \$query \(mixed\) of method Kalnoy\\Nestedset\\Node::newEloquentBuilder\(\)#'
 		- '#Call to an undefined method Geocoder\\Location::getDisplayName\(\)#'
 		- '#Call to an undefined method COM::getfolder\(\).#'


### PR DESCRIPTION
Enable strict mode on models.
This has the following effects:
- lazy loading is disabled (avoid n+1 query problem)
- non-fillable attributes on creation of model are not discarded but throw an exception
- prevent access to missing attributes instead of returning null/empty.
