### PR TITLE
Fixes locale not working (#1754)

### DIFF
--- a/app/Http/Resources/InitResource.php
+++ b/app/Http/Resources/InitResource.php
@@ -34,7 +34,7 @@ class InitResource extends JsonResource
 			$gitHubVersion->hydrate();
 		}
 
-		// we also return the local
+		// we also return the locale
 		$locale = include base_path('lang/' . app()->getLocale() . '/lychee.php');
 
 		return [

--- a/app/Http/Resources/InitResource.php
+++ b/app/Http/Resources/InitResource.php
@@ -34,12 +34,16 @@ class InitResource extends JsonResource
 			$gitHubVersion->hydrate();
 		}
 
+		// we also return the local
+		$locale = include base_path('lang/' . app()->getLocale() . '/lychee.php');
+
 		return [
 			'user' => $this->when(Auth::check(), UserResource::make(Auth::user()), null),
 			'rights' => GlobalRightsResource::make()->toArray($request),
 			'config' => ConfigurationResource::make()->toArray($request),
 			'update_json' => !$fileVersion->isUpToDate(),
 			'update_available' => !$gitHubVersion->isUpToDate(),
+			'locale' => $locale,
 		];
 	}
 }


### PR DESCRIPTION
Fixes #1754 

When moving to Resources, this was done at the same time as migrating the locale to `lang/`, this induced a small bug.
Should now be resolved.