### PR TITLE
Add Unix socket support to Redis

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -170,6 +170,8 @@ return [
 		],
 
 		'default' => [
+			'scheme' => env('REDIS_SCHEME', 'tcp'),
+			'path' => env('REDIS_PATH', null),
 			'url' => env('REDIS_URL'),
 			'host' => env('REDIS_HOST', '127.0.0.1'),
 			'password' => env('REDIS_PASSWORD'),
@@ -178,6 +180,8 @@ return [
 		],
 
 		'cache' => [
+			'scheme' => env('REDIS_SCHEME', 'tcp'),
+			'path' => env('REDIS_PATH', null),
 			'url' => env('REDIS_URL'),
 			'host' => env('REDIS_HOST', '127.0.0.1'),
 			'password' => env('REDIS_PASSWORD', null),


### PR DESCRIPTION
Redis configuration is currently lacking support for Unix sockets. This PR will add it while maintaining current default to TCP connections.

<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.

Don't worry if your code styling isn't perfect! php-cs-fixer will automatically create a pull request with any style fixes. This allows us to focus on the content of the contribution and not the code style.
-->