### PR TITLE
fixes 1608

### DIFF
--- a/app/Models/Extensions/Thumb.php
+++ b/app/Models/Extensions/Thumb.php
@@ -59,7 +59,7 @@ class Thumb extends DTO
 		try {
 			/** @var Photo|null $cover */
 			$cover = $photoQueryable
-				->withOnly(['size_variants' => fn (HasMany $r) => self::sizeVariantsFilter($r)])
+				->withOnly(['size_variants' => (fn (HasMany $r) => self::sizeVariantsFilter($r))])
 				->orderBy('photos.' . PhotoSortingCriterion::COLUMN_IS_STARRED, SortingCriterion::DESC)
 				->orderBy('photos.' . $sorting->column, $sorting->order)
 				->select(['photos.id', 'photos.type'])

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -140,6 +140,13 @@ class Photo extends Model implements HasRandomID
 	];
 
 	/**
+	 * @var array<int,string> By default preload all the size_variants
+	 */
+	protected $with = [
+		'size_variants',
+	];
+
+	/**
 	 * Creates a new instance of {@link LinkedPhotoCollection}.
 	 *
 	 * The only difference between an ordinary {@link Collection} and a

--- a/app/Relations/HasAlbumThumb.php
+++ b/app/Relations/HasAlbumThumb.php
@@ -39,7 +39,7 @@ class HasAlbumThumb extends Relation
 		$this->photoQueryPolicy = resolve(PhotoQueryPolicy::class);
 		$this->sorting = PhotoSortingCriterion::createDefault();
 		parent::__construct(
-			Photo::query()->with(['size_variants' => fn (HasMany $r) => Thumb::sizeVariantsFilter($r)]),
+			Photo::query()->with(['size_variants' => (fn (HasMany $r) => Thumb::sizeVariantsFilter($r))]),
 			$parent
 		);
 	}


### PR DESCRIPTION
Fixes #1608 

The problem was that when loading a cover the associated relation to `size_variants` as not eager loaded.
It is unclear why this behaviour appears. I could reproduce it with my live DB but not on my test bench.
Will possibly need more investigation (to figure out what is the triggering cause).

**This patch proposes to always eager load the size-variants when fetching a Picture model (which is pretty much always the case anyway).**

While this code is no longer necessary, it still helps to decrease the memory load and the number of models hydrated.
```php
->withOnly(['size_variants' => (fn (HasMany $r) => self::sizeVariantsFilter($r))])
```

As follows is the trace of the error.
```
{
    "message": "Attempted to lazy load [size_variants] on model [App\\Models\\Photo] but lazy loading is disabled.",
    "exception": "Illuminate\\Database\\LazyLoadingViolationException",
    "file": "~/Lychee/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php",
    "line": 563,
    "trace": [
        {
            "file": "~/Lychee/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php",
            "line": 522,
            "function": "handleLazyLoadingViolation",
            "class": "Illuminate\\Database\\Eloquent\\Model",
            "type": "->"
        },
        {
            "file": "~/Lychee/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php",
            "line": 453,
            "function": "getRelationValue",
            "class": "Illuminate\\Database\\Eloquent\\Model",
            "type": "->"
        },
        {
            "file": "~/Lychee/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php",
            "line": 2218,
            "function": "getAttribute",
            "class": "Illuminate\\Database\\Eloquent\\Model",
            "type": "->"
        },
        {
            "file": "~/Lychee/app/Models/Extensions/Thumb.php",
            "line": 83,
            "function": "__get",
            "class": "Illuminate\\Database\\Eloquent\\Model",
            "type": "->"
        },
        {
            "file": "~/Lychee/app/Relations/HasAlbumThumb.php",
            "line": 276,
            "function": "createFromPhoto",
            "class": "App\\Models\\Extensions\\Thumb",
            "type": "::"
        },
        {
            "file": "~/Lychee/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php",
            "line": 749,
            "function": "match",
            "class": "App\\Relations\\HasAlbumThumb",
            "type": "->"
        },
        {
            "file": "~/Lychee/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php",
            "line": 719,
            "function": "eagerLoadRelation",
            "class": "Illuminate\\Database\\Eloquent\\Builder",
            "type": "->"
        },
        {
            "file": "~/Lychee/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php",
            "line": 687,
            "function": "eagerLoadRelations",
            "class": "Illuminate\\Database\\Eloquent\\Builder",
            "type": "->"
        },
        {
            "file": "~/Lychee/app/Models/Extensions/SortingDecorator.php",
            "line": 141,
            "function": "get",
            "class": "Illuminate\\Database\\Eloquent\\Builder",
            "type": "->"
        },
        {
            "file": "~/Lychee/app/Actions/Albums/Top.php",
            "line": 101,
            "function": "get",
            "class": "App\\Models\\Extensions\\SortingDecorator",
            "type": "->"
        },
        {
            "file": "~/Lychee/app/Http/Controllers/AlbumsController.php",
            "line": 27,
            "function": "get",
            "class": "App\\Actions\\Albums\\Top",
            "type": "->"
        },
```