### PR TITLE
Remove requirement of Auth in photo upload, pass ownerId as argument

### DIFF
--- a/app/Actions/Import/Exec.php
+++ b/app/Actions/Import/Exec.php
@@ -49,11 +49,11 @@ class Exec
 	 * @param bool       $enableCLIFormatting determines whether the output shall be formatted for CLI or as JSON
 	 * @param int        $memLimit            the threshold when a memory warning shall be reported; `0` means unlimited
 	 */
-	public function __construct(ImportMode $importMode, bool $enableCLIFormatting, int $memLimit = 0)
+	public function __construct(ImportMode $importMode, int $intendedOwnerId, bool $enableCLIFormatting, int $memLimit = 0)
 	{
 		Session::forget('cancel');
 		$this->importMode = $importMode;
-		$this->photoCreate = new PhotoCreate($importMode);
+		$this->photoCreate = new PhotoCreate($importMode, $intendedOwnerId);
 		$this->albumCreate = new AlbumCreate();
 		$this->enableCLIFormatting = $enableCLIFormatting;
 		$this->memLimit = $memLimit;

--- a/app/Actions/Import/FromServer.php
+++ b/app/Actions/Import/FromServer.php
@@ -10,15 +10,16 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 class FromServer
 {
 	/**
-	 * @param string[]   $paths      the server path to import from
-	 * @param Album|null $album      the album to import into
-	 * @param ImportMode $importMode the import mode
+	 * @param string[]   $paths           the server path to import from
+	 * @param Album|null $album           the album to import into
+	 * @param ImportMode $importMode      the import mode
+	 * @param int        $intendedOwnerId the intended owner of those pictures
 	 *
 	 * @return StreamedResponse
 	 */
-	public function do(array $paths, ?Album $album, ImportMode $importMode): StreamedResponse
+	public function do(array $paths, ?Album $album, ImportMode $importMode, int $intendedOwnerId): StreamedResponse
 	{
-		$exec = new Exec($importMode, false, $this->determineMemLimit());
+		$exec = new Exec($importMode, $intendedOwnerId, false, $this->determineMemLimit());
 
 		$response = new StreamedResponse();
 		$response->headers->set('Content-Type', 'application/json');

--- a/app/Actions/Import/FromUrl.php
+++ b/app/Actions/Import/FromUrl.php
@@ -26,19 +26,20 @@ class FromUrl
 	 *
 	 * @param string[]   $urls
 	 * @param Album|null $album
+	 * @param int        $intendedOwnerId
 	 *
 	 * @return Collection<Photo> the collection of imported photos
 	 *
 	 * @throws MassImportException
 	 */
-	public function do(array $urls, ?Album $album): Collection
+	public function do(array $urls, ?Album $album, int $intendedOwnerId): Collection
 	{
 		$result = new Collection();
 		$exceptions = [];
-		$create = new Create(new ImportMode(
-			true,
-			Configs::getValueAsBool('skip_duplicates')
-		));
+		$create = new Create(
+			new ImportMode(deleteImported: true, skipDuplicates: Configs::getValueAsBool('skip_duplicates')),
+			$intendedOwnerId
+		);
 
 		foreach ($urls as $url) {
 			try {

--- a/app/Actions/Photo/Create.php
+++ b/app/Actions/Photo/Create.php
@@ -34,9 +34,9 @@ class Create
 	/** @var AddStrategyParameters the strategy parameters prepared and compiled by this class */
 	protected AddStrategyParameters $strategyParameters;
 
-	public function __construct(?ImportMode $importMode)
+	public function __construct(?ImportMode $importMode, int $intendedOwnerId)
 	{
-		$this->strategyParameters = new AddStrategyParameters($importMode);
+		$this->strategyParameters = new AddStrategyParameters($importMode, $intendedOwnerId);
 	}
 
 	/**

--- a/app/Actions/Photo/Strategies/AbstractAddStrategy.php
+++ b/app/Actions/Photo/Strategies/AbstractAddStrategy.php
@@ -6,17 +6,13 @@ use App\Exceptions\MediaFileOperationException;
 use App\Exceptions\ModelDBException;
 use App\Exceptions\UnauthenticatedException;
 use App\Models\Photo;
-use Illuminate\Support\Facades\Auth;
 
 abstract class AbstractAddStrategy
 {
-	protected AddStrategyParameters $parameters;
-	protected Photo $photo;
-
-	protected function __construct(AddStrategyParameters $parameters, Photo $photo)
-	{
-		$this->parameters = $parameters;
-		$this->photo = $photo;
+	protected function __construct(
+		protected AddStrategyParameters $parameters,
+		protected Photo $photo
+	) {
 	}
 
 	/**
@@ -116,9 +112,7 @@ abstract class AbstractAddStrategy
 			// Avoid unnecessary DB request, when we access the album of a
 			// photo later (e.g. when a notification is sent).
 			$this->photo->setRelation('album', null);
-			/** @var int */
-			$userId = Auth::id() ?? throw new UnauthenticatedException();
-			$this->photo->owner_id = $userId;
+			$this->photo->owner_id = $this->parameters->intendedOwnerId;
 		}
 	}
 }

--- a/app/Actions/Photo/Strategies/AddPhotoPartnerStrategy.php
+++ b/app/Actions/Photo/Strategies/AddPhotoPartnerStrategy.php
@@ -46,7 +46,10 @@ class AddPhotoPartnerStrategy extends AddStandaloneStrategy
 		// "steals away" the stored video file from the existing video entity
 		// and moves it to the correct destination of a live partner for the
 		// photo.
-		$parameters = new AddStrategyParameters(new ImportMode(true));
+		$parameters = new AddStrategyParameters(
+			new ImportMode(deleteImported: true),
+			$this->parameters->intendedOwnerId
+		);
 		$videoStrategy = new AddVideoPartnerStrategy(
 			$parameters,
 			$this->existingVideo->size_variants->getOriginal()->getFile(),

--- a/app/Actions/Photo/Strategies/AddStrategyParameters.php
+++ b/app/Actions/Photo/Strategies/AddStrategyParameters.php
@@ -9,6 +9,9 @@ class AddStrategyParameters
 {
 	public ImportMode $importMode;
 
+	/** @var int Indicates the intended owner of the image. */
+	public int $intendedOwnerId;
+
 	/** @var Album|null the intended parent album */
 	public ?Album $album = null;
 
@@ -21,8 +24,9 @@ class AddStrategyParameters
 	/** @var Extractor|null the extracted EXIF information */
 	public ?Extractor $exifInfo = null;
 
-	public function __construct(ImportMode $importMode)
+	public function __construct(ImportMode $importMode, int $intendedOwnerId)
 	{
 		$this->importMode = $importMode;
+		$this->intendedOwnerId = $intendedOwnerId;
 	}
 }

--- a/app/Actions/Photo/Strategies/ImportMode.php
+++ b/app/Actions/Photo/Strategies/ImportMode.php
@@ -4,32 +4,12 @@ namespace App\Actions\Photo\Strategies;
 
 class ImportMode
 {
-	protected bool $deleteImported = false;
-	protected bool $skipDuplicates = false;
-	protected bool $importViaSymlink = false;
-	protected bool $resyncMetadata = false;
-
 	public function __construct(
-		bool $deleteImported = false,
-		bool $skipDuplicates = false,
-		bool $importViaSymlink = false,
-		bool $resyncMetadata = false
+		protected readonly bool $deleteImported = false,
+		protected readonly bool $skipDuplicates = false,
+		protected bool $importViaSymlink = false,
+		protected bool $resyncMetadata = false
 	) {
-		$this->setMode(
-			$deleteImported, $skipDuplicates, $importViaSymlink, $resyncMetadata
-		);
-	}
-
-	public function setMode(
-		bool $deleteImported = false,
-		bool $skipDuplicates = false,
-		bool $importViaSymlink = false,
-		bool $resyncMetadata = false
-	): void {
-		$this->deleteImported = $deleteImported;
-		$this->skipDuplicates = $skipDuplicates;
-		$this->importViaSymlink = $importViaSymlink;
-		$this->resyncMetadata = $resyncMetadata;
 		// avoid incompatible settings (delete originals takes precedence over symbolic links)
 		if ($deleteImported) {
 			$this->importViaSymlink = false;

--- a/app/Console/Commands/Sync.php
+++ b/app/Console/Commands/Sync.php
@@ -11,7 +11,6 @@ use App\Models\Album;
 use App\Models\Configs;
 use Exception;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Auth;
 use Symfony\Component\Console\Exception\ExceptionInterface as SymfonyConsoleException;
 
 class Sync extends Command
@@ -105,11 +104,10 @@ class Sync extends Command
 					$importViaSymlink,
 					$resyncMetadata
 				),
+				$owner_id,
 				true,
 				0
 			);
-
-			Auth::loginUsingId($owner_id);
 
 			$this->info('Start syncing.');
 

--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -345,7 +345,7 @@ class Extractor
 					// to original timezone of the location where the video
 					// has been recorded.
 					// So we don't need to do anything.
-						//
+					//
 					// The only known example are the mov files from Apple
 					// devices; the time zone will be formatted as "+01:00"
 					// so neither of the two conditions above should trigger.

--- a/app/Models/Extensions/AlbumBuilder.php
+++ b/app/Models/Extensions/AlbumBuilder.php
@@ -129,12 +129,12 @@ class AlbumBuilder extends NSQueryBuilder
 		//     MySQL's built-in heuristic chooses that index with high
 		//     priority and does not consider any alternatives.
 		//     In this specific case, this heuristic fails splendidly.
-			//
+		//
 		// Further note, that PostgreSQL's optimizer is not affected
 		// by any of these tricks.
 		// The optimized query plan for PostgreSQL is always the same.
 		// Good PosgreSQL :-)
-			//
+		//
 		// We must not use `Album::query->` to start the query, but
 		// use a non-Eloquent query here to avoid an infinite loop
 		// with this query builder.


### PR DESCRIPTION
Currently Photo creation requires Auth in order to access the userId. There is no other use for this.
Rights & Permissions have already been checked in the middleware, so this Auth is superfluous and forces the use of Sessions during job executions. 

This PR removes this dependency which should allow to make photo processing less session dependent.