### PR TITLE
Fix URLs in RSS feeds (#1732)

### DIFF
--- a/app/Actions/RSS/Generate.php
+++ b/app/Actions/RSS/Generate.php
@@ -25,7 +25,7 @@ class Generate
 	private function create_link_to_page(Photo $photo_model): string
 	{
 		if ($photo_model->album_id !== null) {
-			return url('/#' . $photo_model->album_id . '/' . $photo_model->id);
+			return url('/gallery#' . $photo_model->album_id . '/' . $photo_model->id);
 		}
 
 		return url('/view?p=' . $photo_model->id);


### PR DESCRIPTION
URLs in RSS feeds are "https://example.com/#xyzzy/aabbcc".

This works in default installations, however the canonical URL to albums (and photos) starts with "/gallery", so these URLs should be
"https://example.com/gallery#xyzzy/aabbcc".

When using the landing page, URLs even _need_ to include "gallery", otherweise all of the RSS URLs only show the landing page.