### PR TITLE
use RuleSets instead of directly rule property

### DIFF
--- a/app/Contracts/Http/Requests/RequestAttribute.php
+++ b/app/Contracts/Http/Requests/RequestAttribute.php
@@ -9,6 +9,8 @@ class RequestAttribute
 	public const USER_ID_ATTRIBUTE = 'userID';
 	public const USER_IDS_ATTRIBUTE = 'userIDs';
 
+	public const EMAIL_ATTRIBUTE = 'email';
+
 	public const PARENT_ID_ATTRIBUTE = 'parent_id';
 
 	public const ALBUM_ID_ATTRIBUTE = 'albumID';
@@ -32,6 +34,17 @@ class RequestAttribute
 	public const SORTING_COLUMN_ATTRIBUTE = 'sorting_column';
 	public const SORTING_ORDER_ATTRIBUTE = 'sorting_order';
 
+	public const IS_NSFW_ATTRIBUTE = 'is_nsfw';
+	public const IS_PUBLIC_ATTRIBUTE = 'is_public';
+	public const IS_LINK_REQUIRED_ATTRIBUTE = 'is_link_required';
+	public const GRANTS_DOWNLOAD_ATTRIBUTE = 'grants_download';
+	public const GRANTS_FULL_PHOTO_ACCESS_ATTRIBUTE = 'grants_full_photo_access';
+
+	public const FILE_ATTRIBUTE = 'file';
+	public const SHALL_OVERRIDE_ATTRIBUTE = 'shall_override';
+	public const IS_STARRED_ATTRIBUTE = 'is_starred';
+	public const DIRECTION_ATTRIBUTE = 'direction';
+
 	/**
 	 * Due to historic reasons the attribute which stores the type of
 	 * size variant is called `kind`.
@@ -44,8 +57,23 @@ class RequestAttribute
 	 * TODO: Maybe rename the attribute in the back- and front-end to avoid overloading the same term.
 	 */
 	public const SIZE_VARIANT_ATTRIBUTE = 'kind';
+
 	public const TAGS_ATTRIBUTE = 'tags';
+	/**
+	 * For historical reasons the parameter of the API is called `show_tags`
+	 * and not only `tags`; otherwise `RequestAttribute::TAGS_ATTRIBUTE` could be used.
+	 */
+	public const SHOW_TAGS_ATTRIBUTE = 'show_tags';
 
 	public const MAY_UPLOAD_ATTRIBUTE = 'may_upload';
 	public const MAY_EDIT_OWN_SETTINGS_ATTRIBUTE = 'may_edit_own_settings';
+
+	/**
+	 * Import from server attributes.
+	 */
+	public const PATH_ATTRIBUTE = 'paths';
+	public const DELETE_IMPORTED_ATTRIBUTE = 'delete_imported';
+	public const SKIP_DUPLICATES_ATTRIBUTE = 'skip_duplicates';
+	public const IMPORT_VIA_SYMLINK_ATTRIBUTE = 'import_via_symlink';
+	public const RESYNC_METADATA_ATTRIBUTE = 'resync_metadata';
 }

--- a/app/Contracts/Http/RuleSet.php
+++ b/app/Contracts/Http/RuleSet.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Contracts\Http;
+
+/**
+ * In order to avoid code duplication, we centralize the rule sets
+ * used during the validation of requests as they are used both
+ * in Livewire and in the Requests class.
+ */
+interface RuleSet
+{
+	/**
+	 * Return an array containing the rules to be applied to the request attributes.
+	 *
+	 * @return array
+	 */
+	public static function rules(): array;
+
+	// TODO: Associate error message to above rules.
+}

--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -25,7 +25,7 @@ use App\Http\Requests\Photo\SetPhotoPublicRequest;
 use App\Http\Requests\Photo\SetPhotosStarredRequest;
 use App\Http\Requests\Photo\SetPhotosTagsRequest;
 use App\Http\Requests\Photo\SetPhotosTitleRequest;
-use App\Http\Requests\Photo\SetPhotoUploadDate;
+use App\Http\Requests\Photo\SetPhotoUploadDateRequest;
 use App\Image\Files\TemporaryLocalFile;
 use App\Image\Files\UploadedFile;
 use App\ModelFunctions\SymLinkFunctions;
@@ -276,13 +276,13 @@ class PhotoController extends Controller
 	/**
 	 * Sets the license of the photo.
 	 *
-	 * @param SetPhotoUploadDate $request
+	 * @param SetPhotoUploadDateRequest $request
 	 *
 	 * @return void
 	 *
 	 * @throws LycheeException
 	 */
-	public function setUploadDate(SetPhotoUploadDate $request): void
+	public function setUploadDate(SetPhotoUploadDateRequest $request): void
 	{
 		$request->photo()->created_at = $request->requestDate();
 		$request->photo()->save();

--- a/app/Http/Requests/Album/AddAlbumRequest.php
+++ b/app/Http/Requests/Album/AddAlbumRequest.php
@@ -9,10 +9,9 @@ use App\Contracts\Models\AbstractAlbum;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasParentAlbumTrait;
 use App\Http\Requests\Traits\HasTitleTrait;
+use App\Http\RuleSets\Album\AddAlbumRuleSet;
 use App\Models\Album;
 use App\Policies\AlbumPolicy;
-use App\Rules\RandomIDRule;
-use App\Rules\TitleRule;
 use Illuminate\Support\Facades\Gate;
 
 class AddAlbumRequest extends BaseApiRequest implements HasTitle, HasParentAlbum
@@ -33,10 +32,7 @@ class AddAlbumRequest extends BaseApiRequest implements HasTitle, HasParentAlbum
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::PARENT_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
-			RequestAttribute::TITLE_ATTRIBUTE => ['required', new TitleRule()],
-		];
+		return AddAlbumRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Album/AddTagAlbumRequest.php
+++ b/app/Http/Requests/Album/AddTagAlbumRequest.php
@@ -9,8 +9,8 @@ use App\Contracts\Models\AbstractAlbum;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasTagsTrait;
 use App\Http\Requests\Traits\HasTitleTrait;
+use App\Http\RuleSets\Album\AddTagAlbumRuleSet;
 use App\Policies\AlbumPolicy;
-use App\Rules\TitleRule;
 use Illuminate\Support\Facades\Gate;
 
 class AddTagAlbumRequest extends BaseApiRequest implements HasTitle, HasTags
@@ -34,11 +34,7 @@ class AddTagAlbumRequest extends BaseApiRequest implements HasTitle, HasTags
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::TITLE_ATTRIBUTE => ['required', new TitleRule()],
-			RequestAttribute::TAGS_ATTRIBUTE => 'required|array|min:1',
-			RequestAttribute::TAGS_ATTRIBUTE . '.*' => 'required|string|min:1',
-		];
+		return AddTagAlbumRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Album/ArchiveAlbumsRequest.php
+++ b/app/Http/Requests/Album/ArchiveAlbumsRequest.php
@@ -7,8 +7,8 @@ use App\Contracts\Http\Requests\RequestAttribute;
 use App\Contracts\Models\AbstractAlbum;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasAlbumsTrait;
+use App\Http\RuleSets\Album\ArchiveAlbumRuleSet;
 use App\Policies\AlbumPolicy;
-use App\Rules\AlbumIDListRule;
 use Illuminate\Support\Facades\Gate;
 
 /**
@@ -38,9 +38,7 @@ class ArchiveAlbumsRequest extends BaseApiRequest implements HasAlbums
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_IDS_ATTRIBUTE => ['required', new AlbumIDListRule()],
-		];
+		return ArchiveAlbumRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Album/DeleteAlbumsRequest.php
+++ b/app/Http/Requests/Album/DeleteAlbumsRequest.php
@@ -6,9 +6,9 @@ use App\Contracts\Http\Requests\HasAlbumIDs;
 use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasAlbumIDsTrait;
+use App\Http\RuleSets\Album\DeleteAlbumsRuleSet;
 use App\Models\Album;
 use App\Policies\AlbumPolicy;
-use App\Rules\AlbumIDRule;
 use Illuminate\Support\Facades\Gate;
 
 class DeleteAlbumsRequest extends BaseApiRequest implements HasAlbumIDs
@@ -28,10 +28,7 @@ class DeleteAlbumsRequest extends BaseApiRequest implements HasAlbumIDs
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_IDS_ATTRIBUTE => 'required|array|min:1',
-			RequestAttribute::ALBUM_IDS_ATTRIBUTE . '.*' => ['required', new AlbumIDRule(false)],
-		];
+		return DeleteAlbumsRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Album/DeleteTrackRequest.php
+++ b/app/Http/Requests/Album/DeleteTrackRequest.php
@@ -7,8 +7,8 @@ use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditAlbumTrait;
 use App\Http\Requests\Traits\HasAlbumTrait;
+use App\Http\RuleSets\Album\BasicAlbumIdRuleSet;
 use App\Models\Album;
-use App\Rules\AlbumIDRule;
 
 class DeleteTrackRequest extends BaseApiRequest implements HasAlbum
 {
@@ -20,9 +20,7 @@ class DeleteTrackRequest extends BaseApiRequest implements HasAlbum
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new AlbumIDRule(false)],
-		];
+		return BasicAlbumIdRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Album/GetAlbumRequest.php
+++ b/app/Http/Requests/Album/GetAlbumRequest.php
@@ -8,9 +8,9 @@ use App\Contracts\Models\AbstractAlbum;
 use App\Exceptions\PasswordRequiredException;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasAbstractAlbumTrait;
+use App\Http\RuleSets\Album\BasicAlbumIdRuleSet;
 use App\Models\Extensions\BaseAlbum;
 use App\Policies\AlbumPolicy;
-use App\Rules\AlbumIDRule;
 use Illuminate\Support\Facades\Gate;
 
 class GetAlbumRequest extends BaseApiRequest implements HasAbstractAlbum
@@ -45,9 +45,7 @@ class GetAlbumRequest extends BaseApiRequest implements HasAbstractAlbum
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new AlbumIDRule(false)],
-		];
+		return BasicAlbumIdRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Album/MergeAlbumsRequest.php
+++ b/app/Http/Requests/Album/MergeAlbumsRequest.php
@@ -9,8 +9,8 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditAlbumAlbumsTrait;
 use App\Http\Requests\Traits\HasAlbumsTrait;
 use App\Http\Requests\Traits\HasAlbumTrait;
+use App\Http\RuleSets\Album\MergeAlbumsRuleSet;
 use App\Models\Album;
-use App\Rules\RandomIDRule;
 
 /**
  * @implements HasAlbums<Album>
@@ -27,11 +27,7 @@ class MergeAlbumsRequest extends BaseApiRequest implements HasAlbum, HasAlbums
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			RequestAttribute::ALBUM_IDS_ATTRIBUTE => 'required|array|min:1',
-			RequestAttribute::ALBUM_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
-		];
+		return MergeAlbumsRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Album/MoveAlbumsRequest.php
+++ b/app/Http/Requests/Album/MoveAlbumsRequest.php
@@ -9,8 +9,8 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditAlbumAlbumsTrait;
 use App\Http\Requests\Traits\HasAlbumsTrait;
 use App\Http\Requests\Traits\HasAlbumTrait;
+use App\Http\RuleSets\Album\MoveAlbumsRuleSet;
 use App\Models\Album;
-use App\Rules\RandomIDRule;
 
 /**
  * @implements HasAlbums<Album>
@@ -27,11 +27,7 @@ class MoveAlbumsRequest extends BaseApiRequest implements HasAlbum, HasAlbums
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
-			RequestAttribute::ALBUM_IDS_ATTRIBUTE => 'required|array|min:1',
-			RequestAttribute::ALBUM_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
-		];
+		return MoveAlbumsRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Album/SetAlbumCoverRequest.php
+++ b/app/Http/Requests/Album/SetAlbumCoverRequest.php
@@ -9,11 +9,11 @@ use App\Contracts\Models\AbstractAlbum;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasAlbumTrait;
 use App\Http\Requests\Traits\HasPhotoTrait;
+use App\Http\RuleSets\Album\SetAlbumCoverRuleSet;
 use App\Models\Album;
 use App\Models\Photo;
 use App\Policies\AlbumPolicy;
 use App\Policies\PhotoPolicy;
-use App\Rules\RandomIDRule;
 use Illuminate\Support\Facades\Gate;
 
 class SetAlbumCoverRequest extends BaseApiRequest implements HasAlbum, HasPhoto
@@ -35,10 +35,7 @@ class SetAlbumCoverRequest extends BaseApiRequest implements HasAlbum, HasPhoto
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
-		];
+		return SetAlbumCoverRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Album/SetAlbumDescriptionRequest.php
+++ b/app/Http/Requests/Album/SetAlbumDescriptionRequest.php
@@ -9,8 +9,7 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditAlbumTrait;
 use App\Http\Requests\Traits\HasBaseAlbumTrait;
 use App\Http\Requests\Traits\HasDescriptionTrait;
-use App\Rules\DescriptionRule;
-use App\Rules\RandomIDRule;
+use App\Http\RuleSets\Album\SetAlbumDescriptionRuleSet;
 
 class SetAlbumDescriptionRequest extends BaseApiRequest implements HasBaseAlbum, HasDescription
 {
@@ -23,10 +22,7 @@ class SetAlbumDescriptionRequest extends BaseApiRequest implements HasBaseAlbum,
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			RequestAttribute::DESCRIPTION_ATTRIBUTE => ['present', new DescriptionRule()],
-		];
+		return SetAlbumDescriptionRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Album/SetAlbumLicenseRequest.php
+++ b/app/Http/Requests/Album/SetAlbumLicenseRequest.php
@@ -9,9 +9,8 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditAlbumTrait;
 use App\Http\Requests\Traits\HasAlbumTrait;
 use App\Http\Requests\Traits\HasLicenseTrait;
+use App\Http\RuleSets\Album\SetAlbumLicenseRuleSet;
 use App\Models\Album;
-use App\Rules\LicenseRule;
-use App\Rules\RandomIDRule;
 
 class SetAlbumLicenseRequest extends BaseApiRequest implements HasAlbum, HasLicense
 {
@@ -24,10 +23,7 @@ class SetAlbumLicenseRequest extends BaseApiRequest implements HasAlbum, HasLice
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			RequestAttribute::LICENSE_ATTRIBUTE => ['required', new LicenseRule()],
-		];
+		return SetAlbumLicenseRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Album/SetAlbumNSFWRequest.php
+++ b/app/Http/Requests/Album/SetAlbumNSFWRequest.php
@@ -7,7 +7,7 @@ use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditAlbumTrait;
 use App\Http\Requests\Traits\HasBaseAlbumTrait;
-use App\Rules\RandomIDRule;
+use App\Http\RuleSets\Album\SetAlbumNSFWRuleSet;
 
 /**
  * Class SetAlbumNSFWRequest.
@@ -17,8 +17,6 @@ class SetAlbumNSFWRequest extends BaseApiRequest implements HasBaseAlbum
 	use HasBaseAlbumTrait;
 	use AuthorizeCanEditAlbumTrait;
 
-	public const IS_NSFW_ATTRIBUTE = 'is_nsfw';
-
 	protected bool $isNSFW = false;
 
 	/**
@@ -26,10 +24,7 @@ class SetAlbumNSFWRequest extends BaseApiRequest implements HasBaseAlbum
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			self::IS_NSFW_ATTRIBUTE => 'required|boolean',
-		];
+		return SetAlbumNSFWRuleSet::rules();
 	}
 
 	/**
@@ -40,7 +35,7 @@ class SetAlbumNSFWRequest extends BaseApiRequest implements HasBaseAlbum
 		$this->album = $this->albumFactory->findBaseAlbumOrFail(
 			$values[RequestAttribute::ALBUM_ID_ATTRIBUTE]
 		);
-		$this->isNSFW = static::toBoolean($values[self::IS_NSFW_ATTRIBUTE]);
+		$this->isNSFW = static::toBoolean($values[RequestAttribute::IS_NSFW_ATTRIBUTE]);
 	}
 
 	public function isNSFW(): bool

--- a/app/Http/Requests/Album/SetAlbumProtectionPolicyRequest.php
+++ b/app/Http/Requests/Album/SetAlbumProtectionPolicyRequest.php
@@ -10,20 +10,13 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditAlbumTrait;
 use App\Http\Requests\Traits\HasBaseAlbumTrait;
 use App\Http\Requests\Traits\HasPasswordTrait;
-use App\Rules\PasswordRule;
-use App\Rules\RandomIDRule;
+use App\Http\RuleSets\Album\SetAlbumProtectionPolicyRuleSet;
 
 class SetAlbumProtectionPolicyRequest extends BaseApiRequest implements HasBaseAlbum, HasPassword
 {
 	use HasBaseAlbumTrait;
 	use HasPasswordTrait;
 	use AuthorizeCanEditAlbumTrait;
-
-	public const IS_NSFW_ATTRIBUTE = 'is_nsfw';
-	public const IS_PUBLIC_ATTRIBUTE = 'is_public';
-	public const IS_LINK_REQUIRED_ATTRIBUTE = 'is_link_required';
-	public const GRANTS_DOWNLOAD_ATTRIBUTE = 'grants_download';
-	public const GRANTS_FULL_PHOTO_ACCESS_ATTRIBUTE = 'grants_full_photo_access';
 
 	protected bool $isPasswordProvided;
 	protected AlbumProtectionPolicy $albumProtectionPolicy;
@@ -33,15 +26,7 @@ class SetAlbumProtectionPolicyRequest extends BaseApiRequest implements HasBaseA
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			RequestAttribute::PASSWORD_ATTRIBUTE => ['sometimes', new PasswordRule(true)],
-			self::IS_PUBLIC_ATTRIBUTE => 'required|boolean',
-			self::IS_LINK_REQUIRED_ATTRIBUTE => 'required|boolean',
-			self::IS_NSFW_ATTRIBUTE => 'required|boolean',
-			self::GRANTS_DOWNLOAD_ATTRIBUTE => 'required|boolean',
-			self::GRANTS_FULL_PHOTO_ACCESS_ATTRIBUTE => 'required|boolean',
-		];
+		return SetAlbumProtectionPolicyRuleSet::rules();
 	}
 
 	/**
@@ -53,11 +38,11 @@ class SetAlbumProtectionPolicyRequest extends BaseApiRequest implements HasBaseA
 			$values[RequestAttribute::ALBUM_ID_ATTRIBUTE]
 		);
 		$this->albumProtectionPolicy = new AlbumProtectionPolicy(
-			is_public: static::toBoolean($values[self::IS_PUBLIC_ATTRIBUTE]),
-			is_link_required: static::toBoolean($values[self::IS_LINK_REQUIRED_ATTRIBUTE]),
-			is_nsfw: static::toBoolean($values[self::IS_NSFW_ATTRIBUTE]),
-			grants_full_photo_access: static::toBoolean($values[self::GRANTS_FULL_PHOTO_ACCESS_ATTRIBUTE]),
-			grants_download: static::toBoolean($values[self::GRANTS_DOWNLOAD_ATTRIBUTE]),
+			is_public: static::toBoolean($values[RequestAttribute::IS_PUBLIC_ATTRIBUTE]),
+			is_link_required: static::toBoolean($values[RequestAttribute::IS_LINK_REQUIRED_ATTRIBUTE]),
+			is_nsfw: static::toBoolean($values[RequestAttribute::IS_NSFW_ATTRIBUTE]),
+			grants_full_photo_access: static::toBoolean($values[RequestAttribute::GRANTS_FULL_PHOTO_ACCESS_ATTRIBUTE]),
+			grants_download: static::toBoolean($values[RequestAttribute::GRANTS_DOWNLOAD_ATTRIBUTE]),
 		);
 		$this->isPasswordProvided = array_key_exists(RequestAttribute::PASSWORD_ATTRIBUTE, $values);
 		$this->password = $this->isPasswordProvided ? $values[RequestAttribute::PASSWORD_ATTRIBUTE] : null;

--- a/app/Http/Requests/Album/SetAlbumSortingRequest.php
+++ b/app/Http/Requests/Album/SetAlbumSortingRequest.php
@@ -12,8 +12,7 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditAlbumTrait;
 use App\Http\Requests\Traits\HasBaseAlbumTrait;
 use App\Http\Requests\Traits\HasSortingCriterionTrait;
-use App\Rules\RandomIDRule;
-use Illuminate\Validation\Rules\Enum;
+use App\Http\RuleSets\Album\SetAlbumSortingRuleSet;
 
 class SetAlbumSortingRequest extends BaseApiRequest implements HasBaseAlbum, HasSortingCriterion
 {
@@ -26,14 +25,7 @@ class SetAlbumSortingRequest extends BaseApiRequest implements HasBaseAlbum, Has
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			RequestAttribute::SORTING_COLUMN_ATTRIBUTE => ['present', 'nullable', new Enum(ColumnSortingPhotoType::class)],
-			RequestAttribute::SORTING_ORDER_ATTRIBUTE => [
-				'required_with:' . RequestAttribute::SORTING_COLUMN_ATTRIBUTE,
-				'nullable', new Enum(OrderSortingType::class),
-			],
-		];
+		return SetAlbumSortingRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Album/SetAlbumTagsRequest.php
+++ b/app/Http/Requests/Album/SetAlbumTagsRequest.php
@@ -9,8 +9,8 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditAlbumTrait;
 use App\Http\Requests\Traits\HasTagAlbumTrait;
 use App\Http\Requests\Traits\HasTagsTrait;
+use App\Http\RuleSets\Album\SetAlbumTagRuleSet;
 use App\Models\TagAlbum;
-use App\Rules\RandomIDRule;
 
 class SetAlbumTagsRequest extends BaseApiRequest implements HasTagAlbum, HasTags
 {
@@ -19,21 +19,11 @@ class SetAlbumTagsRequest extends BaseApiRequest implements HasTagAlbum, HasTags
 	use AuthorizeCanEditAlbumTrait;
 
 	/**
-	 * For historical reasons the parameter of the API is called `show_tags`
-	 * and not only `tags`; otherwise `HasTags::TAGS_ATTRIBUTE` could be used.
-	 */
-	public const SHOW_TAGS_ATTRIBUTE = 'show_tags';
-
-	/**
 	 * {@inheritDoc}
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			self::SHOW_TAGS_ATTRIBUTE => 'required|array|min:1',
-			self::SHOW_TAGS_ATTRIBUTE . '.*' => 'required|string|min:1',
-		];
+		return SetAlbumTagRuleSet::rules();
 	}
 
 	/**
@@ -46,6 +36,6 @@ class SetAlbumTagsRequest extends BaseApiRequest implements HasTagAlbum, HasTags
 		// we never get a collection
 		// @phpstan-ignore-next-line
 		$this->album = TagAlbum::query()->findOrFail($values[RequestAttribute::ALBUM_ID_ATTRIBUTE]);
-		$this->tags = $values[self::SHOW_TAGS_ATTRIBUTE];
+		$this->tags = $values[RequestAttribute::SHOW_TAGS_ATTRIBUTE];
 	}
 }

--- a/app/Http/Requests/Album/SetAlbumsTitleRequest.php
+++ b/app/Http/Requests/Album/SetAlbumsTitleRequest.php
@@ -9,10 +9,9 @@ use App\Contracts\Models\AbstractAlbum;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasAlbumsTrait;
 use App\Http\Requests\Traits\HasTitleTrait;
+use App\Http\RuleSets\Album\SetAlbumsTitleRuleSet;
 use App\Models\Extensions\BaseAlbum;
 use App\Policies\AlbumPolicy;
-use App\Rules\RandomIDRule;
-use App\Rules\TitleRule;
 use Illuminate\Support\Facades\Gate;
 
 /**
@@ -43,11 +42,7 @@ class SetAlbumsTitleRequest extends BaseApiRequest implements HasTitle, HasAlbum
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_IDS_ATTRIBUTE => 'required|array|min:1',
-			RequestAttribute::ALBUM_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
-			RequestAttribute::TITLE_ATTRIBUTE => ['required', new TitleRule()],
-		];
+		return SetAlbumsTitleRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Album/UnlockAlbumRequest.php
+++ b/app/Http/Requests/Album/UnlockAlbumRequest.php
@@ -8,8 +8,7 @@ use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasBaseAlbumTrait;
 use App\Http\Requests\Traits\HasPasswordTrait;
-use App\Rules\PasswordRule;
-use App\Rules\RandomIDRule;
+use App\Http\RuleSets\Album\UnlockAlbumRuleSet;
 
 class UnlockAlbumRequest extends BaseApiRequest implements HasBaseAlbum, HasPassword
 {
@@ -29,10 +28,7 @@ class UnlockAlbumRequest extends BaseApiRequest implements HasBaseAlbum, HasPass
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			RequestAttribute::PASSWORD_ATTRIBUTE => ['required', new PasswordRule(false)],
-		];
+		return UnlockAlbumRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Import/ImportServerRequest.php
+++ b/app/Http/Requests/Import/ImportServerRequest.php
@@ -8,21 +8,15 @@ use App\Contracts\Http\Requests\RequestAttribute;
 use App\Contracts\Models\AbstractAlbum;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasAlbumTrait;
+use App\Http\RuleSets\Import\ImportServerRuleSet;
 use App\Models\Album;
 use App\Models\Configs;
 use App\Policies\AlbumPolicy;
-use App\Rules\RandomIDRule;
 use Illuminate\Support\Facades\Gate;
 
 class ImportServerRequest extends BaseApiRequest implements HasAlbum
 {
 	use HasAlbumTrait;
-
-	public const PATH_ATTRIBUTE = 'paths';
-	public const DELETE_IMPORTED_ATTRIBUTE = 'delete_imported';
-	public const SKIP_DUPLICATES_ATTRIBUTE = 'skip_duplicates';
-	public const IMPORT_VIA_SYMLINK_ATTRIBUTE = 'import_via_symlink';
-	public const RESYNC_METADATA_ATTRIBUTE = 'resync_metadata';
 
 	/** @var string[] */
 	protected array $paths;
@@ -42,15 +36,7 @@ class ImportServerRequest extends BaseApiRequest implements HasAlbum
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
-			self::PATH_ATTRIBUTE => 'required|array|min:1',
-			self::PATH_ATTRIBUTE . '.*' => 'required|string|distinct',
-			self::DELETE_IMPORTED_ATTRIBUTE => 'sometimes|boolean',
-			self::SKIP_DUPLICATES_ATTRIBUTE => 'sometimes|boolean',
-			self::IMPORT_VIA_SYMLINK_ATTRIBUTE => 'sometimes|boolean',
-			self::RESYNC_METADATA_ATTRIBUTE => 'sometimes|boolean',
-		];
+		return ImportServerRuleSet::rules();
 	}
 
 	/**
@@ -62,19 +48,19 @@ class ImportServerRequest extends BaseApiRequest implements HasAlbum
 		$this->album = $albumID === null ?
 			null :
 			Album::query()->findOrFail($albumID);
-		$this->paths = $values[self::PATH_ATTRIBUTE];
+		$this->paths = $values[RequestAttribute::PATH_ATTRIBUTE];
 		$this->importMode = new ImportMode(
-			isset($values[self::DELETE_IMPORTED_ATTRIBUTE]) ?
-				static::toBoolean($values[self::DELETE_IMPORTED_ATTRIBUTE]) :
+			isset($values[RequestAttribute::DELETE_IMPORTED_ATTRIBUTE]) ?
+				static::toBoolean($values[RequestAttribute::DELETE_IMPORTED_ATTRIBUTE]) :
 				Configs::getValueAsBool('delete_imported'),
-			isset($values[self::SKIP_DUPLICATES_ATTRIBUTE]) ?
-				static::toBoolean($values[self::SKIP_DUPLICATES_ATTRIBUTE]) :
+			isset($values[RequestAttribute::SKIP_DUPLICATES_ATTRIBUTE]) ?
+				static::toBoolean($values[RequestAttribute::SKIP_DUPLICATES_ATTRIBUTE]) :
 				Configs::getValueAsBool('skip_duplicates'),
-			isset($values[self::IMPORT_VIA_SYMLINK_ATTRIBUTE]) ?
-				static::toBoolean($values[self::IMPORT_VIA_SYMLINK_ATTRIBUTE]) :
+			isset($values[RequestAttribute::IMPORT_VIA_SYMLINK_ATTRIBUTE]) ?
+				static::toBoolean($values[RequestAttribute::IMPORT_VIA_SYMLINK_ATTRIBUTE]) :
 				Configs::getValueAsBool('import_via_symlink'),
-			isset($values[self::RESYNC_METADATA_ATTRIBUTE]) &&
-				static::toBoolean($values[self::RESYNC_METADATA_ATTRIBUTE])
+			isset($values[RequestAttribute::RESYNC_METADATA_ATTRIBUTE]) &&
+				static::toBoolean($values[RequestAttribute::RESYNC_METADATA_ATTRIBUTE])
 		);
 	}
 

--- a/app/Http/Requests/Photo/AddPhotoRequest.php
+++ b/app/Http/Requests/Photo/AddPhotoRequest.php
@@ -7,7 +7,7 @@ use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditAlbumTrait;
 use App\Http\Requests\Traits\HasAbstractAlbumTrait;
-use App\Rules\AlbumIDRule;
+use App\Http\RuleSets\Photo\AddPhotoRuleSet;
 use Illuminate\Http\UploadedFile;
 
 class AddPhotoRequest extends BaseApiRequest implements HasAbstractAlbum
@@ -15,7 +15,6 @@ class AddPhotoRequest extends BaseApiRequest implements HasAbstractAlbum
 	use HasAbstractAlbumTrait;
 	use AuthorizeCanEditAlbumTrait;
 
-	public const FILE_ATTRIBUTE = 'file';
 	protected UploadedFile $file;
 
 	/**
@@ -23,10 +22,7 @@ class AddPhotoRequest extends BaseApiRequest implements HasAbstractAlbum
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['present', new AlbumIDRule(true)],
-			self::FILE_ATTRIBUTE => 'required|file',
-		];
+		return AddPhotoRuleSet::rules();
 	}
 
 	/**
@@ -38,7 +34,7 @@ class AddPhotoRequest extends BaseApiRequest implements HasAbstractAlbum
 		$this->album = $albumID === null ?
 			null :
 			$this->albumFactory->findAbstractAlbumOrFail($albumID);
-		$this->file = $files[self::FILE_ATTRIBUTE];
+		$this->file = $files[RequestAttribute::FILE_ATTRIBUTE];
 	}
 
 	public function uploadedFile(): UploadedFile

--- a/app/Http/Requests/Photo/ArchivePhotosRequest.php
+++ b/app/Http/Requests/Photo/ArchivePhotosRequest.php
@@ -9,12 +9,11 @@ use App\Enum\DownloadVariantType;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasPhotosTrait;
 use App\Http\Requests\Traits\HasSizeVariantTrait;
+use App\Http\RuleSets\Photo\ArchivePhotosRuleSet;
 use App\Models\Photo;
 use App\Policies\PhotoPolicy;
-use App\Rules\RandomIDListRule;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Validation\Rules\Enum;
 
 class ArchivePhotosRequest extends BaseApiRequest implements HasPhotos, HasSizeVariant
 {
@@ -41,10 +40,7 @@ class ArchivePhotosRequest extends BaseApiRequest implements HasPhotos, HasSizeV
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::PHOTO_IDS_ATTRIBUTE => ['required', new RandomIDListRule()],
-			RequestAttribute::SIZE_VARIANT_ATTRIBUTE => ['required', new Enum(DownloadVariantType::class)],
-		];
+		return ArchivePhotosRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Photo/DeletePhotosRequest.php
+++ b/app/Http/Requests/Photo/DeletePhotosRequest.php
@@ -6,9 +6,9 @@ use App\Contracts\Http\Requests\HasPhotoIDs;
 use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasPhotoIDsTrait;
+use App\Http\RuleSets\Photo\DeletePhotosRuleSet;
 use App\Models\Photo;
 use App\Policies\PhotoPolicy;
-use App\Rules\RandomIDRule;
 use Illuminate\Support\Facades\Gate;
 
 class DeletePhotosRequest extends BaseApiRequest implements HasPhotoIDs
@@ -28,10 +28,7 @@ class DeletePhotosRequest extends BaseApiRequest implements HasPhotoIDs
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
-			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
-		];
+		return DeletePhotosRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Photo/DuplicatePhotosRequest.php
+++ b/app/Http/Requests/Photo/DuplicatePhotosRequest.php
@@ -9,9 +9,9 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditPhotosAlbumTrait;
 use App\Http\Requests\Traits\HasAlbumTrait;
 use App\Http\Requests\Traits\HasPhotosTrait;
+use App\Http\RuleSets\Photo\DuplicatePhotosRuleSet;
 use App\Models\Album;
 use App\Models\Photo;
-use App\Rules\RandomIDRule;
 
 class DuplicatePhotosRequest extends BaseApiRequest implements HasPhotos, HasAlbum
 {
@@ -24,11 +24,7 @@ class DuplicatePhotosRequest extends BaseApiRequest implements HasPhotos, HasAlb
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
-			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
-		];
+		return DuplicatePhotosRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Photo/GetPhotoRequest.php
+++ b/app/Http/Requests/Photo/GetPhotoRequest.php
@@ -6,9 +6,9 @@ use App\Contracts\Http\Requests\HasPhoto;
 use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasPhotoTrait;
+use App\Http\RuleSets\Photo\GetPhotoRuleSet;
 use App\Models\Photo;
 use App\Policies\PhotoPolicy;
-use App\Rules\RandomIDRule;
 use Illuminate\Support\Facades\Gate;
 
 class GetPhotoRequest extends BaseApiRequest implements HasPhoto
@@ -28,9 +28,7 @@ class GetPhotoRequest extends BaseApiRequest implements HasPhoto
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-		];
+		return GetPhotoRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Photo/MovePhotosRequest.php
+++ b/app/Http/Requests/Photo/MovePhotosRequest.php
@@ -9,9 +9,9 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditPhotosAlbumTrait;
 use App\Http\Requests\Traits\HasAlbumTrait;
 use App\Http\Requests\Traits\HasPhotosTrait;
+use App\Http\RuleSets\Photo\MovePhotosRuleSet;
 use App\Models\Album;
 use App\Models\Photo;
-use App\Rules\RandomIDRule;
 
 class MovePhotosRequest extends BaseApiRequest implements HasPhotos, HasAlbum
 {
@@ -24,11 +24,7 @@ class MovePhotosRequest extends BaseApiRequest implements HasPhotos, HasAlbum
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
-			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
-		];
+		return MovePhotosRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Photo/RotatePhotoRequest.php
+++ b/app/Http/Requests/Photo/RotatePhotoRequest.php
@@ -7,16 +7,13 @@ use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditPhotoTrait;
 use App\Http\Requests\Traits\HasPhotoTrait;
+use App\Http\RuleSets\Photo\RotatePhotoRuleSet;
 use App\Models\Photo;
-use App\Rules\RandomIDRule;
-use Illuminate\Validation\Rule;
 
 class RotatePhotoRequest extends BaseApiRequest implements HasPhoto
 {
 	use HasPhotoTrait;
 	use AuthorizeCanEditPhotoTrait;
-
-	public const DIRECTION_ATTRIBUTE = 'direction';
 
 	protected int $direction;
 
@@ -25,10 +22,7 @@ class RotatePhotoRequest extends BaseApiRequest implements HasPhoto
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			self::DIRECTION_ATTRIBUTE => ['required', Rule::in([-1, 1])],
-		];
+		return RotatePhotoRuleSet::rules();
 	}
 
 	/**
@@ -39,7 +33,7 @@ class RotatePhotoRequest extends BaseApiRequest implements HasPhoto
 		$this->photo = Photo::query()
 			->with(['size_variants'])
 			->findOrFail($values[RequestAttribute::PHOTO_ID_ATTRIBUTE]);
-		$this->direction = intval($values[self::DIRECTION_ATTRIBUTE]);
+		$this->direction = intval($values[RequestAttribute::DIRECTION_ATTRIBUTE]);
 	}
 
 	public function direction(): int

--- a/app/Http/Requests/Photo/SetPhotoDescriptionRequest.php
+++ b/app/Http/Requests/Photo/SetPhotoDescriptionRequest.php
@@ -9,9 +9,8 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditPhotoTrait;
 use App\Http\Requests\Traits\HasDescriptionTrait;
 use App\Http\Requests\Traits\HasPhotoTrait;
+use App\Http\RuleSets\Photo\SetPhotoDescriptionRuleSet;
 use App\Models\Photo;
-use App\Rules\DescriptionRule;
-use App\Rules\RandomIDRule;
 
 class SetPhotoDescriptionRequest extends BaseApiRequest implements HasPhoto, HasDescription
 {
@@ -24,10 +23,7 @@ class SetPhotoDescriptionRequest extends BaseApiRequest implements HasPhoto, Has
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			RequestAttribute::DESCRIPTION_ATTRIBUTE => ['present', new DescriptionRule()],
-		];
+		return SetPhotoDescriptionRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Photo/SetPhotoLicenseRequest.php
+++ b/app/Http/Requests/Photo/SetPhotoLicenseRequest.php
@@ -9,9 +9,8 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditPhotoTrait;
 use App\Http\Requests\Traits\HasLicenseTrait;
 use App\Http\Requests\Traits\HasPhotoTrait;
+use App\Http\RuleSets\Photo\SetPhotoLicenseRuleSet;
 use App\Models\Photo;
-use App\Rules\LicenseRule;
-use App\Rules\RandomIDRule;
 
 class SetPhotoLicenseRequest extends BaseApiRequest implements HasPhoto, HasLicense
 {
@@ -24,10 +23,7 @@ class SetPhotoLicenseRequest extends BaseApiRequest implements HasPhoto, HasLice
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			RequestAttribute::LICENSE_ATTRIBUTE => ['required', new LicenseRule()],
-		];
+		return SetPhotoLicenseRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Photo/SetPhotoPublicRequest.php
+++ b/app/Http/Requests/Photo/SetPhotoPublicRequest.php
@@ -7,8 +7,8 @@ use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditPhotoTrait;
 use App\Http\Requests\Traits\HasPhotoTrait;
+use App\Http\RuleSets\Photo\SetPhotoPublicRuleSet;
 use App\Models\Photo;
-use App\Rules\RandomIDRule;
 
 /**
  * Class SetPhotoPublicRequest.
@@ -18,8 +18,6 @@ class SetPhotoPublicRequest extends BaseApiRequest implements HasPhoto
 	use HasPhotoTrait;
 	use AuthorizeCanEditPhotoTrait;
 
-	public const IS_PUBLIC_ATTRIBUTE = 'is_public';
-
 	protected bool $isPublic = false;
 
 	/**
@@ -27,10 +25,7 @@ class SetPhotoPublicRequest extends BaseApiRequest implements HasPhoto
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			self::IS_PUBLIC_ATTRIBUTE => 'required|boolean',
-		];
+		return SetPhotoPublicRuleSet::rules();
 	}
 
 	/**
@@ -39,7 +34,7 @@ class SetPhotoPublicRequest extends BaseApiRequest implements HasPhoto
 	protected function processValidatedValues(array $values, array $files): void
 	{
 		$this->photo = Photo::query()->findOrFail($values[RequestAttribute::PHOTO_ID_ATTRIBUTE]);
-		$this->isPublic = static::toBoolean($values[self::IS_PUBLIC_ATTRIBUTE]);
+		$this->isPublic = static::toBoolean($values[RequestAttribute::IS_PUBLIC_ATTRIBUTE]);
 	}
 
 	public function isPublic(): bool

--- a/app/Http/Requests/Photo/SetPhotoUploadDateRequest.php
+++ b/app/Http/Requests/Photo/SetPhotoUploadDateRequest.php
@@ -9,11 +9,11 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditPhotoTrait;
 use App\Http\Requests\Traits\HasDateTrait;
 use App\Http\Requests\Traits\HasPhotoTrait;
+use App\Http\RuleSets\Photo\SetPhotoUploadDateRuleSet;
 use App\Models\Photo;
-use App\Rules\RandomIDRule;
 use Illuminate\Support\Carbon;
 
-class SetPhotoUploadDate extends BaseApiRequest implements HasPhoto, HasDate
+class SetPhotoUploadDateRequest extends BaseApiRequest implements HasPhoto, HasDate
 {
 	use HasPhotoTrait;
 	use HasDateTrait;
@@ -24,10 +24,7 @@ class SetPhotoUploadDate extends BaseApiRequest implements HasPhoto, HasDate
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
-			RequestAttribute::DATE_ATTRIBUTE => 'required|date',
-		];
+		return SetPhotoUploadDateRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Photo/SetPhotosStarredRequest.php
+++ b/app/Http/Requests/Photo/SetPhotosStarredRequest.php
@@ -7,8 +7,8 @@ use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditPhotosTrait;
 use App\Http\Requests\Traits\HasPhotosTrait;
+use App\Http\RuleSets\Photo\SetPhotosStarredRuleSet;
 use App\Models\Photo;
-use App\Rules\RandomIDRule;
 
 /**
  * Class SetPhotosStarredRequest.
@@ -27,11 +27,7 @@ class SetPhotosStarredRequest extends BaseApiRequest implements HasPhotos
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
-			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
-			self::IS_STARRED_ATTRIBUTE => 'required|boolean',
-		];
+		return SetPhotosStarredRuleSet::rules();
 	}
 
 	/**
@@ -40,7 +36,7 @@ class SetPhotosStarredRequest extends BaseApiRequest implements HasPhotos
 	protected function processValidatedValues(array $values, array $files): void
 	{
 		$this->photos = Photo::query()->findOrFail($values[RequestAttribute::PHOTO_IDS_ATTRIBUTE]);
-		$this->isStarred = static::toBoolean($values[self::IS_STARRED_ATTRIBUTE]);
+		$this->isStarred = static::toBoolean($values[RequestAttribute::IS_STARRED_ATTRIBUTE]);
 	}
 
 	public function isStarred(): bool

--- a/app/Http/Requests/Photo/SetPhotosTagsRequest.php
+++ b/app/Http/Requests/Photo/SetPhotosTagsRequest.php
@@ -9,16 +9,14 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditPhotosTrait;
 use App\Http\Requests\Traits\HasPhotosTrait;
 use App\Http\Requests\Traits\HasTagsTrait;
+use App\Http\RuleSets\Photo\SetPhotosTagsRuleSet;
 use App\Models\Photo;
-use App\Rules\RandomIDRule;
 
 class SetPhotosTagsRequest extends BaseApiRequest implements HasPhotos, HasTags
 {
 	use HasPhotosTrait;
 	use HasTagsTrait;
 	use AuthorizeCanEditPhotosTrait;
-
-	public const SHALL_OVERRIDE_ATTRIBUTE = 'shall_override';
 
 	public bool $shallOverride;
 
@@ -27,13 +25,7 @@ class SetPhotosTagsRequest extends BaseApiRequest implements HasPhotos, HasTags
 	 */
 	public function rules(): array
 	{
-		return [
-			self::SHALL_OVERRIDE_ATTRIBUTE => 'required|boolean',
-			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
-			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
-			RequestAttribute::TAGS_ATTRIBUTE => 'present|array',
-			RequestAttribute::TAGS_ATTRIBUTE . '.*' => 'required|string|min:1',
-		];
+		return SetPhotosTagsRuleSet::rules();
 	}
 
 	/**
@@ -43,6 +35,6 @@ class SetPhotosTagsRequest extends BaseApiRequest implements HasPhotos, HasTags
 	{
 		$this->photos = Photo::query()->findOrFail($values[RequestAttribute::PHOTO_IDS_ATTRIBUTE]);
 		$this->tags = $values[RequestAttribute::TAGS_ATTRIBUTE];
-		$this->shallOverride = $values[self::SHALL_OVERRIDE_ATTRIBUTE];
+		$this->shallOverride = $values[RequestAttribute::SHALL_OVERRIDE_ATTRIBUTE];
 	}
 }

--- a/app/Http/Requests/Photo/SetPhotosTitleRequest.php
+++ b/app/Http/Requests/Photo/SetPhotosTitleRequest.php
@@ -9,9 +9,8 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\Authorize\AuthorizeCanEditPhotosTrait;
 use App\Http\Requests\Traits\HasPhotosTrait;
 use App\Http\Requests\Traits\HasTitleTrait;
+use App\Http\RuleSets\Photo\SetPhotosTitleRuleSet;
 use App\Models\Photo;
-use App\Rules\RandomIDRule;
-use App\Rules\TitleRule;
 
 class SetPhotosTitleRequest extends BaseApiRequest implements HasPhotos, HasTitle
 {
@@ -24,11 +23,7 @@ class SetPhotosTitleRequest extends BaseApiRequest implements HasPhotos, HasTitl
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
-			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
-			RequestAttribute::TITLE_ATTRIBUTE => ['required', new TitleRule()],
-		];
+		return SetPhotosTitleRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Session/LoginRequest.php
+++ b/app/Http/Requests/Session/LoginRequest.php
@@ -8,8 +8,7 @@ use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasPasswordTrait;
 use App\Http\Requests\Traits\HasUsernameTrait;
-use App\Rules\PasswordRule;
-use App\Rules\UsernameRule;
+use App\Http\RuleSets\Session\LoginRuleSet;
 
 class LoginRequest extends BaseApiRequest implements HasUsername, HasPassword
 {
@@ -29,10 +28,7 @@ class LoginRequest extends BaseApiRequest implements HasUsername, HasPassword
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::USERNAME_ATTRIBUTE => ['required', new UsernameRule()],
-			RequestAttribute::PASSWORD_ATTRIBUTE => ['required', new PasswordRule(false)],
-		];
+		return LoginRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/User/ChangeLoginRequest.php
+++ b/app/Http/Requests/User/ChangeLoginRequest.php
@@ -6,10 +6,9 @@ use App\Contracts\Http\Requests\HasPassword;
 use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasPasswordTrait;
+use App\Http\RuleSets\User\ChangeLoginRuleSet;
 use App\Models\User;
 use App\Policies\UserPolicy;
-use App\Rules\PasswordRule;
-use App\Rules\UsernameRule;
 use Illuminate\Support\Facades\Gate;
 
 class ChangeLoginRequest extends BaseApiRequest implements HasPassword
@@ -32,11 +31,7 @@ class ChangeLoginRequest extends BaseApiRequest implements HasPassword
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::USERNAME_ATTRIBUTE => ['sometimes', new UsernameRule(true)],
-			RequestAttribute::PASSWORD_ATTRIBUTE => ['required', new PasswordRule(false)],
-			RequestAttribute::OLD_PASSWORD_ATTRIBUTE => ['required', new PasswordRule(false)],
-		];
+		return ChangeLoginRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/User/SetEmailRequest.php
+++ b/app/Http/Requests/User/SetEmailRequest.php
@@ -2,15 +2,15 @@
 
 namespace App\Http\Requests\User;
 
+use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
+use App\Http\RuleSets\User\SetEmailRuleSet;
 use App\Models\User;
 use App\Policies\UserPolicy;
 use Illuminate\Support\Facades\Gate;
 
 class SetEmailRequest extends BaseApiRequest
 {
-	public const EMAIL_ATTRIBUTE = 'email';
-
 	protected ?string $email = null;
 
 	/**
@@ -26,14 +26,12 @@ class SetEmailRequest extends BaseApiRequest
 	 */
 	public function rules(): array
 	{
-		return [
-			self::EMAIL_ATTRIBUTE => 'present|nullable|email:rfc,dns|max:100',
-		];
+		return SetEmailRuleSet::rules();
 	}
 
 	protected function processValidatedValues(array $values, array $files): void
 	{
-		$this->email = $values[self::EMAIL_ATTRIBUTE];
+		$this->email = $values[RequestAttribute::EMAIL_ATTRIBUTE];
 	}
 
 	public function email(): ?string

--- a/app/Http/Requests/Users/AddUserRequest.php
+++ b/app/Http/Requests/Users/AddUserRequest.php
@@ -8,10 +8,9 @@ use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasPasswordTrait;
 use App\Http\Requests\Traits\HasUsernameTrait;
+use App\Http\RuleSets\Users\AddUserRuleSet;
 use App\Models\User;
 use App\Policies\UserPolicy;
-use App\Rules\PasswordRule;
-use App\Rules\UsernameRule;
 use Illuminate\Support\Facades\Gate;
 
 class AddUserRequest extends BaseApiRequest implements HasUsername, HasPassword
@@ -35,12 +34,7 @@ class AddUserRequest extends BaseApiRequest implements HasUsername, HasPassword
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::USERNAME_ATTRIBUTE => ['required', new UsernameRule()],
-			RequestAttribute::PASSWORD_ATTRIBUTE => ['required', new PasswordRule(false)],
-			RequestAttribute::MAY_UPLOAD_ATTRIBUTE => 'present|boolean',
-			RequestAttribute::MAY_EDIT_OWN_SETTINGS_ATTRIBUTE => 'present|boolean',
-		];
+		return AddUserRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/Users/SetUserSettingsRequest.php
+++ b/app/Http/Requests/Users/SetUserSettingsRequest.php
@@ -10,11 +10,9 @@ use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasPasswordTrait;
 use App\Http\Requests\Traits\HasUsernameTrait;
 use App\Http\Requests\Traits\HasUserTrait;
+use App\Http\RuleSets\Users\SetUserSettingsRuleSet;
 use App\Models\User;
 use App\Policies\UserPolicy;
-use App\Rules\IntegerIDRule;
-use App\Rules\PasswordRule;
-use App\Rules\UsernameRule;
 use Illuminate\Support\Facades\Gate;
 
 class SetUserSettingsRequest extends BaseApiRequest implements HasUsername, HasPassword, HasUser
@@ -39,13 +37,7 @@ class SetUserSettingsRequest extends BaseApiRequest implements HasUsername, HasP
 	 */
 	public function rules(): array
 	{
-		return [
-			RequestAttribute::ID_ATTRIBUTE => ['required', new IntegerIDRule(false)],
-			RequestAttribute::USERNAME_ATTRIBUTE => ['required', new UsernameRule()],
-			RequestAttribute::PASSWORD_ATTRIBUTE => ['sometimes', new PasswordRule(false)],
-			RequestAttribute::MAY_UPLOAD_ATTRIBUTE => 'present|boolean',
-			RequestAttribute::MAY_EDIT_OWN_SETTINGS_ATTRIBUTE => 'present|boolean',
-		];
+		return SetUserSettingsRuleSet::rules();
 	}
 
 	/**

--- a/app/Http/Requests/WebAuthn/DeleteCredentialRequest.php
+++ b/app/Http/Requests/WebAuthn/DeleteCredentialRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\WebAuthn;
 
 use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
+use App\Http\RuleSets\WebAuthn\DeleteCredentialRuleSet;
 use App\Models\User;
 use App\Policies\UserPolicy;
 use Illuminate\Support\Facades\Gate;
@@ -22,7 +23,7 @@ class DeleteCredentialRequest extends BaseApiRequest
 
 	public function rules(): array
 	{
-		return [RequestAttribute::ID_ATTRIBUTE => 'required|string'];
+		return DeleteCredentialRuleSet::rules();
 	}
 
 	protected function processValidatedValues(array $values, array $files): void

--- a/app/Http/RuleSets/Album/AddAlbumRuleSet.php
+++ b/app/Http/RuleSets/Album/AddAlbumRuleSet.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+use App\Rules\TitleRule;
+
+/**
+ * Rules applied when creating an album.
+ */
+class AddAlbumRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::PARENT_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
+			RequestAttribute::TITLE_ATTRIBUTE => ['required', new TitleRule()],
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/AddTagAlbumRuleSet.php
+++ b/app/Http/RuleSets/Album/AddTagAlbumRuleSet.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\TitleRule;
+
+/**
+ * Rules applied when creating a tag album.
+ */
+class AddTagAlbumRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::TITLE_ATTRIBUTE => ['required', new TitleRule()],
+			RequestAttribute::TAGS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::TAGS_ATTRIBUTE . '.*' => 'required|string|min:1',
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/ArchiveAlbumRuleSet.php
+++ b/app/Http/RuleSets/Album/ArchiveAlbumRuleSet.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\AlbumIDListRule;
+
+/**
+ * Rules applied when Zipping an album.
+ */
+class ArchiveAlbumRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_IDS_ATTRIBUTE => ['required', new AlbumIDListRule()],
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/BasicAlbumIdRuleSet.php
+++ b/app/Http/RuleSets/Album/BasicAlbumIdRuleSet.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\AlbumIDRule;
+
+/**
+ * Rules applied when working an album.
+ */
+class BasicAlbumIdRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new AlbumIDRule(false)],
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/DeleteAlbumsRuleSet.php
+++ b/app/Http/RuleSets/Album/DeleteAlbumsRuleSet.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\AlbumIDRule;
+
+/**
+ * Rules applied when working on an albumSet.
+ */
+class DeleteAlbumsRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_IDS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::ALBUM_IDS_ATTRIBUTE . '.*' => ['required', new AlbumIDRule(false)],
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/MergeAlbumsRuleSet.php
+++ b/app/Http/RuleSets/Album/MergeAlbumsRuleSet.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\AlbumIDRule;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when merging albums.
+ */
+class MergeAlbumsRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::ALBUM_IDS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::ALBUM_IDS_ATTRIBUTE . '.*' => ['required', new AlbumIDRule(false)],
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/MoveAlbumsRuleSet.php
+++ b/app/Http/RuleSets/Album/MoveAlbumsRuleSet.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\AlbumIDRule;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when merging albums.
+ */
+class MoveAlbumsRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
+			RequestAttribute::ALBUM_IDS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::ALBUM_IDS_ATTRIBUTE . '.*' => ['required', new AlbumIDRule(false)],
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/SetAlbumCoverRuleSet.php
+++ b/app/Http/RuleSets/Album/SetAlbumCoverRuleSet.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when Setting the cover of an album.
+ */
+class SetAlbumCoverRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/SetAlbumDescriptionRuleSet.php
+++ b/app/Http/RuleSets/Album/SetAlbumDescriptionRuleSet.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\DescriptionRule;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when changing the description of an album.
+ */
+class SetAlbumDescriptionRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::DESCRIPTION_ATTRIBUTE => ['present', new DescriptionRule()],
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/SetAlbumLicenseRuleSet.php
+++ b/app/Http/RuleSets/Album/SetAlbumLicenseRuleSet.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\LicenseRule;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when changing the license of an album.
+ */
+class SetAlbumLicenseRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::LICENSE_ATTRIBUTE => ['required', new LicenseRule()],
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/SetAlbumNSFWRuleSet.php
+++ b/app/Http/RuleSets/Album/SetAlbumNSFWRuleSet.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rule applied when marking an album NSFW.
+ */
+class SetAlbumNSFWRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::IS_NSFW_ATTRIBUTE => 'required|boolean',
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/SetAlbumProtectionPolicyRuleSet.php
+++ b/app/Http/RuleSets/Album/SetAlbumProtectionPolicyRuleSet.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\PasswordRule;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when changing the protection policies of an album.
+ */
+class SetAlbumProtectionPolicyRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::PASSWORD_ATTRIBUTE => ['sometimes', new PasswordRule(true)],
+			RequestAttribute::IS_PUBLIC_ATTRIBUTE => 'required|boolean',
+			RequestAttribute::IS_LINK_REQUIRED_ATTRIBUTE => 'required|boolean',
+			RequestAttribute::IS_NSFW_ATTRIBUTE => 'required|boolean',
+			RequestAttribute::GRANTS_DOWNLOAD_ATTRIBUTE => 'required|boolean',
+			RequestAttribute::GRANTS_FULL_PHOTO_ACCESS_ATTRIBUTE => 'required|boolean',
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/SetAlbumSortingRuleSet.php
+++ b/app/Http/RuleSets/Album/SetAlbumSortingRuleSet.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Enum\ColumnSortingPhotoType;
+use App\Enum\OrderSortingType;
+use App\Rules\RandomIDRule;
+use Illuminate\Validation\Rules\Enum;
+
+/**
+ * Rules applied when changing the sorting mode inside an album.
+ */
+class SetAlbumSortingRuleSet implements RuleSet
+{
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::SORTING_COLUMN_ATTRIBUTE => ['present', 'nullable', new Enum(ColumnSortingPhotoType::class)],
+			RequestAttribute::SORTING_ORDER_ATTRIBUTE => [
+				'required_with:' . RequestAttribute::SORTING_COLUMN_ATTRIBUTE,
+				'nullable', new Enum(OrderSortingType::class),
+			],
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/SetAlbumTagRuleSet.php
+++ b/app/Http/RuleSets/Album/SetAlbumTagRuleSet.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when changing the tag of a tag album.
+ */
+class SetAlbumTagRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::SHOW_TAGS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::SHOW_TAGS_ATTRIBUTE . '.*' => 'required|string|min:1',
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/SetAlbumsTitleRuleSet.php
+++ b/app/Http/RuleSets/Album/SetAlbumsTitleRuleSet.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+use App\Rules\TitleRule;
+
+/**
+ * Rules applied when updating the titles of a group of album.
+ */
+class SetAlbumsTitleRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_IDS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::ALBUM_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
+			RequestAttribute::TITLE_ATTRIBUTE => ['required', new TitleRule()],
+		];
+	}
+}

--- a/app/Http/RuleSets/Album/UnlockAlbumRuleSet.php
+++ b/app/Http/RuleSets/Album/UnlockAlbumRuleSet.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\RuleSets\Album;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\PasswordRule;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when unlocking a password protected album.
+ */
+class UnlockAlbumRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::PASSWORD_ATTRIBUTE => ['required', new PasswordRule(false)],
+		];
+	}
+}

--- a/app/Http/RuleSets/Import/ImportServerRuleSet.php
+++ b/app/Http/RuleSets/Import/ImportServerRuleSet.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\RuleSets\Import;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when importing a file from the server.
+ */
+class ImportServerRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
+			RequestAttribute::PATH_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::PATH_ATTRIBUTE . '.*' => 'required|string|distinct',
+			RequestAttribute::DELETE_IMPORTED_ATTRIBUTE => 'sometimes|boolean',
+			RequestAttribute::SKIP_DUPLICATES_ATTRIBUTE => 'sometimes|boolean',
+			RequestAttribute::IMPORT_VIA_SYMLINK_ATTRIBUTE => 'sometimes|boolean',
+			RequestAttribute::RESYNC_METADATA_ATTRIBUTE => 'sometimes|boolean',
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/AddPhotoRuleSet.php
+++ b/app/Http/RuleSets/Photo/AddPhotoRuleSet.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\AlbumIDRule;
+
+/**
+ * Rules applied when adding a new photo.
+ */
+class AddPhotoRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['present', new AlbumIDRule(true)],
+			RequestAttribute::FILE_ATTRIBUTE => 'required|file',
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/ArchivePhotosRuleSet.php
+++ b/app/Http/RuleSets/Photo/ArchivePhotosRuleSet.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Enum\DownloadVariantType;
+use App\Rules\RandomIDListRule;
+use Illuminate\Validation\Rules\Enum;
+
+/**
+ * Rules applied when downloading one or multiple photo.
+ */
+class ArchivePhotosRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE => ['required', new RandomIDListRule()],
+			RequestAttribute::SIZE_VARIANT_ATTRIBUTE => ['required', new Enum(DownloadVariantType::class)],
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/DeletePhotosRuleSet.php
+++ b/app/Http/RuleSets/Photo/DeletePhotosRuleSet.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when deleting a group of photos.
+ */
+class DeletePhotosRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/DuplicatePhotosRuleSet.php
+++ b/app/Http/RuleSets/Photo/DuplicatePhotosRuleSet.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when duplicating a group of photos.
+ */
+class DuplicatePhotosRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/GetPhotoRuleSet.php
+++ b/app/Http/RuleSets/Photo/GetPhotoRuleSet.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when fetching a photo.
+ */
+class GetPhotoRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/MovePhotosRuleSet.php
+++ b/app/Http/RuleSets/Photo/MovePhotosRuleSet.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when moving a group of photos.
+ */
+class MovePhotosRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/RotatePhotoRuleSet.php
+++ b/app/Http/RuleSets/Photo/RotatePhotoRuleSet.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+use Illuminate\Validation\Rule;
+
+/**
+ * Rules applied when rotating a photo.
+ */
+class RotatePhotoRuleSet implements RuleSet
+{
+	protected int $direction;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::DIRECTION_ATTRIBUTE => ['required', Rule::in([-1, 1])],
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/SetPhotoDescriptionRuleSet.php
+++ b/app/Http/RuleSets/Photo/SetPhotoDescriptionRuleSet.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\DescriptionRule;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when changing the description of a photo.
+ */
+class SetPhotoDescriptionRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::DESCRIPTION_ATTRIBUTE => ['present', new DescriptionRule()],
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/SetPhotoLicenseRuleSet.php
+++ b/app/Http/RuleSets/Photo/SetPhotoLicenseRuleSet.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\LicenseRule;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rule applied when changing the license of a photo.
+ */
+class SetPhotoLicenseRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::LICENSE_ATTRIBUTE => ['required', new LicenseRule()],
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/SetPhotoPublicRuleSet.php
+++ b/app/Http/RuleSets/Photo/SetPhotoPublicRuleSet.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when changing the visibility of a single photo.
+ */
+class SetPhotoPublicRuleSet implements RuleSet
+{
+	protected bool $isPublic = false;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::IS_PUBLIC_ATTRIBUTE => 'required|boolean',
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/SetPhotoUploadDateRuleSet.php
+++ b/app/Http/RuleSets/Photo/SetPhotoUploadDateRuleSet.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when changing the upload date of a photo.
+ */
+class SetPhotoUploadDateRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::DATE_ATTRIBUTE => 'required|date',
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/SetPhotosStarredRuleSet.php
+++ b/app/Http/RuleSets/Photo/SetPhotosStarredRuleSet.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when starring a group of photos.
+ */
+class SetPhotosStarredRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
+			RequestAttribute::IS_STARRED_ATTRIBUTE => 'required|boolean',
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/SetPhotosTagsRuleSet.php
+++ b/app/Http/RuleSets/Photo/SetPhotosTagsRuleSet.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+
+/**
+ * Rules applied when adding tag to a group of photos.
+ */
+class SetPhotosTagsRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::SHALL_OVERRIDE_ATTRIBUTE => 'required|boolean',
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
+			RequestAttribute::TAGS_ATTRIBUTE => 'present|array',
+			RequestAttribute::TAGS_ATTRIBUTE . '.*' => 'required|string|min:1',
+		];
+	}
+}

--- a/app/Http/RuleSets/Photo/SetPhotosTitleRuleSet.php
+++ b/app/Http/RuleSets/Photo/SetPhotosTitleRuleSet.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\RuleSets\Photo;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\RandomIDRule;
+use App\Rules\TitleRule;
+
+/**
+ * Rules applied when changing the title of a group of photos.
+ */
+class SetPhotosTitleRuleSet implements RuleSet
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
+			RequestAttribute::TITLE_ATTRIBUTE => ['required', new TitleRule()],
+		];
+	}
+}

--- a/app/Http/RuleSets/Session/LoginRuleSet.php
+++ b/app/Http/RuleSets/Session/LoginRuleSet.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\RuleSets\Session;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\PasswordRule;
+use App\Rules\UsernameRule;
+
+/**
+ * Rules applied when trying to log in.
+ */
+class LoginRuleSet implements RuleSet
+{
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::USERNAME_ATTRIBUTE => ['required', new UsernameRule()],
+			RequestAttribute::PASSWORD_ATTRIBUTE => ['required', new PasswordRule(false)],
+		];
+	}
+}

--- a/app/Http/RuleSets/User/ChangeLoginRuleSet.php
+++ b/app/Http/RuleSets/User/ChangeLoginRuleSet.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\RuleSets\User;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\PasswordRule;
+use App\Rules\UsernameRule;
+
+/**
+ * Rules applied when changing username/password.
+ */
+class ChangeLoginRuleSet implements RuleSet
+{
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::USERNAME_ATTRIBUTE => ['sometimes', new UsernameRule(true)],
+			RequestAttribute::PASSWORD_ATTRIBUTE => ['required', new PasswordRule(false)],
+			RequestAttribute::OLD_PASSWORD_ATTRIBUTE => ['required', new PasswordRule(false)],
+		];
+	}
+}

--- a/app/Http/RuleSets/User/SetEmailRuleSet.php
+++ b/app/Http/RuleSets/User/SetEmailRuleSet.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\RuleSets\User;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+
+/**
+ * Rules applied when setting a email for notifications.
+ */
+class SetEmailRuleSet implements RuleSet
+{
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::EMAIL_ATTRIBUTE => 'present|nullable|email:rfc,dns|max:100',
+		];
+	}
+}

--- a/app/Http/RuleSets/Users/AddUserRuleSet.php
+++ b/app/Http/RuleSets/Users/AddUserRuleSet.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\RuleSets\Users;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\PasswordRule;
+use App\Rules\UsernameRule;
+
+/**
+ * Rules applied when creating a new user.
+ */
+class AddUserRuleSet implements RuleSet
+{
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::USERNAME_ATTRIBUTE => ['required', new UsernameRule()],
+			RequestAttribute::PASSWORD_ATTRIBUTE => ['required', new PasswordRule(false)],
+			RequestAttribute::MAY_UPLOAD_ATTRIBUTE => 'present|boolean',
+			RequestAttribute::MAY_EDIT_OWN_SETTINGS_ATTRIBUTE => 'present|boolean',
+		];
+	}
+}

--- a/app/Http/RuleSets/Users/SetUserSettingsRuleSet.php
+++ b/app/Http/RuleSets/Users/SetUserSettingsRuleSet.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\RuleSets\Users;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+use App\Rules\IntegerIDRule;
+use App\Rules\PasswordRule;
+use App\Rules\UsernameRule;
+
+/**
+ * Rules applied when updating a user.
+ */
+class SetUserSettingsRuleSet implements RuleSet
+{
+	public static function rules(): array
+	{
+		return [
+			RequestAttribute::ID_ATTRIBUTE => ['required', new IntegerIDRule(false)],
+			RequestAttribute::USERNAME_ATTRIBUTE => ['required', new UsernameRule()],
+			RequestAttribute::PASSWORD_ATTRIBUTE => ['sometimes', new PasswordRule(false)],
+			RequestAttribute::MAY_UPLOAD_ATTRIBUTE => 'present|boolean',
+			RequestAttribute::MAY_EDIT_OWN_SETTINGS_ATTRIBUTE => 'present|boolean',
+		];
+	}
+}

--- a/app/Http/RuleSets/WebAuthn/DeleteCredentialRuleSet.php
+++ b/app/Http/RuleSets/WebAuthn/DeleteCredentialRuleSet.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\RuleSets\WebAuthn;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Http\RuleSet;
+
+/**
+ * Rules applied when deleting a credential.
+ */
+class DeleteCredentialRuleSet implements RuleSet
+{
+	public static function rules(): array
+	{
+		return [RequestAttribute::ID_ATTRIBUTE => 'required|string'];
+	}
+}


### PR DESCRIPTION
This move the code of all the rules applied to request in specific RuleSets. This is in order to be able to use them directly in Livewire validation requests.