### PR TITLE
Dump exception if dying on 500 during tests.

### DIFF
--- a/tests/Feature/ApiTokenTest.php
+++ b/tests/Feature/ApiTokenTest.php
@@ -12,7 +12,6 @@
 
 namespace Tests\Feature;
 
-use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Tests\Feature\Lib\UsersUnitTest;
@@ -43,12 +42,12 @@ class ApiTokenTest extends TestCase
 		$token = $this->resetAdminToken();
 
 		$response = $this->postJson('/api/User::getAuthenticatedUser');
-		$response->assertStatus(204);
+		$this->assertStatus($response, 204);
 
 		$response = $this->postJson('/api/User::getAuthenticatedUser', [], [
 			'Authorization' => $token,
 		]);
-		$response->assertStatus(200);
+		$this->assertStatus($response, 200);
 		$response->assertSee([
 			'id' => 0,
 		], false);
@@ -71,7 +70,7 @@ class ApiTokenTest extends TestCase
 		$response = $this->postJson('/api/User::getAuthenticatedUser', [], [
 			'Authorization' => $adminToken,
 		]);
-		$response->assertStatus(200);
+		$this->assertStatus($response, 200);
 		$response->assertSee([
 			'id' => 0,
 		], false);
@@ -90,7 +89,7 @@ class ApiTokenTest extends TestCase
 		$response = $this->postJson('/api/User::getAuthenticatedUser', [], [
 			'Authorization' => $userToken,
 		]);
-		$response->assertStatus(200);
+		$this->assertStatus($response, 200);
 		$response->assertSee([
 			'id' => $userId,
 		], false);
@@ -111,7 +110,7 @@ class ApiTokenTest extends TestCase
 		$response = $this->postJson('/api/User::getAuthenticatedUser', [], [
 			'Authorization' => $adminToken,
 		]);
-		$response->assertStatus(200);
+		$this->assertStatus($response, 200);
 		$response->assertSee([
 			'id' => 0,
 		], false);
@@ -134,7 +133,7 @@ class ApiTokenTest extends TestCase
 		$response = $this->postJson('/api/User::getAuthenticatedUser', [], [
 			'Authorization' => $userToken,
 		]);
-		$response->assertStatus(401);
+		$this->assertStatus($response, 401);
 	}
 
 	/**
@@ -153,7 +152,7 @@ class ApiTokenTest extends TestCase
 		$response = $this->postJson('/api/User::getAuthenticatedUser', [], [
 			'Authorization' => $userToken,
 		]);
-		$response->assertStatus(200);
+		$this->assertStatus($response, 200);
 		$response->assertSee([
 			'id' => $userId,
 		], false);
@@ -174,13 +173,13 @@ class ApiTokenTest extends TestCase
 		], [
 			'Authorization' => $userToken,
 		]);
-		$response->assertStatus(204);
+		$this->assertStatus($response, 204);
 
 		Auth::forgetGuards();
 
 		// Ensure that we are still logged in even without providing the token
 		$response = $this->postJson('/api/User::getAuthenticatedUser');
-		$response->assertStatus(200);
+		$this->assertStatus($response, 200);
 		$response->assertSee([
 			'id' => $userId,
 		], false);
@@ -191,13 +190,13 @@ class ApiTokenTest extends TestCase
 		$response = $this->postJson('/api/Session::logout', [], [
 			'Authorization' => $userToken,
 		]);
-		$response->assertStatus(204);
+		$this->assertStatus($response, 204);
 
 		Auth::forgetGuards();
 
 		// Ensure that we are logged out without the token
 		$response = $this->postJson('/api/User::getAuthenticatedUser');
-		$response->assertStatus(204);
+		$this->assertStatus($response, 204);
 	}
 
 	/**
@@ -217,7 +216,7 @@ class ApiTokenTest extends TestCase
 		], [
 			'Authorization' => $userToken2,
 		]);
-		$response->assertStatus(400);
+		$this->assertStatus($response, 400);
 	}
 
 	/**
@@ -236,9 +235,9 @@ class ApiTokenTest extends TestCase
 			'username' => 'user1',
 			'password' => 'pwd1',
 		]);
-		$response->assertStatus(204);
+		$this->assertStatus($response, 204);
 		$response = $this->postJson('/api/User::getAuthenticatedUser');
-		$response->assertStatus(200);
+		$this->assertStatus($response, 200);
 		$response->assertSee([
 			'id' => $userId1,
 		], false);
@@ -256,7 +255,7 @@ class ApiTokenTest extends TestCase
 		$response = $this->postJson('/api/User::getAuthenticatedUser', [], [
 			'Authorization' => $userToken2,
 		]);
-		$response->assertStatus(400);
+		$this->assertStatus($response, 400);
 	}
 
 	/**

--- a/tests/Feature/DemoTest.php
+++ b/tests/Feature/DemoTest.php
@@ -32,7 +32,7 @@ class DemoTest extends TestCase
 
 		// check redirection
 		$response = $this->get('/demo');
-		$response->assertStatus(302);
+		$this->assertStatus($response, 302);
 		$response->assertRedirect('/');
 
 		// set back to initial value
@@ -54,7 +54,7 @@ class DemoTest extends TestCase
 
 		// check redirection
 		$response = $this->get('/demo');
-		$response->assertOk();
+		$this->assertOk($response);
 		$response->assertViewIs('demo');
 
 		// set back to initial value

--- a/tests/Feature/DiagnosticsTest.php
+++ b/tests/Feature/DiagnosticsTest.php
@@ -27,20 +27,20 @@ class DiagnosticsTest extends TestCase
 	public function testDiagnostics(): void
 	{
 		$response = $this->get('/Diagnostics');
-		$response->assertOk(); // code 200 something
+		$this->assertOk($response); // code 200 something
 
 		Auth::loginUsingId(0);
 
 		$response = $this->get('/Diagnostics');
-		$response->assertOk(); // code 200 something
+		$this->assertOk($response); // code 200 something
 
 		Configs::query()->where('key', '=', 'lossless_optimization')->update(['value' => null]);
 
 		$response = $this->postJson('/api/Diagnostics::get');
-		$response->assertOk(); // code 200 something too
+		$this->assertOk($response); // code 200 something too
 
 		$response = $this->postJson('/api/Diagnostics::getSize');
-		$response->assertOk(); // code 200 something too
+		$this->assertOk($response); // code 200 something too
 
 		Configs::query()->where('key', '=', 'lossless_optimization')->update(['value' => '1']);
 

--- a/tests/Feature/IndexTest.php
+++ b/tests/Feature/IndexTest.php
@@ -30,10 +30,10 @@ class IndexTest extends TestCase
 		 * check if we can actually get a nice answer.
 		 */
 		$response = $this->get('/');
-		$response->assertOk();
+		$this->assertOk($response);
 
 		$response = $this->postJson('/api/Albums::get');
-		$response->assertOk();
+		$this->assertOk($response);
 	}
 
 	/**
@@ -47,7 +47,7 @@ class IndexTest extends TestCase
 		Session::flush();
 		// we don't want a non admin to access this
 		$response = $this->get('/phpinfo');
-		$response->assertForbidden();
+		$this->assertForbidden($response);
 	}
 
 	public function testLandingPage(): void
@@ -56,11 +56,11 @@ class IndexTest extends TestCase
 		Configs::set('landing_page_enable', 1);
 
 		$response = $this->get('/');
-		$response->assertOk();
+		$this->assertOk($response);
 		$response->assertViewIs('landing');
 
 		$response = $this->get('/gallery');
-		$response->assertOk();
+		$this->assertOk($response);
 
 		Configs::set('landing_page_enable', $landing_on_off);
 	}

--- a/tests/Feature/InstallTest.php
+++ b/tests/Feature/InstallTest.php
@@ -36,7 +36,7 @@ class InstallTest extends TestCase
 		$prevAppKey = config('app.key');
 		config(['app.key' => null]);
 		$response = $this->get('install/');
-		$response->assertOk();
+		$this->assertOk($response);
 		config(['app.key' => $prevAppKey]);
 
 		// TODO: Why does a `git pull` delete `installed.log`? This test needs to be discussed with @ildyria
@@ -47,7 +47,7 @@ class InstallTest extends TestCase
 		 * No installed.log: we should not be redirected to install (case where we have not done the last migration).
 		 */
 		$response = $this->get('/');
-		$response->assertOk();
+		$this->assertOk($response);
 
 		/*
 		 * Clearing things up. We could do an Artisan migrate but this is more efficient.
@@ -88,35 +88,35 @@ class InstallTest extends TestCase
 		 * No database: we should be redirected to install: default case.
 		 */
 		$response = $this->get('/');
-		$response->assertStatus(307);
+		$this->assertStatus($response, 307);
 		$response->assertRedirect('install/');
 
 		/**
 		 * Check the welcome page.
 		 */
 		$response = $this->get('install/');
-		$response->assertOk();
+		$this->assertOk($response);
 		$response->assertViewIs('install.welcome');
 
 		/**
 		 * Check the requirements page.
 		 */
 		$response = $this->get('install/req');
-		$response->assertOk();
+		$this->assertOk($response);
 		$response->assertViewIs('install.requirements');
 
 		/**
 		 * Check the permissions page.
 		 */
 		$response = $this->get('install/perm');
-		$response->assertOk();
+		$this->assertOk($response);
 		$response->assertViewIs('install.permissions');
 
 		/**
 		 * Check the env page.
 		 */
 		$response = $this->get('install/env');
-		$response->assertOk();
+		$this->assertOk($response);
 		$response->assertViewIs('install.env');
 
 		$env = file_get_contents(base_path('.env'));
@@ -125,28 +125,28 @@ class InstallTest extends TestCase
 		 * POST '.env' the env page.
 		 */
 		$response = $this->post('install/env', ['envConfig' => $env]);
-		$response->assertOk();
+		$this->assertOk($response);
 		$response->assertViewIs('install.env');
 
 		/**
 		 * apply migration.
 		 */
 		$response = $this->get('install/migrate');
-		$response->assertOk();
+		$this->assertOk($response);
 		$response->assertViewIs('install.migrate');
 
 		/**
 		 * Re-Installation should be forbidden now.
 		 */
 		$response = $this->get('install/');
-		$response->assertForbidden();
+		$this->assertForbidden($response);
 
 		/**
 		 * We now should NOT be redirected.
 		 */
 		Configs::invalidateCache();
 		$response = $this->get('/');
-		$response->assertOk();
+		$this->assertOk($response);
 
 		$admin->save();
 		$admin->id = 0;

--- a/tests/Feature/Lib/AlbumsUnitTest.php
+++ b/tests/Feature/Lib/AlbumsUnitTest.php
@@ -14,10 +14,13 @@ namespace Tests\Feature\Lib;
 
 use Illuminate\Testing\TestResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Tests\Feature\Traits\CatchFailures;
 use Tests\TestCase;
 
 class AlbumsUnitTest
 {
+	use CatchFailures;
+
 	private TestCase $testCase;
 
 	public function __construct(TestCase $testCase)
@@ -45,7 +48,7 @@ class AlbumsUnitTest
 			'title' => $title,
 			'parent_id' => $parent_id,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -73,7 +76,7 @@ class AlbumsUnitTest
 			'title' => $title,
 			'tags' => $tags,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -99,7 +102,7 @@ class AlbumsUnitTest
 			'albumID' => $to,
 			'albumIDs' => $ids,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -123,7 +126,7 @@ class AlbumsUnitTest
 			'albumID' => $to,
 			'albumIDs' => $ids,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -149,7 +152,7 @@ class AlbumsUnitTest
 			'/api/Album::get',
 			['albumID' => $id]
 		);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -176,7 +179,7 @@ class AlbumsUnitTest
 			'/api/Album::unlock',
 			['albumID' => $id, 'password' => $password]
 		);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -200,7 +203,7 @@ class AlbumsUnitTest
 			'/api/Album::setTitle',
 			['albumIDs' => [$id], 'title' => $title]
 		);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -224,7 +227,7 @@ class AlbumsUnitTest
 			'/api/Album::setDescription',
 			['albumID' => $id, 'description' => $description]
 		);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -248,7 +251,7 @@ class AlbumsUnitTest
 			'/api/Album::setCover',
 			['albumID' => $id, 'photoID' => $photoID]
 		);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -272,7 +275,7 @@ class AlbumsUnitTest
 			'albumID' => $id,
 			'license' => $license,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -299,7 +302,7 @@ class AlbumsUnitTest
 			'sorting_column' => $sortingCol,
 			'sorting_order' => $sortingOrder,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -349,7 +352,7 @@ class AlbumsUnitTest
 		}
 
 		$response = $this->testCase->postJson('/api/Album::setProtectionPolicy', $params);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -371,7 +374,7 @@ class AlbumsUnitTest
 			'albumID' => $id,
 			'show_tags' => $tags,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -393,7 +396,7 @@ class AlbumsUnitTest
 				'Accept' => '*/*',
 			]
 		);
-		$response->assertOk();
+		$this->assertOk($response);
 		if ($response->baseResponse instanceof StreamedResponse) {
 			// The content of a streamed response is not generated unless
 			// the content is fetched.
@@ -417,7 +420,7 @@ class AlbumsUnitTest
 		?string $assertSee = null
 	): void {
 		$response = $this->testCase->postJson('/api/Album::delete', ['albumIDs' => $ids]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -443,7 +446,7 @@ class AlbumsUnitTest
 			'albumID' => $id,
 			'includeSubAlbums' => $includeSubAlbums,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}

--- a/tests/Feature/Lib/PhotosUnitTest.php
+++ b/tests/Feature/Lib/PhotosUnitTest.php
@@ -16,10 +16,13 @@ use App\Actions\Photo\Archive;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Testing\TestResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Tests\Feature\Traits\CatchFailures;
 use Tests\TestCase;
 
 class PhotosUnitTest
 {
+	use CatchFailures;
+
 	private TestCase $testCase;
 
 	public function __construct(TestCase $testCase)
@@ -51,7 +54,7 @@ class PhotosUnitTest
 			]
 		);
 
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -114,7 +117,7 @@ class PhotosUnitTest
 		$response = $this->testCase->postJson('/api/Photo::get', [
 			'photoID' => $photo_id,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -143,7 +146,7 @@ class PhotosUnitTest
 			'title' => $title,
 			'photoIDs' => [$id],
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -169,7 +172,7 @@ class PhotosUnitTest
 				'photoID' => $id,
 			]
 		);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -193,7 +196,7 @@ class PhotosUnitTest
 			'photoIDs' => $ids,
 			'is_starred' => $isStarred,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -220,7 +223,7 @@ class PhotosUnitTest
 			'tags' => $tags,
 			'shall_override' => $override,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -246,7 +249,7 @@ class PhotosUnitTest
 				'is_public' => $isPublic,
 			]
 		);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -272,7 +275,7 @@ class PhotosUnitTest
 				'license' => $license,
 			]
 		);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -298,7 +301,7 @@ class PhotosUnitTest
 				'date' => $date,
 			]
 		);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -324,7 +327,7 @@ class PhotosUnitTest
 				'albumID' => $album_id,
 			]
 		);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -350,7 +353,7 @@ class PhotosUnitTest
 			'photoIDs' => $ids,
 			'albumID' => $targetAlbumID,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -379,7 +382,7 @@ class PhotosUnitTest
 				'Accept' => '*/*',
 			]
 		);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($response->baseResponse instanceof StreamedResponse) {
 			// The content of a streamed response is not generated unless
 			// the content is fetched.
@@ -405,7 +408,7 @@ class PhotosUnitTest
 		$response = $this->testCase->postJson('/api/Photo::delete', [
 			'photoIDs' => $ids,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -461,7 +464,7 @@ class PhotosUnitTest
 			$requestParams
 		);
 
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -491,7 +494,7 @@ class PhotosUnitTest
 				'urls' => $urls,
 			]);
 
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -519,7 +522,7 @@ class PhotosUnitTest
 			'photoID' => $id,
 			'direction' => $direction,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}

--- a/tests/Feature/Lib/RootAlbumUnitTest.php
+++ b/tests/Feature/Lib/RootAlbumUnitTest.php
@@ -13,10 +13,13 @@
 namespace Tests\Feature\Lib;
 
 use Illuminate\Testing\TestResponse;
+use Tests\Feature\Traits\CatchFailures;
 use Tests\TestCase;
 
 class RootAlbumUnitTest
 {
+	use CatchFailures;
+
 	private TestCase $testCase;
 
 	public function __construct(TestCase $testCase)
@@ -39,7 +42,7 @@ class RootAlbumUnitTest
 		?string $assertDontSee = null
 	): TestResponse {
 		$response = $this->testCase->postJson('/api/Albums::get');
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -65,7 +68,7 @@ class RootAlbumUnitTest
 		?string $assertDontSee = null
 	): TestResponse {
 		$response = $this->testCase->postJson('/api/Albums::tree');
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -89,7 +92,7 @@ class RootAlbumUnitTest
 		?string $assertSee = null
 	): TestResponse {
 		$response = $this->testCase->postJson('/api/Albums::getPositionData');
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}

--- a/tests/Feature/Lib/SessionUnitTest.php
+++ b/tests/Feature/Lib/SessionUnitTest.php
@@ -13,10 +13,13 @@
 namespace Tests\Feature\Lib;
 
 use Illuminate\Testing\TestResponse;
+use Tests\Feature\Traits\CatchFailures;
 use Tests\TestCase;
 
 class SessionUnitTest
 {
+	use CatchFailures;
+
 	private TestCase $testCase;
 
 	public function __construct(TestCase $testCase)
@@ -44,7 +47,7 @@ class SessionUnitTest
 			'username' => $username,
 			'password' => $password,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -63,7 +66,7 @@ class SessionUnitTest
 		?string $assertSee = null
 	): TestResponse {
 		$response = $this->testCase->postJson('/api/Session::init');
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -104,7 +107,7 @@ class SessionUnitTest
 			'username' => $login,
 			'password' => $password,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -135,7 +138,7 @@ class SessionUnitTest
 			'password' => $password,
 			'oldPassword' => $oldPassword,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}

--- a/tests/Feature/Lib/SharingUnitTest.php
+++ b/tests/Feature/Lib/SharingUnitTest.php
@@ -13,10 +13,13 @@
 namespace Tests\Feature\Lib;
 
 use Illuminate\Testing\TestResponse;
+use Tests\Feature\Traits\CatchFailures;
 use Tests\TestCase;
 
 class SharingUnitTest
 {
+	use CatchFailures;
+
 	private TestCase $testCase;
 
 	public function __construct(TestCase $testCase)
@@ -37,7 +40,7 @@ class SharingUnitTest
 		?string $assertSee = null
 	): TestResponse {
 		$response = $this->testCase->postJson('/api/Sharing::list');
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -66,7 +69,7 @@ class SharingUnitTest
 				'albumIDs' => $albumIDs,
 				'userIDs' => $userIDs,
 			]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}

--- a/tests/Feature/Lib/UsersUnitTest.php
+++ b/tests/Feature/Lib/UsersUnitTest.php
@@ -13,10 +13,13 @@
 namespace Tests\Feature\Lib;
 
 use Illuminate\Testing\TestResponse;
+use Tests\Feature\Traits\CatchFailures;
 use Tests\TestCase;
 
 class UsersUnitTest
 {
+	use CatchFailures;
+
 	private TestCase $testCase;
 
 	public function __construct(TestCase $testCase)
@@ -37,7 +40,7 @@ class UsersUnitTest
 		?string $assertSee = null
 	): TestResponse {
 		$response = $this->testCase->postJson('/api/User::list');
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -56,7 +59,7 @@ class UsersUnitTest
 		?string $assertSee = null
 	): TestResponse {
 		$response = $this->testCase->postJson('/php/index.php');
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -90,7 +93,7 @@ class UsersUnitTest
 			'may_upload' => $mayUpload,
 			'is_locked' => $isLocked,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -115,7 +118,7 @@ class UsersUnitTest
 		$response = $this->testCase->postJson('/api/User::delete', [
 			'id' => $id,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -152,7 +155,7 @@ class UsersUnitTest
 			'may_upload' => $mayUpload,
 			'is_locked' => $isLocked,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -177,7 +180,7 @@ class UsersUnitTest
 		$response = $this->testCase->postJson('/api/User::setEmail', [
 			'email' => $email,
 		]);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -198,7 +201,7 @@ class UsersUnitTest
 		?string $assertSee = null
 	): TestResponse {
 		$response = $this->testCase->postJson('/api/User::getEmail');
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}
@@ -219,7 +222,7 @@ class UsersUnitTest
 		string|array|null $assertSee = null
 	): TestResponse {
 		$response = $this->testCase->postJson('/api/User::getAuthenticatedUser');
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee !== null) {
 			$response->assertSee($assertSee, false);
 		}
@@ -240,7 +243,7 @@ class UsersUnitTest
 		?string $assertSee = null
 	): TestResponse {
 		$response = $this->testCase->postJson('/api/User::resetToken');
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee !== null) {
 			$response->assertSee($assertSee, false);
 		}
@@ -261,7 +264,7 @@ class UsersUnitTest
 		?string $assertSee = null
 	): TestResponse {
 		$response = $this->testCase->postJson('/api/User::unsetToken');
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee !== null) {
 			$response->assertSee($assertSee, false);
 		}

--- a/tests/Feature/LogsTest.php
+++ b/tests/Feature/LogsTest.php
@@ -27,14 +27,14 @@ class LogsTest extends TestCase
 	public function testLogs(): void
 	{
 		$response = $this->get('/Logs');
-		$response->assertForbidden();
+		$this->assertForbidden($response);
 
 		// set user as admin
 		Auth::loginUsingId(0);
 
 		Logs::notice(__METHOD__, __LINE__, 'test');
 		$response = $this->get('/Logs');
-		$response->assertOk();
+		$this->assertOk($response);
 		$response->assertViewIs('logs.list');
 
 		Auth::logout();
@@ -44,28 +44,28 @@ class LogsTest extends TestCase
 	public function testApiLogs(): void
 	{
 		$response = $this->postJson('/api/Logs::list');
-		$response->assertForbidden();
+		$this->assertForbidden($response);
 	}
 
 	public function testClearLogs(): void
 	{
 		$response = $this->postJson('/api/Logs::clearNoise');
-		$response->assertForbidden();
+		$this->assertForbidden($response);
 
 		$response = $this->postJson('/api/Logs::clear');
-		$response->assertForbidden();
+		$this->assertForbidden($response);
 
 		// set user as admin
 		Auth::loginUsingId(0);
 
 		$response = $this->postJson('/api/Logs::clearNoise');
-		$response->assertNoContent();
+		$this->assertNoContent($response);
 
 		$response = $this->postJson('/api/Logs::clear');
-		$response->assertNoContent();
+		$this->assertNoContent($response);
 
 		$response = $this->get('/Logs');
-		$response->assertOk();
+		$this->assertOk($response);
 		$response->assertSeeText('Everything looks fine, Lychee has not reported any problems!');
 
 		Auth::logout();

--- a/tests/Feature/NotificationTest.php
+++ b/tests/Feature/NotificationTest.php
@@ -65,7 +65,7 @@ class NotificationTest extends TestCase
 			$response = $this->postJson('/api/Settings::setNewPhotosNotification', [
 				'new_photos_notification' => '1',
 			]);
-			$response->assertNoContent();
+			$this->assertNoContent($response);
 			static::assertEquals('1', Configs::getValue('new_photos_notification'));
 		} finally {
 			// set to initial

--- a/tests/Feature/PhotosOperationsTest.php
+++ b/tests/Feature/PhotosOperationsTest.php
@@ -158,7 +158,7 @@ class PhotosOperationsTest extends PhotoTestBase
 		 * Actually try to display the picture.
 		 */
 		$response = $this->postJson('/api/Photo::getRandom');
-		$response->assertOk();
+		$this->assertOk($response);
 
 		/*
 		 * Erase tag
@@ -237,7 +237,7 @@ class PhotosOperationsTest extends PhotoTestBase
 		 * Actually try to display the picture.
 		 */
 		$response = $this->postJson('/api/Photo::getRandom');
-		$response->assertOk();
+		$this->assertOk($response);
 
 		// delete the picture after displaying it
 		$this->photos_tests->delete([$ids[1]]);
@@ -255,7 +255,7 @@ class PhotosOperationsTest extends PhotoTestBase
 		// check redirection
 		$this->clearCachedSmartAlbums();
 		$response = $this->get('/demo');
-		$response->assertOk();
+		$this->assertOk($response);
 		$response->assertViewIs('demo');
 
 		// set back to initial value
@@ -264,7 +264,7 @@ class PhotosOperationsTest extends PhotoTestBase
 		$this->albums_tests->delete([$albumID]);
 
 		$response = $this->postJson('/api/Photo::clearSymLink');
-		$response->assertNoContent();
+		$this->assertNoContent($response);
 	}
 
 	/**

--- a/tests/Feature/RSSTest.php
+++ b/tests/Feature/RSSTest.php
@@ -54,7 +54,7 @@ class RSSTest extends TestCase
 
 			// check redirection
 			$response = $this->get('/feed');
-			$response->assertStatus(412);
+			$this->assertStatus($response, 412);
 		} finally {
 			Configs::set('rss_enable', $init_config_value);
 		}
@@ -74,7 +74,7 @@ class RSSTest extends TestCase
 
 			// check redirection
 			$response = $this->get('/feed');
-			$response->assertOk();
+			$this->assertOk($response);
 
 			// log as admin
 			Auth::loginUsingId(0);
@@ -92,7 +92,7 @@ class RSSTest extends TestCase
 
 			// try to get the RSS feed.
 			$response = $this->get('/feed');
-			$response->assertOk();
+			$this->assertOk($response);
 
 			// set picture to private
 			$this->photos_tests->set_public($photoID, false);
@@ -103,7 +103,7 @@ class RSSTest extends TestCase
 
 			// try to get the RSS feed.
 			$response = $this->get('/feed');
-			$response->assertOk();
+			$this->assertOk($response);
 
 			$this->albums_tests->delete([$albumID]);
 		} finally {

--- a/tests/Feature/RedirectTest.php
+++ b/tests/Feature/RedirectTest.php
@@ -25,12 +25,12 @@ class RedirectTest extends TestCase
 	{
 		$response = $this->get('r/aaaaaaaaaaaaaaaaaaaaaaaa');
 
-		$response->assertStatus(302);
+		$this->assertStatus($response, 302);
 		$response->assertRedirect('gallery#aaaaaaaaaaaaaaaaaaaaaaaa');
 
 		$response = $this->get('r/aaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbb');
 
-		$response->assertStatus(302);
+		$this->assertStatus($response, 302);
 		$response->assertRedirect('gallery#aaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbb');
 	}
 }

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -334,7 +334,7 @@ class SearchTest extends PhotoTestBase
 			'/api/Search::run',
 			['term' => $term]
 		);
-		$response->assertStatus($expectedStatusCode);
+		$this->assertStatus($response, $expectedStatusCode);
 		if ($assertSee) {
 			$response->assertSee($assertSee, false);
 		}

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -47,7 +47,7 @@ class SettingsTest extends TestCase
 				SetSortingRequest::PHOTO_SORTING_ORDER_ATTRIBUTE => SortingCriterion::ASC,
 			]);
 
-		$response->assertStatus(422);
+		$this->assertStatus($response, 422);
 		$response->assertSee('sorting albums column must be null or one out of');
 
 		Auth::logout();
@@ -66,7 +66,7 @@ class SettingsTest extends TestCase
 				SetSortingRequest::PHOTO_SORTING_ORDER_ATTRIBUTE => SortingCriterion::ASC,
 			]);
 
-		$response->assertStatus(422);
+		$this->assertStatus($response, 422);
 		$response->assertSee('sorting photos column must be null or one out of');
 
 		Auth::logout();
@@ -85,7 +85,7 @@ class SettingsTest extends TestCase
 				SetSortingRequest::PHOTO_SORTING_ORDER_ATTRIBUTE => '123',
 			]);
 
-		$response->assertStatus(422);
+		$this->assertStatus($response, 422);
 		$response->assertSee('order must be either');
 
 		Auth::logout();

--- a/tests/Feature/Traits/CatchFailures.php
+++ b/tests/Feature/Traits/CatchFailures.php
@@ -17,7 +17,7 @@ trait CatchFailures
 			$this->trimException($exception);
 			dump($exception);
 		}
-		$this->assertStatus($response, $expectedStatusCode);
+		$response->assertStatus($expectedStatusCode);
 	}
 
 	/**

--- a/tests/Feature/Traits/CatchFailures.php
+++ b/tests/Feature/Traits/CatchFailures.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\Traits;
+
+use Illuminate\Testing\TestResponse;
+
+/**
+ * This trait allows to retrieve the message returned by the back-end in case of unexpected results.
+ * This provides more readable results than: "status code 500 does match expected status code 200".
+ */
+trait CatchFailures
+{
+	protected function assertStatus(TestResponse $response, int $expectedStatusCode): void
+	{
+		if ($response->getStatusCode() === 500) {
+			$exception = $response->json();
+			$this->trimException($exception);
+			dump($exception);
+		}
+		$this->assertStatus($response, $expectedStatusCode);
+	}
+
+	/**
+	 * An exception is an array of the shape:
+	 * array{message:string, exception:string, file:string, line:int, trace:array{}, previous_exception: obj }
+	 * Unfortunately the trace contains the full call stack and dumping it completely does not add significant
+	 * information. Most of the time only the first 3 values of the trace are of interest.
+	 *
+	 * For this reason this function only keeps the first 3 values of the trace of the exception returned.
+	 *
+	 * Additionally, this transformation is applied recursively on the previous_exception in the case of
+	 * exception encapsulation.
+	 *
+	 * @param array $exception
+	 *
+	 * @return void
+	 */
+	private function trimException(array &$exception): void
+	{
+		$exception['trace'] = array_slice($exception['trace'], 0, 3);
+
+		if ($exception['previous_exception'] !== null) {
+			$exception['previous_exception'] = $this->trimException($exception['previous_exception']);
+		}
+	}
+
+	protected function assertOk(TestResponse $response): void
+	{
+		$this->assertStatus($response, 200);
+	}
+
+	protected function assertForbidden(TestResponse $response): void
+	{
+		$this->assertStatus($response, 403);
+	}
+
+	protected function assertUnauthorized(TestResponse $response): void
+	{
+		$this->assertStatus($response, 401);
+	}
+
+	protected function assertNoContent(TestResponse $response): void
+	{
+		$this->assertStatus($response, 204);
+	}
+}

--- a/tests/Feature/UpdateTest.php
+++ b/tests/Feature/UpdateTest.php
@@ -27,13 +27,13 @@ class UpdateTest extends TestCase
 	public function testDoNotLogged(): void
 	{
 		$response = $this->get('/Update', []);
-		$response->assertForbidden();
+		$this->assertForbidden($response);
 
 		$response = $this->postJson('/api/Update::apply');
-		$response->assertForbidden();
+		$this->assertForbidden($response);
 
 		$response = $this->postJson('/api/Update::check');
-		$response->assertForbidden();
+		$this->assertForbidden($response);
 	}
 
 	public function testDoLogged(): void
@@ -44,16 +44,16 @@ class UpdateTest extends TestCase
 
 		Configs::set('allow_online_git_pull', '0');
 		$response = $this->postJson('/api/Update::apply');
-		$response->assertStatus(412);
+		$this->assertStatus($response, 412);
 		$response->assertSee('Online updates are disabled by configuration');
 
 		Configs::set('allow_online_git_pull', '1');
 
 		$response = $this->get('/Update', []);
-		$response->assertOk();
+		$this->assertOk($response);
 
 		$response = $this->postJson('/api/Update::apply');
-		$response->assertOk();
+		$this->assertOk($response);
 
 		$response = $this->postJson('/api/Update::check');
 		if ($response->status() === 500) {
@@ -70,7 +70,7 @@ class UpdateTest extends TestCase
 				$response->assertSee('Could not determine the branch');
 			}
 		} else {
-			$response->assertOk();
+			$this->assertOk($response);
 		}
 
 		Configs::set('allow_online_git_pull', $gitpull);
@@ -102,10 +102,10 @@ class UpdateTest extends TestCase
 		Auth::logout();
 		Session::flush();
 		$response = $this->postJson('/migrate');
-		$response->assertForbidden();
+		$this->assertForbidden($response);
 
 		$response = $this->postJson('/migrate', ['username' => 'test_login', 'password' => 'test_password']);
-		$response->assertOk();
+		$this->assertOk($response);
 
 		// check that Legacy did change the username
 		$adminUser = User::findOrFail(0);

--- a/tests/Feature/WebAuthTest.php
+++ b/tests/Feature/WebAuthTest.php
@@ -30,7 +30,7 @@ class WebAuthTest extends TestCase
 		Auth::loginUsingId(0);
 
 		$response = $this->postJson('/api/WebAuthn::register/options');
-		$response->assertOk();
+		$this->assertOk($response);
 
 		$response = $this->postJson('/api/WebAuthn::register', [
 			'id' => '-PhslGzltOv3nJ0j8Or1AuNHh9kgmMQmOdM0A7eF7yJcAuSZzFa9YhSHfrYvyllhNUhuIMTE6hFYA3Ef7gCOwg',
@@ -41,13 +41,13 @@ class WebAuthTest extends TestCase
 			],
 			'type' => 'public-key',
 		]);
-		$response->assertStatus(422);
+		$this->assertStatus($response, 422);
 
 		Auth::logout();
 		Session::flush();
 
 		$response = $this->postJson('/api/WebAuthn::login/options', ['user_id' => 0]);
-		$response->assertOk();
+		$this->assertOk($response);
 
 		$response = $this->postJson('/api/WebAuthn::login', [
 			'id' => 'jQJF5u0Fn-MsdabIxKJoxc19XSLXDCSDqs4g8TV1rXXXBDSEoT6LeRN60CfxZskRxq15EEl43OIbPluD7dVT0A',
@@ -60,7 +60,7 @@ class WebAuthTest extends TestCase
 			],
 			'type' => 'public-key',
 		]);
-		$response->assertStatus(422);
+		$this->assertStatus($response, 422);
 
 		$key = (new WebAuthnCredential())->forceFill([
 			'id' => 'hyxPTjCUCWYPcVTxFy7WjCXATwU7UDLI9nPGqifqs9ohskBuVih4Nzdp3UAl-wHTda4CUoAE_ylfQveayx07ug',
@@ -81,15 +81,15 @@ class WebAuthTest extends TestCase
 		Auth::loginUsingId(0);
 
 		$response = $this->postJson('/api/WebAuthn::list');
-		$response->assertOk(); // code 200 something
+		$this->assertOk($response); // code 200 something
 
 		$response = $this->postJson('/api/WebAuthn::delete', ['id' => 'hyxPTjCUCWYPcVTxFy7WjCXATwU7UDLI9nPGqifqs9ohskBuVih4Nzdp3UAl-wHTda4CUoAE_ylfQveayx07ug']);
-		$response->assertNoContent();
+		$this->assertNoContent($response);
 
 		Auth::logout();
 		Session::flush();
 
 		$response = $this->postJson('/api/WebAuthn::delete', ['id' => 'hyxPTjCUCWYPcVTxFy7WjCXATwU7UDLI9nPGqifqs9ohskBuVih4Nzdp3UAl-wHTda4CUoAE_ylfQveayx07ug']);
-		$response->assertUnauthorized();
+		$this->assertUnauthorized($response);
 	}
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,10 +22,12 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Testing\TestResponse;
 use function Safe\json_decode;
 use function Safe\tempnam;
+use Tests\Feature\Traits\CatchFailures;
 
 abstract class TestCase extends BaseTestCase
 {
 	use CreatesApplication;
+	use CatchFailures;
 
 	public const PATH_IMPORT_DIR = 'uploads/import/';
 


### PR DESCRIPTION
Exceptions 500 in tests are quite hard to debug. This provides a trace when one is encountered during tests, allowing for a more targeted debugging.
This is already included in #1539, but this aims to merge it to master faster.