### PR TITLE
Improve tests to also use users.

### DIFF
--- a/tests/Feature/Abstract/AbstractPhotosAddHandlerGDTest.php
+++ b/tests/Feature/Abstract/AbstractPhotosAddHandlerGDTest.php
@@ -10,16 +10,17 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature;
+namespace Tests\Feature\Abstract;
 
 use Tests\AbstractTestCase;
+use Tests\Feature\Base\BasePhotosAddHandler;
 use Tests\Feature\Traits\InteractsWithRaw;
 use Tests\Feature\Traits\RequiresImageHandler;
 
 /**
- * Runs the tests of {@link PhotosAddHandlerTestAbstract} with GD as image handler.
+ * Runs the tests of {@link BasePhotosAddHandler} with GD as image handler.
  */
-class PhotosAddHandlerGDTest extends BasePhotosAddHandler
+abstract class AbstractPhotosAddHandlerGDTest extends BasePhotosAddHandler
 {
 	use InteractsWithRaw;
 	use RequiresImageHandler;

--- a/tests/Feature/Abstract/AbstractPhotosAddHandlerImagickTest.php
+++ b/tests/Feature/Abstract/AbstractPhotosAddHandlerImagickTest.php
@@ -10,16 +10,17 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature;
+namespace Tests\Feature\Abstract;
 
 use Tests\AbstractTestCase;
+use Tests\Feature\Base\BasePhotosAddHandler;
 use Tests\Feature\Traits\InteractsWithRaw;
 use Tests\Feature\Traits\RequiresImageHandler;
 
 /**
- * Runs the tests of {@link PhotosAddHandlerTestAbstract} with Imagick as image handler.
+ * Runs the tests of {@link BasePhotosAddHandler} with Imagick as image handler.
  */
-class PhotosAddHandlerImagickTest extends BasePhotosAddHandler
+abstract class AbstractPhotosAddHandlerImagickTest extends BasePhotosAddHandler
 {
 	use InteractsWithRaw;
 	use RequiresImageHandler;

--- a/tests/Feature/Abstract/AbstractPhotosAddNegativeTest.php
+++ b/tests/Feature/Abstract/AbstractPhotosAddNegativeTest.php
@@ -10,7 +10,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature;
+namespace Tests\Feature\Abstract;
 
 use function Safe\chmod;
 use function Safe\copy;
@@ -23,7 +23,7 @@ use Tests\Feature\Traits\InteractsWithRaw;
 /**
  * Contains all tests which add photos to Lychee and are expected to fail.
  */
-class PhotosAddNegativeTest extends BasePhotoTest
+abstract class AbstractPhotosAddNegativeTest extends BasePhotoTest
 {
 	use InteractsWithRaw;
 	use InteractsWithFilesystemPermissions;

--- a/tests/Feature/Abstract/AbstractPhotosAddSpecialAlbumTest.php
+++ b/tests/Feature/Abstract/AbstractPhotosAddSpecialAlbumTest.php
@@ -10,7 +10,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature;
+namespace Tests\Feature\Abstract;
 
 use App\SmartAlbums\PublicAlbum;
 use App\SmartAlbums\RecentAlbum;
@@ -22,7 +22,7 @@ use Tests\Feature\Traits\InteractWithSmartAlbums;
 /**
  * Contains tests which add photos to Lychee and directly set an album.
  */
-class PhotosAddSpecialAlbumTest extends BasePhotoTest
+abstract class AbstractPhotosAddSpecialAlbumTest extends BasePhotoTest
 {
 	use InteractWithSmartAlbums;
 

--- a/tests/Feature/Abstract/AbstractPhotosDownloadTest.php
+++ b/tests/Feature/Abstract/AbstractPhotosDownloadTest.php
@@ -10,9 +10,8 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature;
+namespace Tests\Feature\Abstract;
 
-use App\Actions\Photo\Archive;
 use App\Enum\DownloadVariantType;
 use App\Image\Files\InMemoryBuffer;
 use App\Image\Files\TemporaryLocalFile;
@@ -26,13 +25,14 @@ use function Safe\filesize;
 use function Safe\fwrite;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 use Tests\AbstractTestCase;
+use Tests\Feature\Base\BasePhotoTest;
 use Tests\Feature\Lib\AssertableZipArchive;
 use Tests\Feature\Lib\SharingUnitTest;
 use Tests\Feature\Lib\UsersUnitTest;
 use Tests\Feature\Traits\RequiresEmptyAlbums;
 use Tests\Feature\Traits\RequiresEmptyUsers;
 
-class PhotosDownloadTest extends Base\BasePhotoTest
+abstract class AbstractPhotosDownloadTest extends BasePhotoTest
 {
 	use RequiresEmptyUsers;
 	use RequiresEmptyAlbums;

--- a/tests/Feature/Abstract/AbstractSearchTest.php
+++ b/tests/Feature/Abstract/AbstractSearchTest.php
@@ -10,7 +10,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature;
+namespace Tests\Feature\Abstract;
 
 use App\Models\Configs;
 use Illuminate\Support\Facades\Auth;
@@ -23,7 +23,7 @@ use Tests\Feature\Lib\UsersUnitTest;
 use Tests\Feature\Traits\RequiresEmptyAlbums;
 use Tests\Feature\Traits\RequiresEmptyUsers;
 
-class SearchTest extends BasePhotoTest
+abstract class AbstractSearchTest extends BasePhotoTest
 {
 	use RequiresEmptyAlbums;
 	use RequiresEmptyUsers;

--- a/tests/Feature/AdminAlbumTest.php
+++ b/tests/Feature/AdminAlbumTest.php
@@ -28,13 +28,15 @@ use Tests\Feature\Lib\PhotosUnitTest;
 use Tests\Feature\Lib\RootAlbumUnitTest;
 use Tests\Feature\Lib\SharingUnitTest;
 use Tests\Feature\Lib\UsersUnitTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
 use Tests\Feature\Traits\InteractWithSmartAlbums;
 use Tests\Feature\Traits\RequiresEmptyAlbums;
 use Tests\Feature\Traits\RequiresEmptyPhotos;
 use Tests\Feature\Traits\RequiresEmptyUsers;
 
-class AlbumTest extends AbstractTestCase
+class AdminAlbumTest extends AbstractTestCase
 {
+	use ExecuteAsAdmin;
 	use InteractWithSmartAlbums;
 	use RequiresEmptyAlbums;
 	use RequiresEmptyUsers;

--- a/tests/Feature/AdminApiTokenTest.php
+++ b/tests/Feature/AdminApiTokenTest.php
@@ -16,11 +16,13 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Tests\AbstractTestCase;
 use Tests\Feature\Lib\UsersUnitTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
 use Tests\Feature\Traits\RequiresEmptyUsers;
 
-class ApiTokenTest extends AbstractTestCase
+class AdminApiTokenTest extends AbstractTestCase
 {
 	use RequiresEmptyUsers;
+	use ExecuteAsAdmin;
 
 	protected UsersUnitTest $users_tests;
 

--- a/tests/Feature/AdminPhotosAddHandlerGDTest.php
+++ b/tests/Feature/AdminPhotosAddHandlerGDTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature;
+
+use Tests\Feature\Abstract\AbstractPhotosAddHandlerGDTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
+
+/**
+ * Runs the tests as Admin of {@link BasePhotosAddHandler} with GD as image handler.
+ */
+class AdminPhotosAddHandlerGDTest extends AbstractPhotosAddHandlerGDTest
+{
+	use ExecuteAsAdmin;
+}

--- a/tests/Feature/AdminPhotosAddHandlerImagickTest.php
+++ b/tests/Feature/AdminPhotosAddHandlerImagickTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature;
+
+use Tests\Feature\Abstract\AbstractPhotosAddHandlerImagickTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
+
+/**
+ * Runs the tests as Admin of {@link PhotosAddHandlerTestAbstract} with Imagick as image handler.
+ */
+class AdminPhotosAddHandlerImagickTest extends AbstractPhotosAddHandlerImagickTest
+{
+	use ExecuteAsAdmin;
+}

--- a/tests/Feature/AdminPhotosAddMethodsTest.php
+++ b/tests/Feature/AdminPhotosAddMethodsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature;
+
+use Tests\Feature\Abstract\AbstractPhotosAddMethodsTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
+
+/**
+ * Contains all tests as Admin for the various ways of adding images to Lychee
+ * (upload, download, import) and their various options.
+ */
+class AdminPhotosAddMethodsTest extends AbstractPhotosAddMethodsTest
+{
+	use ExecuteAsAdmin;
+}

--- a/tests/Feature/AdminPhotosAddNegativeTest.php
+++ b/tests/Feature/AdminPhotosAddNegativeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature;
+
+use Tests\Feature\Abstract\AbstractPhotosAddNegativeTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
+
+/**
+ * Contains all tests which add photos to Lychee and are expected to fail as Admin.
+ */
+class AdminPhotosAddNegativeTest extends AbstractPhotosAddNegativeTest
+{
+	use ExecuteAsAdmin;
+}

--- a/tests/Feature/AdminPhotosAddSpecialAlbumTest.php
+++ b/tests/Feature/AdminPhotosAddSpecialAlbumTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature;
+
+use Tests\Feature\Abstract\AbstractPhotosAddSpecialAlbumTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
+
+/**
+ * Contains tests as Admin which add photos to Lychee and directly set an album.
+ */
+class AdminPhotosAddSpecialAlbumTest extends AbstractPhotosAddSpecialAlbumTest
+{
+	use ExecuteAsAdmin;
+}

--- a/tests/Feature/AdminPhotosDownloadTest.php
+++ b/tests/Feature/AdminPhotosDownloadTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature;
+
+use Tests\Feature\Abstract\AbstractPhotosDownloadTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
+
+class AdminPhotosDownloadTest extends AbstractPhotosDownloadTest
+{
+	use ExecuteAsAdmin;
+}

--- a/tests/Feature/AdminPhotosRotateGDTest.php
+++ b/tests/Feature/AdminPhotosRotateGDTest.php
@@ -13,14 +13,16 @@
 namespace Tests\Feature;
 
 use Tests\Feature\Base\BasePhotosRotateTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
 use Tests\Feature\Traits\RequiresImageHandler;
 
 /**
  * Runs the tests of {@link PhotosRotateTestAbstract} with GD as image handler.
  */
-class PhotosRotateGDTest extends BasePhotosRotateTest
+class AdminPhotosRotateGDTest extends BasePhotosRotateTest
 {
 	use RequiresImageHandler;
+	use ExecuteAsAdmin;
 
 	public function setUp(): void
 	{

--- a/tests/Feature/AdminPhotosRotateImagickTest.php
+++ b/tests/Feature/AdminPhotosRotateImagickTest.php
@@ -13,14 +13,16 @@
 namespace Tests\Feature;
 
 use Tests\Feature\Base\BasePhotosRotateTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
 use Tests\Feature\Traits\RequiresImageHandler;
 
 /**
  * Runs the tests of {@link BasePhotosRotateTest} with Imagick as image handler.
  */
-class PhotosRotateImagickTest extends BasePhotosRotateTest
+class AdminPhotosRotateImagickTest extends BasePhotosRotateTest
 {
 	use RequiresImageHandler;
+	use ExecuteAsAdmin;
 
 	public function setUp(): void
 	{

--- a/tests/Feature/AdminSearchTest.php
+++ b/tests/Feature/AdminSearchTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature;
+
+use Tests\Feature\Abstract\AbstractSearchTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
+
+class AdminSearchTest extends AbstractSearchTest
+{
+	use ExecuteAsAdmin;
+}

--- a/tests/Feature/Base/BasePhotoTest.php
+++ b/tests/Feature/Base/BasePhotoTest.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Session;
 use Tests\AbstractTestCase;
 use Tests\Feature\Lib\AlbumsUnitTest;
 use Tests\Feature\Lib\PhotosUnitTest;
+use Tests\Feature\Traits\RequiresAdmin;
 use Tests\Feature\Traits\RequiresEmptyPhotos;
 use Tests\Feature\Traits\RequiresExifTool;
 use Tests\Feature\Traits\RequiresFFMpeg;
@@ -26,6 +27,7 @@ abstract class BasePhotoTest extends AbstractTestCase
 	use RequiresEmptyPhotos;
 	use RequiresExifTool;
 	use RequiresFFMpeg;
+	use RequiresAdmin;
 
 	protected AlbumsUnitTest $albums_tests;
 	protected PhotosUnitTest $photos_tests;
@@ -38,7 +40,7 @@ abstract class BasePhotoTest extends AbstractTestCase
 		$this->setUpRequiresExifTool();
 		$this->setUpRequiresFFMpeg();
 		$this->setUpRequiresEmptyPhotos();
-		Auth::loginUsingId(1);
+		Auth::loginUsingId($this->executeAs());
 	}
 
 	public function tearDown(): void
@@ -48,6 +50,22 @@ abstract class BasePhotoTest extends AbstractTestCase
 		$this->tearDownRequiresEmptyPhotos();
 		$this->tearDownRequiresFFMpeg();
 		$this->tearDownRequiresExifTool();
+		$this->logoutAs();
 		parent::tearDown();
 	}
+
+	/**
+	 * Allow selection of which user to log in with.
+	 *
+	 * @return int user ID
+	 */
+	abstract protected function executeAs(): int;
+
+	/**
+	 * Because we can use executeAs() to create an extra user.
+	 * It is also necessary to be able to remove it.
+	 *
+	 * @return void
+	 */
+	abstract protected function logoutAs(): void;
 }

--- a/tests/Feature/Base/BasePhotosAddHandler.php
+++ b/tests/Feature/Base/BasePhotosAddHandler.php
@@ -10,13 +10,12 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature;
+namespace Tests\Feature\Base;
 
 use App\Models\Configs;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Tests\AbstractTestCase;
-use Tests\Feature\Base\BasePhotoTest;
 
 /**
  * Contains all tests for adding photos to Lychee which involve the image

--- a/tests/Feature/Base/BaseSharingTest.php
+++ b/tests/Feature/Base/BaseSharingTest.php
@@ -17,6 +17,7 @@ use Tests\AbstractTestCase;
 use Tests\Feature\Lib\RootAlbumUnitTest;
 use Tests\Feature\Lib\SharingUnitTest;
 use Tests\Feature\Lib\UsersUnitTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
 use Tests\Feature\Traits\InteractWithSmartAlbums;
 use Tests\Feature\Traits\RequiresEmptyAlbums;
 use Tests\Feature\Traits\RequiresEmptyUsers;
@@ -26,6 +27,7 @@ abstract class BaseSharingTest extends BasePhotoTest
 	use RequiresEmptyAlbums;
 	use RequiresEmptyUsers;
 	use InteractWithSmartAlbums;
+	use ExecuteAsAdmin;
 
 	public const PHOTO_NIGHT_TITLE = 'night';
 	public const PHOTO_MONGOLIA_TITLE = 'mongolia';

--- a/tests/Feature/Base/BaseSharingWithAnonUser.php
+++ b/tests/Feature/Base/BaseSharingWithAnonUser.php
@@ -18,7 +18,7 @@ use App\SmartAlbums\StarredAlbum;
 use App\SmartAlbums\UnsortedAlbum;
 
 /**
- * Implements the tests of {@link SharingTestScenariosAbstract} for an
+ * Implements the tests of {@link BaseSharingTestScenarios} for an
  * anonymous user whose results are independent of the setting for public
  * search.
  */

--- a/tests/Feature/Base/BaseSharingWithNonAdminUser.php
+++ b/tests/Feature/Base/BaseSharingWithNonAdminUser.php
@@ -19,7 +19,7 @@ use App\SmartAlbums\UnsortedAlbum;
 use Illuminate\Support\Facades\Auth;
 
 /**
- * Implements the tests of {@link SharingTestScenariosAbstract} for a
+ * Implements the tests of {@link BaseSharingTestScenarios} for a
  * non-admin user whose results are independent of the setting for public
  * search.
  */

--- a/tests/Feature/CommandFixPermissionsTest.php
+++ b/tests/Feature/CommandFixPermissionsTest.php
@@ -15,9 +15,13 @@ namespace Tests\Feature;
 use function Safe\chmod;
 use function Safe\fileperms;
 use Tests\AbstractTestCase;
+use Tests\Feature\Base\BasePhotoTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
 
-class CommandFixPermissionsTest extends Base\BasePhotoTest
+class CommandFixPermissionsTest extends BasePhotoTest
 {
+	use ExecuteAsAdmin;
+
 	public const COMMAND = 'lychee:fix-permissions';
 
 	/**

--- a/tests/Feature/CommandGenerateThumbsTest.php
+++ b/tests/Feature/CommandGenerateThumbsTest.php
@@ -17,9 +17,12 @@ use Illuminate\Support\Facades\DB;
 use function Safe\unlink;
 use Tests\AbstractTestCase;
 use Tests\Feature\Base\BasePhotoTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
 
 class CommandGenerateThumbsTest extends BasePhotoTest
 {
+	use ExecuteAsAdmin;
+
 	public const COMMAND = 'lychee:generate_thumbs';
 
 	public function testNoArguments(): void

--- a/tests/Feature/CommandGhostbusterTest.php
+++ b/tests/Feature/CommandGhostbusterTest.php
@@ -14,9 +14,12 @@ namespace Tests\Feature;
 
 use Illuminate\Support\Facades\DB;
 use Tests\AbstractTestCase;
+use Tests\Feature\Traits\ExecuteAsAdmin;
 
 class CommandGhostbusterTest extends Base\BasePhotoTest
 {
+	use ExecuteAsAdmin;
+
 	public const COMMAND = 'lychee:ghostbuster';
 
 	public function testRemoveOrphanedFiles(): void

--- a/tests/Feature/CommandTakeDateTest.php
+++ b/tests/Feature/CommandTakeDateTest.php
@@ -16,9 +16,12 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Tests\AbstractTestCase;
 use Tests\Feature\Base\BasePhotoTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
 
 class CommandTakeDateTest extends BasePhotoTest
 {
+	use ExecuteAsAdmin;
+
 	public const COMMAND = 'lychee:takedate';
 
 	public function testNoUpdateRequired(): void

--- a/tests/Feature/CommandVideoDataTest.php
+++ b/tests/Feature/CommandVideoDataTest.php
@@ -16,9 +16,12 @@ use App\Enum\SizeVariantType;
 use Illuminate\Support\Facades\DB;
 use Tests\AbstractTestCase;
 use Tests\Feature\Base\BasePhotoTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
 
 class CommandVideoDataTest extends BasePhotoTest
 {
+	use ExecuteAsAdmin;
+
 	public const COMMAND = 'lychee:video_data';
 
 	public function testThumbRecreation(): void

--- a/tests/Feature/LegacyTest.php
+++ b/tests/Feature/LegacyTest.php
@@ -19,12 +19,14 @@ use Illuminate\Support\Facades\Session;
 use Tests\AbstractTestCase;
 use Tests\Feature\Lib\AlbumsUnitTest;
 use Tests\Feature\Lib\PhotosUnitTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
 use Tests\Feature\Traits\RequiresEmptyAlbums;
 use Tests\Feature\Traits\RequiresEmptyPhotos;
 use Tests\Feature\Traits\RequiresEmptyUsers;
 
 class LegacyTest extends AbstractTestCase
 {
+	use ExecuteAsAdmin;
 	use RequiresEmptyAlbums;
 	use RequiresEmptyUsers;
 	use RequiresEmptyPhotos;

--- a/tests/Feature/Lib/PhotosUnitTest.php
+++ b/tests/Feature/Lib/PhotosUnitTest.php
@@ -467,8 +467,11 @@ class PhotosUnitTest
 		if ($assertSee !== null) {
 			$response->assertSee($assertSee, false);
 		}
+		if ($expectedStatusCode === 200) {
+			return $response->streamedContent();
+		}
 
-		return $response->streamedContent();
+		return 'content is irrelevant';
 	}
 
 	/**

--- a/tests/Feature/MayUploadUserPhotosAddHandlerGDTest.php
+++ b/tests/Feature/MayUploadUserPhotosAddHandlerGDTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature;
+
+use Tests\Feature\Abstract\AbstractPhotosAddHandlerGDTest;
+use Tests\Feature\Traits\ExecuteAsMayUploadUser;
+
+/**
+ * Runs the tests as MayUploadUser of {@link BasePhotosAddHandler} with GD as image handler.
+ */
+class MayUploadUserPhotosAddHandlerGDTest extends AbstractPhotosAddHandlerGDTest
+{
+	use ExecuteAsMayUploadUser;
+}

--- a/tests/Feature/MayUploadUserPhotosAddHandlerImagickTest.php
+++ b/tests/Feature/MayUploadUserPhotosAddHandlerImagickTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature;
+
+use Tests\Feature\Abstract\AbstractPhotosAddHandlerImagickTest;
+use Tests\Feature\Traits\ExecuteAsMayUploadUser;
+
+/**
+ * Runs the tests as MayUploadUser of {@link PhotosAddHandlerTestAbstract} with Imagick as image handler.
+ */
+class MayUploadUserPhotosAddHandlerImagickTest extends AbstractPhotosAddHandlerImagickTest
+{
+	use ExecuteAsMayUploadUser;
+}

--- a/tests/Feature/MayUploadUserPhotosAddMethodsTest.php
+++ b/tests/Feature/MayUploadUserPhotosAddMethodsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature;
+
+use Tests\Feature\Abstract\AbstractPhotosAddMethodsTest;
+use Tests\Feature\Traits\ExecuteAsMayUploadUser;
+
+/**
+ * Contains all tests as MayUploadUser for the various ways of adding images to Lychee
+ * (upload, download, import) and their various options.
+ */
+class MayUploadUserPhotosAddMethodsTest extends AbstractPhotosAddMethodsTest
+{
+	use ExecuteAsMayUploadUser;
+}

--- a/tests/Feature/MayUploadUserPhotosAddSpecialAlbumTest.php
+++ b/tests/Feature/MayUploadUserPhotosAddSpecialAlbumTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature;
+
+use Tests\Feature\Abstract\AbstractPhotosAddSpecialAlbumTest;
+use Tests\Feature\Traits\ExecuteAsMayUploadUser;
+
+/**
+ * Contains tests as MayUploadUser which add photos to Lychee and directly set an album.
+ */
+class MayUploadUserPhotosAddSpecialAlbumTest extends AbstractPhotosAddSpecialAlbumTest
+{
+	use ExecuteAsMayUploadUser;
+}

--- a/tests/Feature/MayUploadUserPhotosDownloadTest.php
+++ b/tests/Feature/MayUploadUserPhotosDownloadTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature;
+
+use Tests\Feature\Abstract\AbstractPhotosDownloadTest;
+use Tests\Feature\Traits\ExecuteAsMayUploadUser;
+
+class MayUploadUserPhotosDownloadTest extends AbstractPhotosDownloadTest
+{
+	use ExecuteAsMayUploadUser;
+}

--- a/tests/Feature/NotificationTest.php
+++ b/tests/Feature/NotificationTest.php
@@ -21,12 +21,14 @@ use Tests\AbstractTestCase;
 use Tests\Feature\Lib\AlbumsUnitTest;
 use Tests\Feature\Lib\PhotosUnitTest;
 use Tests\Feature\Lib\UsersUnitTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
 use Tests\Feature\Traits\RequiresEmptyAlbums;
 use Tests\Feature\Traits\RequiresEmptyPhotos;
 use Tests\Feature\Traits\RequiresEmptyUsers;
 
 class NotificationTest extends AbstractTestCase
 {
+	use ExecuteAsAdmin;
 	use RequiresEmptyAlbums;
 	use RequiresEmptyUsers;
 	use RequiresEmptyPhotos;

--- a/tests/Feature/PhotosOperationsTest.php
+++ b/tests/Feature/PhotosOperationsTest.php
@@ -28,6 +28,7 @@ use Tests\Feature\Base\BasePhotoTest;
 use Tests\Feature\Lib\RootAlbumUnitTest;
 use Tests\Feature\Lib\SharingUnitTest;
 use Tests\Feature\Lib\UsersUnitTest;
+use Tests\Feature\Traits\ExecuteAsAdmin;
 use Tests\Feature\Traits\InteractWithSmartAlbums;
 use Tests\Feature\Traits\RequiresEmptyAlbums;
 use Tests\Feature\Traits\RequiresEmptyUsers;
@@ -37,6 +38,7 @@ class PhotosOperationsTest extends BasePhotoTest
 	use InteractWithSmartAlbums;
 	use RequiresEmptyAlbums;
 	use RequiresEmptyUsers;
+	use ExecuteAsAdmin;
 
 	protected RootAlbumUnitTest $root_album_tests;
 	protected UsersUnitTest $users_tests;

--- a/tests/Feature/SharingBasicTest.php
+++ b/tests/Feature/SharingBasicTest.php
@@ -12,7 +12,7 @@
 
 namespace Tests\Feature;
 
-class SharingBasicTest extends Base\BaseSharingTest
+class AbstractSharingBasicTest extends Base\BaseSharingTest
 {
 	/**
 	 * @return void

--- a/tests/Feature/SharingSpecialTest.php
+++ b/tests/Feature/SharingSpecialTest.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Facades\Session;
 use Tests\AbstractTestCase;
 use Tests\Feature\Base\BaseSharingTest;
 
-class SharingSpecialTest extends BaseSharingTest
+class AbstractSharingSpecialTest extends BaseSharingTest
 {
 	public const ALBUM_TITLE_4 = 'Test Album 4';
 	public const ALBUM_TITLE_5 = 'Test Album 5';

--- a/tests/Feature/SharingWithAnonUserAndNoPublicSearchTest.php
+++ b/tests/Feature/SharingWithAnonUserAndNoPublicSearchTest.php
@@ -33,7 +33,7 @@ class SharingWithAnonUserAndNoPublicSearchTest extends BaseSharingWithAnonUser
 	 * "401 - Unauthenticated" for the other.
 	 *
 	 * See
-	 * {@link SharingTestScenariosAbstract::prepareUnsortedPublicAndPrivatePhoto()}
+	 * {@link AbstractSharingTestScenarios::prepareUnsortedPublicAndPrivatePhoto()}
 	 * for description of scenario.
 	 *
 	 * @return void

--- a/tests/Feature/Traits/ExecuteAsAdmin.php
+++ b/tests/Feature/Traits/ExecuteAsAdmin.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Traits;
+
+/**
+ * This trait allows BasePhotoTests to be executed as Admin directly.
+ */
+trait ExecuteAsAdmin
+{
+	/**
+	 * We just return the ID of admin, i.e. 1.
+	 *
+	 * @return int
+	 */
+	protected function executeAs(): int
+	{
+		return 1;
+	}
+
+	/**
+	 * Nothing to do, admin user always exists.
+	 *
+	 * @return void
+	 */
+	protected function logoutAs(): void
+	{
+	}
+}

--- a/tests/Feature/Traits/ExecuteAsMayUploadUser.php
+++ b/tests/Feature/Traits/ExecuteAsMayUploadUser.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Traits;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * This trait allows BasePhotoTests to be executed as user with Upload Rights directly.
+ */
+trait ExecuteAsMayUploadUser
+{
+	/**
+	 * We create a new user with ID 2 and upload rights.
+	 *
+	 * @return int
+	 */
+	protected function executeAs(): int
+	{
+		/** @var User|null $user */
+		$user = User::find(2);
+		if ($user === null) {
+			$user = new User();
+			$user->incrementing = false;
+			$user->id = 2;
+			$user->may_upload = true;
+			$user->may_edit_own_settings = false;
+			$user->may_administrate = false;
+			$user->username = 'NOT admin';
+			$user->password = Hash::make('password');
+			$user->save();
+
+			if (Schema::connection(null)->getConnection()->getDriverName() === 'pgsql' && DB::table('users')->count() > 0) {
+				// when using PostgreSQL, the next ID value is kept when inserting without incrementing
+				// which results in errors because trying to insert a user with ID = 1.
+				// Thus, we need to reset the index to the greatest ID + 1
+				/** @var User $lastUser */
+				$lastUser = User::query()->orderByDesc('id')->first();
+				DB::statement('ALTER SEQUENCE users_id_seq1 RESTART WITH ' . strval($lastUser->id + 1));
+			}
+		} elseif (!$user->may_upload) {
+			$user->may_upload = true;
+			$user->save();
+		}
+
+		return 2;
+	}
+
+	/**
+	 * Delete User created.
+	 *
+	 * @return void
+	 */
+	protected function logoutAs(): void
+	{
+		// RIP
+		User::where('id', '=', 2)->delete();
+	}
+}

--- a/tests/Feature/Traits/RequiresAdmin.php
+++ b/tests/Feature/Traits/RequiresAdmin.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature\Traits;
+
+use Illuminate\Support\Facades\Auth;
+
+trait RequiresAdmin
+{
+	protected function assertIsAdminOrSkip(): void
+	{
+		if (Auth::user()?->may_administrate !== true) {
+			static::markTestSkipped('Test only relevant if executed as admin user.');
+		}
+	}
+
+	abstract public static function markTestSkipped(string $message = ''): void;
+}

--- a/tests/Feature/Traits/RequiresEmptyUsers.php
+++ b/tests/Feature/Traits/RequiresEmptyUsers.php
@@ -16,6 +16,8 @@ use Illuminate\Support\Facades\DB;
 
 trait RequiresEmptyUsers
 {
+	abstract protected function executeAs(): int;
+
 	abstract protected function assertDatabaseCount($table, int $count, $connection = null);
 
 	protected function setUpRequiresEmptyUsers(): void
@@ -24,7 +26,7 @@ trait RequiresEmptyUsers
 		static::assertEquals(
 			0,
 			DB::table('users')
-				->where('may_administrate', '=', false)
+				->where('id', '>', $this->executeAs())
 				->count()
 		);
 	}
@@ -32,6 +34,8 @@ trait RequiresEmptyUsers
 	protected function tearDownRequiresEmptyUsers(): void
 	{
 		// Clean up remaining stuff from tests
-		DB::table('users')->where('may_administrate', '=', false)->delete();
+		DB::table('users')
+			->where('may_administrate', '=', false)
+			->delete();
 	}
 }


### PR DESCRIPTION
Fixes #634  - Last tests missing

**Still unsure we want those changes as they complexify the tests quite a bit...**

Change can be summarized as follows:
tests requiring a logged user via `setUp` are now using an abstract method which provides which user to run.
The rest of those change is to accomodate this abstract method.
