### PR TITLE
allow forcing https scheme

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=production
 APP_KEY=
 APP_DEBUG=false
 APP_URL=http://localhost
+APP_FORCE_HTTPS=false
 
 # enable or disable debug bar. By default it is disabled.
 DEBUGBAR_ENABLED=false

--- a/config/app.php
+++ b/config/app.php
@@ -69,6 +69,8 @@ return [
 
 	'asset_url' => null,
 
+	'force_https' => (bool) env('APP_FORCE_HTTPS', false),
+
 	/*
 	|--------------------------------------------------------------------------
 	| Application Timezone

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,10 +16,7 @@ use Illuminate\Support\Facades\URL;
 |
 */
 
-// We need that to force https everywhere
-// if (env('APP_ENV') === 'production') {
-
-if (config('app.env') === 'dev') {
+if (config('app.force_https')) {
 	URL::forceScheme('https');
 }
 

--- a/routes/web-admin.php
+++ b/routes/web-admin.php
@@ -17,10 +17,7 @@ use Illuminate\Support\Facades\URL;
 |
 */
 
-// We need that to force https everywhere
-// if (env('APP_ENV') === 'production') {
-
-if (env('APP_ENV') === 'dev') {
+if (config('app.force_https')) {
 	URL::forceScheme('https');
 }
 

--- a/routes/web-install.php
+++ b/routes/web-install.php
@@ -16,10 +16,7 @@ use Illuminate\Support\Facades\URL;
 |
 */
 
-// We need that to force https everywhere
-// if (env('APP_ENV') === 'production') {
-
-if (env('APP_ENV') === 'dev') {
+if (config('app.force_https')) {
 	URL::forceScheme('https');
 }
 

--- a/routes/web-livewire.php
+++ b/routes/web-livewire.php
@@ -3,6 +3,7 @@
 namespace App\Http\Livewire;
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\URL;
 
 /*
 |--------------------------------------------------------------------------
@@ -14,6 +15,9 @@ use Illuminate\Support\Facades\Route;
 | contains the "web" middleware group. Now create something great!
 |
 */
+if (config('app.force_https')) {
+	URL::forceScheme('https');
+}
 
 if (config('app.livewire')) {
 	Route::group(['layout' => ''], function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,10 +16,7 @@ use Illuminate\Support\Facades\URL;
 |
 */
 
-// We need that to force https everywhere
-// if (env('APP_ENV') === 'production') {
-
-if (config('app.env') === 'dev') {
+if (config('app.force_https')) {
 	URL::forceScheme('https');
 }
 


### PR DESCRIPTION
By default Laravel recognise the scheme and return the appropriate http/https.
However it is sometimes necessary to force it (e.g. behind a reverse proxy).