### PR TITLE
Support very old versions (untestable code)

### DIFF
--- a/app/Legacy/AdminAuthentication.php
+++ b/app/Legacy/AdminAuthentication.php
@@ -74,6 +74,7 @@ class AdminAuthentication
 		if (Hash::check($username, $username_hash) && Hash::check($password, $password_hash)) {
 			// Prior version 4.6.3 we are using ID 0 as admin
 			// We create admin at ID 0 because the 2022_12_10_183251_increment_user_i_ds will be taking care to push it to 1.
+			/** @var User $adminUser */
 			$adminUser = User::query()->findOrNew(0);
 			$adminUser->username = $username;
 			$adminUser->password = Hash::make($password);

--- a/app/Legacy/AdminAuthentication.php
+++ b/app/Legacy/AdminAuthentication.php
@@ -2,6 +2,8 @@
 
 namespace App\Legacy;
 
+use App\Metadata\Versions\InstalledVersion;
+use App\Models\Configs;
 use App\Models\Logs;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
@@ -24,8 +26,21 @@ class AdminAuthentication
 	 */
 	public static function loginAsAdmin(string $username, string $password, string $ip): bool
 	{
+		$installed_version = new InstalledVersion();
+		$db_version_number = $installed_version->getVersion();
+
+		// For version up to 4.0.8 the admin password is stored in the settings
+		if ($db_version_number->toInteger() <= 40008) {
+			return self::logAsAdminFromConfig($username, $password, $ip);
+		}
+
+		// For version up to 4.6.3
+		$admin_id = $db_version_number->toInteger() <= 40603 ? 0 : 1;
+		// Note there is a small edge case where a user could be at version 4.6.3 AND having already bumped the ID.
+		// We consider this risk to be too small to actually mitigate it.
+
 		/** @var User|null $adminUser */
-		$adminUser = User::query()->find(1);
+		$adminUser = User::query()->find($admin_id);
 
 		// Admin User exists, so we check against it.
 		if ($adminUser !== null && Hash::check($username, $adminUser->username) && Hash::check($password, $adminUser->password)) {
@@ -35,6 +50,37 @@ class AdminAuthentication
 			// update the admin username so we do not need to go through here anymore.
 			$adminUser->username = $username;
 			$adminUser->save();
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * This is only applicable if we are up to version 4.0.8 in which the refactoring of admin append.
+	 *
+	 * @param string $username
+	 * @param string $password
+	 * @param string $ip
+	 *
+	 * @return bool
+	 */
+	public static function logAsAdminFromConfig(string $username, string $password, string $ip): bool
+	{
+		$username_hash = Configs::getValueAsString('username');
+		$password_hash = Configs::getValueAsString('password');
+
+		if (Hash::check($username, $username_hash) && Hash::check($password, $password_hash)) {
+			// Prior version 4.6.3 we are using ID 0 as admin
+			// We create admin at ID 0 because the 2022_12_10_183251_increment_user_i_ds will be taking care to push it to 1.
+			$adminUser = User::query()->findOrNew(0);
+			$adminUser->username = $username;
+			$adminUser->password = Hash::make($password);
+			$adminUser->save();
+
+			Auth::login($adminUser);
+			Logs::notice(__METHOD__, __LINE__, 'User (' . $username . ') has logged in from ' . $ip . ' (legacy)');
 
 			return true;
 		}


### PR DESCRIPTION
Fixes #1779 

Tested with version 4.4.0:
- Created a new Lychee instance at version 4.4.0
- composer install with ignore req and fix vendor autoload.
- Created an admin user
- Uploaded an album & photo
- switched to version 4.8.0
- apply migration from webinterface (migration requires to be on master branch but at least it no longer pop a 403).
- some trickery to make Lychee believe we are on master and migration passes.
- It generates a byte allocation error but the migration worked successfully.

Unfortunately I could not test on version 4.0.8 as this required an older php version.