### PR TITLE
Fix list of shares

### DIFF
--- a/app/Http/Controllers/Administration/SharingController.php
+++ b/app/Http/Controllers/Administration/SharingController.php
@@ -28,7 +28,7 @@ class SharingController extends Controller
 	 */
 	public function list(ListSharingRequest $request, ListShare $listShare): Shares
 	{
-		return $listShare->do($request->user2(), $request->album());
+		return $listShare->do($request->participant(), $request->owner(), $request->album());
 	}
 
 	/**

--- a/public/dist/main.js
+++ b/public/dist/main.js
@@ -10485,10 +10485,19 @@ sharing.delete = function () {
 };
 
 /**
+ * Queries the backend for a list of active shares, sharable albums and users
+ * with whom albums can be shared.
+ *
+ * For admin user, the query is unrestricted, for non-admin user the
+ * query is restricted to albums which are owned by the currently
+ * authenticated user.
+ * The latter is required as the backend forbids unrestricted queries for
+ * non-admin users.
+ *
  * @returns {void}
  */
 sharing.list = function () {
-	api.post("Sharing::list", {},
+	api.post("Sharing::list", lychee.rights.is_admin ? {} : { ownerID: lychee.user.id },
 	/** @param {SharingInfo} data */
 	function (data) {
 		sharing.json = data;


### PR DESCRIPTION
This fixes the list of shares (from the left menu) for non-admin, authenticated users. As @kamil4 reported [on Gitter at Nov 7th 2022 18:20](https://gitter.im/LycheeOrg/Developers?at=63693e5e21df5f7a54da0ec2) non-admin user receive a `403 Forbidden` response. This is a regression due to https://github.com/LycheeOrg/Lychee/pull/1519.

Before https://github.com/LycheeOrg/Lychee/pull/1519 the request `Sharing::list` had unconditionally returned a list of all active shares for all users and all albums as well as a list of all existing albums and all users. The the frontend filtered the received list for the the album or user of interest. The frontend code was not only ugly as hell, but the whole approach had been inefficient. There is no reason to query and transmit everything only to throw way 97% on the frontend. Hence, https://github.com/LycheeOrg/Lychee/pull/1519 introduced two query parameters `albumID` and `userID` to enable filtering on the backend.

However, I went one step further and thought it would clever to forbid unrestricted queries `Share::list` for non-admin users. This was fine when one used the dialog from the toolbar ![Sharing](https://user-images.githubusercontent.com/7428426/201480100-d483fe89-d6df-4806-8b1d-17feba5982a2.png), but it did no occur to me that non-admin users can also open the page with all sharings from the left menu.

I also discovered related, lurking bug. Do you remember that @kamil4 once said that he doesn't like the attribute name `user2` on a request? Here, this actually gave leeway to a trap. The request `Sharing::list` is one of the rare instances with actually _three_ users being involved: the authenticated user who makes the request, the user who owns the album and the user with whom the album is shared.`user2` was used for the last two, but surely they are different. I renamed them to `owner` and `participant`.

