### PR TITLE
Add setting `auto_fix_orientation` to enable auto image rotation

### DIFF
--- a/app/Actions/Photo/Strategies/AddStandaloneStrategy.php
+++ b/app/Actions/Photo/Strategies/AddStandaloneStrategy.php
@@ -21,6 +21,7 @@ use App\Image\Handlers\GoogleMotionPictureHandler;
 use App\Image\Handlers\ImageHandler;
 use App\Image\Handlers\VideoHandler;
 use App\Image\StreamStat;
+use App\Models\Configs;
 use App\Models\Photo;
 use Illuminate\Contracts\Container\BindingResolutionException;
 
@@ -255,7 +256,9 @@ class AddStandaloneStrategy extends AbstractAddStrategy
 				\Safe\symlink($sourcePath, $targetPath);
 				$streamStat = StreamStat::createFromLocalFile($this->sourceFile);
 			} else {
-				$shallNormalize = $this->sourceImage !== null && $this->parameters->exifInfo->orientation !== 1;
+				$shallNormalize = Configs::getValueAsBool('editor_enabled') &&
+					$this->sourceImage !== null &&
+					$this->parameters->exifInfo->orientation !== 1;
 
 				if ($shallNormalize) {
 					// Saving the loaded image to the final target normalizes

--- a/app/Actions/Photo/Strategies/AddStandaloneStrategy.php
+++ b/app/Actions/Photo/Strategies/AddStandaloneStrategy.php
@@ -256,7 +256,7 @@ class AddStandaloneStrategy extends AbstractAddStrategy
 				\Safe\symlink($sourcePath, $targetPath);
 				$streamStat = StreamStat::createFromLocalFile($this->sourceFile);
 			} else {
-				$shallNormalize = Configs::getValueAsBool('editor_enabled') &&
+				$shallNormalize = Configs::getValueAsBool('auto_fix_orientation') &&
 					$this->sourceImage !== null &&
 					$this->parameters->exifInfo->orientation !== 1;
 

--- a/app/Http/Resources/ConfigurationResource.php
+++ b/app/Http/Resources/ConfigurationResource.php
@@ -78,6 +78,7 @@ class ConfigurationResource extends JsonResource
 				'delete_imported' => Configs::getValueAsBool('delete_imported'),
 				'dropbox_key' => Configs::getValueAsString('dropbox_key'),
 				'editor_enabled' => Configs::getValueAsBool('editor_enabled'),
+				'auto_fix_orientation' => Configs::getValueAsBool('auto_fix_orientation'),
 				'force_32bit_ids' => Configs::getValueAsBool('force_32bit_ids'),
 				'force_migration_in_production' => Configs::getValueAsBool('force_migration_in_production'),
 				'has_exiftool' => Configs::getValueAsBool('has_exiftool'),

--- a/database/migrations/2023_02_23_192505_add_auto_fix_orientation_setting.php
+++ b/database/migrations/2023_02_23_192505_add_auto_fix_orientation_setting.php
@@ -1,18 +1,15 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
-    public function up()
-    {
+return new class() extends Migration {
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
 		defined('BOOL') or define('BOOL', '0|1');
 
 		DB::table('configs')->insert([
@@ -23,15 +20,15 @@ return new class extends Migration
 			'confidentiality' => '0',
 			'description' => 'Automatically rotate imported images',
 		]);
-    }
+	}
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
 		DB::table('configs')->where('key', '=', 'auto_fix_orientation')->delete();
-    }
+	}
 };

--- a/database/migrations/2023_02_23_192505_add_auto_fix_orientation_setting.php
+++ b/database/migrations/2023_02_23_192505_add_auto_fix_orientation_setting.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+		defined('BOOL') or define('BOOL', '0|1');
+
+		DB::table('configs')->insert([
+			'key' => 'auto_fix_orientation',
+			'value' => '1',
+			'cat' => 'Image Processing',
+			'type_range' => BOOL,
+			'confidentiality' => '0',
+			'description' => 'Automatically rotate imported images',
+		]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+		DB::table('configs')->where('key', '=', 'auto_fix_orientation')->delete();
+    }
+};


### PR DESCRIPTION
Currently, imported images are automatically rotated even when the editor_enabled is disabled, the automatic rotation takes place as part of the image normalization process.
 This feels a bit unintuitive and this PR fixes it by taking into account this setting when normalizing the image.

<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.

Don't worry if your code styling isn't perfect! php-cs-fixer will automatically create a pull request with any style fixes. This allows us to focus on the content of the contribution and not the code style.
-->