### PR TITLE
Fixes unknown orientation in GdHandler

### DIFF
--- a/app/Image/Handlers/GdHandler.php
+++ b/app/Image/Handlers/GdHandler.php
@@ -265,7 +265,7 @@ class GdHandler extends BaseImageHandler
 	{
 		try {
 			$angle = match ($orientation) {
-				1, 2, 4 => 0,
+				0, 1, 2, 4 => 0,
 				3 => -180,
 				5, 6 => -90,
 				7, 8 => 90,
@@ -273,7 +273,7 @@ class GdHandler extends BaseImageHandler
 			};
 
 			$flip = match ($orientation) {
-				1, 3, 6, 8 => 0,
+				0, 1, 3, 6, 8 => 0,
 				2, 7, 5 => IMG_FLIP_HORIZONTAL,
 				4 => IMG_FLIP_VERTICAL,
 				default => throw new ImageProcessingException('Image orientation out of range')


### PR DESCRIPTION
The GdHandler can't handle images that have the Orientation Exif tag set to 0 (Unknown), because of this the image is not processed correctly.

This PR just aligns the rotate logic of GdHandler with the one in ImagickHandler, which handles such case (see Imagick::ORIENTATION_UNDEFINED).

<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.

Don't worry if your code styling isn't perfect! php-cs-fixer will automatically create a pull request with any style fixes. This allows us to focus on the content of the contribution and not the code style.
-->