### PR TITLE
Fix wording for authentication guard option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,8 +60,7 @@ DB_LIST_FOREIGN_KEYS=true
 # LYCHEE_DIST_URL="dist/"
 # LYCHEE_SYM_URL="sym/"
 
-# Support for token based authentication like basic auth. Enabled by default.
-# Disable when running Lychee behind 3rd party managed authentication.
+# Support for token based authentication used by API requests. Enabled by default.
 # ENABLE_TOKEN_AUTH="true"
 
 CACHE_DRIVER=file

--- a/.env.example
+++ b/.env.example
@@ -61,7 +61,7 @@ DB_LIST_FOREIGN_KEYS=true
 # LYCHEE_SYM_URL="sym/"
 
 # Support for token based authentication used by API requests. Enabled by default.
-# ENABLE_TOKEN_AUTH="true"
+# ENABLE_TOKEN_AUTH=true
 
 CACHE_DRIVER=file
 SESSION_DRIVER=file


### PR DESCRIPTION
As discussed [here](https://github.com/LycheeOrg/LycheeOrg.github.io/pull/85), the wording was approved by mistake. This PR will fix it.