### PR TITLE
Add configuration option to set auth guard driver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,16 @@ DB_LIST_FOREIGN_KEYS=true
 # LYCHEE_DIST_URL="dist/"
 # LYCHEE_SYM_URL="sym/"
 
+# Authentication guard. This defines how the users are actually retrieved
+# out of your database or other storage mechanisms used by this application
+# to persist your user's data.
+# Possible values are:
+#
+# - session: user is retrieved from session
+# - token: user is retrieved from token like basic auth
+# - session-or-token: uses both (the default)
+# LYCHEE_AUTH_GUARD="session-or-token"
+
 CACHE_DRIVER=file
 SESSION_DRIVER=file
 SESSION_LIFETIME=120

--- a/.env.example
+++ b/.env.example
@@ -60,15 +60,9 @@ DB_LIST_FOREIGN_KEYS=true
 # LYCHEE_DIST_URL="dist/"
 # LYCHEE_SYM_URL="sym/"
 
-# Authentication guard. This defines how the users are actually retrieved
-# out of your database or other storage mechanisms used by this application
-# to persist your user's data.
-# Possible values are:
-#
-# - session: user is retrieved from session
-# - token: user is retrieved from token like basic auth
-# - session-or-token: uses both (the default)
-# LYCHEE_AUTH_GUARD="session-or-token"
+# Support for token based authentication like basic auth. Enabled by default.
+# Disable when running Lychee behind 3rd party managed authentication.
+# ENABLE_TOKEN_AUTH="true"
 
 CACHE_DRIVER=file
 SESSION_DRIVER=file

--- a/config/auth.php
+++ b/config/auth.php
@@ -39,7 +39,7 @@ return [
 
 	'guards' => [
 		'lychee' => [
-			'driver' => env('LYCHEE_AUTH_GUARD', 'session-or-token'),
+			'driver' => env('ENABLE_TOKEN_AUTH', true) ? 'session-or-token' : 'session',
 			'provider' => 'users',
 		],
 	],

--- a/config/auth.php
+++ b/config/auth.php
@@ -39,7 +39,7 @@ return [
 
 	'guards' => [
 		'lychee' => [
-			'driver' => 'session-or-token',
+			'driver' => env('LYCHEE_AUTH_GUARD', 'session-or-token'),
 			'provider' => 'users',
 		],
 	],


### PR DESCRIPTION
Lychee extends the auth guard driver to be able to use session and token at the same time. It also defaults to this option by setting it to: `session-or-token` but does not provide an option for users to set this driver when needed.

Using tokens breaks Lychee when running behind a basic auth from Apache / Nginx with a user not related to Lychee and will only display a `BadRequestHeaderException` error.

This PR adds an option called `LYCHEE_AUTH_GUARD` which will default to `session-or-token` as it is the default already. It allows users with select between `session`, `token` and `session-or-token`.

I will add another PR for the docs.