### PR TITLE
Docs: broken FAQ link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ In order to use the new photos email notification you will need to have configur
 
 ## Troubleshooting
 
-Take a look at the [Documentation](https://lycheeorg.github.io/docs/), particularly the [FAQ](https://lycheeorg.github.io/docs/faq.html) if you have problems. Discovered a bug? Please create an issue [here](https://github.com/LycheeOrg/Lychee/issues) on GitHub! You can also contact us directly on [gitter (login with your github account). &#187;](https://gitter.im/LycheeOrg/Lobby)
+Take a look at the [Documentation](https://lycheeorg.github.io/docs/), particularly the [FAQ](https://lycheeorg.github.io/docs/faq_troubleshooting.html) if you have problems. Discovered a bug? Please create an issue [here](https://github.com/LycheeOrg/Lychee/issues) on GitHub! You can also contact us directly on [gitter (login with your github account). &#187;](https://gitter.im/LycheeOrg/Lobby)
 
 ## Open Source Community Support
 


### PR DESCRIPTION
Fixing broken FAQ link in the readme. Chose to link to the troubleshooting FAQ but open to other suggestions.