### PR TITLE
Fix cache busting on user.css

### DIFF
--- a/app/Http/Controllers/Administration/SettingsController.php
+++ b/app/Http/Controllers/Administration/SettingsController.php
@@ -329,7 +329,9 @@ class SettingsController extends Controller
 		/** @var string $css */
 		$css = $request->getSettingValue();
 		if (Storage::disk('dist')->put('user.css', $css) === false) {
-			throw new InsufficientFilesystemPermissions('Could not save CSS');
+			if (Storage::disk('dist')->get('user.css') !== $css) {
+				throw new InsufficientFilesystemPermissions('Could not save CSS');
+			}
 		}
 	}
 

--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -61,7 +61,7 @@ class IndexController extends Controller
 					'infos' => $infos,
 					'page_config' => $page_config,
 					'rss_enable' => $rss_enable,
-					'user_css_url' => Storage::disk('dist')->url('user.css'),
+					'user_css_url' => $this->getUserCss(),
 				]);
 			}
 
@@ -190,10 +190,25 @@ class IndexController extends Controller
 				'pageUrl' => url()->current(),
 				'rssEnable' => Configs::getValueAsBool('rss_enable'),
 				'bodyHtml' => file_get_contents(public_path('dist/frontend.html')),
-				'userCssUrl' => Storage::disk('dist')->url('user.css'),
+				'userCssUrl' => $this->getUserCss(),
 			]);
 		} catch (BindingResolutionException $e) {
 			throw new FrameworkException('Laravel\'s container component', $e);
 		}
+	}
+
+	/**
+	 * Returns user.css url with cache busting if file has been updated.
+	 *
+	 * @return string
+	 */
+	private function getUserCss(): string
+	{
+		$cssCacheBusting = '';
+		if (Storage::disk('dist')->fileExists('user.css')) {
+			$cssCacheBusting = '?' . Storage::disk('dist')->lastModified('user.css');
+		}
+
+		return Storage::disk('dist')->url('user.css') . $cssCacheBusting;
 	}
 }


### PR DESCRIPTION
Fixes #1699 

Code was working, just that the caching of the file was interfering with the expected behavior.
Caching is now properly fixed by appending the modified time to the file name as query string.