### PR TITLE
fix migration when photo do not have an album

### DIFF
--- a/database/migrations/2018_08_15_103716_move_photos.php
+++ b/database/migrations/2018_08_15_103716_move_photos.php
@@ -36,7 +36,7 @@ return new class() extends Migration {
 					$photoAttributes['album_id'] = null;
 				} else {
 					$albumID = Helpers::trancateIf32($result->album, 0);
-					$exists = DB::table('albums')->select('*')->where('id', '=', $albumID)->count() !== 0;
+					$exists = DB::table('albums')->select('id')->where('id', '=', $albumID)->count() > 0;
 					$photoAttributes['album_id'] = $exists ? $albumID : null;
 				}
 				$photoAttributes['title'] = $result->title;

--- a/database/migrations/2018_08_15_103716_move_photos.php
+++ b/database/migrations/2018_08_15_103716_move_photos.php
@@ -35,7 +35,9 @@ return new class() extends Migration {
 				if ($result->album === 0) {
 					$photoAttributes['album_id'] = null;
 				} else {
-					$photoAttributes['album_id'] = Helpers::trancateIf32($result->album, 0);
+					$albumID = Helpers::trancateIf32($result->album, 0);
+					$exists = DB::table('albums')->select('*')->where('id', '=', $albumID)->count() !== 0;
+					$photoAttributes['album_id'] = $exists ? $albumID : null;
 				}
 				$photoAttributes['title'] = $result->title;
 				$photoAttributes['description'] = $result->description;


### PR DESCRIPTION
Fixes #1695 

If a Lychee DB is corrupted (because some album have been removed but the photos are still there) then the first migration fails.

This small patch makes sure that all photos are transferred, those with no longer existing albums will be moved to `unsorted`.