### PR TITLE
move constants to own class

### DIFF
--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -23,96 +23,13 @@ use Illuminate\Testing\TestResponse;
 use function Safe\copy;
 use function Safe\json_decode;
 use function Safe\tempnam;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Traits\CatchFailures;
 
 abstract class AbstractTestCase extends BaseTestCase
 {
 	use CreatesApplication;
 	use CatchFailures;
-
-	public const PATH_IMPORT_DIR = 'uploads/import/';
-
-	public const MIME_TYPE_APP_PDF = 'application/pdf';
-	public const MIME_TYPE_IMG_GIF = 'image/gif';
-	public const MIME_TYPE_IMG_JPEG = 'image/jpeg';
-	public const MIME_TYPE_IMG_PNG = 'image/png';
-	public const MIME_TYPE_IMG_TIFF = 'image/tiff';
-	public const MIME_TYPE_IMG_WEBP = 'image/webp';
-	public const MIME_TYPE_IMG_XCF = 'image/x-xcf';
-	public const MIME_TYPE_VID_MP4 = 'video/mp4';
-	public const MIME_TYPE_VID_QUICKTIME = 'video/quicktime';
-
-	public const SAMPLE_DOWNLOAD_JPG = 'https://github.com/LycheeOrg/Lychee/raw/master/tests/Samples/mongolia.jpeg';
-	public const SAMPLE_DOWNLOAD_TIFF = 'https://github.com/LycheeOrg/Lychee/raw/master/tests/Samples/tiff.tif';
-
-	public const SAMPLE_FILE_AARHUS = 'tests/Samples/aarhus.jpg';
-	public const SAMPLE_FILE_ETTLINGEN = 'tests/Samples/ettlinger-alb.jpg';
-	public const SAMPLE_FILE_GAMING_VIDEO = 'tests/Samples/gaming.mp4';
-	public const SAMPLE_FILE_GIF = 'tests/Samples/gif.gif';
-	public const SAMPLE_FILE_GMP_BROKEN_IMAGE = 'tests/Samples/google_motion_photo_broken.jpg';
-	public const SAMPLE_FILE_GMP_IMAGE = 'tests/Samples/google_motion_photo.jpg';
-	public const SAMPLE_FILE_HOCHUFERWEG = 'tests/Samples/hochuferweg.jpg';
-	public const SAMPLE_FILE_MONGOLIA_IMAGE = 'tests/Samples/mongolia.jpeg';
-	public const SAMPLE_FILE_NIGHT_IMAGE = 'tests/Samples/night.jpg';
-	public const SAMPLE_FILE_ORIENTATION_180 = 'tests/Samples/orientation-180.jpg';
-	public const SAMPLE_FILE_ORIENTATION_270 = 'tests/Samples/orientation-270.jpg';
-	public const SAMPLE_FILE_ORIENTATION_90 = 'tests/Samples/orientation-90.jpg';
-	public const SAMPLE_FILE_ORIENTATION_HFLIP = 'tests/Samples/orientation-hflip.jpg';
-	public const SAMPLE_FILE_ORIENTATION_VFLIP = 'tests/Samples/orientation-vflip.jpg';
-	public const SAMPLE_FILE_PDF = 'tests/Samples/pdf.pdf';
-	public const SAMPLE_FILE_PNG = 'tests/Samples/png.png';
-	public const SAMPLE_FILE_SUNSET_IMAGE = 'tests/Samples/fin de journée.jpg';
-	public const SAMPLE_FILE_TIFF = 'tests/Samples/tiff.tif';
-	public const SAMPLE_FILE_TRAIN_IMAGE = 'tests/Samples/train.jpg';
-	public const SAMPLE_FILE_TRAIN_VIDEO = 'tests/Samples/train.mov';
-	public const SAMPLE_FILE_UNDEFINED_EXIF_TAG = 'tests/Samples/undefined-exif-tag.jpg';
-	public const SAMPLE_FILE_WEBP = 'tests/Samples/webp.webp';
-	public const SAMPLE_FILE_XCF = 'tests/Samples/xcf.xcf';
-
-	public const SAMPLE_FILES_2_MIME = [
-		self::SAMPLE_FILE_AARHUS => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_ETTLINGEN => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_GAMING_VIDEO => self::MIME_TYPE_VID_MP4,
-		self::SAMPLE_FILE_GIF => self::MIME_TYPE_IMG_GIF,
-		self::SAMPLE_FILE_GMP_BROKEN_IMAGE => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_GMP_IMAGE => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_HOCHUFERWEG => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_MONGOLIA_IMAGE => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_NIGHT_IMAGE => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_ORIENTATION_180 => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_ORIENTATION_270 => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_ORIENTATION_90 => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_ORIENTATION_HFLIP => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_ORIENTATION_VFLIP => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_PDF => self::MIME_TYPE_APP_PDF,
-		self::SAMPLE_FILE_PNG => self::MIME_TYPE_IMG_PNG,
-		self::SAMPLE_FILE_SUNSET_IMAGE => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_TIFF => self::MIME_TYPE_IMG_TIFF,
-		self::SAMPLE_FILE_TRAIN_IMAGE => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_TRAIN_VIDEO => self::MIME_TYPE_VID_QUICKTIME,
-		self::SAMPLE_FILE_UNDEFINED_EXIF_TAG => self::MIME_TYPE_IMG_JPEG,
-		self::SAMPLE_FILE_WEBP => self::MIME_TYPE_IMG_WEBP,
-		self::SAMPLE_FILE_XCF => self::MIME_TYPE_IMG_XCF,
-	];
-
-	public const CONFIG_ALBUMS_SORTING_COL = 'sorting_albums_col';
-	public const CONFIG_ALBUMS_SORTING_ORDER = 'sorting_albums_order';
-	public const CONFIG_DOWNLOADABLE = 'grants_download';
-	public const CONFIG_HAS_EXIF_TOOL = 'has_exiftool';
-	public const CONFIG_HAS_FFMPEG = 'has_ffmpeg';
-	public const CONFIG_HAS_IMAGICK = 'imagick';
-	public const CONFIG_MAP_DISPLAY = 'map_display';
-	public const CONFIG_MAP_DISPLAY_PUBLIC = 'map_display_public';
-	public const CONFIG_MAP_INCLUDE_SUBALBUMS = 'map_include_subalbums';
-	public const CONFIG_PHOTOS_SORTING_COL = 'sorting_photos_col';
-	public const CONFIG_PHOTOS_SORTING_ORDER = 'sorting_photos_order';
-	public const CONFIG_PUBLIC_HIDDEN = 'public_photos_hidden';
-	public const CONFIG_PUBLIC_RECENT = 'public_recent';
-	public const CONFIG_PUBLIC_SEARCH = 'public_search';
-	public const CONFIG_PUBLIC_STARRED = 'public_starred';
-	public const CONFIG_PUBLIC_ON_THIS_DAY = 'public_on_this_day';
-	public const CONFIG_RAW_FORMATS = 'raw_formats';
-	public const CONFIG_USE_JOB_QUEUES = 'use_job_queues';
 
 	/**
 	 * Visit the given URI with a GET request.
@@ -173,7 +90,7 @@ abstract class AbstractTestCase extends BaseTestCase
 		return new UploadedFile(
 			$tmpFilename,
 			pathinfo($sampleFilePath, PATHINFO_BASENAME),
-			self::SAMPLE_FILES_2_MIME[$sampleFilePath],
+			TestConstants::SAMPLE_FILES_2_MIME[$sampleFilePath],
 			UPLOAD_ERR_OK,
 			true
 		);
@@ -181,7 +98,7 @@ abstract class AbstractTestCase extends BaseTestCase
 
 	protected static function importPath(string $path = ''): string
 	{
-		return public_path(self::PATH_IMPORT_DIR . $path);
+		return public_path(TestConstants::PATH_IMPORT_DIR . $path);
 	}
 
 	/**

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Session;
 use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Lib\AlbumsUnitTest;
 use Tests\Feature\Lib\PhotosUnitTest;
 use Tests\Feature\Lib\RootAlbumUnitTest;
@@ -503,13 +504,13 @@ class AlbumTest extends AbstractTestCase
 
 	public function testAlbumTree(): void
 	{
-		$albumSortingColumn = Configs::getValueAsString(self::CONFIG_ALBUMS_SORTING_COL);
-		$albumSortingOrder = Configs::getValueAsString(self::CONFIG_ALBUMS_SORTING_ORDER);
+		$albumSortingColumn = Configs::getValueAsString(TestConstants::CONFIG_ALBUMS_SORTING_COL);
+		$albumSortingOrder = Configs::getValueAsString(TestConstants::CONFIG_ALBUMS_SORTING_ORDER);
 
 		try {
 			Auth::loginUsingId(1);
-			Configs::set(self::CONFIG_ALBUMS_SORTING_COL, 'title');
-			Configs::set(self::CONFIG_ALBUMS_SORTING_ORDER, 'ASC');
+			Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_COL, 'title');
+			Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_ORDER, 'ASC');
 
 			// Sic! This out-of-order creation of albums is on purpose in order to
 			// catch errors where the album tree is accidentally ordered as
@@ -551,8 +552,8 @@ class AlbumTest extends AbstractTestCase
 				'shared_albums' => [],
 			]);
 		} finally {
-			Configs::set(self::CONFIG_ALBUMS_SORTING_COL, $albumSortingColumn);
-			Configs::set(self::CONFIG_ALBUMS_SORTING_ORDER, $albumSortingOrder);
+			Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_COL, $albumSortingColumn);
+			Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_ORDER, $albumSortingOrder);
 			Auth::logout();
 			Session::flush();
 		}
@@ -699,7 +700,7 @@ class AlbumTest extends AbstractTestCase
 		Auth::loginUsingId(1);
 		$regularAlbumID = $this->albums_tests->add(null, 'Regular Album for Delete Test')->offsetGet('id');
 		$photoID = $this->photos_tests->upload(
-			self::createUploadedFile(self::SAMPLE_FILE_MONGOLIA_IMAGE), $regularAlbumID
+			self::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $regularAlbumID
 		)->offsetGet('id');
 		$this->photos_tests->set_tag([$photoID], ['tag-for-delete-test']);
 		$tagAlbumID = $this->albums_tests->addByTags('Tag Album for Delete Test', ['tag-for-delete-test'])->offsetGet('id');
@@ -728,7 +729,7 @@ class AlbumTest extends AbstractTestCase
 		$userID = $this->users_tests->add('Test user', 'Test password 1')->offsetGet('id');
 		$albumID = $this->albums_tests->add(null, 'Test Album')->offsetGet('id');
 		$photoID1 = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE),
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE),
 			$albumID
 		)->offsetGet('id');
 		Auth::logout();
@@ -752,11 +753,11 @@ class AlbumTest extends AbstractTestCase
 		Auth::loginUsingId(1);
 		$albumID = $this->albums_tests->add(null, 'Test Album')->offsetGet('id');
 		$photoID1 = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE),
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE),
 			$albumID
 		)->offsetGet('id');
 		$photoID2 = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_HOCHUFERWEG),
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_HOCHUFERWEG),
 			$albumID
 		)->offsetGet('id');
 		$initialCoverID = $this->albums_tests->get($albumID)->offsetGet('cover_id');
@@ -786,7 +787,7 @@ class AlbumTest extends AbstractTestCase
 	{
 		Auth::loginUsingId(1);
 		$id = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		)->offsetGet('id');
 
 		$this->photos_tests->get($id);
@@ -848,7 +849,7 @@ class AlbumTest extends AbstractTestCase
 		Auth::loginUsingId(1);
 		$today = CarbonImmutable::today();
 		$photoID = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		)->offsetGet('id');
 
 		DB::table('photos')
@@ -870,7 +871,7 @@ class AlbumTest extends AbstractTestCase
 		Auth::loginUsingId(1);
 		$today = CarbonImmutable::today();
 		$photoID = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		)->offsetGet('id');
 
 		DB::table('photos')
@@ -891,7 +892,7 @@ class AlbumTest extends AbstractTestCase
 		Auth::loginUsingId(1);
 		$today = CarbonImmutable::today();
 		$photoID = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		)->offsetGet('id');
 
 		DB::table('photos')

--- a/tests/Feature/Base/BasePhotosRotateTest.php
+++ b/tests/Feature/Base/BasePhotosRotateTest.php
@@ -14,6 +14,7 @@ namespace Tests\Feature\Base;
 
 use App\Models\Configs;
 use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 
 abstract class BasePhotosRotateTest extends BasePhotoTest
 {
@@ -38,7 +39,7 @@ abstract class BasePhotosRotateTest extends BasePhotoTest
 	{
 		Configs::set(self::CONFIG_EDITOR_ENABLED, 0);
 		$id = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		)->offsetGet('id');
 
 		$this->photos_tests->rotate($id, 1, 412, 'support for rotation disabled by configuration');
@@ -47,7 +48,7 @@ abstract class BasePhotosRotateTest extends BasePhotoTest
 	public function testInvalidValues(): void
 	{
 		$id = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		)->offsetGet('id');
 
 		$this->photos_tests->rotate('-1', 1, 422);
@@ -60,7 +61,7 @@ abstract class BasePhotosRotateTest extends BasePhotoTest
 	public function testSimpleRotation(): void
 	{
 		$response = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		);
 		$response->assertJson([
 			'size_variants' => [
@@ -85,7 +86,7 @@ abstract class BasePhotosRotateTest extends BasePhotoTest
 		static::assertHasFFMpegOrSkip();
 
 		$id = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_TRAIN_VIDEO)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_VIDEO)
 		)->offsetGet('id');
 
 		$this->photos_tests->rotate($id, 1, 422, 'MediaFileUnsupportedException');
@@ -97,7 +98,7 @@ abstract class BasePhotosRotateTest extends BasePhotoTest
 		static::assertHasFFMpegOrSkip();
 
 		$id = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_GMP_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_GMP_IMAGE)
 		)->offsetGet('id');
 
 		$this->photos_tests->rotate($id, 1, 422, 'MediaFileUnsupportedException');
@@ -106,7 +107,7 @@ abstract class BasePhotosRotateTest extends BasePhotoTest
 	public function testDuplicatePhotoRotation(): void
 	{
 		$photoResponse1 = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		);
 		$photoID1 = $photoResponse1->offsetGet('id');
 		$photoResponse2 = $this->photos_tests->duplicate(

--- a/tests/Feature/Base/BaseSharingTest.php
+++ b/tests/Feature/Base/BaseSharingTest.php
@@ -16,6 +16,7 @@ use App\Models\Configs;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Lib\RootAlbumUnitTest;
 use Tests\Feature\Lib\SharingUnitTest;
 use Tests\Feature\Lib\UsersUnitTest;
@@ -28,95 +29,6 @@ abstract class BaseSharingTest extends BasePhotoTest
 	use RequiresEmptyAlbums;
 	use RequiresEmptyUsers;
 	use InteractWithSmartAlbums;
-
-	public const PHOTO_NIGHT_TITLE = 'night';
-	public const PHOTO_MONGOLIA_TITLE = 'mongolia';
-	public const PHOTO_SUNSET_TITLE = 'fin de journée';
-	public const PHOTO_TRAIN_TITLE = 'train';
-
-	public const ALBUM_TITLE_1 = 'Test Album 1';
-	public const ALBUM_TITLE_2 = 'Test Album 2';
-	public const ALBUM_TITLE_3 = 'Test Album 3';
-
-	public const ALBUM_PWD_1 = 'Album Password 1';
-	public const ALBUM_PWD_2 = 'Album Password 2';
-	public const ALBUM_PWD_3 = 'Album Password 3';
-
-	public const USER_NAME_1 = 'Test User 1';
-	public const USER_NAME_2 = 'Test User 2';
-	public const USER_NAME_3 = 'Test User 3';
-
-	public const USER_PWD_1 = 'User Password 1';
-	public const USER_PWD_2 = 'User Password 2';
-	public const USER_PWD_3 = 'User Password 3';
-
-	/** @var array[] EXPECTED_PHOTO_JSON defines the expected JSON result for each sample image such that we can avoid repeating this again and again during the tests */
-	public const EXPECTED_PHOTO_JSON = [
-		AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE => [
-			'id' => null,
-			'album_id' => null,
-			'title' => self::PHOTO_NIGHT_TITLE,
-			'type' => 'image/jpeg',
-			'size_variants' => [
-				'original' => ['type' => 0, 'width' => 6720, 'height' => 4480],
-				'medium2x' => ['type' => 1, 'width' => 3240, 'height' => 2160],
-				'medium' => ['type' => 2, 'width' => 1620, 'height' => 1080],
-				'small2x' => ['type' => 3, 'width' => 1080,	'height' => 720],
-				'small' => ['type' => 4, 'width' => 540, 'height' => 360],
-				'thumb2x' => ['type' => 5, 'width' => 400, 'height' => 400],
-				'thumb' => ['type' => 6, 'width' => 200, 'height' => 200],
-			],
-		],
-		AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE => [
-			'id' => null,
-			'album_id' => null,
-			'title' => self::PHOTO_MONGOLIA_TITLE,
-			'type' => 'image/jpeg',
-			'size_variants' => [
-				'original' => ['type' => 0, 'width' => 1280, 'height' => 850],
-				'medium2x' => null,
-				'medium' => null,
-				'small2x' => ['type' => 3, 'width' => 1084,	'height' => 720],
-				'small' => ['type' => 4, 'width' => 542, 'height' => 360],
-				'thumb2x' => ['type' => 5, 'width' => 400, 'height' => 400],
-				'thumb' => ['type' => 6, 'width' => 200, 'height' => 200],
-			],
-		],
-		AbstractTestCase::SAMPLE_FILE_SUNSET_IMAGE => [
-			'id' => null,
-			'album_id' => null,
-			'title' => self::PHOTO_SUNSET_TITLE,
-			'type' => 'image/jpeg',
-			'size_variants' => [
-				'original' => ['type' => 0, 'width' => 914, 'height' => 1625],
-				'medium2x' => null,
-				'medium' => ['type' => 2, 'width' => 607, 'height' => 1080],
-				'small2x' => ['type' => 3, 'width' => 405,	'height' => 720],
-				'small' => ['type' => 4, 'width' => 202, 'height' => 360],
-				'thumb2x' => ['type' => 5, 'width' => 400, 'height' => 400],
-				'thumb' => ['type' => 6, 'width' => 200, 'height' => 200],
-			],
-		],
-		AbstractTestCase::SAMPLE_FILE_TRAIN_IMAGE => [
-			'id' => null,
-			'album_id' => null,
-			'title' => self::PHOTO_TRAIN_TITLE,
-			'type' => 'image/jpeg',
-			'size_variants' => [
-				'original' => ['type' => 0, 'width' => 4032, 'height' => 3024],
-				'medium2x' => ['type' => 1, 'width' => 2880, 'height' => 2160],
-				'medium' => ['type' => 2, 'width' => 1440, 'height' => 1080],
-				'small2x' => ['type' => 3, 'width' => 960,	'height' => 720],
-				'small' => ['type' => 4, 'width' => 480, 'height' => 360],
-				'thumb2x' => ['type' => 5, 'width' => 400, 'height' => 400],
-				'thumb' => ['type' => 6, 'width' => 200, 'height' => 200],
-			],
-		],
-	];
-
-	public const EXPECTED_UNAUTHENTICATED_MSG = 'User is not authenticated';
-	public const EXPECTED_FORBIDDEN_MSG = 'Insufficient privileges';
-	public const EXPECTED_PASSWORD_REQUIRED_MSG = 'Password required';
 
 	protected SharingUnitTest $sharing_tests;
 	protected UsersUnitTest $users_tests;
@@ -158,34 +70,34 @@ abstract class BaseSharingTest extends BasePhotoTest
 		// creation time is not reliable as models get identical timestamps.
 		// (This is not so much a problem for photos as photo processing
 		// takes some time, but it is a problem for albums.)
-		$this->albumsSortingCol = Configs::getValueAsString(AbstractTestCase::CONFIG_ALBUMS_SORTING_COL);
-		Configs::set(AbstractTestCase::CONFIG_ALBUMS_SORTING_COL, 'title');
-		$this->albumsSortingOrder = Configs::getValueAsString(AbstractTestCase::CONFIG_ALBUMS_SORTING_ORDER);
-		Configs::set(AbstractTestCase::CONFIG_ALBUMS_SORTING_ORDER, 'ASC');
-		$this->photosSortingCol = Configs::getValueAsString(AbstractTestCase::CONFIG_PHOTOS_SORTING_COL);
-		Configs::set(AbstractTestCase::CONFIG_PHOTOS_SORTING_COL, 'title');
-		$this->photosSortingOrder = Configs::getValueAsString(AbstractTestCase::CONFIG_PHOTOS_SORTING_ORDER);
-		Configs::set(AbstractTestCase::CONFIG_PHOTOS_SORTING_ORDER, 'ASC');
+		$this->albumsSortingCol = Configs::getValueAsString(TestConstants::CONFIG_ALBUMS_SORTING_COL);
+		Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_COL, 'title');
+		$this->albumsSortingOrder = Configs::getValueAsString(TestConstants::CONFIG_ALBUMS_SORTING_ORDER);
+		Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_ORDER, 'ASC');
+		$this->photosSortingCol = Configs::getValueAsString(TestConstants::CONFIG_PHOTOS_SORTING_COL);
+		Configs::set(TestConstants::CONFIG_PHOTOS_SORTING_COL, 'title');
+		$this->photosSortingOrder = Configs::getValueAsString(TestConstants::CONFIG_PHOTOS_SORTING_ORDER);
+		Configs::set(TestConstants::CONFIG_PHOTOS_SORTING_ORDER, 'ASC');
 
-		$this->isRecentAlbumPublic = Configs::getValueAsBool(AbstractTestCase::CONFIG_PUBLIC_RECENT);
-		Configs::set(AbstractTestCase::CONFIG_PUBLIC_RECENT, true);
-		$this->isStarredAlbumPublic = Configs::getValueAsBool(AbstractTestCase::CONFIG_PUBLIC_STARRED);
-		Configs::set(AbstractTestCase::CONFIG_PUBLIC_STARRED, true);
-		$this->isOnThisDayAlbumPublic = Configs::getValueAsBool(AbstractTestCase::CONFIG_PUBLIC_ON_THIS_DAY);
-		Configs::set(AbstractTestCase::CONFIG_PUBLIC_ON_THIS_DAY, true);
+		$this->isRecentAlbumPublic = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_RECENT);
+		Configs::set(TestConstants::CONFIG_PUBLIC_RECENT, true);
+		$this->isStarredAlbumPublic = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_STARRED);
+		Configs::set(TestConstants::CONFIG_PUBLIC_STARRED, true);
+		$this->isOnThisDayAlbumPublic = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_ON_THIS_DAY);
+		Configs::set(TestConstants::CONFIG_PUBLIC_ON_THIS_DAY, true);
 		$this->clearCachedSmartAlbums();
 	}
 
 	public function tearDown(): void
 	{
-		Configs::set(AbstractTestCase::CONFIG_ALBUMS_SORTING_COL, $this->albumsSortingCol);
-		Configs::set(AbstractTestCase::CONFIG_ALBUMS_SORTING_ORDER, $this->albumsSortingOrder);
-		Configs::set(AbstractTestCase::CONFIG_PHOTOS_SORTING_COL, $this->photosSortingCol);
-		Configs::set(AbstractTestCase::CONFIG_PHOTOS_SORTING_ORDER, $this->photosSortingOrder);
+		Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_COL, $this->albumsSortingCol);
+		Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_ORDER, $this->albumsSortingOrder);
+		Configs::set(TestConstants::CONFIG_PHOTOS_SORTING_COL, $this->photosSortingCol);
+		Configs::set(TestConstants::CONFIG_PHOTOS_SORTING_ORDER, $this->photosSortingOrder);
 
-		Configs::set(AbstractTestCase::CONFIG_PUBLIC_RECENT, $this->isRecentAlbumPublic);
-		Configs::set(AbstractTestCase::CONFIG_PUBLIC_STARRED, $this->isStarredAlbumPublic);
-		Configs::set(AbstractTestCase::CONFIG_PUBLIC_ON_THIS_DAY, $this->isOnThisDayAlbumPublic);
+		Configs::set(TestConstants::CONFIG_PUBLIC_RECENT, $this->isRecentAlbumPublic);
+		Configs::set(TestConstants::CONFIG_PUBLIC_STARRED, $this->isStarredAlbumPublic);
+		Configs::set(TestConstants::CONFIG_PUBLIC_ON_THIS_DAY, $this->isOnThisDayAlbumPublic);
 		$this->clearCachedSmartAlbums();
 
 		$this->tearDownRequiresEmptyPhotos();
@@ -213,7 +125,7 @@ abstract class BaseSharingTest extends BasePhotoTest
 	 */
 	protected function generateExpectedPhotoJson(string $samplePhotoID, string $photoID, ?string $albumID, array $attrToMerge = []): array
 	{
-		$json = self::EXPECTED_PHOTO_JSON[$samplePhotoID];
+		$json = TestConstants::EXPECTED_PHOTO_JSON[$samplePhotoID];
 		$json['id'] = $photoID;
 		$json['album_id'] = $albumID;
 

--- a/tests/Feature/Base/BaseSharingTestScenarios.php
+++ b/tests/Feature/Base/BaseSharingTestScenarios.php
@@ -23,7 +23,7 @@ use App\SmartAlbums\RecentAlbum;
 use App\SmartAlbums\StarredAlbum;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
-use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 
 /**
  * Defines the "core" of common test cases which needs to be repeated
@@ -85,7 +85,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	{
 		parent::setUp();
 
-		$this->arePublicPhotosHidden = Configs::getValueAsBool(AbstractTestCase::CONFIG_PUBLIC_HIDDEN);
+		$this->arePublicPhotosHidden = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_HIDDEN);
 
 		// Reset all variables to ensure that a test implementation of the
 		// child class does not accidentally use a value which it should not.
@@ -95,12 +95,12 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$this->photoID1 = null;
 		$this->photoID2 = null;
 		$this->photoID3 = null;
-		$this->userID = $this->users_tests->add(self::USER_NAME_1, self::USER_PWD_1)->offsetGet('id');
+		$this->userID = $this->users_tests->add(TestConstants::USER_NAME_1, TestConstants::USER_PWD_1)->offsetGet('id');
 	}
 
 	public function tearDown(): void
 	{
-		Configs::set(AbstractTestCase::CONFIG_PUBLIC_HIDDEN, $this->arePublicPhotosHidden);
+		Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, $this->arePublicPhotosHidden);
 		parent::tearDown();
 	}
 
@@ -129,7 +129,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	 */
 	protected function prepareUnsortedPrivatePhoto(): void
 	{
-		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_MONGOLIA_IMAGE))->offsetGet('id');
+		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE))->offsetGet('id');
 		Auth::logout();
 		Session::flush();
 		$this->clearCachedSmartAlbums();
@@ -179,8 +179,8 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	 */
 	protected function prepareUnsortedPublicAndPrivatePhoto(): void
 	{
-		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_TRAIN_IMAGE))->offsetGet('id');
-		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_MONGOLIA_IMAGE))->offsetGet('id');
+		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE))->offsetGet('id');
+		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE))->offsetGet('id');
 		$this->photos_tests->set_public($this->photoID1, true);
 		$this->photos_tests->set_star([$this->photoID1], true);
 		Auth::logout();
@@ -203,9 +203,9 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	 */
 	protected function preparePublicAndPrivatePhotoInPrivateAlbum(): void
 	{
-		$this->albumID1 = $this->albums_tests->add(null, self::ALBUM_TITLE_1)->offsetGet('id');
-		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID1)->offsetGet('id');
-		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->albumID1 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_1)->offsetGet('id');
+		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
 		$this->photos_tests->set_public($this->photoID1, true);
 		$this->photos_tests->set_star([$this->photoID1], true);
 		Auth::logout();
@@ -224,10 +224,10 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	 */
 	protected function prepareThreePhotosInPublicAlbum(): void
 	{
-		$this->albumID1 = $this->albums_tests->add(null, self::ALBUM_TITLE_1)->offsetGet('id');
-		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID1)->offsetGet('id');
-		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
-		$this->photoID3 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_SUNSET_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->albumID1 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_1)->offsetGet('id');
+		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->photoID3 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_SUNSET_IMAGE), $this->albumID1)->offsetGet('id');
 		$this->albums_tests->set_protection_policy($this->albumID1);
 		$this->photos_tests->set_star([$this->photoID1], true);
 		Auth::logout();
@@ -265,7 +265,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 			$this->photoID1,
 			$this->photoID2, [
 				// photo 1 is thumb, because starred photo are always picked first
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
 			])
 		);
 		$arrayUnexpected = $this->generateUnexpectedRootJson(null, $this->photoID1, null, $this->photoID1);
@@ -279,9 +279,9 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 			true,
 			$this->photoID1, [
 				// photo 1 is the thumb, because starred photo are always picked first
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_SUNSET_IMAGE, $this->photoID3, $this->albumID1), // photo 3 is alphabetically first
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1), // photo 2 is next alphabetically
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1), // despite that photo 1 is starred
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_SUNSET_IMAGE, $this->photoID3, $this->albumID1), // photo 3 is alphabetically first
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1), // photo 2 is next alphabetically
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1), // despite that photo 1 is starred
 			]
 		));
 
@@ -289,7 +289,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForStarred->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForStarred->assertJsonMissing(['id' => $this->photoID2]);
@@ -299,7 +299,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID2, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID1]);
@@ -307,20 +307,20 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1), // photo 1 is thumb, because starred photo are always picked first
+			$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1), // photo 1 is thumb, because starred photo are always picked first
 		]));
 		$responseForTree->assertJsonMissing(['id' => $this->photoID3]);
 
 		$responseForAlbum = $this->albums_tests->get($this->albumID1);
 		$responseForAlbum->assertJson([
 			'id' => $this->albumID1,
-			'title' => self::ALBUM_TITLE_1,
+			'title' => TestConstants::ALBUM_TITLE_1,
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID1), // photo 1 is thumb, because starred photo are always picked first
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_SUNSET_IMAGE, $this->photoID3, $this->albumID1), // photo 2 is alphabetically first
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1), // photo 2 is alphabetically first
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1), // despite that photo 1 is starred
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_SUNSET_IMAGE, $this->photoID3, $this->albumID1), // photo 2 is alphabetically first
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1), // photo 2 is alphabetically first
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1), // despite that photo 1 is starred
 			],
 		]);
 		$this->photos_tests->get($this->photoID1);
@@ -337,9 +337,9 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	 */
 	protected function preparePublicUnsortedPhotoAndPhotoInSharedAlbum(): void
 	{
-		$this->albumID1 = $this->albums_tests->add(null, self::ALBUM_TITLE_1)->offsetGet('id');
-		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_TRAIN_IMAGE))->offsetGet('id');
-		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->albumID1 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_1)->offsetGet('id');
+		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE))->offsetGet('id');
+		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
 		$this->sharing_tests->add([$this->albumID1], [$this->userID]);
 		$this->photos_tests->set_public($this->photoID1, true);
 		$this->photos_tests->set_star([$this->photoID1, $this->photoID2], true);
@@ -360,11 +360,11 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	 */
 	protected function preparePublicAlbumAndPasswordProtectedAlbum(): void
 	{
-		$this->albumID1 = $this->albums_tests->add(null, self::ALBUM_TITLE_1)->offsetGet('id');
-		$this->albumID2 = $this->albums_tests->add(null, self::ALBUM_TITLE_2)->offsetGet('id');
-		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
-		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
-		$this->albums_tests->set_protection_policy(id: $this->albumID1, password: self::ALBUM_PWD_1);
+		$this->albumID1 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_1)->offsetGet('id');
+		$this->albumID2 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_2)->offsetGet('id');
+		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
+		$this->albums_tests->set_protection_policy(id: $this->albumID1, password: TestConstants::ALBUM_PWD_1);
 		$this->albums_tests->set_protection_policy(id: $this->albumID2);
 		Auth::logout();
 		Session::flush();
@@ -385,8 +385,8 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 			null,
 			$this->photoID2,
 			$this->photoID2, [
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1), // album 1 is in password protected, still locked album
-				$this->generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1), // album 1 is in password protected, still locked album
+				$this->generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
 			]
 		));
 		$arrayUnexpected = $this->generateUnexpectedRootJson(null, null, null, $this->photoID2);
@@ -399,7 +399,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID2, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 		$responseForRecent->assertJsonMissing(['id' => $this->photoID1]);
@@ -408,7 +408,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID2, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID1]);
@@ -418,24 +418,24 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForStarred->assertJsonMissing(['id' => $this->photoID1]);
 		$responseForStarred->assertJsonMissing(['id' => $this->photoID2]);
 
-		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), self::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
+		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
 		$this->photos_tests->get($this->photoID1, $this->getExpectedInaccessibleHttpStatusCode());
 
 		$responseForAlbum2 = $this->albums_tests->get($this->albumID2);
 		$responseForAlbum2->assertJson([
 			'id' => $this->albumID2,
-			'title' => self::ALBUM_TITLE_2,
+			'title' => TestConstants::ALBUM_TITLE_2,
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID2),
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			],
 		]);
 		$this->photos_tests->get($this->photoID2);
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			self::generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
+			self::generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
 		]));
 		$responseForTree->assertJsonMissing(['id' => $this->albumID1]);
 		$responseForTree->assertJsonMissing(['id' => $this->photoID1]);
@@ -448,7 +448,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$this->ensurePhotosWereTakenOnThisDay($this->photoID2);
 		$this->ensurePhotosWereNotTakenOnThisDay($this->photoID1);
 
-		$this->albums_tests->unlock($this->albumID1, self::ALBUM_PWD_1);
+		$this->albums_tests->unlock($this->albumID1, TestConstants::ALBUM_PWD_1);
 
 		$responseForRoot = $this->root_album_tests->get();
 		$responseForRoot->assertJson($this->generateExpectedRootJson(
@@ -457,8 +457,8 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 			null,
 			$this->photoID1,
 			$this->photoID2, [  // album 1 is unlocked, and photo 1 is alphabetically first
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
-				$this->generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
+				$this->generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
 			]
 		));
 		$arrayUnexpected = $this->generateUnexpectedRootJson(null, null, null, $this->photoID1);
@@ -470,8 +470,8 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [ // album 1 is unlocked, and photo 1 is alphabetically first
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 
@@ -479,7 +479,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID2, [ // photo 2 was taken on this day
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID1]);
@@ -492,11 +492,11 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForAlbum1 = $this->albums_tests->get($this->albumID1);
 		$responseForAlbum1->assertJson([
 			'id' => $this->albumID1,
-			'title' => self::ALBUM_TITLE_1,
+			'title' => TestConstants::ALBUM_TITLE_1,
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID1),
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			],
 		]);
 		$this->photos_tests->get($this->photoID1);
@@ -504,19 +504,19 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForAlbum2 = $this->albums_tests->get($this->albumID2);
 		$responseForAlbum2->assertJson([
 			'id' => $this->albumID2,
-			'title' => self::ALBUM_TITLE_2,
+			'title' => TestConstants::ALBUM_TITLE_2,
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID2),
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			],
 		]);
 		$this->photos_tests->get($this->photoID2);
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			self::generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
-			self::generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
+			self::generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
+			self::generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
 		]));
 	}
 
@@ -528,11 +528,11 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	 */
 	protected function preparePublicAlbumAndPasswordProtectedAlbumWithStarredPhoto(): void
 	{
-		$this->albumID1 = $this->albums_tests->add(null, self::ALBUM_TITLE_1)->offsetGet('id');
-		$this->albumID2 = $this->albums_tests->add(null, self::ALBUM_TITLE_2)->offsetGet('id');
-		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
-		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
-		$this->albums_tests->set_protection_policy(id: $this->albumID1, password: self::ALBUM_PWD_1);
+		$this->albumID1 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_1)->offsetGet('id');
+		$this->albumID2 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_2)->offsetGet('id');
+		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
+		$this->albums_tests->set_protection_policy(id: $this->albumID1, password: TestConstants::ALBUM_PWD_1);
 		$this->albums_tests->set_protection_policy($this->albumID2);
 		$this->photos_tests->set_star([$this->photoID1], true);
 		Auth::logout();
@@ -554,8 +554,8 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 			null,
 			$this->photoID2,
 			$this->photoID2, [  // album 1 is password protected, hence photo 2 is the thumb
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1), // album 1 is in password protected, still locked album
-				$this->generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1), // album 1 is in password protected, still locked album
+				$this->generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
 			]
 		));
 		$arrayUnexpected = $this->generateUnexpectedRootJson(null, null, null, $this->photoID2);
@@ -568,7 +568,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID2, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 		$responseForRecent->assertJsonMissing(['id' => $this->photoID1]);
@@ -582,29 +582,29 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID2, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID1]);
 
-		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), self::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
+		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
 		$this->photos_tests->get($this->photoID1, $this->getExpectedInaccessibleHttpStatusCode());
 
 		$responseForAlbum2 = $this->albums_tests->get($this->albumID2);
 		$responseForAlbum2->assertJson([
 			'id' => $this->albumID2,
-			'title' => self::ALBUM_TITLE_2,
+			'title' => TestConstants::ALBUM_TITLE_2,
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID2),
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			],
 		]);
 		$this->photos_tests->get($this->photoID2);
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			self::generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
+			self::generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
 		]));
 		$responseForTree->assertJsonMissing(['id' => $this->albumID1]);
 		$responseForTree->assertJsonMissing(['id' => $this->photoID1]);
@@ -613,7 +613,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	public function testPublicAlbumAndPasswordProtectedUnlockedAlbumWithStarredPhoto(): void
 	{
 		$this->preparePublicAlbumAndPasswordProtectedAlbumWithStarredPhoto();
-		$this->albums_tests->unlock($this->albumID1, self::ALBUM_PWD_1);
+		$this->albums_tests->unlock($this->albumID1, TestConstants::ALBUM_PWD_1);
 
 		$this->ensurePhotosWereNotTakenOnThisDay($this->photoID1, $this->photoID2);
 
@@ -624,8 +624,8 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 			null,
 			$this->photoID1,
 			null, [  // album 1 is unlocked, and photo 1 is alphabetically first
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
-				$this->generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
+				$this->generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
 			]
 		));
 		$arrayUnexpected = $this->generateUnexpectedRootJson(null, $this->photoID1, null, $this->photoID1);
@@ -637,8 +637,8 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [ // album 1 is unlocked, and photo 1 is alphabetically first
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 
@@ -646,7 +646,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForStarred->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [ // album 1 is unlocked, and photo 1 is alphabetically first
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForStarred->assertJsonMissing(['id' => $this->photoID2]);
@@ -659,11 +659,11 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForAlbum1 = $this->albums_tests->get($this->albumID1);
 		$responseForAlbum1->assertJson([
 			'id' => $this->albumID1,
-			'title' => self::ALBUM_TITLE_1,
+			'title' => TestConstants::ALBUM_TITLE_1,
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID1),
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			],
 		]);
 		$this->photos_tests->get($this->photoID1);
@@ -671,19 +671,19 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForAlbum2 = $this->albums_tests->get($this->albumID2);
 		$responseForAlbum2->assertJson([
 			'id' => $this->albumID2,
-			'title' => self::ALBUM_TITLE_2,
+			'title' => TestConstants::ALBUM_TITLE_2,
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID2),
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			],
 		]);
 		$this->photos_tests->get($this->photoID2);
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			self::generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
-			self::generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
+			self::generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
+			self::generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
 		]));
 	}
 
@@ -696,10 +696,10 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	 */
 	protected function preparePublicAlbumAndHiddenAlbum(): void
 	{
-		$this->albumID1 = $this->albums_tests->add(null, self::ALBUM_TITLE_1)->offsetGet('id');
-		$this->albumID2 = $this->albums_tests->add(null, self::ALBUM_TITLE_2)->offsetGet('id');
-		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
-		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
+		$this->albumID1 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_1)->offsetGet('id');
+		$this->albumID2 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_2)->offsetGet('id');
+		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
 		$this->albums_tests->set_protection_policy(id: $this->albumID1);
 		$this->albums_tests->set_protection_policy(id: $this->albumID2, is_link_required: true);
 		$this->photos_tests->set_star([$this->photoID2], true);
@@ -722,7 +722,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 			null,
 			$this->photoID1,
 			$this->photoID1, [ // album 2 is hidden
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
 			]
 		));
 		$arrayUnexpected = $this->generateUnexpectedRootJson(null, null, null, $this->photoID1);
@@ -736,7 +736,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForRecent->assertJsonMissing(['id' => $this->photoID2]);
@@ -750,18 +750,18 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			]));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID2]);
 
 		$responseForAlbum1 = $this->albums_tests->get($this->albumID1);
 		$responseForAlbum1->assertJson([
 			'id' => $this->albumID1,
-			'title' => self::ALBUM_TITLE_1,
+			'title' => TestConstants::ALBUM_TITLE_1,
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID1),
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			],
 		]);
 		$this->photos_tests->get($this->photoID1);
@@ -769,18 +769,18 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForAlbum2 = $this->albums_tests->get($this->albumID2);
 		$responseForAlbum2->assertJson([
 			'id' => $this->albumID2,
-			'title' => self::ALBUM_TITLE_2,
+			'title' => TestConstants::ALBUM_TITLE_2,
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID2),
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			],
 		]);
 		$this->photos_tests->get($this->photoID2);
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			self::generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
+			self::generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
 		]));
 		$responseForTree->assertDontSee(['id' => $this->albumID2]);
 	}
@@ -793,12 +793,12 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	 */
 	protected function preparePublicAlbumAndHiddenPasswordProtectedAlbum(): void
 	{
-		$this->albumID1 = $this->albums_tests->add(null, self::ALBUM_TITLE_1)->offsetGet('id');
-		$this->albumID2 = $this->albums_tests->add(null, self::ALBUM_TITLE_2)->offsetGet('id');
-		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
-		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
+		$this->albumID1 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_1)->offsetGet('id');
+		$this->albumID2 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_2)->offsetGet('id');
+		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
 		$this->albums_tests->set_protection_policy(id: $this->albumID1);
-		$this->albums_tests->set_protection_policy(id: $this->albumID2, is_link_required: true, password: self::ALBUM_PWD_2);
+		$this->albums_tests->set_protection_policy(id: $this->albumID2, is_link_required: true, password: TestConstants::ALBUM_PWD_2);
 		$this->photos_tests->set_star([$this->photoID2], true);
 		Auth::logout();
 		Session::flush();
@@ -819,7 +819,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 			null,
 			$this->photoID1,
 			$this->photoID1, [ // album 2 is hidden
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
 			]
 		));
 		$arrayUnexpected = $this->generateUnexpectedRootJson(null, null, null, $this->photoID1);
@@ -833,7 +833,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForRecent->assertJsonMissing(['id' => $this->photoID2]);
@@ -847,7 +847,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID2]);
@@ -855,21 +855,21 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForAlbum1 = $this->albums_tests->get($this->albumID1);
 		$responseForAlbum1->assertJson([
 			'id' => $this->albumID1,
-			'title' => self::ALBUM_TITLE_1,
+			'title' => TestConstants::ALBUM_TITLE_1,
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID1),
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			],
 		]);
 		$this->photos_tests->get($this->photoID1);
 
-		$this->albums_tests->get($this->albumID2, $this->getExpectedInaccessibleHttpStatusCode(), self::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
+		$this->albums_tests->get($this->albumID2, $this->getExpectedInaccessibleHttpStatusCode(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
 		$this->photos_tests->get($this->photoID2, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage());
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			self::generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
+			self::generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
 		]));
 		$responseForTree->assertDontSee(['id' => $this->albumID2]);
 	}
@@ -880,7 +880,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 
 		$this->ensurePhotosWereTakenOnThisDay($this->photoID1, $this->photoID2);
 
-		$this->albums_tests->unlock($this->albumID2, self::ALBUM_PWD_2);
+		$this->albums_tests->unlock($this->albumID2, TestConstants::ALBUM_PWD_2);
 
 		$responseForRoot = $this->root_album_tests->get();
 		$responseForRoot->assertJson($this->generateExpectedRootJson(
@@ -889,7 +889,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 			null,
 			$this->photoID1,
 			$this->photoID1, [ // album 2 is hidden
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
 			]
 		));
 		$arrayUnexpected = $this->generateUnexpectedRootJson(null, null, null, $this->photoID1);
@@ -903,7 +903,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForRecent->assertJsonMissing(['id' => $this->photoID2]);
@@ -917,7 +917,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID2]);
@@ -925,11 +925,11 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForAlbum1 = $this->albums_tests->get($this->albumID1);
 		$responseForAlbum1->assertJson([
 			'id' => $this->albumID1,
-			'title' => self::ALBUM_TITLE_1,
+			'title' => TestConstants::ALBUM_TITLE_1,
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID1),
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			],
 		]);
 		$this->photos_tests->get($this->photoID1);
@@ -937,18 +937,18 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForAlbum2 = $this->albums_tests->get($this->albumID2);
 		$responseForAlbum2->assertJson([
 			'id' => $this->albumID2,
-			'title' => self::ALBUM_TITLE_2,
+			'title' => TestConstants::ALBUM_TITLE_2,
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID2),
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			],
 		]);
 		$this->photos_tests->get($this->photoID2);
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			self::generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
+			self::generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
 		]));
 		$responseForTree->assertDontSee(['id' => $this->albumID2]);
 	}
@@ -961,12 +961,12 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	 */
 	protected function preparePhotosInSharedAndPrivateAndRequireLinkAlbum(): void
 	{
-		$this->albumID1 = $this->albums_tests->add(null, self::ALBUM_TITLE_1)->offsetGet('id');
-		$this->albumID2 = $this->albums_tests->add(null, self::ALBUM_TITLE_2)->offsetGet('id');
-		$this->albumID3 = $this->albums_tests->add(null, self::ALBUM_TITLE_3)->offsetGet('id');
-		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
-		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
-		$this->photoID3 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_SUNSET_IMAGE), $this->albumID3)->offsetGet('id');
+		$this->albumID1 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_1)->offsetGet('id');
+		$this->albumID2 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_2)->offsetGet('id');
+		$this->albumID3 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_3)->offsetGet('id');
+		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
+		$this->photoID3 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_SUNSET_IMAGE), $this->albumID3)->offsetGet('id');
 		$this->sharing_tests->add([$this->albumID1, $this->albumID3], [$this->userID]);
 		$this->albums_tests->set_protection_policy(id: $this->albumID3, is_link_required: true);
 		Auth::logout();
@@ -988,9 +988,9 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	 */
 	protected function preparePhotoInSharedPublicPasswordProtectedAlbum(): void
 	{
-		$this->albumID1 = $this->albums_tests->add(null, self::ALBUM_TITLE_1)->offsetGet('id');
-		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
-		$this->albums_tests->set_protection_policy(id: $this->albumID1, password: self::ALBUM_PWD_1);
+		$this->albumID1 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_1)->offsetGet('id');
+		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->albums_tests->set_protection_policy(id: $this->albumID1, password: TestConstants::ALBUM_PWD_1);
 		$this->sharing_tests->add([$this->albumID1], [$this->userID]);
 		Auth::logout();
 		Session::flush();
@@ -1003,7 +1003,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	public function testPhotoInSharedPublicPasswordProtectedUnlockedAlbum(): void
 	{
 		$this->preparePhotoInSharedPublicPasswordProtectedAlbum();
-		$this->albums_tests->unlock($this->albumID1, self::ALBUM_PWD_1);
+		$this->albums_tests->unlock($this->albumID1, TestConstants::ALBUM_PWD_1);
 
 		$this->ensurePhotosWereTakenOnThisDay($this->photoID1);
 
@@ -1014,7 +1014,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 			null,
 			$this->photoID1,
 			$this->photoID1, [
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
 			]
 		));
 		$arrayUnexpected = $this->generateUnexpectedRootJson(null, null, null, $this->photoID1);
@@ -1031,7 +1031,7 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 
@@ -1039,18 +1039,18 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
+			$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
 		]));
 
 		$responseForAlbum = $this->albums_tests->get($this->albumID1);
 		$responseForAlbum->assertJson($this->generateExpectedAlbumJson(
-			$this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1
+			$this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1
 		));
 		$this->photos_tests->get($this->photoID1);
 	}
@@ -1068,22 +1068,22 @@ abstract class BaseSharingTestScenarios extends BaseSharingTest
 	 */
 	protected function prepareThreeAlbumsWithMixedSharingAndPasswordProtection(): void
 	{
-		$this->albumID1 = $this->albums_tests->add(null, self::ALBUM_TITLE_1)->offsetGet('id');
-		$this->albumID2 = $this->albums_tests->add(null, self::ALBUM_TITLE_2)->offsetGet('id');
-		$this->albumID3 = $this->albums_tests->add(null, self::ALBUM_TITLE_3)->offsetGet('id');
+		$this->albumID1 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_1)->offsetGet('id');
+		$this->albumID2 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_2)->offsetGet('id');
+		$this->albumID3 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_3)->offsetGet('id');
 		// The mis-order of photos by there title (N, T, M) is on purpose such that
 		// we first receive the result (N, T) as long as album 3 is locked and
 		// then (M, N, T) after album 3 has been unlocked, with album 3
 		// being in the front position.
-		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_NIGHT_IMAGE), $this->albumID1)->offsetGet('id');
-		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
-		$this->photoID3 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID3)->offsetGet('id');
+		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
+		$this->photoID3 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID3)->offsetGet('id');
 		$this->sharing_tests->add([$this->albumID1, $this->albumID2], [$this->userID]);
 		// Sic! We use the same password for both albums here, because we want
 		// to ensure that incidentally "unlocking" an album which is also
 		// shared has no negative side effect.
-		$this->albums_tests->set_protection_policy(id: $this->albumID2, is_nsfw: true, password: self::ALBUM_PWD_1);
-		$this->albums_tests->set_protection_policy(id: $this->albumID3, is_nsfw: true, password: self::ALBUM_PWD_1);
+		$this->albums_tests->set_protection_policy(id: $this->albumID2, is_nsfw: true, password: TestConstants::ALBUM_PWD_1);
+		$this->albums_tests->set_protection_policy(id: $this->albumID3, is_nsfw: true, password: TestConstants::ALBUM_PWD_1);
 
 		Auth::logout();
 		Session::flush();

--- a/tests/Feature/Base/BaseSharingWithAnonUser.php
+++ b/tests/Feature/Base/BaseSharingWithAnonUser.php
@@ -17,6 +17,7 @@ use App\SmartAlbums\PublicAlbum;
 use App\SmartAlbums\RecentAlbum;
 use App\SmartAlbums\StarredAlbum;
 use App\SmartAlbums\UnsortedAlbum;
+use Tests\Feature\Constants\TestConstants;
 
 /**
  * Implements the tests of {@link SharingTestScenariosAbstract} for an
@@ -73,9 +74,9 @@ abstract class BaseSharingWithAnonUser extends BaseSharingTestScenarios
 		$responseForTree->assertJsonMissing(['id' => $this->albumID3]);
 		$responseForTree->assertJsonMissing(['id' => $this->photoID3]);
 
-		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), self::EXPECTED_PASSWORD_REQUIRED_MSG);
+		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG);
 		$this->photos_tests->get($this->photoID1, $this->getExpectedInaccessibleHttpStatusCode());
-		$this->albums_tests->get($this->albumID2, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), self::EXPECTED_PASSWORD_REQUIRED_MSG);
+		$this->albums_tests->get($this->albumID2, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG);
 		$this->photos_tests->get($this->photoID2, $this->getExpectedInaccessibleHttpStatusCode());
 	}
 
@@ -92,7 +93,7 @@ abstract class BaseSharingWithAnonUser extends BaseSharingTestScenarios
 			null,
 			null,
 			null, [
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1),
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1),
 			]
 		));
 		$responseForRoot->assertJsonMissing(['id' => $this->photoID1]);
@@ -116,7 +117,7 @@ abstract class BaseSharingWithAnonUser extends BaseSharingTestScenarios
 		$responseForTree->assertJsonMissing(['id' => $this->albumID1]);
 		$responseForTree->assertJsonMissing(['id' => $this->photoID1]);
 
-		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), self::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
+		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
 		$this->photos_tests->get($this->photoID1, $this->getExpectedInaccessibleHttpStatusCode());
 	}
 
@@ -133,8 +134,8 @@ abstract class BaseSharingWithAnonUser extends BaseSharingTestScenarios
 			null,
 			null,
 			null, [
-				$this->generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2),
-				$this->generateExpectedAlbumJson($this->albumID3, self::ALBUM_TITLE_3),
+				$this->generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2),
+				$this->generateExpectedAlbumJson($this->albumID3, TestConstants::ALBUM_TITLE_3),
 			]
 		));
 		$responseForRoot->assertJsonMissing(['id' => $this->albumID1]);
@@ -176,18 +177,18 @@ abstract class BaseSharingWithAnonUser extends BaseSharingTestScenarios
 		$responseForTree->assertJsonMissing(['id' => $this->albumID3]);
 		$responseForTree->assertJsonMissing(['id' => $this->photoID3]);
 
-		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), self::EXPECTED_PASSWORD_REQUIRED_MSG);
+		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG);
 		$this->photos_tests->get($this->photoID1, $this->getExpectedInaccessibleHttpStatusCode());
-		$this->albums_tests->get($this->albumID2, $this->getExpectedInaccessibleHttpStatusCode(), self::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
+		$this->albums_tests->get($this->albumID2, $this->getExpectedInaccessibleHttpStatusCode(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
 		$this->photos_tests->get($this->photoID2, $this->getExpectedInaccessibleHttpStatusCode());
-		$this->albums_tests->get($this->albumID3, $this->getExpectedInaccessibleHttpStatusCode(), self::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
+		$this->albums_tests->get($this->albumID3, $this->getExpectedInaccessibleHttpStatusCode(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
 		$this->photos_tests->get($this->photoID3, $this->getExpectedInaccessibleHttpStatusCode());
 	}
 
 	public function testThreeUnlockedAlbumsWithMixedSharingAndPasswordProtection(): void
 	{
 		$this->prepareThreeAlbumsWithMixedSharingAndPasswordProtection();
-		$this->albums_tests->unlock($this->albumID3, self::ALBUM_PWD_1);
+		$this->albums_tests->unlock($this->albumID3, TestConstants::ALBUM_PWD_1);
 
 		$this->ensurePhotosWereTakenOnThisDay($this->photoID1, $this->photoID2);
 		$this->ensurePhotosWereNotTakenOnThisDay($this->photoID3);
@@ -200,8 +201,8 @@ abstract class BaseSharingWithAnonUser extends BaseSharingTestScenarios
 			$this->photoID3,
 			$this->photoID2,
 			[ // photo 3 is alphabetically first
-				$this->generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
-				$this->generateExpectedAlbumJson($this->albumID3, self::ALBUM_TITLE_3, null, $this->photoID3),
+				$this->generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
+				$this->generateExpectedAlbumJson($this->albumID3, TestConstants::ALBUM_TITLE_3, null, $this->photoID3),
 			],
 		));
 
@@ -221,8 +222,8 @@ abstract class BaseSharingWithAnonUser extends BaseSharingTestScenarios
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID3, [ // photo 3 is alphabetically first
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID3, $this->albumID3),
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID3, $this->albumID3),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 		$responseForRecent->assertJsonMissing(['id' => $this->albumID1]);
@@ -232,7 +233,7 @@ abstract class BaseSharingWithAnonUser extends BaseSharingTestScenarios
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID2, [ // photo 2 was taken on this day
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID1]);
@@ -240,22 +241,22 @@ abstract class BaseSharingWithAnonUser extends BaseSharingTestScenarios
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			$this->generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
-			$this->generateExpectedAlbumJson($this->albumID3, self::ALBUM_TITLE_3, null, $this->photoID3),
+			$this->generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
+			$this->generateExpectedAlbumJson($this->albumID3, TestConstants::ALBUM_TITLE_3, null, $this->photoID3),
 		]));
 		$responseForTree->assertJsonMissing(['id' => $this->albumID1]);
 		$responseForTree->assertJsonMissing(['id' => $this->photoID1]);
 
-		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), self::EXPECTED_PASSWORD_REQUIRED_MSG);
+		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG);
 		$this->photos_tests->get($this->photoID1, $this->getExpectedInaccessibleHttpStatusCode());
 		$responseForAlbum2 = $this->albums_tests->get($this->albumID2);
 		$responseForAlbum2->assertJson($this->generateExpectedAlbumJson(
-			$this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2
+			$this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2
 		));
 		$this->photos_tests->get($this->photoID2);
 		$responseForAlbum3 = $this->albums_tests->get($this->albumID3);
 		$responseForAlbum3->assertJson($this->generateExpectedAlbumJson(
-			$this->albumID3, self::ALBUM_TITLE_3, null, $this->photoID3
+			$this->albumID3, TestConstants::ALBUM_TITLE_3, null, $this->photoID3
 		));
 		$this->photos_tests->get($this->photoID3);
 	}
@@ -338,6 +339,6 @@ abstract class BaseSharingWithAnonUser extends BaseSharingTestScenarios
 
 	protected function getExpectedDefaultInaccessibleMessage(): string
 	{
-		return self::EXPECTED_UNAUTHENTICATED_MSG;
+		return TestConstants::EXPECTED_UNAUTHENTICATED_MSG;
 	}
 }

--- a/tests/Feature/Base/BaseSharingWithNonAdminUser.php
+++ b/tests/Feature/Base/BaseSharingWithNonAdminUser.php
@@ -18,6 +18,7 @@ use App\SmartAlbums\RecentAlbum;
 use App\SmartAlbums\StarredAlbum;
 use App\SmartAlbums\UnsortedAlbum;
 use Illuminate\Support\Facades\Auth;
+use Tests\Feature\Constants\TestConstants;
 
 /**
  * Implements the tests of {@link SharingTestScenariosAbstract} for a
@@ -65,8 +66,8 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 			null,
 			$this->photoID3,
 			$this->photoID1, [
-				self::generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
-				self::generateExpectedAlbumJson($this->albumID3, self::ALBUM_TITLE_3, null, $this->photoID3),
+				self::generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
+				self::generateExpectedAlbumJson($this->albumID3, TestConstants::ALBUM_TITLE_3, null, $this->photoID3),
 			]
 		));
 		$responseForRoot->assertJsonMissing(['id' => $this->albumID2]);
@@ -83,8 +84,8 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID3, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_SUNSET_IMAGE, $this->photoID3, $this->albumID3),
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_SUNSET_IMAGE, $this->photoID3, $this->albumID3),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForRecent->assertJsonMissing(['id' => $this->albumID2]);
@@ -94,7 +95,7 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID2]);
@@ -102,24 +103,24 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			self::generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
-			self::generateExpectedAlbumJson($this->albumID3, self::ALBUM_TITLE_3, null, $this->photoID3),
+			self::generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
+			self::generateExpectedAlbumJson($this->albumID3, TestConstants::ALBUM_TITLE_3, null, $this->photoID3),
 		]));
 		$responseForTree->assertJsonMissing(['id' => $this->albumID2]);
 		$responseForTree->assertJsonMissing(['id' => $this->photoID2]);
 
 		$responseForAlbum1 = $this->albums_tests->get($this->albumID1);
 		$responseForAlbum1->assertJson(self::generateExpectedAlbumJson(
-			$this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1
+			$this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1
 		));
 		$this->photos_tests->get($this->photoID1);
 
-		$this->albums_tests->get($this->albumID2, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), self::EXPECTED_PASSWORD_REQUIRED_MSG);
+		$this->albums_tests->get($this->albumID2, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG);
 		$this->photos_tests->get($this->photoID2, $this->getExpectedInaccessibleHttpStatusCode());
 
 		$responseForAlbum3 = $this->albums_tests->get($this->albumID3);
 		$responseForAlbum3->assertJson(self::generateExpectedAlbumJson(
-			$this->albumID3, self::ALBUM_TITLE_3, null, $this->photoID3
+			$this->albumID3, TestConstants::ALBUM_TITLE_3, null, $this->photoID3
 		));
 		$this->photos_tests->get($this->photoID3);
 	}
@@ -137,7 +138,7 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 			null,
 			$this->photoID1,
 			$this->photoID1, [
-				self::generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
+				self::generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
 			]
 		));
 
@@ -150,7 +151,7 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 
@@ -158,18 +159,18 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			self::generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
+			self::generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
 		]));
 
 		$responseForAlbum = $this->albums_tests->get($this->albumID1);
 		$responseForAlbum->assertJson($this->generateExpectedAlbumJson(
-			$this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1
+			$this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1
 		));
 		$this->photos_tests->get($this->photoID1);
 	}
@@ -189,9 +190,9 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 			$this->photoID1,  // photo 1 is alphabetically first, as photo 3 is locked
 			$this->photoID2,  // photo 1 was not taken on this day and photo 3 is locked
 			[
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
-				$this->generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
-				$this->generateExpectedAlbumJson($this->albumID3, self::ALBUM_TITLE_3), // album 3 is locked, hence no thumb
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
+				$this->generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
+				$this->generateExpectedAlbumJson($this->albumID3, TestConstants::ALBUM_TITLE_3), // album 3 is locked, hence no thumb
 			]
 		));
 		$responseForRoot->assertJsonMissing(['id' => $this->photoID3]);
@@ -209,8 +210,8 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [ // photo 1 is alphabetically first, as photo 3 is locked
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_NIGHT_IMAGE, $this->photoID1, $this->albumID1),
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_NIGHT_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 		$responseForRecent->assertJsonMissing(['id' => $this->albumID3]);
@@ -220,7 +221,7 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID2, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID1]);
@@ -229,30 +230,30 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 		// TODO: Should public and password-protected albums appear in tree? Regression?
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
-			$this->generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
+			$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
+			$this->generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
 		]));
 		$responseForTree->assertJsonMissing(['id' => $this->albumID3]);
 		$responseForTree->assertJsonMissing(['id' => $this->photoID3]);
 
 		$responseForAlbum1 = $this->albums_tests->get($this->albumID1);
 		$responseForAlbum1->assertJson($this->generateExpectedAlbumJson(
-			$this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1
+			$this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1
 		));
 		$this->photos_tests->get($this->photoID1);
 		$responseForAlbum2 = $this->albums_tests->get($this->albumID2);
 		$responseForAlbum2->assertJson($this->generateExpectedAlbumJson(
-			$this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2
+			$this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2
 		));
 		$this->photos_tests->get($this->photoID2);
-		$this->albums_tests->get($this->albumID3, $this->getExpectedInaccessibleHttpStatusCode(), self::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
+		$this->albums_tests->get($this->albumID3, $this->getExpectedInaccessibleHttpStatusCode(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG, $this->getExpectedDefaultInaccessibleMessage());
 		$this->photos_tests->get($this->photoID3, $this->getExpectedInaccessibleHttpStatusCode());
 	}
 
 	public function testThreeUnlockedAlbumsWithMixedSharingAndPasswordProtection(): void
 	{
 		$this->prepareThreeAlbumsWithMixedSharingAndPasswordProtection();
-		$this->albums_tests->unlock($this->albumID3, self::ALBUM_PWD_1);
+		$this->albums_tests->unlock($this->albumID3, TestConstants::ALBUM_PWD_1);
 
 		$this->ensurePhotosWereTakenOnThisDay($this->photoID2);
 		$this->ensurePhotosWereNotTakenOnThisDay($this->photoID1, $this->photoID3);
@@ -265,9 +266,9 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 			$this->photoID3, // photo 3 is alphabetically first
 			$this->photoID2, // photo 2 was taken on this day
 			[
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
-				$this->generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
-				$this->generateExpectedAlbumJson($this->albumID3, self::ALBUM_TITLE_3, null, $this->photoID3),
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
+				$this->generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
+				$this->generateExpectedAlbumJson($this->albumID3, TestConstants::ALBUM_TITLE_3, null, $this->photoID3),
 			]
 		));
 
@@ -284,9 +285,9 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID3, [ // photo 1 is alphabetically first
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID3, $this->albumID3),
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_NIGHT_IMAGE, $this->photoID1, $this->albumID1),
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID3, $this->albumID3),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_NIGHT_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 
@@ -294,7 +295,7 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID2, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID1]);
@@ -302,24 +303,24 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1),
-			$this->generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2),
-			$this->generateExpectedAlbumJson($this->albumID3, self::ALBUM_TITLE_3, null, $this->photoID3),
+			$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1),
+			$this->generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2),
+			$this->generateExpectedAlbumJson($this->albumID3, TestConstants::ALBUM_TITLE_3, null, $this->photoID3),
 		]));
 
 		$responseForAlbum1 = $this->albums_tests->get($this->albumID1);
 		$responseForAlbum1->assertJson($this->generateExpectedAlbumJson(
-			$this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID1
+			$this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID1
 		));
 		$this->photos_tests->get($this->photoID1);
 		$responseForAlbum2 = $this->albums_tests->get($this->albumID2);
 		$responseForAlbum2->assertJson($this->generateExpectedAlbumJson(
-			$this->albumID2, self::ALBUM_TITLE_2, null, $this->photoID2
+			$this->albumID2, TestConstants::ALBUM_TITLE_2, null, $this->photoID2
 		));
 		$this->photos_tests->get($this->photoID2);
 		$responseForAlbum3 = $this->albums_tests->get($this->albumID3);
 		$responseForAlbum3->assertJson($this->generateExpectedAlbumJson(
-			$this->albumID3, self::ALBUM_TITLE_3, null, $this->photoID3
+			$this->albumID3, TestConstants::ALBUM_TITLE_3, null, $this->photoID3
 		));
 		$this->photos_tests->get($this->photoID3);
 	}
@@ -376,6 +377,6 @@ abstract class BaseSharingWithNonAdminUser extends BaseSharingTestScenarios
 
 	protected function getExpectedDefaultInaccessibleMessage(): string
 	{
-		return self::EXPECTED_FORBIDDEN_MSG;
+		return TestConstants::EXPECTED_FORBIDDEN_MSG;
 	}
 }

--- a/tests/Feature/BasePhotosAddHandler.php
+++ b/tests/Feature/BasePhotosAddHandler.php
@@ -17,6 +17,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Tests\AbstractTestCase;
 use Tests\Feature\Base\BasePhotoTest;
+use Tests\Feature\Constants\TestConstants;
 
 /**
  * Contains all tests for adding photos to Lychee which involve the image
@@ -35,7 +36,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 	public function testSimpleUploadToRoot(): void
 	{
 		$response = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		);
 		/*
 		 * Check some Exif data
@@ -56,7 +57,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 			'taken_at' => $taken_at->format('Y-m-d\TH:i:sP'),
 			'taken_at_orig_tz' => $taken_at->getTimezone()->getName(),
 			'title' => 'night',
-			'type' => AbstractTestCase::MIME_TYPE_IMG_JPEG,
+			'type' => TestConstants::MIME_TYPE_IMG_JPEG,
 			'size_variants' => [
 				'thumb' => ['width' => 200, 'height' => 200],
 				'thumb2x' => ['width' => 400, 'height' => 400],
@@ -79,7 +80,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 		$this->assertHasExifToolOrSkip();
 
 		$response = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_ORIENTATION_90)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_ORIENTATION_90)
 		);
 
 		/*
@@ -104,7 +105,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 		$this->assertHasExifToolOrSkip();
 
 		$response = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_ORIENTATION_180)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_ORIENTATION_180)
 		);
 
 		/*
@@ -129,7 +130,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 		$this->assertHasExifToolOrSkip();
 
 		$response = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_ORIENTATION_270)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_ORIENTATION_270)
 		);
 
 		/*
@@ -154,7 +155,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 		$this->assertHasExifToolOrSkip();
 
 		$response = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_ORIENTATION_HFLIP)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_ORIENTATION_HFLIP)
 		);
 
 		/*
@@ -179,7 +180,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 		$this->assertHasExifToolOrSkip();
 
 		$response = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_ORIENTATION_VFLIP)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_ORIENTATION_VFLIP)
 		);
 
 		/*
@@ -198,7 +199,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 	{
 		/** @var \App\Models\Photo $photo */
 		$photo = static::convertJsonToObject($this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_PNG)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_PNG)
 		));
 		$this->assertStringEndsWith('.png', $photo->size_variants->original->url);
 	}
@@ -207,7 +208,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 	{
 		/** @var \App\Models\Photo $photo */
 		$photo = static::convertJsonToObject($this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_GIF)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_GIF)
 		));
 		$this->assertStringEndsWith('.gif', $photo->size_variants->original->url);
 	}
@@ -216,7 +217,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 	{
 		/** @var \App\Models\Photo $photo */
 		$photo = static::convertJsonToObject($this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_WEBP)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_WEBP)
 		));
 		$this->assertStringEndsWith('.webp', $photo->size_variants->original->url);
 	}
@@ -232,11 +233,11 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 
 		/** @var \App\Models\Photo $photo */
 		$photo = static::convertJsonToObject($this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_TRAIN_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE)
 		));
 		/** @var \App\Models\Photo $video */
 		$video = static::convertJsonToObject($this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_TRAIN_VIDEO),
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_VIDEO),
 			null,
 			200
 		));
@@ -258,11 +259,11 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 
 		/** @var \App\Models\Photo $video */
 		$video = static::convertJsonToObject($this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_TRAIN_VIDEO)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_VIDEO)
 		));
 		/** @var \App\Models\Photo $photo */
 		$photo = static::convertJsonToObject($this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_TRAIN_IMAGE),
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE),
 			null,
 			200 // associated image to video.
 		));
@@ -287,7 +288,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 
 		/** @var \App\Models\Photo $photo */
 		$photo = static::convertJsonToObject($this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_GMP_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_GMP_IMAGE)
 		));
 
 		$this->assertStringEndsWith('.mov', $photo->live_photo_url);
@@ -318,14 +319,14 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 		DB::table('logs')->delete();
 
 		$response = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_GMP_BROKEN_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_GMP_BROKEN_IMAGE)
 		);
 		// Size variants are generated, because they are extracted from the
 		// still part of the GMP, not the video part.
 		$response->assertJson([
 			'album_id' => null,
 			'title' => 'google_motion_photo_broken',
-			'type' => AbstractTestCase::MIME_TYPE_IMG_JPEG,
+			'type' => TestConstants::MIME_TYPE_IMG_JPEG,
 			'size_variants' => [
 				'original' => ['width' => 2016, 'height' => 1512],
 				'medium2x' => null,
@@ -355,12 +356,12 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 		$this->assertHasFFMpegOrSkip();
 
 		$response = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_GAMING_VIDEO)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_GAMING_VIDEO)
 		);
 		$response->assertJson([
 			'album_id' => null,
 			'title' => 'gaming',
-			'type' => AbstractTestCase::MIME_TYPE_VID_MP4,
+			'type' => TestConstants::MIME_TYPE_VID_MP4,
 			'size_variants' => [
 				'thumb' => [
 					'width' => 200,
@@ -394,21 +395,21 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 	 */
 	public function testVideoUploadWithoutFFmpeg(): void
 	{
-		$hasExifTool = Configs::getValueAsInt(self::CONFIG_HAS_EXIF_TOOL);
-		Configs::set(self::CONFIG_HAS_EXIF_TOOL, 0);
+		$hasExifTool = Configs::getValueAsInt(TestConstants::CONFIG_HAS_EXIF_TOOL);
+		Configs::set(TestConstants::CONFIG_HAS_EXIF_TOOL, 0);
 
-		$hasFFMpeg = Configs::getValueAsInt(AbstractTestCase::CONFIG_HAS_FFMPEG);
-		Configs::set(AbstractTestCase::CONFIG_HAS_FFMPEG, 0);
+		$hasFFMpeg = Configs::getValueAsInt(TestConstants::CONFIG_HAS_FFMPEG);
+		Configs::set(TestConstants::CONFIG_HAS_FFMPEG, 0);
 
 		DB::table('logs')->delete();
 
 		$response = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_GAMING_VIDEO)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_GAMING_VIDEO)
 		);
 		$response->assertJson([
 			'album_id' => null,
 			'title' => 'gaming',
-			'type' => AbstractTestCase::MIME_TYPE_VID_MP4,
+			'type' => TestConstants::MIME_TYPE_VID_MP4,
 			'size_variants' => [
 				'original' => [
 					'width' => 0,
@@ -436,8 +437,8 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 			->count();
 		$this->assertEquals(1, $logCount);
 
-		Configs::set(self::CONFIG_HAS_FFMPEG, $hasFFMpeg);
-		Configs::set(self::CONFIG_HAS_EXIF_TOOL, $hasExifTool);
+		Configs::set(TestConstants::CONFIG_HAS_FFMPEG, $hasFFMpeg);
+		Configs::set(TestConstants::CONFIG_HAS_EXIF_TOOL, $hasExifTool);
 	}
 
 	/**
@@ -449,11 +450,11 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 	 */
 	public function testPhotoUploadWithUndefinedExifTag(): void
 	{
-		$hasExifTool = Configs::getValueAsBool(self::CONFIG_HAS_EXIF_TOOL);
-		Configs::set(self::CONFIG_HAS_EXIF_TOOL, false);
+		$hasExifTool = Configs::getValueAsBool(TestConstants::CONFIG_HAS_EXIF_TOOL);
+		Configs::set(TestConstants::CONFIG_HAS_EXIF_TOOL, false);
 
 		$response = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_UNDEFINED_EXIF_TAG)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_UNDEFINED_EXIF_TAG)
 		);
 		$response->assertJson([
 			'album_id' => null,
@@ -464,7 +465,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 			'make' => 'Canon',
 			'model' => 'Canon EOS 100D',
 			'shutter' => '1/250 s',
-			'type' => AbstractTestCase::MIME_TYPE_IMG_JPEG,
+			'type' => TestConstants::MIME_TYPE_IMG_JPEG,
 			'size_variants' => [
 				'thumb' => ['width' => 200, 'height' => 200],
 				'thumb2x' => ['width' => 400, 'height' => 400],
@@ -476,13 +477,13 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 			],
 		]);
 
-		Configs::set(self::CONFIG_HAS_EXIF_TOOL, $hasExifTool);
+		Configs::set(TestConstants::CONFIG_HAS_EXIF_TOOL, $hasExifTool);
 	}
 
 	public function testUploadMultibyteTitle(): void
 	{
 		$id = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_SUNSET_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_SUNSET_IMAGE)
 		)->offsetGet('id');
 
 		$response = $this->photos_tests->get($id);
@@ -501,7 +502,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 			'aperture' => 'f/8.0',
 			'shutter' => '1/320 s',
 			'focal' => '200 mm',
-			'type' => AbstractTestCase::MIME_TYPE_IMG_JPEG,
+			'type' => TestConstants::MIME_TYPE_IMG_JPEG,
 			'size_variants' => [
 				'small' => [
 					'width' => 202,
@@ -522,9 +523,9 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 
 	public function testUploadMultibyteTitleWithoutExifTool(): void
 	{
-		$hasExifTool = Configs::getValueAsBool(self::CONFIG_HAS_EXIF_TOOL);
-		Configs::set(self::CONFIG_HAS_EXIF_TOOL, false);
+		$hasExifTool = Configs::getValueAsBool(TestConstants::CONFIG_HAS_EXIF_TOOL);
+		Configs::set(TestConstants::CONFIG_HAS_EXIF_TOOL, false);
 		$this->testUploadMultibyteTitle();
-		Configs::set(self::CONFIG_HAS_EXIF_TOOL, $hasExifTool);
+		Configs::set(TestConstants::CONFIG_HAS_EXIF_TOOL, $hasExifTool);
 	}
 }

--- a/tests/Feature/CommandFixPermissionsTest.php
+++ b/tests/Feature/CommandFixPermissionsTest.php
@@ -14,7 +14,7 @@ namespace Tests\Feature;
 
 use function Safe\chmod;
 use function Safe\fileperms;
-use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 
 class CommandFixPermissionsTest extends Base\BasePhotoTest
 {
@@ -35,7 +35,7 @@ class CommandFixPermissionsTest extends Base\BasePhotoTest
 
 		/** @var \App\Models\Photo $photo */
 		$photo = static::convertJsonToObject($this->photos_tests->upload(
-			static::createUploadedFile(AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE)
+			static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE)
 		));
 
 		$filePath = public_path($photo->size_variants->original->url);

--- a/tests/Feature/CommandGenerateThumbsTest.php
+++ b/tests/Feature/CommandGenerateThumbsTest.php
@@ -15,8 +15,8 @@ namespace Tests\Feature;
 use App\Enum\SizeVariantType;
 use Illuminate\Support\Facades\DB;
 use function Safe\unlink;
-use Tests\AbstractTestCase;
 use Tests\Feature\Base\BasePhotoTest;
+use Tests\Feature\Constants\TestConstants;
 
 class CommandGenerateThumbsTest extends BasePhotoTest
 {
@@ -47,7 +47,7 @@ class CommandGenerateThumbsTest extends BasePhotoTest
 	{
 		/** @var \App\Models\Photo $photo1 */
 		$photo1 = static::convertJsonToObject($this->photos_tests->upload(
-			static::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			static::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		));
 
 		// Remove the size variant "small" from disk and from DB

--- a/tests/Feature/CommandGhostbusterTest.php
+++ b/tests/Feature/CommandGhostbusterTest.php
@@ -13,7 +13,7 @@
 namespace Tests\Feature;
 
 use Illuminate\Support\Facades\DB;
-use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 
 class CommandGhostbusterTest extends Base\BasePhotoTest
 {
@@ -23,7 +23,7 @@ class CommandGhostbusterTest extends Base\BasePhotoTest
 	{
 		/** @var \App\Models\Photo $photo */
 		$photo = static::convertJsonToObject($this->photos_tests->upload(
-			static::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			static::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		));
 
 		// The question mark operator is deliberately omitted for original
@@ -71,7 +71,7 @@ class CommandGhostbusterTest extends Base\BasePhotoTest
 	{
 		/** @var \App\Models\Photo $photo */
 		$photo = static::convertJsonToObject($this->photos_tests->upload(
-			static::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			static::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		));
 
 		// The question mark operator is deliberately omitted for original

--- a/tests/Feature/CommandTakeDateTest.php
+++ b/tests/Feature/CommandTakeDateTest.php
@@ -14,8 +14,8 @@ namespace Tests\Feature;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Tests\AbstractTestCase;
 use Tests\Feature\Base\BasePhotoTest;
+use Tests\Feature\Constants\TestConstants;
 
 class CommandTakeDateTest extends BasePhotoTest
 {
@@ -31,7 +31,7 @@ class CommandTakeDateTest extends BasePhotoTest
 	public function testSetUploadTimeFromFileTime(): void
 	{
 		$id = $this->photos_tests->upload(
-			static::createUploadedFile(AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE)
+			static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE)
 		)->offsetGet('id');
 
 		DB::table('photos')

--- a/tests/Feature/CommandVideoDataTest.php
+++ b/tests/Feature/CommandVideoDataTest.php
@@ -14,8 +14,8 @@ namespace Tests\Feature;
 
 use App\Enum\SizeVariantType;
 use Illuminate\Support\Facades\DB;
-use Tests\AbstractTestCase;
 use Tests\Feature\Base\BasePhotoTest;
+use Tests\Feature\Constants\TestConstants;
 
 class CommandVideoDataTest extends BasePhotoTest
 {
@@ -27,7 +27,7 @@ class CommandVideoDataTest extends BasePhotoTest
 
 		/** @var \App\Models\Photo $photo1 */
 		$photo1 = static::convertJsonToObject($this->photos_tests->upload(
-			static::createUploadedFile(AbstractTestCase::SAMPLE_FILE_TRAIN_VIDEO)
+			static::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_VIDEO)
 		));
 
 		// Remove the size variant "thumb" from disk and from DB

--- a/tests/Feature/Constants/TestsConstants.php
+++ b/tests/Feature/Constants/TestsConstants.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Tests\Feature\Constants;
+
+class TestConstants
+{
+	public const PATH_IMPORT_DIR = 'uploads/import/';
+
+	public const MIME_TYPE_APP_PDF = 'application/pdf';
+	public const MIME_TYPE_IMG_GIF = 'image/gif';
+	public const MIME_TYPE_IMG_JPEG = 'image/jpeg';
+	public const MIME_TYPE_IMG_PNG = 'image/png';
+	public const MIME_TYPE_IMG_TIFF = 'image/tiff';
+	public const MIME_TYPE_IMG_WEBP = 'image/webp';
+	public const MIME_TYPE_IMG_XCF = 'image/x-xcf';
+	public const MIME_TYPE_VID_MP4 = 'video/mp4';
+	public const MIME_TYPE_VID_QUICKTIME = 'video/quicktime';
+
+	public const SAMPLE_DOWNLOAD_JPG = 'https://github.com/LycheeOrg/Lychee/raw/master/tests/Samples/mongolia.jpeg';
+	public const SAMPLE_DOWNLOAD_TIFF = 'https://github.com/LycheeOrg/Lychee/raw/master/tests/Samples/tiff.tif';
+
+	public const SAMPLE_FILE_AARHUS = 'tests/Samples/aarhus.jpg';
+	public const SAMPLE_FILE_ETTLINGEN = 'tests/Samples/ettlinger-alb.jpg';
+	public const SAMPLE_FILE_GAMING_VIDEO = 'tests/Samples/gaming.mp4';
+	public const SAMPLE_FILE_GIF = 'tests/Samples/gif.gif';
+	public const SAMPLE_FILE_GMP_BROKEN_IMAGE = 'tests/Samples/google_motion_photo_broken.jpg';
+	public const SAMPLE_FILE_GMP_IMAGE = 'tests/Samples/google_motion_photo.jpg';
+	public const SAMPLE_FILE_HOCHUFERWEG = 'tests/Samples/hochuferweg.jpg';
+	public const SAMPLE_FILE_MONGOLIA_IMAGE = 'tests/Samples/mongolia.jpeg';
+	public const SAMPLE_FILE_NIGHT_IMAGE = 'tests/Samples/night.jpg';
+	public const SAMPLE_FILE_ORIENTATION_180 = 'tests/Samples/orientation-180.jpg';
+	public const SAMPLE_FILE_ORIENTATION_270 = 'tests/Samples/orientation-270.jpg';
+	public const SAMPLE_FILE_ORIENTATION_90 = 'tests/Samples/orientation-90.jpg';
+	public const SAMPLE_FILE_ORIENTATION_HFLIP = 'tests/Samples/orientation-hflip.jpg';
+	public const SAMPLE_FILE_ORIENTATION_VFLIP = 'tests/Samples/orientation-vflip.jpg';
+	public const SAMPLE_FILE_PDF = 'tests/Samples/pdf.pdf';
+	public const SAMPLE_FILE_PNG = 'tests/Samples/png.png';
+	public const SAMPLE_FILE_SUNSET_IMAGE = 'tests/Samples/fin de journée.jpg';
+	public const SAMPLE_FILE_TIFF = 'tests/Samples/tiff.tif';
+	public const SAMPLE_FILE_TRAIN_IMAGE = 'tests/Samples/train.jpg';
+	public const SAMPLE_FILE_TRAIN_VIDEO = 'tests/Samples/train.mov';
+	public const SAMPLE_FILE_UNDEFINED_EXIF_TAG = 'tests/Samples/undefined-exif-tag.jpg';
+	public const SAMPLE_FILE_WEBP = 'tests/Samples/webp.webp';
+	public const SAMPLE_FILE_XCF = 'tests/Samples/xcf.xcf';
+
+	public const SAMPLE_FILES_2_MIME = [
+		self::SAMPLE_FILE_AARHUS => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_ETTLINGEN => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_GAMING_VIDEO => self::MIME_TYPE_VID_MP4,
+		self::SAMPLE_FILE_GIF => self::MIME_TYPE_IMG_GIF,
+		self::SAMPLE_FILE_GMP_BROKEN_IMAGE => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_GMP_IMAGE => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_HOCHUFERWEG => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_MONGOLIA_IMAGE => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_NIGHT_IMAGE => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_ORIENTATION_180 => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_ORIENTATION_270 => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_ORIENTATION_90 => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_ORIENTATION_HFLIP => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_ORIENTATION_VFLIP => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_PDF => self::MIME_TYPE_APP_PDF,
+		self::SAMPLE_FILE_PNG => self::MIME_TYPE_IMG_PNG,
+		self::SAMPLE_FILE_SUNSET_IMAGE => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_TIFF => self::MIME_TYPE_IMG_TIFF,
+		self::SAMPLE_FILE_TRAIN_IMAGE => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_TRAIN_VIDEO => self::MIME_TYPE_VID_QUICKTIME,
+		self::SAMPLE_FILE_UNDEFINED_EXIF_TAG => self::MIME_TYPE_IMG_JPEG,
+		self::SAMPLE_FILE_WEBP => self::MIME_TYPE_IMG_WEBP,
+		self::SAMPLE_FILE_XCF => self::MIME_TYPE_IMG_XCF,
+	];
+
+	public const CONFIG_ALBUMS_SORTING_COL = 'sorting_albums_col';
+	public const CONFIG_ALBUMS_SORTING_ORDER = 'sorting_albums_order';
+	public const CONFIG_DOWNLOADABLE = 'grants_download';
+	public const CONFIG_HAS_EXIF_TOOL = 'has_exiftool';
+	public const CONFIG_HAS_FFMPEG = 'has_ffmpeg';
+	public const CONFIG_HAS_IMAGICK = 'imagick';
+	public const CONFIG_MAP_DISPLAY = 'map_display';
+	public const CONFIG_MAP_DISPLAY_PUBLIC = 'map_display_public';
+	public const CONFIG_MAP_INCLUDE_SUBALBUMS = 'map_include_subalbums';
+	public const CONFIG_PHOTOS_SORTING_COL = 'sorting_photos_col';
+	public const CONFIG_PHOTOS_SORTING_ORDER = 'sorting_photos_order';
+	public const CONFIG_PUBLIC_HIDDEN = 'public_photos_hidden';
+	public const CONFIG_PUBLIC_RECENT = 'public_recent';
+	public const CONFIG_PUBLIC_SEARCH = 'public_search';
+	public const CONFIG_PUBLIC_STARRED = 'public_starred';
+	public const CONFIG_PUBLIC_ON_THIS_DAY = 'public_on_this_day';
+	public const CONFIG_RAW_FORMATS = 'raw_formats';
+	public const CONFIG_USE_JOB_QUEUES = 'use_job_queues';
+
+	public const PHOTO_NIGHT_TITLE = 'night';
+	public const PHOTO_MONGOLIA_TITLE = 'mongolia';
+	public const PHOTO_SUNSET_TITLE = 'fin de journée';
+	public const PHOTO_TRAIN_TITLE = 'train';
+
+	public const ALBUM_TITLE_1 = 'Test Album 1';
+	public const ALBUM_TITLE_2 = 'Test Album 2';
+	public const ALBUM_TITLE_3 = 'Test Album 3';
+	public const ALBUM_TITLE_4 = 'Test Album 4';
+	public const ALBUM_TITLE_5 = 'Test Album 5';
+	public const ALBUM_TITLE_6 = 'Test Album 6';
+
+	public const ALBUM_PWD_1 = 'Album Password 1';
+	public const ALBUM_PWD_2 = 'Album Password 2';
+	public const ALBUM_PWD_3 = 'Album Password 3';
+
+	public const USER_NAME_1 = 'Test User 1';
+	public const USER_NAME_2 = 'Test User 2';
+	public const USER_NAME_3 = 'Test User 3';
+
+	public const USER_PWD_1 = 'User Password 1';
+	public const USER_PWD_2 = 'User Password 2';
+	public const USER_PWD_3 = 'User Password 3';
+
+	/** @var array[] EXPECTED_PHOTO_JSON defines the expected JSON result for each sample image such that we can avoid repeating this again and again during the tests */
+	public const EXPECTED_PHOTO_JSON = [
+		self::SAMPLE_FILE_NIGHT_IMAGE => [
+			'id' => null,
+			'album_id' => null,
+			'title' => self::PHOTO_NIGHT_TITLE,
+			'type' => 'image/jpeg',
+			'size_variants' => [
+				'original' => ['type' => 0, 'width' => 6720, 'height' => 4480],
+				'medium2x' => ['type' => 1, 'width' => 3240, 'height' => 2160],
+				'medium' => ['type' => 2, 'width' => 1620, 'height' => 1080],
+				'small2x' => ['type' => 3, 'width' => 1080,	'height' => 720],
+				'small' => ['type' => 4, 'width' => 540, 'height' => 360],
+				'thumb2x' => ['type' => 5, 'width' => 400, 'height' => 400],
+				'thumb' => ['type' => 6, 'width' => 200, 'height' => 200],
+			],
+		],
+		self::SAMPLE_FILE_MONGOLIA_IMAGE => [
+			'id' => null,
+			'album_id' => null,
+			'title' => self::PHOTO_MONGOLIA_TITLE,
+			'type' => 'image/jpeg',
+			'size_variants' => [
+				'original' => ['type' => 0, 'width' => 1280, 'height' => 850],
+				'medium2x' => null,
+				'medium' => null,
+				'small2x' => ['type' => 3, 'width' => 1084,	'height' => 720],
+				'small' => ['type' => 4, 'width' => 542, 'height' => 360],
+				'thumb2x' => ['type' => 5, 'width' => 400, 'height' => 400],
+				'thumb' => ['type' => 6, 'width' => 200, 'height' => 200],
+			],
+		],
+		self::SAMPLE_FILE_SUNSET_IMAGE => [
+			'id' => null,
+			'album_id' => null,
+			'title' => self::PHOTO_SUNSET_TITLE,
+			'type' => 'image/jpeg',
+			'size_variants' => [
+				'original' => ['type' => 0, 'width' => 914, 'height' => 1625],
+				'medium2x' => null,
+				'medium' => ['type' => 2, 'width' => 607, 'height' => 1080],
+				'small2x' => ['type' => 3, 'width' => 405,	'height' => 720],
+				'small' => ['type' => 4, 'width' => 202, 'height' => 360],
+				'thumb2x' => ['type' => 5, 'width' => 400, 'height' => 400],
+				'thumb' => ['type' => 6, 'width' => 200, 'height' => 200],
+			],
+		],
+		self::SAMPLE_FILE_TRAIN_IMAGE => [
+			'id' => null,
+			'album_id' => null,
+			'title' => self::PHOTO_TRAIN_TITLE,
+			'type' => 'image/jpeg',
+			'size_variants' => [
+				'original' => ['type' => 0, 'width' => 4032, 'height' => 3024],
+				'medium2x' => ['type' => 1, 'width' => 2880, 'height' => 2160],
+				'medium' => ['type' => 2, 'width' => 1440, 'height' => 1080],
+				'small2x' => ['type' => 3, 'width' => 960,	'height' => 720],
+				'small' => ['type' => 4, 'width' => 480, 'height' => 360],
+				'thumb2x' => ['type' => 5, 'width' => 400, 'height' => 400],
+				'thumb' => ['type' => 6, 'width' => 200, 'height' => 200],
+			],
+		],
+	];
+
+	public const EXPECTED_UNAUTHENTICATED_MSG = 'User is not authenticated';
+	public const EXPECTED_FORBIDDEN_MSG = 'Insufficient privileges';
+	public const EXPECTED_PASSWORD_REQUIRED_MSG = 'Password required';
+}

--- a/tests/Feature/GeoDataTest.php
+++ b/tests/Feature/GeoDataTest.php
@@ -19,6 +19,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Lib\AlbumsUnitTest;
 use Tests\Feature\Lib\PhotosUnitTest;
 use Tests\Feature\Lib\RootAlbumUnitTest;
@@ -64,11 +65,11 @@ class GeoDataTest extends AbstractTestCase
 	public function testGeo(): void
 	{
 		// save initial value
-		$map_display_value = Configs::getValue(self::CONFIG_MAP_DISPLAY);
+		$map_display_value = Configs::getValue(TestConstants::CONFIG_MAP_DISPLAY);
 
 		try {
 			$photoResponse = $this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE)
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE)
 			);
 			$photoID = $photoResponse->offsetGet('id');
 
@@ -91,7 +92,7 @@ class GeoDataTest extends AbstractTestCase
 				[
 					'id' => $photoID,
 					'title' => 'mongolia',
-					'type' => AbstractTestCase::MIME_TYPE_IMG_JPEG,
+					'type' => TestConstants::MIME_TYPE_IMG_JPEG,
 					'iso' => '200',
 					'aperture' => 'f/13.0',
 					'make' => 'NIKON CORPORATION',
@@ -139,13 +140,13 @@ class GeoDataTest extends AbstractTestCase
 			// now we test position Data
 
 			// set to false
-			Configs::set(self::CONFIG_MAP_DISPLAY, false);
-			static::assertEquals(false, Configs::getValueAsBool(self::CONFIG_MAP_DISPLAY));
+			Configs::set(TestConstants::CONFIG_MAP_DISPLAY, false);
+			static::assertEquals(false, Configs::getValueAsBool(TestConstants::CONFIG_MAP_DISPLAY));
 			$this->root_album_tests->getPositionData();
 
 			// set to true
-			Configs::set(self::CONFIG_MAP_DISPLAY, true);
-			static::assertEquals(true, Configs::getValueAsBool(self::CONFIG_MAP_DISPLAY));
+			Configs::set(TestConstants::CONFIG_MAP_DISPLAY, true);
+			static::assertEquals(true, Configs::getValueAsBool(TestConstants::CONFIG_MAP_DISPLAY));
 			$positionDataResponse = $this->root_album_tests->getPositionData();
 			/** @var \App\Http\Resources\Collections\PositionDataResource $positionData */
 			$positionData = static::convertJsonToObject($positionDataResponse);
@@ -155,13 +156,13 @@ class GeoDataTest extends AbstractTestCase
 			static::assertEquals($photoID, $positionData->photos[0]->id);
 
 			// set to false
-			Configs::set(self::CONFIG_MAP_DISPLAY, false);
-			static::assertEquals(false, Configs::getValueAsBool(self::CONFIG_MAP_DISPLAY));
+			Configs::set(TestConstants::CONFIG_MAP_DISPLAY, false);
+			static::assertEquals(false, Configs::getValueAsBool(TestConstants::CONFIG_MAP_DISPLAY));
 			$this->albums_tests->getPositionData($albumID, false);
 
 			// set to true
-			Configs::set(self::CONFIG_MAP_DISPLAY, true);
-			static::assertEquals(true, Configs::getValueAsBool(self::CONFIG_MAP_DISPLAY));
+			Configs::set(TestConstants::CONFIG_MAP_DISPLAY, true);
+			static::assertEquals(true, Configs::getValueAsBool(TestConstants::CONFIG_MAP_DISPLAY));
 			$positionDataResponse = $this->albums_tests->getPositionData($albumID, false);
 			/** @var \App\Http\Resources\Collections\PositionDataResource $positionData */
 			$positionData = static::convertJsonToObject($positionDataResponse);
@@ -170,7 +171,7 @@ class GeoDataTest extends AbstractTestCase
 			static::assertCount(1, $positionData->photos);
 			static::assertEquals($photoID, $positionData->photos[0]->id);
 		} finally {
-			Configs::set(self::CONFIG_MAP_DISPLAY, $map_display_value);
+			Configs::set(TestConstants::CONFIG_MAP_DISPLAY, $map_display_value);
 		}
 	}
 
@@ -189,21 +190,21 @@ class GeoDataTest extends AbstractTestCase
 	 */
 	public function testThumbnailsInsideHiddenAlbum(): void
 	{
-		$isRecentPublic = Configs::getValueAsBool(self::CONFIG_PUBLIC_RECENT);
-		$arePublicPhotosHidden = Configs::getValueAsBool(self::CONFIG_PUBLIC_HIDDEN);
-		$isPublicSearchEnabled = Configs::getValueAsBool(self::CONFIG_PUBLIC_SEARCH);
-		$displayMap = Configs::getValueAsBool(self::CONFIG_MAP_DISPLAY);
-		$displayMapPublicly = Configs::getValueAsBool(self::CONFIG_MAP_DISPLAY_PUBLIC);
-		$includeSubAlbums = Configs::getValueAsBool(self::CONFIG_MAP_INCLUDE_SUBALBUMS);
+		$isRecentPublic = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_RECENT);
+		$arePublicPhotosHidden = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_HIDDEN);
+		$isPublicSearchEnabled = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_SEARCH);
+		$displayMap = Configs::getValueAsBool(TestConstants::CONFIG_MAP_DISPLAY);
+		$displayMapPublicly = Configs::getValueAsBool(TestConstants::CONFIG_MAP_DISPLAY_PUBLIC);
+		$includeSubAlbums = Configs::getValueAsBool(TestConstants::CONFIG_MAP_INCLUDE_SUBALBUMS);
 
 		try {
 			Auth::loginUsingId(1);
-			Configs::set(self::CONFIG_PUBLIC_RECENT, true);
-			Configs::set(self::CONFIG_PUBLIC_HIDDEN, false);
-			Configs::set(self::CONFIG_PUBLIC_SEARCH, true);
-			Configs::set(self::CONFIG_MAP_DISPLAY, true);
-			Configs::set(self::CONFIG_MAP_DISPLAY_PUBLIC, true);
-			Configs::set(self::CONFIG_MAP_INCLUDE_SUBALBUMS, true);
+			Configs::set(TestConstants::CONFIG_PUBLIC_RECENT, true);
+			Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, false);
+			Configs::set(TestConstants::CONFIG_PUBLIC_SEARCH, true);
+			Configs::set(TestConstants::CONFIG_MAP_DISPLAY, true);
+			Configs::set(TestConstants::CONFIG_MAP_DISPLAY_PUBLIC, true);
+			Configs::set(TestConstants::CONFIG_MAP_INCLUDE_SUBALBUMS, true);
 
 			$albumID1 = $this->albums_tests->add(null, 'Test Album 1')->offsetGet('id');
 			$albumID11 = $this->albums_tests->add($albumID1, 'Test Album 1.1')->offsetGet('id');
@@ -212,19 +213,19 @@ class GeoDataTest extends AbstractTestCase
 			$albumID13 = $this->albums_tests->add($albumID1, 'Test Album 1.3')->offsetGet('id');
 
 			$photoID1 = $this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_AARHUS), $albumID1
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_AARHUS), $albumID1
 			)->offsetGet('id');
 			$photoID11 = $this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_ETTLINGEN), $albumID11
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_ETTLINGEN), $albumID11
 			)->offsetGet('id');
 			$photoID12 = $this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_TRAIN_IMAGE), $albumID12
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), $albumID12
 			)->offsetGet('id');
 			$photoID121 = $this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_HOCHUFERWEG), $albumID121
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_HOCHUFERWEG), $albumID121
 			)->offsetGet('id');
 			$photoID13 = $this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE), $albumID13
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $albumID13
 			)->offsetGet('id');
 
 			$this->albums_tests->set_protection_policy(id: $albumID1, grants_full_photo_access: true, is_public: true, is_link_required: true);
@@ -313,12 +314,12 @@ class GeoDataTest extends AbstractTestCase
 				$response->assertJsonMissing(['id' => $id]);
 			}
 		} finally {
-			Configs::set(self::CONFIG_PUBLIC_HIDDEN, $arePublicPhotosHidden);
-			Configs::set(self::CONFIG_PUBLIC_SEARCH, $isPublicSearchEnabled);
-			Configs::set(self::CONFIG_PUBLIC_RECENT, $isRecentPublic);
-			Configs::set(self::CONFIG_MAP_DISPLAY, $displayMap);
-			Configs::set(self::CONFIG_MAP_DISPLAY_PUBLIC, $displayMapPublicly);
-			Configs::set(self::CONFIG_MAP_INCLUDE_SUBALBUMS, $includeSubAlbums);
+			Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, $arePublicPhotosHidden);
+			Configs::set(TestConstants::CONFIG_PUBLIC_SEARCH, $isPublicSearchEnabled);
+			Configs::set(TestConstants::CONFIG_PUBLIC_RECENT, $isRecentPublic);
+			Configs::set(TestConstants::CONFIG_MAP_DISPLAY, $displayMap);
+			Configs::set(TestConstants::CONFIG_MAP_DISPLAY_PUBLIC, $displayMapPublicly);
+			Configs::set(TestConstants::CONFIG_MAP_INCLUDE_SUBALBUMS, $includeSubAlbums);
 			Auth::logout();
 			Session::flush();
 		}

--- a/tests/Feature/LegacyTest.php
+++ b/tests/Feature/LegacyTest.php
@@ -17,6 +17,7 @@ use App\Models\Photo;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Lib\AlbumsUnitTest;
 use Tests\Feature\Lib\PhotosUnitTest;
 use Tests\Feature\Traits\RequiresEmptyAlbums;
@@ -60,7 +61,7 @@ class LegacyTest extends AbstractTestCase
 		Auth::loginUsingId(1);
 		$albumID = $this->albums_tests->add(null, 'Test Album')->offsetGet('id');
 		$photoID = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE),
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE),
 			$albumID
 		)->offsetGet('id');
 

--- a/tests/Feature/NotificationTest.php
+++ b/tests/Feature/NotificationTest.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Session;
 use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Lib\AlbumsUnitTest;
 use Tests\Feature\Lib\PhotosUnitTest;
 use Tests\Feature\Lib\UsersUnitTest;
@@ -123,7 +124,7 @@ class NotificationTest extends AbstractTestCase
 		Auth::loginUsingId(1);
 		$albumID = $this->albums_tests->add(null, 'Album 1')->offsetGet('id');
 		$photoID = $this->photos_tests->upload(
-			self::createUploadedFile(self::SAMPLE_FILE_MONGOLIA_IMAGE))->offsetGet('id');
+			self::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE))->offsetGet('id');
 
 		$this->photos_tests->set_album($albumID, [$photoID]);
 

--- a/tests/Feature/PhotosAddHandlerGDTest.php
+++ b/tests/Feature/PhotosAddHandlerGDTest.php
@@ -13,6 +13,7 @@
 namespace Tests\Feature;
 
 use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Traits\InteractsWithRaw;
 use Tests\Feature\Traits\RequiresImageHandler;
 
@@ -52,7 +53,7 @@ class PhotosAddHandlerGDTest extends BasePhotosAddHandler
 
 			/** @var \App\Models\Photo $photo */
 			$photo = static::convertJsonToObject($this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_TIFF)
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_TIFF)
 			));
 
 			static::assertStringEndsWith('.tif', $photo->size_variants->original->url);

--- a/tests/Feature/PhotosAddHandlerImagickTest.php
+++ b/tests/Feature/PhotosAddHandlerImagickTest.php
@@ -13,6 +13,7 @@
 namespace Tests\Feature;
 
 use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Traits\InteractsWithRaw;
 use Tests\Feature\Traits\RequiresImageHandler;
 
@@ -51,11 +52,11 @@ class PhotosAddHandlerImagickTest extends BasePhotosAddHandler
 
 			/** @var \App\Models\Photo $photo */
 			$photo = static::convertJsonToObject($this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_TIFF)
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_TIFF)
 			));
 
 			$this->assertStringEndsWith('.tif', $photo->size_variants->original->url);
-			$this->assertEquals(AbstractTestCase::MIME_TYPE_IMG_TIFF, $photo->type);
+			$this->assertEquals(TestConstants::MIME_TYPE_IMG_TIFF, $photo->type);
 			$this->assertNotNull($photo->size_variants->thumb);
 		} finally {
 			static::setAcceptedRawFormats($acceptedRawFormats);

--- a/tests/Feature/PhotosAddMethodsTest.php
+++ b/tests/Feature/PhotosAddMethodsTest.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Facades\Queue;
 use function Safe\copy;
 use Tests\AbstractTestCase;
 use Tests\Feature\Base\BasePhotoTest;
+use Tests\Feature\Constants\TestConstants;
 
 /**
  * Contains all tests for the various ways of adding images to Lychee
@@ -33,7 +34,7 @@ class PhotosAddMethodsTest extends BasePhotoTest
 	public function testImportViaMove(): void
 	{
 		// import the photo
-		copy(base_path(static::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('night.jpg'));
+		copy(base_path(TestConstants::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('night.jpg'));
 		$this->photos_tests->importFromServer(static::importPath(), null, true, false, false);
 
 		// check if the file has been moved
@@ -43,7 +44,7 @@ class PhotosAddMethodsTest extends BasePhotoTest
 	public function testImportViaCopy(): void
 	{
 		// import the photo
-		copy(base_path(static::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('night.jpg'));
+		copy(base_path(TestConstants::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('night.jpg'));
 		$this->photos_tests->importFromServer(static::importPath(), null, false, false, false);
 
 		// check if the file is still there
@@ -55,7 +56,7 @@ class PhotosAddMethodsTest extends BasePhotoTest
 		$ids_before = static::getRecentPhotoIDs();
 
 		// import the photo
-		copy(base_path(static::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('night.jpg'));
+		copy(base_path(TestConstants::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('night.jpg'));
 		$this->photos_tests->importFromServer(static::importPath(), null, false, false, true);
 
 		// check if the file is still there
@@ -75,7 +76,7 @@ class PhotosAddMethodsTest extends BasePhotoTest
 		// Upload the photo the first time and remove some information
 		// such that there is really something to re-sync
 		$first_id = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		)->offsetGet('id');
 		DB::table('photos')
 			->where('id', '=', $first_id)
@@ -89,7 +90,7 @@ class PhotosAddMethodsTest extends BasePhotoTest
 		]);
 
 		// import the photo a second time and request re-sync
-		copy(base_path(static::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('night.jpg'));
+		copy(base_path(TestConstants::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('night.jpg'));
 		$report = $this->photos_tests->importFromServer(static::importPath(), null, false, true, false, true);
 		$this->assertStringNotContainsString('PhotoSkippedException', $report);
 		$this->assertStringContainsString('PhotoResyncedException', $report);
@@ -107,11 +108,11 @@ class PhotosAddMethodsTest extends BasePhotoTest
 	{
 		// Upload the photo the first time
 		$this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		);
 
 		// import the photo a second time and skip the duplicate
-		copy(base_path(static::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('night.jpg'));
+		copy(base_path(TestConstants::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('night.jpg'));
 		$report = $this->photos_tests->importFromServer(static::importPath(), null, false, true, false, false);
 		$this->assertStringContainsString('PhotoSkippedException', $report);
 		$this->assertStringNotContainsString('PhotoResyncedException', $report);
@@ -122,7 +123,7 @@ class PhotosAddMethodsTest extends BasePhotoTest
 		// Upload the photo the first time and remove some information
 		// such that we can be sure that **no** re-sync happens later
 		$first_id = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		)->offsetGet('id');
 		$response = $this->photos_tests->get($first_id);
 		$response->assertJson([
@@ -142,7 +143,7 @@ class PhotosAddMethodsTest extends BasePhotoTest
 
 		// Import the photo a second time and do not skip the duplicate,
 		// but don't resync the metadata either.
-		copy(base_path(static::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('night.jpg'));
+		copy(base_path(TestConstants::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('night.jpg'));
 		$this->photos_tests->importFromServer(static::importPath(), null, false, false);
 		$report = $this->photos_tests->importFromServer(static::importPath(), null, false, false);
 		$this->assertStringNotContainsString('PhotoSkippedException', $report);
@@ -170,8 +171,8 @@ class PhotosAddMethodsTest extends BasePhotoTest
 		$ids_before = static::getRecentPhotoIDs();
 
 		// import the photo and video
-		copy(base_path(AbstractTestCase::SAMPLE_FILE_TRAIN_IMAGE), static::importPath('train.jpg'));
-		copy(base_path(AbstractTestCase::SAMPLE_FILE_TRAIN_VIDEO), static::importPath('train.mov'));
+		copy(base_path(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), static::importPath('train.jpg'));
+		copy(base_path(TestConstants::SAMPLE_FILE_TRAIN_VIDEO), static::importPath('train.mov'));
 		$this->photos_tests->importFromServer(static::importPath(), null, false, false, true);
 
 		// check if the files are still there
@@ -197,12 +198,12 @@ class PhotosAddMethodsTest extends BasePhotoTest
 
 	public function testImportFromUrl(): void
 	{
-		$response = $this->photos_tests->importFromUrl([AbstractTestCase::SAMPLE_DOWNLOAD_JPG]);
+		$response = $this->photos_tests->importFromUrl([TestConstants::SAMPLE_DOWNLOAD_JPG]);
 
 		$response->assertJson([[
 			'album_id' => null,
 			'title' => 'mongolia',
-			'type' => AbstractTestCase::MIME_TYPE_IMG_JPEG,
+			'type' => TestConstants::MIME_TYPE_IMG_JPEG,
 			'size_variants' => [
 				'original' => [
 					'width' => 1280,
@@ -225,18 +226,18 @@ class PhotosAddMethodsTest extends BasePhotoTest
 	 */
 	public function testRawImportFromUrl(): void
 	{
-		$acceptedRawFormats = Configs::getValueAsString(self::CONFIG_RAW_FORMATS);
+		$acceptedRawFormats = Configs::getValueAsString(TestConstants::CONFIG_RAW_FORMATS);
 		try {
-			Configs::set(self::CONFIG_RAW_FORMATS, '.tif');
+			Configs::set(TestConstants::CONFIG_RAW_FORMATS, '.tif');
 			$reflection = new \ReflectionClass(BaseMediaFile::class);
 			$reflection->setStaticPropertyValue('cachedAcceptedRawFileExtensions', []);
 
-			$response = $this->photos_tests->importFromUrl([AbstractTestCase::SAMPLE_DOWNLOAD_TIFF]);
+			$response = $this->photos_tests->importFromUrl([TestConstants::SAMPLE_DOWNLOAD_TIFF]);
 
 			$response->assertJson([[
 				'album_id' => null,
 				'title' => 'tiff',
-				'type' => AbstractTestCase::MIME_TYPE_IMG_TIFF,
+				'type' => TestConstants::MIME_TYPE_IMG_TIFF,
 				'size_variants' => [
 					'original' => [
 						'width' => 400,
@@ -246,21 +247,21 @@ class PhotosAddMethodsTest extends BasePhotoTest
 				],
 			]]);
 		} finally {
-			Configs::set(self::CONFIG_RAW_FORMATS, $acceptedRawFormats);
+			Configs::set(TestConstants::CONFIG_RAW_FORMATS, $acceptedRawFormats);
 		}
 	}
 
 	public function testJobUploadWithFaking(): void
 	{
-		$useJobQueues = Configs::getValueAsString(self::CONFIG_USE_JOB_QUEUES);
+		$useJobQueues = Configs::getValueAsString(TestConstants::CONFIG_USE_JOB_QUEUES);
 		try {
-			Configs::set(self::CONFIG_USE_JOB_QUEUES, '1');
+			Configs::set(TestConstants::CONFIG_USE_JOB_QUEUES, '1');
 
 			Queue::fake();
 			Queue::assertNothingPushed();
 
 			$this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 			);
 
 			Queue::assertPushed(ProcessImageJob::class, 1);
@@ -268,20 +269,20 @@ class PhotosAddMethodsTest extends BasePhotoTest
 			self::assertEquals(1, JobHistory::where('status', '=', '0')->count());
 			self::assertEquals(1, Queue::size());
 		} finally {
-			Configs::set(self::CONFIG_USE_JOB_QUEUES, $useJobQueues);
+			Configs::set(TestConstants::CONFIG_USE_JOB_QUEUES, $useJobQueues);
 		}
 	}
 
 	public function testJobUploadWithoutFaking(): void
 	{
-		$useJobQueues = Configs::getValueAsString(self::CONFIG_USE_JOB_QUEUES);
+		$useJobQueues = Configs::getValueAsString(TestConstants::CONFIG_USE_JOB_QUEUES);
 		$defaultQueue = Config::get('queue.default', 'sync');
 		try {
-			Configs::set(self::CONFIG_USE_JOB_QUEUES, '1');
+			Configs::set(TestConstants::CONFIG_USE_JOB_QUEUES, '1');
 			Config::set('queue.default', 'sync');
 
 			$this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 			);
 
 			self::assertEquals(1, JobHistory::where('status', '=', '1')->count());
@@ -290,7 +291,7 @@ class PhotosAddMethodsTest extends BasePhotoTest
 
 			self::assertEquals(1, Photo::count());
 		} finally {
-			Configs::set(self::CONFIG_USE_JOB_QUEUES, $useJobQueues);
+			Configs::set(TestConstants::CONFIG_USE_JOB_QUEUES, $useJobQueues);
 			Config::set('queue.default', $defaultQueue);
 		}
 	}

--- a/tests/Feature/PhotosAddNegativeTest.php
+++ b/tests/Feature/PhotosAddNegativeTest.php
@@ -17,6 +17,7 @@ use function Safe\copy;
 use function Safe\scandir;
 use Tests\AbstractTestCase;
 use Tests\Feature\Base\BasePhotoTest;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Traits\InteractsWithFilesystemPermissions;
 use Tests\Feature\Traits\InteractsWithRaw;
 
@@ -49,7 +50,7 @@ class PhotosAddNegativeTest extends BasePhotoTest
 		// of a file is based on the write-privilege of the containing directory,
 		// because all these operations require an update of a directory entry.
 		// Making the file read-only is not sufficient to prevent deletion.
-		copy(base_path(static::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('read-only.jpg'));
+		copy(base_path(TestConstants::SAMPLE_FILE_NIGHT_IMAGE), static::importPath('read-only.jpg'));
 		try {
 			chmod(static::importPath('read-only.jpg'), 0444);
 			chmod(static::importPath(), 0555);
@@ -69,7 +70,7 @@ class PhotosAddNegativeTest extends BasePhotoTest
 		self::restrictDirectoryAccess(public_path('uploads/'));
 
 		$this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE),
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE),
 			null,
 			500,
 			'Unable to create a directory'
@@ -88,7 +89,7 @@ class PhotosAddNegativeTest extends BasePhotoTest
 			static::setAcceptedRawFormats('');
 
 			static::convertJsonToObject($this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_TIFF),
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_TIFF),
 				null,
 				422,
 				'MediaFileUnsupportedException'
@@ -115,7 +116,7 @@ class PhotosAddNegativeTest extends BasePhotoTest
 			static::setAcceptedRawFormats('');
 
 			$this->photos_tests->importFromUrl(
-				[AbstractTestCase::SAMPLE_DOWNLOAD_TIFF],
+				[TestConstants::SAMPLE_DOWNLOAD_TIFF],
 				null,
 				422,
 				'MediaFileUnsupportedException'

--- a/tests/Feature/PhotosAddSpecialAlbumTest.php
+++ b/tests/Feature/PhotosAddSpecialAlbumTest.php
@@ -17,6 +17,7 @@ use App\SmartAlbums\RecentAlbum;
 use App\SmartAlbums\StarredAlbum;
 use Tests\AbstractTestCase;
 use Tests\Feature\Base\BasePhotoTest;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Traits\InteractWithSmartAlbums;
 
 /**
@@ -39,7 +40,7 @@ class PhotosAddSpecialAlbumTest extends BasePhotoTest
 			$album_id = $this->albums_tests->add(null, 'Test Album')->offsetGet('id');
 
 			$response = $this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE),
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE),
 				$album_id
 			);
 			$response->assertJson(['album_id' => $album_id]);
@@ -58,7 +59,7 @@ class PhotosAddSpecialAlbumTest extends BasePhotoTest
 	public function testSimpleUploadToPublic(): void
 	{
 		$response = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE),
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE),
 			PublicAlbum::ID
 		);
 		$response->assertJson([
@@ -75,7 +76,7 @@ class PhotosAddSpecialAlbumTest extends BasePhotoTest
 	public function testSimpleUploadToIsStarred(): void
 	{
 		$response = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE),
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE),
 			StarredAlbum::ID
 		);
 		$response->assertJson([
@@ -94,7 +95,7 @@ class PhotosAddSpecialAlbumTest extends BasePhotoTest
 		static::assertCount($ids_before->count(), $recentAlbumBefore->photos);
 
 		$photo_id = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		)->offsetGet('id');
 		$ids_after = static::getRecentPhotoIDs();
 

--- a/tests/Feature/PhotosDownloadTest.php
+++ b/tests/Feature/PhotosDownloadTest.php
@@ -26,6 +26,7 @@ use function Safe\filesize;
 use function Safe\fwrite;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Lib\AssertableZipArchive;
 use Tests\Feature\Lib\SharingUnitTest;
 use Tests\Feature\Lib\UsersUnitTest;
@@ -67,7 +68,7 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 	public function testSinglePhotoDownload(): void
 	{
 		$photoUploadResponse = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		);
 		$photoArchiveResponse = $this->photos_tests->download(
 			[$photoUploadResponse->offsetGet('id')], DownloadVariantType::ORIGINAL->value);
@@ -95,10 +96,10 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 	public function testMultiplePhotoDownload(): void
 	{
 		$photoID1 = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		)->offsetGet('id');
 		$photoID2 = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE)
 		)->offsetGet('id');
 
 		$photoArchiveResponse = $this->photos_tests->download(
@@ -106,8 +107,8 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 
 		$zipArchive = AssertableZipArchive::createFromResponse($photoArchiveResponse);
 		$zipArchive->assertContainsFilesExactly([
-			'night.jpg' => ['size' => filesize(base_path(self::SAMPLE_FILE_NIGHT_IMAGE))],
-			'mongolia.jpeg' => ['size' => filesize(base_path(self::SAMPLE_FILE_MONGOLIA_IMAGE))],
+			'night.jpg' => ['size' => filesize(base_path(TestConstants::SAMPLE_FILE_NIGHT_IMAGE))],
+			'mongolia.jpeg' => ['size' => filesize(base_path(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE))],
 		]);
 	}
 
@@ -122,7 +123,7 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 		static::assertHasFFMpegOrSkip();
 
 		$photoUploadResponse = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_GMP_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_GMP_IMAGE)
 		);
 		$photoArchiveResponse = $this->photos_tests->download(
 			[$photoUploadResponse->offsetGet('id')],
@@ -152,10 +153,10 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 	public function testAmbiguousPhotoDownload(): void
 	{
 		$photoID1 = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_TRAIN_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE)
 		)->offsetGet('id');
 		$photoID2a = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE)
 		)->offsetGet('id');
 		$photoID2b = $this->photos_tests->duplicate(
 			[$photoID2a], null
@@ -166,28 +167,28 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 
 		$zipArchive = AssertableZipArchive::createFromResponse($photoArchiveResponse);
 		$zipArchive->assertContainsFilesExactly([
-			'train.jpg' => ['size' => filesize(base_path(self::SAMPLE_FILE_TRAIN_IMAGE))],
-			'mongolia-1.jpeg' => ['size' => filesize(base_path(self::SAMPLE_FILE_MONGOLIA_IMAGE))],
-			'mongolia-2.jpeg' => ['size' => filesize(base_path(self::SAMPLE_FILE_MONGOLIA_IMAGE))],
+			'train.jpg' => ['size' => filesize(base_path(TestConstants::SAMPLE_FILE_TRAIN_IMAGE))],
+			'mongolia-1.jpeg' => ['size' => filesize(base_path(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE))],
+			'mongolia-2.jpeg' => ['size' => filesize(base_path(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE))],
 		]);
 	}
 
 	public function testPhotoDownloadWithMultiByteFilename(): void
 	{
 		$id = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_SUNSET_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_SUNSET_IMAGE)
 		)->offsetGet('id');
 
 		$download = $this->photos_tests->download([$id], DownloadVariantType::ORIGINAL->value);
-		$download->assertHeader('Content-Type', AbstractTestCase::MIME_TYPE_IMG_JPEG);
-		$download->assertHeader('Content-Length', filesize(base_path(AbstractTestCase::SAMPLE_FILE_SUNSET_IMAGE)));
+		$download->assertHeader('Content-Type', TestConstants::MIME_TYPE_IMG_JPEG);
+		$download->assertHeader('Content-Length', filesize(base_path(TestConstants::SAMPLE_FILE_SUNSET_IMAGE)));
 		$download->assertHeader('Content-Disposition', HeaderUtils::makeDisposition(
 			HeaderUtils::DISPOSITION_ATTACHMENT,
 			'fin de journée.jpg',
 			'Photo.jpg'
 		));
 		$fileContent = $download->streamedContent();
-		$this->assertEquals(file_get_contents(base_path(AbstractTestCase::SAMPLE_FILE_SUNSET_IMAGE)), $fileContent);
+		$this->assertEquals(file_get_contents(base_path(TestConstants::SAMPLE_FILE_SUNSET_IMAGE)), $fileContent);
 	}
 
 	/**
@@ -199,18 +200,18 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 	public function testMultiplePhotoDownloadWithMultiByteFilename(): void
 	{
 		$photoID1 = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_SUNSET_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_SUNSET_IMAGE)
 		)->offsetGet('id');
 		$photoID2 = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE)
 		)->offsetGet('id');
 
 		$photoArchiveResponse = $this->photos_tests->download([$photoID1, $photoID2], DownloadVariantType::ORIGINAL->value);
 
 		$zipArchive = AssertableZipArchive::createFromResponse($photoArchiveResponse);
 		$zipArchive->assertContainsFilesExactly([
-			'fin de journée.jpg' => ['size' => filesize(base_path(AbstractTestCase::SAMPLE_FILE_SUNSET_IMAGE))],
-			'mongolia.jpeg' => ['size' => filesize(base_path(AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE))],
+			'fin de journée.jpg' => ['size' => filesize(base_path(TestConstants::SAMPLE_FILE_SUNSET_IMAGE))],
+			'mongolia.jpeg' => ['size' => filesize(base_path(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE))],
 		]);
 	}
 
@@ -218,10 +219,10 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 	{
 		$albumID = $this->albums_tests->add(null, self::MULTI_BYTE_ALBUM_TITLE)->offsetGet('id');
 		$this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_SUNSET_IMAGE), $albumID
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_SUNSET_IMAGE), $albumID
 		);
 		$this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE), $albumID
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $albumID
 		);
 
 		$albumArchiveResponse = $this->albums_tests->download($albumID);
@@ -234,8 +235,8 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 
 		$zipArchive = AssertableZipArchive::createFromResponse($albumArchiveResponse);
 		$zipArchive->assertContainsFilesExactly([
-			self::MULTI_BYTE_ALBUM_TITLE . '/fin de journée.jpg' => ['size' => filesize(base_path(AbstractTestCase::SAMPLE_FILE_SUNSET_IMAGE))],
-			self::MULTI_BYTE_ALBUM_TITLE . '/mongolia.jpeg' => ['size' => filesize(base_path(AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE))],
+			self::MULTI_BYTE_ALBUM_TITLE . '/fin de journée.jpg' => ['size' => filesize(base_path(TestConstants::SAMPLE_FILE_SUNSET_IMAGE))],
+			self::MULTI_BYTE_ALBUM_TITLE . '/mongolia.jpeg' => ['size' => filesize(base_path(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE))],
 		]);
 
 		$this->albums_tests->delete([$albumID]);
@@ -250,7 +251,7 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 		Session::flush();
 		Auth::loginUsingId($userID1);
 		$photoID = $this->photos_tests->upload(
-			self::createUploadedFile(self::SAMPLE_FILE_MONGOLIA_IMAGE)
+			self::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE)
 		)->offsetGet('id');
 		Auth::logout();
 		Session::flush();
@@ -260,9 +261,9 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 
 	public function testDownloadOfPhotoInSharedDownloadableAlbum(): void
 	{
-		$areAlbumsDownloadable = Configs::getValueAsBool(self::CONFIG_DOWNLOADABLE);
+		$areAlbumsDownloadable = Configs::getValueAsBool(TestConstants::CONFIG_DOWNLOADABLE);
 		try {
-			Configs::set(self::CONFIG_DOWNLOADABLE, true);
+			Configs::set(TestConstants::CONFIG_DOWNLOADABLE, true);
 			Auth::loginUsingId(1);
 			$userID1 = $this->users_tests->add('Test user 1', 'Test password 1')->offsetGet('id');
 			$userID2 = $this->users_tests->add('Test user 2', 'Test password 2')->offsetGet('id');
@@ -271,7 +272,7 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 			Auth::loginUsingId($userID1);
 			$albumID = $this->albums_tests->add(null, 'Test Album')->offsetGet('id');
 			$photoID = $this->photos_tests->upload(
-				self::createUploadedFile(self::SAMPLE_FILE_MONGOLIA_IMAGE),
+				self::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE),
 				$albumID
 			)->offsetGet('id');
 			$this->sharing_tests->add([$albumID], [$userID2]);
@@ -280,15 +281,15 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 			Auth::loginUsingId($userID2);
 			$this->photos_tests->download([$photoID], DownloadVariantType::ORIGINAL->value);
 		} finally {
-			Configs::set(self::CONFIG_DOWNLOADABLE, $areAlbumsDownloadable);
+			Configs::set(TestConstants::CONFIG_DOWNLOADABLE, $areAlbumsDownloadable);
 		}
 	}
 
 	public function testDownloadOfPhotoInSharedNonDownloadableAlbum(): void
 	{
-		$areAlbumsDownloadable = Configs::getValueAsBool(self::CONFIG_DOWNLOADABLE);
+		$areAlbumsDownloadable = Configs::getValueAsBool(TestConstants::CONFIG_DOWNLOADABLE);
 		try {
-			Configs::set(self::CONFIG_DOWNLOADABLE, false);
+			Configs::set(TestConstants::CONFIG_DOWNLOADABLE, false);
 			Auth::loginUsingId(1);
 			$userID1 = $this->users_tests->add('Test user 1', 'Test password 1')->offsetGet('id');
 			$userID2 = $this->users_tests->add('Test user 2', 'Test password 2')->offsetGet('id');
@@ -297,7 +298,7 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 			Auth::loginUsingId($userID1);
 			$albumID = $this->albums_tests->add(null, 'Test Album')->offsetGet('id');
 			$photoID = $this->photos_tests->upload(
-				self::createUploadedFile(self::SAMPLE_FILE_MONGOLIA_IMAGE),
+				self::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE),
 				$albumID
 			)->offsetGet('id');
 			$this->sharing_tests->add([$albumID], [$userID2]);
@@ -306,7 +307,7 @@ class PhotosDownloadTest extends Base\BasePhotoTest
 			Auth::loginUsingId($userID2);
 			$this->photos_tests->download([$photoID], DownloadVariantType::ORIGINAL->value, 403);
 		} finally {
-			Configs::set(self::CONFIG_DOWNLOADABLE, $areAlbumsDownloadable);
+			Configs::set(TestConstants::CONFIG_DOWNLOADABLE, $areAlbumsDownloadable);
 		}
 	}
 }

--- a/tests/Feature/PhotosOperationsTest.php
+++ b/tests/Feature/PhotosOperationsTest.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Tests\AbstractTestCase;
 use Tests\Feature\Base\BasePhotoTest;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Lib\RootAlbumUnitTest;
 use Tests\Feature\Lib\SharingUnitTest;
 use Tests\Feature\Lib\UsersUnitTest;
@@ -71,7 +72,7 @@ class PhotosOperationsTest extends BasePhotoTest
 	public function testManyFunctionsAtOnce(): void
 	{
 		$id = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		)->offsetGet('id');
 
 		$this->photos_tests->get($id);
@@ -199,7 +200,7 @@ class PhotosOperationsTest extends BasePhotoTest
 				'taken_at' => '2019-06-01T01:28:25+02:00',
 				'taken_at_orig_tz' => '+02:00',
 				'title' => "Night in Ploumanac'h",
-				'type' => AbstractTestCase::MIME_TYPE_IMG_JPEG,
+				'type' => TestConstants::MIME_TYPE_IMG_JPEG,
 				'size_variants' => [
 					'small' => [
 						'width' => 540,
@@ -318,23 +319,23 @@ class PhotosOperationsTest extends BasePhotoTest
 	 */
 	public function testThumbnailsInsideHiddenAlbum(): void
 	{
-		$isRecentPublic = Configs::getValueAsBool(self::CONFIG_PUBLIC_RECENT);
-		$arePublicPhotosHidden = Configs::getValueAsBool(self::CONFIG_PUBLIC_HIDDEN);
-		$isPublicSearchEnabled = Configs::getValueAsBool(self::CONFIG_PUBLIC_SEARCH);
-		$albumSortingColumn = Configs::getValueAsString(self::CONFIG_ALBUMS_SORTING_COL);
-		$albumSortingOrder = Configs::getValueAsString(self::CONFIG_ALBUMS_SORTING_ORDER);
-		$photoSortingColumn = Configs::getValueAsString(self::CONFIG_PHOTOS_SORTING_COL);
-		$photoSortingOrder = Configs::getValueAsString(self::CONFIG_PHOTOS_SORTING_ORDER);
+		$isRecentPublic = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_RECENT);
+		$arePublicPhotosHidden = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_HIDDEN);
+		$isPublicSearchEnabled = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_SEARCH);
+		$albumSortingColumn = Configs::getValueAsString(TestConstants::CONFIG_ALBUMS_SORTING_COL);
+		$albumSortingOrder = Configs::getValueAsString(TestConstants::CONFIG_ALBUMS_SORTING_ORDER);
+		$photoSortingColumn = Configs::getValueAsString(TestConstants::CONFIG_PHOTOS_SORTING_COL);
+		$photoSortingOrder = Configs::getValueAsString(TestConstants::CONFIG_PHOTOS_SORTING_ORDER);
 
 		try {
 			Auth::loginUsingId(1);
-			Configs::set(self::CONFIG_PUBLIC_RECENT, true);
-			Configs::set(self::CONFIG_PUBLIC_HIDDEN, false);
-			Configs::set(self::CONFIG_PUBLIC_SEARCH, true);
-			Configs::set(self::CONFIG_ALBUMS_SORTING_COL, 'title');
-			Configs::set(self::CONFIG_ALBUMS_SORTING_ORDER, 'ASC');
-			Configs::set(self::CONFIG_PHOTOS_SORTING_COL, 'title');
-			Configs::set(self::CONFIG_PHOTOS_SORTING_ORDER, 'ASC');
+			Configs::set(TestConstants::CONFIG_PUBLIC_RECENT, true);
+			Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, false);
+			Configs::set(TestConstants::CONFIG_PUBLIC_SEARCH, true);
+			Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_COL, 'title');
+			Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_ORDER, 'ASC');
+			Configs::set(TestConstants::CONFIG_PHOTOS_SORTING_COL, 'title');
+			Configs::set(TestConstants::CONFIG_PHOTOS_SORTING_ORDER, 'ASC');
 
 			// Sic! This out-of-order creation of albums is on purpose in order to
 			// catch errors where the album tree is accidentally ordered as
@@ -346,16 +347,16 @@ class PhotosOperationsTest extends BasePhotoTest
 			$albumID11 = $this->albums_tests->add($albumID1, 'Test Album 1.1')->offsetGet('id');
 
 			$photoID11 = $this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE), $albumID11
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE), $albumID11
 			)->offsetGet('id');
 			$photoID13 = $this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE), $albumID13
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $albumID13
 			)->offsetGet('id');
 			$photoID12 = $this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_TRAIN_IMAGE), $albumID12
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), $albumID12
 			)->offsetGet('id');
 			$photoID121 = $this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_SUNSET_IMAGE), $albumID121
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_SUNSET_IMAGE), $albumID121
 			)->offsetGet('id');
 
 			$this->albums_tests->set_protection_policy(id: $albumID1, grants_full_photo_access: true, is_public: true, is_link_required: true);
@@ -447,13 +448,13 @@ class PhotosOperationsTest extends BasePhotoTest
 				]],
 			]);
 		} finally {
-			Configs::set(self::CONFIG_ALBUMS_SORTING_COL, $albumSortingColumn);
-			Configs::set(self::CONFIG_ALBUMS_SORTING_ORDER, $albumSortingOrder);
-			Configs::set(self::CONFIG_PHOTOS_SORTING_COL, $photoSortingColumn);
-			Configs::set(self::CONFIG_PHOTOS_SORTING_ORDER, $photoSortingOrder);
-			Configs::set(self::CONFIG_PUBLIC_HIDDEN, $arePublicPhotosHidden);
-			Configs::set(self::CONFIG_PUBLIC_SEARCH, $isPublicSearchEnabled);
-			Configs::set(self::CONFIG_PUBLIC_RECENT, $isRecentPublic);
+			Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_COL, $albumSortingColumn);
+			Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_ORDER, $albumSortingOrder);
+			Configs::set(TestConstants::CONFIG_PHOTOS_SORTING_COL, $photoSortingColumn);
+			Configs::set(TestConstants::CONFIG_PHOTOS_SORTING_ORDER, $photoSortingOrder);
+			Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, $arePublicPhotosHidden);
+			Configs::set(TestConstants::CONFIG_PUBLIC_SEARCH, $isPublicSearchEnabled);
+			Configs::set(TestConstants::CONFIG_PUBLIC_RECENT, $isRecentPublic);
 			Auth::logout();
 			Session::flush();
 		}
@@ -464,10 +465,10 @@ class PhotosOperationsTest extends BasePhotoTest
 		Auth::loginUsingId(1);
 		$albumID = $this->albums_tests->add(null, 'Test Album')->offsetGet('id');
 		$photoID1 = $this->photos_tests->upload(
-			self::createUploadedFile(self::SAMPLE_FILE_MONGOLIA_IMAGE), $albumID
+			self::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $albumID
 		)->offsetGet('id');
 		$photoID2 = $this->photos_tests->upload(
-			self::createUploadedFile(self::SAMPLE_FILE_TRAIN_IMAGE), $albumID
+			self::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), $albumID
 		)->offsetGet('id');
 		$this->albums_tests->set_protection_policy($albumID);
 		Auth::logout();
@@ -485,10 +486,10 @@ class PhotosOperationsTest extends BasePhotoTest
 		Auth::loginUsingId($userID1);
 		$albumID = $this->albums_tests->add(null, 'Test Album')->offsetGet('id');
 		$photoID1 = $this->photos_tests->upload(
-			self::createUploadedFile(self::SAMPLE_FILE_MONGOLIA_IMAGE), $albumID
+			self::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $albumID
 		)->offsetGet('id');
 		$photoID2 = $this->photos_tests->upload(
-			self::createUploadedFile(self::SAMPLE_FILE_TRAIN_IMAGE), $albumID
+			self::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), $albumID
 		)->offsetGet('id');
 		$this->sharing_tests->add([$albumID], [$userID2]);
 		Auth::logout();

--- a/tests/Feature/RSSTest.php
+++ b/tests/Feature/RSSTest.php
@@ -16,6 +16,7 @@ use App\Models\Configs;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Lib\AlbumsUnitTest;
 use Tests\Feature\Lib\PhotosUnitTest;
 use Tests\Feature\Traits\RequiresEmptyPhotos;
@@ -84,7 +85,7 @@ class RSSTest extends AbstractTestCase
 
 			// upload a picture
 			$photoID = $this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 			)->offsetGet('id');
 
 			// set it to public

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Session;
 use Illuminate\Testing\TestResponse;
 use Tests\AbstractTestCase;
 use Tests\Feature\Base\BasePhotoTest;
+use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\Lib\SharingUnitTest;
 use Tests\Feature\Lib\UsersUnitTest;
 use Tests\Feature\Traits\RequiresEmptyAlbums;
@@ -51,10 +52,10 @@ class SearchTest extends BasePhotoTest
 	public function testSearchPhotoByTitle(): void
 	{
 		$photoId1 = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		)->offsetGet('id');
 		$photoId2 = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE)
 		)->offsetGet('id');
 		$this->photos_tests->set_title($photoId1, 'photo search');
 		$this->photos_tests->set_title($photoId2, 'do not find me');
@@ -106,10 +107,10 @@ class SearchTest extends BasePhotoTest
 	public function testSearchPhotoByTag(): void
 	{
 		$photoId1 = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_NIGHT_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
 		)->offsetGet('id');
 		$photoId2 = $this->photos_tests->upload(
-			AbstractTestCase::createUploadedFile(AbstractTestCase::SAMPLE_FILE_MONGOLIA_IMAGE)
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE)
 		)->offsetGet('id');
 		$this->photos_tests->set_title($photoId1, 'photo search');
 		$this->photos_tests->set_title($photoId2, 'do not find me');
@@ -191,25 +192,25 @@ class SearchTest extends BasePhotoTest
 
 	public function testDisabledPublicSearchWithAnonUser(): void
 	{
-		$isPublicSearchEnabled = Configs::getValueAsBool(self::CONFIG_PUBLIC_SEARCH);
+		$isPublicSearchEnabled = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_SEARCH);
 		try {
-			Configs::set(self::CONFIG_PUBLIC_SEARCH, false);
+			Configs::set(TestConstants::CONFIG_PUBLIC_SEARCH, false);
 			$this->albums_tests->add(null, 'Matching private album')->offsetGet('id');
 			Auth::logout();
 			Session::flush();
 			$this->runSearch('Matching', 401);
 		} finally {
-			Configs::set(self::CONFIG_PUBLIC_SEARCH, $isPublicSearchEnabled);
+			Configs::set(TestConstants::CONFIG_PUBLIC_SEARCH, $isPublicSearchEnabled);
 		}
 	}
 
 	public function testSearchAlbumByTitleWithAnonUser(): void
 	{
-		$arePublicPhotosHidden = Configs::getValueAsBool(self::CONFIG_PUBLIC_HIDDEN);
-		$isPublicSearchEnabled = Configs::getValueAsBool(self::CONFIG_PUBLIC_SEARCH);
+		$arePublicPhotosHidden = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_HIDDEN);
+		$isPublicSearchEnabled = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_SEARCH);
 		try {
-			Configs::set(self::CONFIG_PUBLIC_HIDDEN, false);
-			Configs::set(self::CONFIG_PUBLIC_SEARCH, true);
+			Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, false);
+			Configs::set(TestConstants::CONFIG_PUBLIC_SEARCH, true);
 
 			$albumID1 = $this->albums_tests->add(null, 'Matching private album')->offsetGet('id');
 			$albumID2 = $this->albums_tests->add(null, 'Matching shared album')->offsetGet('id');
@@ -238,22 +239,22 @@ class SearchTest extends BasePhotoTest
 			$response->assertJsonMissing(['id' => $albumID2]);
 			$response->assertJsonMissing(['id' => $albumID4]);
 		} finally {
-			Configs::set(self::CONFIG_PUBLIC_HIDDEN, $arePublicPhotosHidden);
-			Configs::set(self::CONFIG_PUBLIC_SEARCH, $isPublicSearchEnabled);
+			Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, $arePublicPhotosHidden);
+			Configs::set(TestConstants::CONFIG_PUBLIC_SEARCH, $isPublicSearchEnabled);
 		}
 	}
 
 	public function testSearchAlbumByTitleWithNonAdminUser(): void
 	{
-		$arePublicPhotosHidden = Configs::getValueAsBool(self::CONFIG_PUBLIC_HIDDEN);
-		$isPublicSearchEnabled = Configs::getValueAsBool(self::CONFIG_PUBLIC_SEARCH);
-		$albumSortingColumn = Configs::getValueAsString(self::CONFIG_ALBUMS_SORTING_COL);
-		$albumSortingOrder = Configs::getValueAsString(self::CONFIG_ALBUMS_SORTING_ORDER);
+		$arePublicPhotosHidden = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_HIDDEN);
+		$isPublicSearchEnabled = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_SEARCH);
+		$albumSortingColumn = Configs::getValueAsString(TestConstants::CONFIG_ALBUMS_SORTING_COL);
+		$albumSortingOrder = Configs::getValueAsString(TestConstants::CONFIG_ALBUMS_SORTING_ORDER);
 		try {
-			Configs::set(self::CONFIG_PUBLIC_HIDDEN, false);
-			Configs::set(self::CONFIG_PUBLIC_SEARCH, true);
-			Configs::set(self::CONFIG_ALBUMS_SORTING_COL, 'title');
-			Configs::set(self::CONFIG_ALBUMS_SORTING_ORDER, 'ASC');
+			Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, false);
+			Configs::set(TestConstants::CONFIG_PUBLIC_SEARCH, true);
+			Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_COL, 'title');
+			Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_ORDER, 'ASC');
 
 			$albumID1 = $this->albums_tests->add(null, 'Matching private album')->offsetGet('id');
 			$albumID2 = $this->albums_tests->add(null, 'Matching shared album')->offsetGet('id');
@@ -284,10 +285,10 @@ class SearchTest extends BasePhotoTest
 			$response->assertJsonMissing(['id' => $albumID1]);
 			$response->assertJsonMissing(['id' => $albumID4]);
 		} finally {
-			Configs::set(self::CONFIG_ALBUMS_SORTING_COL, $albumSortingColumn);
-			Configs::set(self::CONFIG_ALBUMS_SORTING_ORDER, $albumSortingOrder);
-			Configs::set(self::CONFIG_PUBLIC_HIDDEN, $arePublicPhotosHidden);
-			Configs::set(self::CONFIG_PUBLIC_SEARCH, $isPublicSearchEnabled);
+			Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_COL, $albumSortingColumn);
+			Configs::set(TestConstants::CONFIG_ALBUMS_SORTING_ORDER, $albumSortingOrder);
+			Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, $arePublicPhotosHidden);
+			Configs::set(TestConstants::CONFIG_PUBLIC_SEARCH, $isPublicSearchEnabled);
 		}
 	}
 

--- a/tests/Feature/SharingBasicTest.php
+++ b/tests/Feature/SharingBasicTest.php
@@ -12,6 +12,8 @@
 
 namespace Tests\Feature;
 
+use Tests\Feature\Constants\TestConstants;
+
 class SharingBasicTest extends Base\BaseSharingTest
 {
 	/**
@@ -32,15 +34,15 @@ class SharingBasicTest extends Base\BaseSharingTest
 	 */
 	public function testSharingListWithAlbums(): void
 	{
-		$albumID1 = $this->albums_tests->add(null, self::ALBUM_TITLE_1)->offsetGet('id');
-		$albumID2 = $this->albums_tests->add($albumID1, self::ALBUM_TITLE_2)->offsetGet('id');
+		$albumID1 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_1)->offsetGet('id');
+		$albumID2 = $this->albums_tests->add($albumID1, TestConstants::ALBUM_TITLE_2)->offsetGet('id');
 
 		$response = $this->sharing_tests->list();
 		$response->assertSimilarJson([
 			'shared' => [],
 			'albums' => [
-				['id' => $albumID1, 'title' => self::ALBUM_TITLE_1],
-				['id' => $albumID2, 'title' => self::ALBUM_TITLE_1 . '/' . self::ALBUM_TITLE_2],
+				['id' => $albumID1, 'title' => TestConstants::ALBUM_TITLE_1],
+				['id' => $albumID2, 'title' => TestConstants::ALBUM_TITLE_1 . '/' . TestConstants::ALBUM_TITLE_2],
 			],
 			'users' => [],
 		]);
@@ -54,10 +56,10 @@ class SharingBasicTest extends Base\BaseSharingTest
 	 */
 	public function testSharingListWithSharedAlbums(): void
 	{
-		$albumID1 = $this->albums_tests->add(null, self::ALBUM_TITLE_1)->offsetGet('id');
-		$albumID2 = $this->albums_tests->add(null, self::ALBUM_TITLE_2)->offsetGet('id');
-		$userID1 = $this->users_tests->add(self::USER_NAME_1, self::USER_PWD_1)->offsetGet('id');
-		$userID2 = $this->users_tests->add(self::USER_NAME_2, self::USER_PWD_2)->offsetGet('id');
+		$albumID1 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_1)->offsetGet('id');
+		$albumID2 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_2)->offsetGet('id');
+		$userID1 = $this->users_tests->add(TestConstants::USER_NAME_1, TestConstants::USER_PWD_1)->offsetGet('id');
+		$userID2 = $this->users_tests->add(TestConstants::USER_NAME_2, TestConstants::USER_PWD_2)->offsetGet('id');
 
 		$this->sharing_tests->add([$albumID1], [$userID1]);
 		$response = $this->sharing_tests->list();
@@ -66,19 +68,19 @@ class SharingBasicTest extends Base\BaseSharingTest
 			'shared' => [[
 				'user_id' => $userID1,
 				'album_id' => $albumID1,
-				'username' => self::USER_NAME_1,
-				'title' => self::ALBUM_TITLE_1,
+				'username' => TestConstants::USER_NAME_1,
+				'title' => TestConstants::ALBUM_TITLE_1,
 			]],
 			'albums' => [
-				['id' => $albumID1, 'title' => self::ALBUM_TITLE_1],
-				['id' => $albumID2, 'title' => self::ALBUM_TITLE_2],
+				['id' => $albumID1, 'title' => TestConstants::ALBUM_TITLE_1],
+				['id' => $albumID2, 'title' => TestConstants::ALBUM_TITLE_2],
 			],
 		]);
 
 		/** @var array $users */
 		$users = $response->offsetGet('users');
-		self::assertContains(['id' => $userID1, 'username' => self::USER_NAME_1], $users);
-		self::assertContains(['id' => $userID2, 'username' => self::USER_NAME_2], $users);
+		self::assertContains(['id' => $userID1, 'username' => TestConstants::USER_NAME_1], $users);
+		self::assertContains(['id' => $userID2, 'username' => TestConstants::USER_NAME_2], $users);
 		self::assertNotContains(['id' => 1, 'username' => 'admin'], $users);
 	}
 }

--- a/tests/Feature/SharingSpecialTest.php
+++ b/tests/Feature/SharingSpecialTest.php
@@ -18,15 +18,11 @@ use App\SmartAlbums\RecentAlbum;
 use App\SmartAlbums\StarredAlbum;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
-use Tests\AbstractTestCase;
 use Tests\Feature\Base\BaseSharingTest;
+use Tests\Feature\Constants\TestConstants;
 
 class SharingSpecialTest extends BaseSharingTest
 {
-	public const ALBUM_TITLE_4 = 'Test Album 4';
-	public const ALBUM_TITLE_5 = 'Test Album 5';
-	public const ALBUM_TITLE_6 = 'Test Album 6';
-
 	protected ?string $albumID1 = null;
 	protected ?string $albumID2 = null;
 	protected ?string $albumID3 = null;
@@ -60,13 +56,13 @@ class SharingSpecialTest extends BaseSharingTest
 		$this->photoID5 = null;
 		$this->photoID6 = null;
 
-		$this->arePublicPhotosHidden = Configs::getValueAsBool(AbstractTestCase::CONFIG_PUBLIC_HIDDEN);
-		Configs::set(AbstractTestCase::CONFIG_PUBLIC_HIDDEN, false);
+		$this->arePublicPhotosHidden = Configs::getValueAsBool(TestConstants::CONFIG_PUBLIC_HIDDEN);
+		Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, false);
 	}
 
 	public function tearDown(): void
 	{
-		Configs::set(AbstractTestCase::CONFIG_PUBLIC_HIDDEN, $this->arePublicPhotosHidden);
+		Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, $this->arePublicPhotosHidden);
 		parent::tearDown();
 	}
 
@@ -95,16 +91,16 @@ class SharingSpecialTest extends BaseSharingTest
 	 */
 	protected function prepareSixAlbumsWithDifferentProtectionSettings(): void
 	{
-		$this->albumID1 = $this->albums_tests->add(null, self::ALBUM_TITLE_1)->offsetGet('id');
-		$this->albumID2 = $this->albums_tests->add($this->albumID1, self::ALBUM_TITLE_2)->offsetGet('id');
-		$this->albumID3 = $this->albums_tests->add($this->albumID1, self::ALBUM_TITLE_3)->offsetGet('id');
-		$this->albumID4 = $this->albums_tests->add($this->albumID1, self::ALBUM_TITLE_4)->offsetGet('id');
-		$this->albumID5 = $this->albums_tests->add($this->albumID1, self::ALBUM_TITLE_5)->offsetGet('id');
-		$this->albumID6 = $this->albums_tests->add($this->albumID1, self::ALBUM_TITLE_6)->offsetGet('id');
-		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_NIGHT_IMAGE), $this->albumID1)->offsetGet('id');
-		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
-		$this->photoID3 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID3)->offsetGet('id');
-		$this->photoID4 = $this->photos_tests->upload(static::createUploadedFile(static::SAMPLE_FILE_SUNSET_IMAGE), $this->albumID4)->offsetGet('id');
+		$this->albumID1 = $this->albums_tests->add(null, TestConstants::ALBUM_TITLE_1)->offsetGet('id');
+		$this->albumID2 = $this->albums_tests->add($this->albumID1, TestConstants::ALBUM_TITLE_2)->offsetGet('id');
+		$this->albumID3 = $this->albums_tests->add($this->albumID1, TestConstants::ALBUM_TITLE_3)->offsetGet('id');
+		$this->albumID4 = $this->albums_tests->add($this->albumID1, TestConstants::ALBUM_TITLE_4)->offsetGet('id');
+		$this->albumID5 = $this->albums_tests->add($this->albumID1, TestConstants::ALBUM_TITLE_5)->offsetGet('id');
+		$this->albumID6 = $this->albums_tests->add($this->albumID1, TestConstants::ALBUM_TITLE_6)->offsetGet('id');
+		$this->photoID1 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE), $this->albumID1)->offsetGet('id');
+		$this->photoID2 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_TRAIN_IMAGE), $this->albumID2)->offsetGet('id');
+		$this->photoID3 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE), $this->albumID3)->offsetGet('id');
+		$this->photoID4 = $this->photos_tests->upload(static::createUploadedFile(TestConstants::SAMPLE_FILE_SUNSET_IMAGE), $this->albumID4)->offsetGet('id');
 		$this->photoID5 = $this->photos_tests->duplicate([$this->photoID4], $this->albumID5)->json()[0]['id'];
 		$this->photoID6 = $this->photos_tests->duplicate([$this->photoID2], $this->albumID6)->json()[0]['id'];
 		$this->photos_tests->set_title($this->photoID5, 'Abenddämmerung'); // we rename the duplicated images, such that we can ensure
@@ -113,12 +109,12 @@ class SharingSpecialTest extends BaseSharingTest
 		$this->ensurePhotosWereTakenOnThisDay($this->photoID1, $this->photoID5);
 		$this->ensurePhotosWereNotTakenOnThisDay($this->photoID2, $this->photoID3, $this->photoID4, $this->photoID6);
 
-		$this->albums_tests->set_protection_policy(id: $this->albumID1, password: self::ALBUM_PWD_1);
+		$this->albums_tests->set_protection_policy(id: $this->albumID1, password: TestConstants::ALBUM_PWD_1);
 		$this->albums_tests->set_protection_policy(id: $this->albumID2);
-		$this->albums_tests->set_protection_policy(id: $this->albumID3, password: self::ALBUM_PWD_1);
-		$this->albums_tests->set_protection_policy(id: $this->albumID4, is_link_required: true, password: self::ALBUM_PWD_1);
-		$this->albums_tests->set_protection_policy(id: $this->albumID5, password: self::ALBUM_PWD_2);
-		$this->albums_tests->set_protection_policy(id: $this->albumID6, is_link_required: true, password: self::ALBUM_PWD_2);
+		$this->albums_tests->set_protection_policy(id: $this->albumID3, password: TestConstants::ALBUM_PWD_1);
+		$this->albums_tests->set_protection_policy(id: $this->albumID4, is_link_required: true, password: TestConstants::ALBUM_PWD_1);
+		$this->albums_tests->set_protection_policy(id: $this->albumID5, password: TestConstants::ALBUM_PWD_2);
+		$this->albums_tests->set_protection_policy(id: $this->albumID6, is_link_required: true, password: TestConstants::ALBUM_PWD_2);
 
 		Auth::logout();
 		Session::flush();
@@ -155,7 +151,7 @@ class SharingSpecialTest extends BaseSharingTest
 			null,
 			null,
 			[
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1), // no thumb as album 1 is still locked
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1), // no thumb as album 1 is still locked
 			]
 		));
 		foreach ([
@@ -213,7 +209,7 @@ class SharingSpecialTest extends BaseSharingTest
 		$responseForTree = $this->root_album_tests->getTree();
 		// TODO: Should public and password-protected albums appear in tree? Regression?
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			// $this->generateExpectedAlbumJson($albumID1, self::ALBUM_TITLE_1), // no thumb as album 1 is still locked
+			// $this->generateExpectedAlbumJson($albumID1, TestConstants::ALBUM_TITLE_1), // no thumb as album 1 is still locked
 		]));
 		foreach ([
 			$this->albumID1,
@@ -241,7 +237,7 @@ class SharingSpecialTest extends BaseSharingTest
 			$this->albumID5,
 			$this->albumID6,
 		] as $id) {
-			$this->albums_tests->get($id, 401, self::EXPECTED_PASSWORD_REQUIRED_MSG, self::EXPECTED_UNAUTHENTICATED_MSG);
+			$this->albums_tests->get($id, 401, TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG, TestConstants::EXPECTED_UNAUTHENTICATED_MSG);
 		}
 		foreach ([$this->photoID1, $this->photoID3, $this->photoID4, $this->photoID5, $this->photoID6] as $id) {
 			$this->photos_tests->get($id, 401);
@@ -254,7 +250,7 @@ class SharingSpecialTest extends BaseSharingTest
 		// TODO: Do we want this that way?
 		$responseForAlbum2 = $this->albums_tests->get($this->albumID2);
 		$responseForAlbum2->assertJson($this->generateExpectedAlbumJson(
-			$this->albumID2, self::ALBUM_TITLE_2, $this->albumID1, $this->photoID2
+			$this->albumID2, TestConstants::ALBUM_TITLE_2, $this->albumID1, $this->photoID2
 		));
 		$this->photos_tests->get($this->photoID2);
 	}
@@ -285,7 +281,7 @@ class SharingSpecialTest extends BaseSharingTest
 	public function testSixAlbumsWithDifferentProtectionSettingsAndSomeUnlocked(): void
 	{
 		$this->prepareSixAlbumsWithDifferentProtectionSettings();
-		$this->albums_tests->unlock($this->albumID1, self::ALBUM_PWD_1);
+		$this->albums_tests->unlock($this->albumID1, TestConstants::ALBUM_PWD_1);
 
 		// 1. Check root album
 
@@ -293,7 +289,7 @@ class SharingSpecialTest extends BaseSharingTest
 		$responseForRoot->assertJson($this->generateExpectedRootJson(
 			$this->photoID3,
 			$this->photoID1, [ // albums 1-3 are accessible, photo 3 is alphabetically first
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID3), // thumb available as album 1 has been unlocked
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID3), // thumb available as album 1 has been unlocked
 			]
 		));
 		foreach ([
@@ -316,9 +312,9 @@ class SharingSpecialTest extends BaseSharingTest
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID3, [ // albums 1-3 are accessible, photo 3 is alphabetically first
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID3, $this->albumID3),
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_NIGHT_IMAGE, $this->photoID1, $this->albumID1),
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID3, $this->albumID3),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_NIGHT_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 		foreach ([$this->albumID4, $this->photoID4, $this->albumID5, $this->photoID5, $this->albumID6, $this->photoID6] as $id) {
@@ -329,7 +325,7 @@ class SharingSpecialTest extends BaseSharingTest
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_NIGHT_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_NIGHT_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		foreach ([$this->photoID2, $this->photoID3, $this->photoID4, $this->photoID5, $this->photoID6] as $id) {
@@ -343,14 +339,14 @@ class SharingSpecialTest extends BaseSharingTest
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
 			$this->generateExpectedAlbumJson(
 				$this->albumID1,
-				self::ALBUM_TITLE_1,
+				TestConstants::ALBUM_TITLE_1,
 				null,
 				$this->photoID3,
 				['albums' => [
-					$this->generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, $this->albumID1, $this->photoID2),
-					$this->generateExpectedAlbumJson($this->albumID3, self::ALBUM_TITLE_3, $this->albumID1, $this->photoID3),
+					$this->generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, $this->albumID1, $this->photoID2),
+					$this->generateExpectedAlbumJson($this->albumID3, TestConstants::ALBUM_TITLE_3, $this->albumID1, $this->photoID3),
 					// album 4 has been unlocked simultaneously with password 1, but is hidden and hence not part of the tree
-					// $this->generateExpectedAlbumJson($albumID5, self::ALBUM_TITLE_5, $albumID1), // shown without thumb, as album 5 is still locked
+					// $this->generateExpectedAlbumJson($albumID5, TestConstants::ALBUM_TITLE_5, $albumID1), // shown without thumb, as album 5 is still locked
 					// album 5 is not part of the tree, because it protected by a different password and still locked; regression?
 				]]
 			),
@@ -370,10 +366,10 @@ class SharingSpecialTest extends BaseSharingTest
 		// 4. Check album/photo access
 
 		foreach ([
-			[$this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID3], // photo 3 is alphabetically first of all child photos
-			[$this->albumID2, self::ALBUM_TITLE_2, $this->albumID1, $this->photoID2],
-			[$this->albumID3, self::ALBUM_TITLE_3, $this->albumID1, $this->photoID3],
-			[$this->albumID4, self::ALBUM_TITLE_4, $this->albumID1, $this->photoID4], // album 4 has been unlocked simultaneously with password 1 and hence is directly accessible, although it is hidden
+			[$this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID3], // photo 3 is alphabetically first of all child photos
+			[$this->albumID2, TestConstants::ALBUM_TITLE_2, $this->albumID1, $this->photoID2],
+			[$this->albumID3, TestConstants::ALBUM_TITLE_3, $this->albumID1, $this->photoID3],
+			[$this->albumID4, TestConstants::ALBUM_TITLE_4, $this->albumID1, $this->photoID4], // album 4 has been unlocked simultaneously with password 1 and hence is directly accessible, although it is hidden
 		] as $albumInfo) {
 			$responseForAlbum = $this->albums_tests->get($albumInfo[0]);
 			$responseForAlbum->assertJson($this->generateExpectedAlbumJson(
@@ -381,7 +377,7 @@ class SharingSpecialTest extends BaseSharingTest
 			));
 		}
 		foreach ([$this->albumID5, $this->albumID6] as $id) {
-			$this->albums_tests->get($id, 401, self::EXPECTED_PASSWORD_REQUIRED_MSG, self::EXPECTED_UNAUTHENTICATED_MSG);
+			$this->albums_tests->get($id, 401, TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG, TestConstants::EXPECTED_UNAUTHENTICATED_MSG);
 		}
 
 		foreach ([$this->photoID1, $this->photoID2, $this->photoID3, $this->photoID4] as $id) {
@@ -413,8 +409,8 @@ class SharingSpecialTest extends BaseSharingTest
 	public function testSixAlbumsWithDifferentProtectionSettingsAndAllUnlocked(): void
 	{
 		$this->prepareSixAlbumsWithDifferentProtectionSettings();
-		$this->albums_tests->unlock($this->albumID1, self::ALBUM_PWD_1);
-		$this->albums_tests->unlock($this->albumID5, self::ALBUM_PWD_2);
+		$this->albums_tests->unlock($this->albumID1, TestConstants::ALBUM_PWD_1);
+		$this->albums_tests->unlock($this->albumID5, TestConstants::ALBUM_PWD_2);
 
 		// 1. Check root album
 
@@ -422,7 +418,7 @@ class SharingSpecialTest extends BaseSharingTest
 		$responseForRoot->assertJson($this->generateExpectedRootJson(
 			$this->photoID5,
 			$this->photoID5, [ // albums 1-6 are accessible, photo 5 is alphabetically first
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID5), // thumb available as album 1 has been unlocked
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID5), // thumb available as album 1 has been unlocked
 			]
 		));
 		foreach ([$this->photoID1, $this->albumID2, $this->photoID2, $this->albumID3, $this->photoID3, $this->albumID4, $this->photoID4, $this->albumID5, $this->albumID6, $this->photoID6] as $id) {
@@ -435,10 +431,10 @@ class SharingSpecialTest extends BaseSharingTest
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID5, [ // albums 1-3 and 5 are accessible, photo 5 is alphabetically first
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_SUNSET_IMAGE, $this->photoID5, $this->albumID5, ['title' => 'Abenddämmerung']),
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID3, $this->albumID3),
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_NIGHT_IMAGE, $this->photoID1, $this->albumID1),
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_SUNSET_IMAGE, $this->photoID5, $this->albumID5, ['title' => 'Abenddämmerung']),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID3, $this->albumID3),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_NIGHT_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID2, $this->albumID2),
 			]
 		));
 		foreach ([$this->albumID4, $this->photoID4, $this->albumID6, $this->photoID6] as $id) {
@@ -449,8 +445,8 @@ class SharingSpecialTest extends BaseSharingTest
 		$responseForOnThisDayAlbum->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID5, [ // photos 1 and 5 were taken on this day and accessible, photo 5 is alphabetically first
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_SUNSET_IMAGE, $this->photoID5, $this->albumID5, ['title' => 'Abenddämmerung']),
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_NIGHT_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_SUNSET_IMAGE, $this->photoID5, $this->albumID5, ['title' => 'Abenddämmerung']),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_NIGHT_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		foreach ([$this->photoID2, $this->photoID3, $this->photoID4, $this->photoID6] as $id) {
@@ -463,14 +459,14 @@ class SharingSpecialTest extends BaseSharingTest
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
 			$this->generateExpectedAlbumJson(
 				$this->albumID1,
-				self::ALBUM_TITLE_1,
+				TestConstants::ALBUM_TITLE_1,
 				null,
 				$this->photoID5,
 				['albums' => [
-					$this->generateExpectedAlbumJson($this->albumID2, self::ALBUM_TITLE_2, $this->albumID1, $this->photoID2),
-					$this->generateExpectedAlbumJson($this->albumID3, self::ALBUM_TITLE_3, $this->albumID1, $this->photoID3),
+					$this->generateExpectedAlbumJson($this->albumID2, TestConstants::ALBUM_TITLE_2, $this->albumID1, $this->photoID2),
+					$this->generateExpectedAlbumJson($this->albumID3, TestConstants::ALBUM_TITLE_3, $this->albumID1, $this->photoID3),
 					// album 4 has been unlocked simultaneously with password 1, but is hidden and hence not part of the tree
-					$this->generateExpectedAlbumJson($this->albumID5, self::ALBUM_TITLE_5, $this->albumID1, $this->photoID5),
+					$this->generateExpectedAlbumJson($this->albumID5, TestConstants::ALBUM_TITLE_5, $this->albumID1, $this->photoID5),
 					// album 6 has been unlocked simultaneously with password 2, but is hidden and hence not part of the tree
 				]]
 			),
@@ -488,12 +484,12 @@ class SharingSpecialTest extends BaseSharingTest
 		// 4. Check album/photo access
 
 		foreach ([
-			[$this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID5], // photo 5 is alphabetically first of all child photos
-			[$this->albumID2, self::ALBUM_TITLE_2, $this->albumID1, $this->photoID2],
-			[$this->albumID3, self::ALBUM_TITLE_3, $this->albumID1, $this->photoID3],
-			[$this->albumID4, self::ALBUM_TITLE_4, $this->albumID1, $this->photoID4], // album 4 has been unlocked simultaneously with password 1 and hence is directly accessible, although it is hidden
-			[$this->albumID5, self::ALBUM_TITLE_5, $this->albumID1, $this->photoID5],
-			[$this->albumID6, self::ALBUM_TITLE_6, $this->albumID1, $this->photoID6], // album 6 has been unlocked simultaneously with password 2 and hence is directly accessible, although it is hidden
+			[$this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID5], // photo 5 is alphabetically first of all child photos
+			[$this->albumID2, TestConstants::ALBUM_TITLE_2, $this->albumID1, $this->photoID2],
+			[$this->albumID3, TestConstants::ALBUM_TITLE_3, $this->albumID1, $this->photoID3],
+			[$this->albumID4, TestConstants::ALBUM_TITLE_4, $this->albumID1, $this->photoID4], // album 4 has been unlocked simultaneously with password 1 and hence is directly accessible, although it is hidden
+			[$this->albumID5, TestConstants::ALBUM_TITLE_5, $this->albumID1, $this->photoID5],
+			[$this->albumID6, TestConstants::ALBUM_TITLE_6, $this->albumID1, $this->photoID6], // album 6 has been unlocked simultaneously with password 2 and hence is directly accessible, although it is hidden
 		] as $albumInfo) {
 			$responseForAlbum = $this->albums_tests->get($albumInfo[0]);
 			$responseForAlbum->assertJson($this->generateExpectedAlbumJson(

--- a/tests/Feature/SharingWithAnonUserAndNoPublicSearchTest.php
+++ b/tests/Feature/SharingWithAnonUserAndNoPublicSearchTest.php
@@ -16,15 +16,15 @@ use App\Models\Configs;
 use App\SmartAlbums\OnThisDayAlbum;
 use App\SmartAlbums\RecentAlbum;
 use App\SmartAlbums\StarredAlbum;
-use Tests\AbstractTestCase;
 use Tests\Feature\Base\BaseSharingWithAnonUser;
+use Tests\Feature\Constants\TestConstants;
 
 class SharingWithAnonUserAndNoPublicSearchTest extends BaseSharingWithAnonUser
 {
 	public function setUp(): void
 	{
 		parent::setUp();
-		Configs::set(AbstractTestCase::CONFIG_PUBLIC_HIDDEN, true);
+		Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, true);
 	}
 
 	/**
@@ -118,7 +118,7 @@ class SharingWithAnonUserAndNoPublicSearchTest extends BaseSharingWithAnonUser
 		// The album and photo 2 are not accessible, but photo 1 is
 		// because it is public even though it is contained in an inaccessible
 		// album
-		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), self::EXPECTED_PASSWORD_REQUIRED_MSG);
+		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG);
 		$this->photos_tests->get($this->photoID1);
 		$this->photos_tests->get($this->photoID2, $this->getExpectedInaccessibleHttpStatusCode());
 	}
@@ -155,7 +155,7 @@ class SharingWithAnonUserAndNoPublicSearchTest extends BaseSharingWithAnonUser
 		$responseForTree->assertJson($this->generateExpectedTreeJson());
 		$responseForTree->assertJsonMissing(['id' => $this->photoID2]);
 
-		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), self::EXPECTED_PASSWORD_REQUIRED_MSG);
+		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG);
 		$this->photos_tests->get($this->photoID1);
 		$this->photos_tests->get($this->photoID2, $this->getExpectedInaccessibleHttpStatusCode());
 	}

--- a/tests/Feature/SharingWithAnonUserAndPublicSearchTest.php
+++ b/tests/Feature/SharingWithAnonUserAndPublicSearchTest.php
@@ -16,15 +16,15 @@ use App\Models\Configs;
 use App\SmartAlbums\OnThisDayAlbum;
 use App\SmartAlbums\RecentAlbum;
 use App\SmartAlbums\StarredAlbum;
-use Tests\AbstractTestCase;
 use Tests\Feature\Base\BaseSharingWithAnonUser;
+use Tests\Feature\Constants\TestConstants;
 
 class SharingWithAnonUserAndPublicSearchTest extends BaseSharingWithAnonUser
 {
 	public function setUp(): void
 	{
 		parent::setUp();
-		Configs::set(AbstractTestCase::CONFIG_PUBLIC_HIDDEN, false);
+		Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, false);
 	}
 
 	/**
@@ -56,7 +56,7 @@ class SharingWithAnonUserAndPublicSearchTest extends BaseSharingWithAnonUser
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			]
 		));
 		$responseForRecent->assertJsonMissing(['id' => $this->photoID2]);
@@ -65,7 +65,7 @@ class SharingWithAnonUserAndPublicSearchTest extends BaseSharingWithAnonUser
 		$responseForStarred->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			]
 		));
 		$responseForStarred->assertJsonMissing(['id' => $this->photoID2]);
@@ -74,7 +74,7 @@ class SharingWithAnonUserAndPublicSearchTest extends BaseSharingWithAnonUser
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID2]);
@@ -109,7 +109,7 @@ class SharingWithAnonUserAndPublicSearchTest extends BaseSharingWithAnonUser
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForRecent->assertJsonMissing(['id' => $this->photoID2]);
@@ -118,7 +118,7 @@ class SharingWithAnonUserAndPublicSearchTest extends BaseSharingWithAnonUser
 		$responseForStarred->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForStarred->assertJsonMissing(['id' => $this->photoID2]);
@@ -127,7 +127,7 @@ class SharingWithAnonUserAndPublicSearchTest extends BaseSharingWithAnonUser
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID2]);
@@ -138,7 +138,7 @@ class SharingWithAnonUserAndPublicSearchTest extends BaseSharingWithAnonUser
 		$responseForTree->assertJsonMissing(['id' => $this->photoID1]);
 		$responseForTree->assertJsonMissing(['id' => $this->photoID2]);
 
-		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), self::EXPECTED_PASSWORD_REQUIRED_MSG);
+		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG);
 		$this->photos_tests->get($this->photoID1);
 		$this->photos_tests->get($this->photoID2, $this->getExpectedInaccessibleHttpStatusCode());
 	}
@@ -161,7 +161,7 @@ class SharingWithAnonUserAndPublicSearchTest extends BaseSharingWithAnonUser
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			],
 		));
 		$responseForRoot->assertJsonMissing(['id' => $this->photoID2]);
@@ -170,7 +170,7 @@ class SharingWithAnonUserAndPublicSearchTest extends BaseSharingWithAnonUser
 		$responseForStarred->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			],
 		));
 		$responseForStarred->assertJsonMissing(['id' => $this->photoID2]);
@@ -179,7 +179,7 @@ class SharingWithAnonUserAndPublicSearchTest extends BaseSharingWithAnonUser
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			],
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID2]);
@@ -188,7 +188,7 @@ class SharingWithAnonUserAndPublicSearchTest extends BaseSharingWithAnonUser
 		$responseForTree->assertJson($this->generateExpectedTreeJson());
 		$responseForTree->assertJsonMissing(['id' => $this->photoID2]);
 
-		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), self::EXPECTED_PASSWORD_REQUIRED_MSG);
+		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG);
 		$this->photos_tests->get($this->photoID1);
 		$this->photos_tests->get($this->photoID2, $this->getExpectedInaccessibleHttpStatusCode());
 	}

--- a/tests/Feature/SharingWithNonAdminUserAndNoPublicSearchTest.php
+++ b/tests/Feature/SharingWithNonAdminUserAndNoPublicSearchTest.php
@@ -17,15 +17,15 @@ use App\SmartAlbums\OnThisDayAlbum;
 use App\SmartAlbums\RecentAlbum;
 use App\SmartAlbums\StarredAlbum;
 use App\SmartAlbums\UnsortedAlbum;
-use Tests\AbstractTestCase;
 use Tests\Feature\Base\BaseSharingWithNonAdminUser;
+use Tests\Feature\Constants\TestConstants;
 
 class SharingWithNonAdminUserAndNoPublicSearchTest extends BaseSharingWithNonAdminUser
 {
 	public function setUp(): void
 	{
 		parent::setUp();
-		Configs::set(AbstractTestCase::CONFIG_PUBLIC_HIDDEN, true);
+		Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, true);
 	}
 
 	/**
@@ -131,7 +131,7 @@ class SharingWithNonAdminUserAndNoPublicSearchTest extends BaseSharingWithNonAdm
 		$responseForTree->assertJsonMissing(['id' => $this->photoID1]);
 		$responseForTree->assertJsonMissing(['id' => $this->photoID2]);
 
-		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), self::EXPECTED_PASSWORD_REQUIRED_MSG);
+		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG);
 		// Even though public search is disabled, the photo is accessible
 		// by its direct link, because it is public.
 		$this->photos_tests->get($this->photoID1);
@@ -151,7 +151,7 @@ class SharingWithNonAdminUserAndNoPublicSearchTest extends BaseSharingWithNonAdm
 			null,
 			$this->photoID2,
 			$this->photoID2, [
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID2),
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID2),
 			]
 		));
 		$arrayUnexpected = $this->generateUnexpectedRootJson(
@@ -171,7 +171,7 @@ class SharingWithNonAdminUserAndNoPublicSearchTest extends BaseSharingWithNonAdm
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID2, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1),
 			]
 		));
 		$responseForRecent->assertJsonMissing(['id' => $this->photoID1]);
@@ -180,7 +180,7 @@ class SharingWithNonAdminUserAndNoPublicSearchTest extends BaseSharingWithNonAdm
 		$responseForStarred->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID2, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1),
 			]
 		));
 		$responseForStarred->assertJsonMissing(['id' => $this->photoID1]);
@@ -188,24 +188,24 @@ class SharingWithNonAdminUserAndNoPublicSearchTest extends BaseSharingWithNonAdm
 		$responseForOnThisDay = $this->albums_tests->get(OnThisDayAlbum::ID);
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(true,
 			$this->photoID2, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID1]);
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID2),
+			$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID2),
 		]));
 
 		$responseForAlbum = $this->albums_tests->get($this->albumID1);
 		$responseForAlbum->assertJson([
 			'id' => $this->albumID1,
-			'title' => self::ALBUM_TITLE_1,
+			'title' => TestConstants::ALBUM_TITLE_1,
 			'policy' => ['is_public' => false],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID2),
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1),
 			],
 		]);
 

--- a/tests/Feature/SharingWithNonAdminUserAndPublicSearchTest.php
+++ b/tests/Feature/SharingWithNonAdminUserAndPublicSearchTest.php
@@ -17,15 +17,15 @@ use App\SmartAlbums\OnThisDayAlbum;
 use App\SmartAlbums\RecentAlbum;
 use App\SmartAlbums\StarredAlbum;
 use App\SmartAlbums\UnsortedAlbum;
-use Tests\AbstractTestCase;
 use Tests\Feature\Base\BaseSharingWithNonAdminUser;
+use Tests\Feature\Constants\TestConstants;
 
 class SharingWithNonAdminUserAndPublicSearchTest extends BaseSharingWithNonAdminUser
 {
 	public function setUp(): void
 	{
 		parent::setUp();
-		Configs::set(AbstractTestCase::CONFIG_PUBLIC_HIDDEN, false);
+		Configs::set(TestConstants::CONFIG_PUBLIC_HIDDEN, false);
 	}
 
 	/**
@@ -62,41 +62,41 @@ class SharingWithNonAdminUserAndPublicSearchTest extends BaseSharingWithNonAdmin
 		$responseForUnsorted->assertJson($this->generateExpectedSmartAlbumJson(
 			false,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			]
 		));
 		$responseForUnsorted->assertJsonMissing(['id' => $this->photoID2]);
-		$responseForUnsorted->assertJsonMissing(['title' => self::PHOTO_MONGOLIA_TITLE]);
+		$responseForUnsorted->assertJsonMissing(['title' => TestConstants::PHOTO_MONGOLIA_TITLE]);
 
 		$responseForRecent = $this->albums_tests->get(RecentAlbum::ID);
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			]
 		));
 		$responseForRecent->assertJsonMissing(['id' => $this->photoID2]);
-		$responseForRecent->assertJsonMissing(['title' => self::PHOTO_MONGOLIA_TITLE]);
+		$responseForRecent->assertJsonMissing(['title' => TestConstants::PHOTO_MONGOLIA_TITLE]);
 
 		$responseForStarred = $this->albums_tests->get(StarredAlbum::ID);
 		$responseForStarred->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			]
 		));
 		$responseForStarred->assertJsonMissing(['id' => $this->photoID2]);
-		$responseForStarred->assertJsonMissing(['title' => self::PHOTO_MONGOLIA_TITLE]);
+		$responseForStarred->assertJsonMissing(['title' => TestConstants::PHOTO_MONGOLIA_TITLE]);
 
 		$responseForOnThisDay = $this->albums_tests->get(OnThisDayAlbum::ID);
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID2]);
-		$responseForOnThisDay->assertJsonMissing(['title' => self::PHOTO_MONGOLIA_TITLE]);
+		$responseForOnThisDay->assertJsonMissing(['title' => TestConstants::PHOTO_MONGOLIA_TITLE]);
 
 		$this->photos_tests->get($this->photoID1);
 		$this->photos_tests->get($this->photoID2, $this->getExpectedInaccessibleHttpStatusCode());
@@ -133,7 +133,7 @@ class SharingWithNonAdminUserAndPublicSearchTest extends BaseSharingWithNonAdmin
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForRecent->assertJsonMissing(['id' => $this->photoID2]);
@@ -142,7 +142,7 @@ class SharingWithNonAdminUserAndPublicSearchTest extends BaseSharingWithNonAdmin
 		$responseForStarred->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForStarred->assertJsonMissing(['id' => $this->photoID2]);
@@ -151,7 +151,7 @@ class SharingWithNonAdminUserAndPublicSearchTest extends BaseSharingWithNonAdmin
 		$responseForOnThisDay->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, $this->albumID1),
 			]
 		));
 		$responseForOnThisDay->assertJsonMissing(['id' => $this->photoID2]);
@@ -162,7 +162,7 @@ class SharingWithNonAdminUserAndPublicSearchTest extends BaseSharingWithNonAdmin
 		$responseForTree->assertJsonMissing(['id' => $this->photoID1]);
 		$responseForTree->assertJsonMissing(['id' => $this->photoID2]);
 
-		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), self::EXPECTED_PASSWORD_REQUIRED_MSG);
+		$this->albums_tests->get($this->albumID1, $this->getExpectedInaccessibleHttpStatusCode(), $this->getExpectedDefaultInaccessibleMessage(), TestConstants::EXPECTED_PASSWORD_REQUIRED_MSG);
 		$this->photos_tests->get($this->photoID1);
 		$this->photos_tests->get($this->photoID2, $this->getExpectedInaccessibleHttpStatusCode());
 	}
@@ -181,7 +181,7 @@ class SharingWithNonAdminUserAndPublicSearchTest extends BaseSharingWithNonAdmin
 			$this->photoID1,
 			$this->photoID2,
 			$this->photoID1, [
-				$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID2),
+				$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID2),
 			]
 		));
 		$arrayUnexpected = $this->generateUnexpectedRootJson(
@@ -195,7 +195,7 @@ class SharingWithNonAdminUserAndPublicSearchTest extends BaseSharingWithNonAdmin
 		$responseForUnsorted->assertJson($this->generateExpectedSmartAlbumJson(
 			false,
 			$this->photoID1, [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			]
 		));
 		$responseForUnsorted->assertJsonMissing(['id' => $this->photoID2]);
@@ -204,8 +204,8 @@ class SharingWithNonAdminUserAndPublicSearchTest extends BaseSharingWithNonAdmin
 		$responseForRecent->assertJson($this->generateExpectedSmartAlbumJson(
 			true,
 			$this->photoID2, [ // photo 2 is thumb, because both photos are starred, but photo 2 is sorted first
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1), // photo 2 is alphabetically first
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1), // photo 2 is alphabetically first
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			]
 		));
 
@@ -214,8 +214,8 @@ class SharingWithNonAdminUserAndPublicSearchTest extends BaseSharingWithNonAdmin
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID2),
 			'photos' => [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1), // photo 2 is alphabetically first
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1), // photo 2 is alphabetically first
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			],
 		]);
 
@@ -224,23 +224,23 @@ class SharingWithNonAdminUserAndPublicSearchTest extends BaseSharingWithNonAdmin
 			'policy' => ['is_public' => true],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID1),
 			'photos' => [
-				$this->generateExpectedPhotoJson(static::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_TRAIN_IMAGE, $this->photoID1, null),
 			],
 		]);
 
 		$responseForTree = $this->root_album_tests->getTree();
 		$responseForTree->assertJson($this->generateExpectedTreeJson([
-			$this->generateExpectedAlbumJson($this->albumID1, self::ALBUM_TITLE_1, null, $this->photoID2),
+			$this->generateExpectedAlbumJson($this->albumID1, TestConstants::ALBUM_TITLE_1, null, $this->photoID2),
 		]));
 
 		$responseForAlbum = $this->albums_tests->get($this->albumID1);
 		$responseForAlbum->assertJson([
 			'id' => $this->albumID1,
-			'title' => self::ALBUM_TITLE_1,
+			'title' => TestConstants::ALBUM_TITLE_1,
 			'policy' => ['is_public' => false],
 			'thumb' => $this->generateExpectedThumbJson($this->photoID2),
 			'photos' => [
-				$this->generateExpectedPhotoJson(self::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1),
+				$this->generateExpectedPhotoJson(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, $this->photoID2, $this->albumID1),
 			],
 		]);
 

--- a/tests/Feature/Traits/InteractsWithRaw.php
+++ b/tests/Feature/Traits/InteractsWithRaw.php
@@ -4,18 +4,18 @@ namespace Tests\Feature\Traits;
 
 use App\Image\Files\BaseMediaFile;
 use App\Models\Configs;
-use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 
 trait InteractsWithRaw
 {
 	public static function getAcceptedRawFormats(): string
 	{
-		return Configs::getValueAsString(AbstractTestCase::CONFIG_RAW_FORMATS);
+		return Configs::getValueAsString(TestConstants::CONFIG_RAW_FORMATS);
 	}
 
 	public static function setAcceptedRawFormats(string $acceptedRawFormats): void
 	{
-		Configs::set(AbstractTestCase::CONFIG_RAW_FORMATS, $acceptedRawFormats);
+		Configs::set(TestConstants::CONFIG_RAW_FORMATS, $acceptedRawFormats);
 		$reflection = new \ReflectionClass(BaseMediaFile::class);
 		$reflection->setStaticPropertyValue('cachedAcceptedRawFileExtensions', []);
 	}

--- a/tests/Feature/Traits/RequiresExifTool.php
+++ b/tests/Feature/Traits/RequiresExifTool.php
@@ -13,7 +13,7 @@
 namespace Tests\Feature\Traits;
 
 use App\Models\Configs;
-use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 
 trait RequiresExifTool
 {
@@ -22,14 +22,14 @@ trait RequiresExifTool
 
 	protected function setUpRequiresExifTool(): void
 	{
-		$this->hasExifToolInit = Configs::getValueAsInt(AbstractTestCase::CONFIG_HAS_EXIF_TOOL);
-		Configs::set(AbstractTestCase::CONFIG_HAS_EXIF_TOOL, 2);
+		$this->hasExifToolInit = Configs::getValueAsInt(TestConstants::CONFIG_HAS_EXIF_TOOL);
+		Configs::set(TestConstants::CONFIG_HAS_EXIF_TOOL, 2);
 		$this->hasExifTools = Configs::hasExiftool();
 	}
 
 	protected function tearDownRequiresExifTool(): void
 	{
-		Configs::set(AbstractTestCase::CONFIG_HAS_EXIF_TOOL, $this->hasExifToolInit);
+		Configs::set(TestConstants::CONFIG_HAS_EXIF_TOOL, $this->hasExifToolInit);
 	}
 
 	protected function assertHasExifToolOrSkip(): void

--- a/tests/Feature/Traits/RequiresFFMpeg.php
+++ b/tests/Feature/Traits/RequiresFFMpeg.php
@@ -13,7 +13,7 @@
 namespace Tests\Feature\Traits;
 
 use App\Models\Configs;
-use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 
 trait RequiresFFMpeg
 {
@@ -22,14 +22,14 @@ trait RequiresFFMpeg
 
 	protected function setUpRequiresFFMpeg(): void
 	{
-		$this->hasFFMpegInit = Configs::getValueAsInt(AbstractTestCase::CONFIG_HAS_FFMPEG);
-		Configs::set(AbstractTestCase::CONFIG_HAS_FFMPEG, 2);
+		$this->hasFFMpegInit = Configs::getValueAsInt(TestConstants::CONFIG_HAS_FFMPEG);
+		Configs::set(TestConstants::CONFIG_HAS_FFMPEG, 2);
 		$this->hasFFMpeg = Configs::hasFFmpeg();
 	}
 
 	protected function tearDownRequiresFFMpeg(): void
 	{
-		Configs::set(AbstractTestCase::CONFIG_HAS_FFMPEG, $this->hasFFMpegInit);
+		Configs::set(TestConstants::CONFIG_HAS_FFMPEG, $this->hasFFMpegInit);
 	}
 
 	protected function assertHasFFMpegOrSkip(): void

--- a/tests/Feature/Traits/RequiresImageHandler.php
+++ b/tests/Feature/Traits/RequiresImageHandler.php
@@ -13,7 +13,7 @@
 namespace Tests\Feature\Traits;
 
 use App\Models\Configs;
-use Tests\AbstractTestCase;
+use Tests\Feature\Constants\TestConstants;
 
 trait RequiresImageHandler
 {
@@ -21,8 +21,8 @@ trait RequiresImageHandler
 
 	protected function setUpRequiresImagick(): void
 	{
-		$this->hasImagickInit = Configs::getValueAsInt(AbstractTestCase::CONFIG_HAS_IMAGICK);
-		Configs::set(AbstractTestCase::CONFIG_HAS_IMAGICK, 1);
+		$this->hasImagickInit = Configs::getValueAsInt(TestConstants::CONFIG_HAS_IMAGICK);
+		Configs::set(TestConstants::CONFIG_HAS_IMAGICK, 1);
 
 		if (!Configs::hasImagick()) {
 			static::markTestSkipped('Imagick is not available. Test Skipped.');
@@ -31,8 +31,8 @@ trait RequiresImageHandler
 
 	protected function setUpRequiresGD(): void
 	{
-		$this->hasImagickInit = Configs::getValueAsInt(AbstractTestCase::CONFIG_HAS_IMAGICK);
-		Configs::set(AbstractTestCase::CONFIG_HAS_IMAGICK, 0);
+		$this->hasImagickInit = Configs::getValueAsInt(TestConstants::CONFIG_HAS_IMAGICK);
+		Configs::set(TestConstants::CONFIG_HAS_IMAGICK, 0);
 
 		if (Configs::hasImagick()) {
 			static::markTestSkipped('Imagick still enabled although it shouldn\'t. Test Skipped.');
@@ -41,7 +41,7 @@ trait RequiresImageHandler
 
 	protected function tearDownRequiresImageHandler(): void
 	{
-		Configs::set(AbstractTestCase::CONFIG_HAS_IMAGICK, $this->hasImagickInit);
+		Configs::set(TestConstants::CONFIG_HAS_IMAGICK, $this->hasImagickInit);
 	}
 
 	abstract public static function markTestSkipped(string $message = ''): void;


### PR DESCRIPTION
Moving constants used by tests in own class so there is no longer a mess between `static` `self` and `AbstractTestCase`