### PR TITLE
Fix remove album cover throwing 403

### DIFF
--- a/app/Http/Requests/Album/SetAlbumCoverRequest.php
+++ b/app/Http/Requests/Album/SetAlbumCoverRequest.php
@@ -26,7 +26,8 @@ class SetAlbumCoverRequest extends BaseApiRequest implements HasAlbum, HasPhoto
 	 */
 	public function authorize(): bool
 	{
-		return Gate::check(AlbumPolicy::CAN_EDIT, [AbstractAlbum::class, $this->album]) && Gate::check(PhotoPolicy::IS_VISIBLE, $this->photo);
+		return Gate::check(AlbumPolicy::CAN_EDIT, [AbstractAlbum::class, $this->album]) &&
+			($this->photo === null || Gate::check(PhotoPolicy::IS_VISIBLE, $this->photo));
 	}
 
 	/**

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -559,15 +559,15 @@ class AlbumTest extends TestCase
 
 		$this->albums_tests->set_cover($albumID, $photoID1);
 		$coverID = $this->albums_tests->get($albumID)->offsetGet('cover_id');
-		assert($photoID1, $coverID);
+		$this->assertEquals($photoID1, $coverID);
 
 		$this->albums_tests->set_cover($albumID, $photoID2);
 		$coverID = $this->albums_tests->get($albumID)->offsetGet('cover_id');
-		assert($photoID2, $coverID);
+		$this->assertEquals($photoID2, $coverID);
 
 		$this->albums_tests->set_cover($albumID, null);
 		$coverID = $this->albums_tests->get($albumID)->offsetGet('cover_id');
-		assert($initialCoverID, $coverID);
+		$this->assertEquals($initialCoverID, $coverID);
 
 		Auth::logout();
 		Session::flush();

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -527,6 +527,13 @@ class AlbumTest extends TestCase
 		$this->photos_tests->get($photoID);
 	}
 
+	/**
+	 * Creates an extra User.
+	 * Creates a (regular) album, put a photo in it.
+	 * Log are extra user, and try to set the cover of the album, expect to fail.
+	 *
+	 * @return void
+	 */
 	public function testSetCoverByNonOwner()
 	{
 		Auth::loginUsingId(0);
@@ -543,6 +550,15 @@ class AlbumTest extends TestCase
 		$this->albums_tests->set_cover($albumID, $photoID1, 403);
 	}
 
+	/**
+	 * Creates a (regular) album, put 2 photos in it.
+	 * Get original cover_id.
+	 * Set cover of album to photo 1, check that cover_id is photo1.
+	 * Set cover of album to photo 2, check that cover_id is photo2.
+	 * Unset cover of album, check that cover_id is back to original.
+	 *
+	 * @return void
+	 */
 	public function testSetCoverByOwner()
 	{
 		Auth::loginUsingId(0);

--- a/tests/Feature/Lib/AlbumsUnitTest.php
+++ b/tests/Feature/Lib/AlbumsUnitTest.php
@@ -207,6 +207,30 @@ class AlbumsUnitTest
 	}
 
 	/**
+	 * Change cover.
+	 *
+	 * @param string      $id
+	 * @param string|null $photoID
+	 * @param int         $expectedStatusCode
+	 * @param string|null $assertSee
+	 */
+	public function set_cover(
+		string $id,
+		?string $photoID,
+		int $expectedStatusCode = 204,
+		?string $assertSee = null
+	): void {
+		$response = $this->testCase->postJson(
+			'/api/Album::setCover',
+			['albumID' => $id, 'photoID' => $photoID]
+		);
+		$response->assertStatus($expectedStatusCode);
+		if ($assertSee) {
+			$response->assertSee($assertSee, false);
+		}
+	}
+
+	/**
 	 * Set the licence.
 	 *
 	 * @param string      $id


### PR DESCRIPTION
Fixes bug reported by @ezek1el

- creates test that exhibit the behavior (_regression check_).
- fixes unexpected behavior.