### PR TITLE
fix api

### DIFF
--- a/app/Http/Resources/Collections/AlbumForestResource.php
+++ b/app/Http/Resources/Collections/AlbumForestResource.php
@@ -15,7 +15,8 @@ class AlbumForestResource extends JsonResource
 		private Collection $albums,
 		private ?Collection $sharedAlbums = null
 	) {
-		parent::__construct(null);
+		// Laravel applies a shortcut when this value === null but not when it is something else.
+		parent::__construct('must_not_be_null');
 
 		$this->albums = $albums;
 		$this->sharedAlbums = $sharedAlbums ?? new Collection();
@@ -31,8 +32,8 @@ class AlbumForestResource extends JsonResource
 	public function toArray($request)
 	{
 		return [
-			'albums' => AlbumTreeResource::collection($this->albums)->toArray($request),
-			'shared_albums' => AlbumTreeResource::collection($this->sharedAlbums)->toArray($request),
+			'albums' => AlbumTreeResource::collection($this->albums),
+			'shared_albums' => AlbumTreeResource::collection($this->sharedAlbums),
 		];
 	}
 }

--- a/app/Http/Resources/Collections/PositionDataResource.php
+++ b/app/Http/Resources/Collections/PositionDataResource.php
@@ -45,7 +45,7 @@ class PositionDataResource extends JsonResource
 		return [
 			'id' => $this->id,
 			'title' => $this->title,
-			'photos' => PhotoResource::collection($this->resource)->toArray($request),
+			'photos' => PhotoResource::collection($this->resource),
 			'track_url' => $this->track_url,
 		];
 	}

--- a/app/Http/Resources/Collections/TopAlbumsResource.php
+++ b/app/Http/Resources/Collections/TopAlbumsResource.php
@@ -26,7 +26,8 @@ class TopAlbumsResource extends JsonResource
 		public Collection $albums,
 		public ?Collection $shared_albums = null
 	) {
-		parent::__construct(null);
+		// Laravel applies a shortcut when this value === null but not when it is something else.
+		parent::__construct('must_not_be_null');
 
 		$this->shared_albums ??= new Collection();
 	}

--- a/app/Http/Resources/ConfigurationResource.php
+++ b/app/Http/Resources/ConfigurationResource.php
@@ -20,7 +20,8 @@ class ConfigurationResource extends JsonResource
 {
 	public function __construct()
 	{
-		parent::__construct(null);
+		// Laravel applies a shortcut when this value === null but not when it is something else.
+		parent::__construct('must_not_be_null');
 	}
 
 	/**

--- a/app/Http/Resources/InitResource.php
+++ b/app/Http/Resources/InitResource.php
@@ -14,7 +14,8 @@ class InitResource extends JsonResource
 {
 	public function __construct()
 	{
-		parent::__construct(null);
+		// Laravel applies a shortcut when this value === null but not when it is something else.
+		parent::__construct('must_not_be_null');
 	}
 
 	/**
@@ -39,8 +40,8 @@ class InitResource extends JsonResource
 
 		return [
 			'user' => $this->when(Auth::check(), UserResource::make(Auth::user()), null),
-			'rights' => GlobalRightsResource::make()->toArray($request),
-			'config' => ConfigurationResource::make()->toArray($request),
+			'rights' => GlobalRightsResource::make(),
+			'config' => ConfigurationResource::make(),
 			'update_json' => !$fileVersion->isUpToDate(),
 			'update_available' => !$gitHubVersion->isUpToDate(),
 			'locale' => $locale,

--- a/app/Http/Resources/Models/AlbumResource.php
+++ b/app/Http/Resources/Models/AlbumResource.php
@@ -47,7 +47,7 @@ class AlbumResource extends JsonResource
 			'parent_id' => $this->resource->parent_id,
 			'has_albums' => !$this->resource->isLeaf(),
 			'albums' => AlbumResource::collection($this->whenLoaded('children')),
-			'photos' => new PhotoCollectionResource($this->whenLoaded('photos')),
+			'photos' => PhotoCollectionResource::make($this->whenLoaded('photos')),
 			'num_subalbums' => $this->resource->num_children,
 			'num_photos' => $this->resource->num_photos,
 

--- a/app/Http/Resources/Rights/AlbumRightsResource.php
+++ b/app/Http/Resources/Rights/AlbumRightsResource.php
@@ -26,7 +26,8 @@ class AlbumRightsResource extends JsonResource
 	 */
 	public function __construct(AbstractAlbum $abstractAlbum)
 	{
-		parent::__construct(null);
+		// Laravel applies a shortcut when this value === null but not when it is something else.
+		parent::__construct('must_not_be_null');
 
 		$this->can_edit = Gate::check(AlbumPolicy::CAN_EDIT, [AbstractAlbum::class, $abstractAlbum]);
 		$this->can_share_with_users = Gate::check(AlbumPolicy::CAN_SHARE_WITH_USERS, [AbstractAlbum::class, $abstractAlbum]);

--- a/app/Http/Resources/Rights/GlobalRightsResource.php
+++ b/app/Http/Resources/Rights/GlobalRightsResource.php
@@ -11,7 +11,8 @@ class GlobalRightsResource extends JsonResource
 {
 	public function __construct()
 	{
-		parent::__construct(null);
+		// Laravel applies a shortcut when this value === null but not when it is something else.
+		parent::__construct('must_not_be_null');
 	}
 
 	/**
@@ -24,10 +25,10 @@ class GlobalRightsResource extends JsonResource
 	public function toArray($request)
 	{
 		return [
-			'root_album' => RootAlbumRightsResource::make()->toArray($request),
-			'settings' => SettingsRightsResource::make()->toArray($request),
-			'user_management' => UserManagementRightsResource::make()->toArray($request),
-			'user' => UserRightsResource::make()->toArray($request),
+			'root_album' => RootAlbumRightsResource::make(),
+			'settings' => SettingsRightsResource::make(),
+			'user_management' => UserManagementRightsResource::make(),
+			'user' => UserRightsResource::make(),
 		];
 	}
 }

--- a/app/Http/Resources/Rights/PhotoRightsResource.php
+++ b/app/Http/Resources/Rights/PhotoRightsResource.php
@@ -25,7 +25,8 @@ class PhotoRightsResource extends JsonResource
 	 */
 	public function __construct(Photo $photo)
 	{
-		parent::__construct(null);
+		// Laravel applies a shortcut when this value === null but not when it is something else.
+		parent::__construct('must_not_be_null');
 		$this->can_edit = Gate::check(PhotoPolicy::CAN_EDIT, [Photo::class, $photo]);
 		$this->can_download = Gate::check(PhotoPolicy::CAN_DOWNLOAD, [Photo::class, $photo]);
 		$this->can_access_full_photo = Gate::check(PhotoPolicy::CAN_ACCESS_FULL_PHOTO, [Photo::class, $photo]);

--- a/app/Http/Resources/Rights/RootAlbumRightsResource.php
+++ b/app/Http/Resources/Rights/RootAlbumRightsResource.php
@@ -14,7 +14,8 @@ class RootAlbumRightsResource extends JsonResource
 {
 	public function __construct()
 	{
-		parent::__construct(null);
+		// Laravel applies a shortcut when this value === null but not when it is something else.
+		parent::__construct('must_not_be_null');
 	}
 
 	/**

--- a/app/Http/Resources/Rights/SettingsRightsResource.php
+++ b/app/Http/Resources/Rights/SettingsRightsResource.php
@@ -14,7 +14,8 @@ class SettingsRightsResource extends JsonResource
 {
 	public function __construct()
 	{
-		parent::__construct(null);
+		// Laravel applies a shortcut when this value === null but not when it is something else.
+		parent::__construct('must_not_be_null');
 	}
 
 	/**

--- a/app/Http/Resources/Rights/UserManagementRightsResource.php
+++ b/app/Http/Resources/Rights/UserManagementRightsResource.php
@@ -14,7 +14,8 @@ class UserManagementRightsResource extends JsonResource
 {
 	public function __construct()
 	{
-		parent::__construct(null);
+		// Laravel applies a shortcut when this value === null but not when it is something else.
+		parent::__construct('must_not_be_null');
 	}
 
 	/**

--- a/app/Http/Resources/Rights/UserRightsResource.php
+++ b/app/Http/Resources/Rights/UserRightsResource.php
@@ -14,7 +14,8 @@ class UserRightsResource extends JsonResource
 {
 	public function __construct()
 	{
-		parent::__construct(null);
+		// Laravel applies a shortcut when this value === null but not when it is something else.
+		parent::__construct('must_not_be_null');
 	}
 
 	/**

--- a/app/Http/Resources/SearchResource.php
+++ b/app/Http/Resources/SearchResource.php
@@ -18,7 +18,8 @@ class SearchResource extends JsonResource
 		public Collection $tag_albums,
 		public Collection $photos,
 	) {
-		parent::__construct(null);
+		// Laravel applies a shortcut when this value === null but not when it is something else.
+		parent::__construct('must_not_be_null');
 	}
 
 	/**

--- a/app/Http/Resources/Sharing/SharesResource.php
+++ b/app/Http/Resources/Sharing/SharesResource.php
@@ -15,7 +15,8 @@ class SharesResource extends JsonResource
 		public Collection $albums,
 		public Collection $users)
 	{
-		parent::__construct(null);
+		// Laravel applies a shortcut when this value === null but not when it is something else.
+		parent::__construct('must_not_be_null');
 	}
 
 	/**
@@ -28,9 +29,9 @@ class SharesResource extends JsonResource
 	public function toArray($request): array
 	{
 		return [
-			'shared' => SharedAlbumResource::collection($this->shared)->toArray($request),
-			'albums' => ListedAlbumsResource::collection($this->albums)->toArray($request),
-			'users' => UserSharedResource::collection($this->users)->toArray($request),
+			'shared' => SharedAlbumResource::collection($this->shared),
+			'albums' => ListedAlbumsResource::collection($this->albums),
+			'users' => UserSharedResource::collection($this->users),
 		];
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -65,14 +65,15 @@
         "ext-zip": "*",
         "barryvdh/laravel-debugbar": "^3.6",
         "barryvdh/laravel-ide-helper": "^2.10",
+        "dedoc/scramble": "^0.7.2",
         "filp/whoops": "^2.5",
         "friendsofphp/php-cs-fixer": "^3.3",
         "itsgoingd/clockwork": "^5.1",
         "lychee-org/phpstan-lychee": "^v1.0.1",
         "mockery/mockery": "^1.5",
-        "phpunit/phpunit": "^10.0",
         "nunomaduro/larastan": "^2.0",
-        "php-parallel-lint/php-parallel-lint": "^1.3"
+        "php-parallel-lint/php-parallel-lint": "^1.3",
+        "phpunit/phpunit": "^10.0"
     },
     "autoload": {
         "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b6943a43e5f6a8cba8fedae66fa9a26",
+    "content-hash": "be90132645e61bffa40f4fb227aee7ae",
     "packages": [
         {
             "name": "bepsvpt/secure-headers",
@@ -8164,6 +8164,81 @@
                 }
             ],
             "time": "2022-02-25T21:32:43+00:00"
+        },
+        {
+            "name": "dedoc/scramble",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dedoc/scramble.git",
+                "reference": "dc1971fde68105697f872b2fb9aacebd3b91cca4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dedoc/scramble/zipball/dc1971fde68105697f872b2fb9aacebd3b91cca4",
+                "reference": "dc1971fde68105697f872b2fb9aacebd3b91cca4",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^8.0.0|^9.0.0|^10.0.0",
+                "nikic/php-parser": "^4.0",
+                "php": "^7.4|^8.0|^8.1",
+                "phpstan/phpdoc-parser": "^1.0",
+                "spatie/laravel-package-tools": "^1.9.2"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.4",
+                "laravel/pint": "^v1.1.0",
+                "nunomaduro/collision": "^5.0|^v6.0",
+                "orchestra/testbench": "^6.0|^7.0|^8.0",
+                "pestphp/pest": "^1.21",
+                "pestphp/pest-plugin-laravel": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "spatie/pest-plugin-snapshots": "^1.1"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Dedoc\\Scramble\\ScrambleServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dedoc\\Scramble\\": "src",
+                    "Dedoc\\Scramble\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Lytvynenko",
+                    "email": "litvinenko95@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Automatic generation of API documentation for Laravel applications.",
+            "homepage": "https://github.com/dedoc/scramble",
+            "keywords": [
+                "documentation",
+                "laravel",
+                "openapi"
+            ],
+            "support": {
+                "issues": "https://github.com/dedoc/scramble/issues",
+                "source": "https://github.com/dedoc/scramble/tree/v0.7.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/romalytvynenko",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-20T08:34:36+00:00"
         },
         {
             "name": "doctrine/annotations",

--- a/config/scramble.php
+++ b/config/scramble.php
@@ -1,0 +1,52 @@
+<?php
+
+use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
+
+return [
+	/*
+	 * Your API path. By default, all routes starting with this path will be added to the docs.
+	 * If you need to change this behavior, you can add your custom routes resolver using `Scramble::routes()`.
+	 */
+	'api_path' => 'api',
+
+	/*
+	 * Your API domain. By default, app domain is used. This is also a part of the default API routes
+	 * matcher, so when implementing your own, make sure you use this config if needed.
+	 */
+	'api_domain' => null,
+
+	'info' => [
+		/*
+		 * API version.
+		 */
+		'version' => env('API_VERSION', '0.0.1'),
+
+		/*
+		 * Description rendered on the home page of the API documentation (`/docs/api`).
+		 */
+		'description' => '',
+	],
+
+	/*
+	 * The list of servers of the API. By default (when `null`), server URL will be created from
+	 * `scramble.api_path` and `scramble.api_domain` config variables. When providing an array, you
+	 * will need to specify the local server URL manually (if needed).
+	 *
+	 * Example of non-default config (final URLs are generated using Laravel `url` helper):
+	 *
+	 * ```php
+	 * 'servers' => [
+	 *     'Live' => 'api',
+	 *     'Prod' => 'https://scramble.dedoc.co/api',
+	 * ],
+	 * ```
+	 */
+	'servers' => null,
+
+	'middleware' => [
+		'web',
+		// RestrictedDocsAccess::class,
+	],
+
+	'extensions' => [],
+];

--- a/config/scramble.php
+++ b/config/scramble.php
@@ -1,7 +1,5 @@
 <?php
 
-use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
-
 return [
 	/*
 	 * Your API path. By default, all routes starting with this path will be added to the docs.
@@ -44,8 +42,8 @@ return [
 	'servers' => null,
 
 	'middleware' => [
-		'web',
-		// RestrictedDocsAccess::class,
+		// Only available for admin
+		'web-admin',
 	],
 
 	'extensions' => [],

--- a/routes/api.php
+++ b/routes/api.php
@@ -157,7 +157,6 @@ Route::post('/Logs::clearNoise', [Administration\LogController::class, 'clearNoi
 /**
  * SETTINGS.
  */
-Route::post('/Settings::setLogin', [Administration\SettingsController::class, 'setLogin']);
 Route::post('/Settings::setSorting', [Administration\SettingsController::class, 'setSorting']);
 Route::post('/Settings::setLang', [Administration\SettingsController::class, 'setLang']);
 Route::post('/Settings::setLayout', [Administration\SettingsController::class, 'setLayout']);

--- a/tests/Feature/LibUnitTests/SessionUnitTest.php
+++ b/tests/Feature/LibUnitTests/SessionUnitTest.php
@@ -92,34 +92,6 @@ class SessionUnitTest
 	 *
 	 * @param string      $login
 	 * @param string      $password
-	 * @param int         $expectedStatusCode
-	 * @param string|null $assertSee
-	 *
-	 * @return TestResponse
-	 */
-	public function set_admin(
-		string $login,
-		string $password,
-		int $expectedStatusCode = 200,
-		?string $assertSee = null
-	): TestResponse {
-		$response = $this->testCase->postJson('/api/Settings::setLogin', [
-			'username' => $login,
-			'password' => $password,
-		]);
-		$this->assertStatus($response, $expectedStatusCode);
-		if ($assertSee !== null) {
-			$response->assertSee($assertSee, false);
-		}
-
-		return $response;
-	}
-
-	/**
-	 * Set a new login and password.
-	 *
-	 * @param string      $login
-	 * @param string      $password
 	 * @param string      $oldPassword
 	 * @param int         $expectedStatusCode
 	 * @param string|null $assertSee


### PR DESCRIPTION
Add support for automatic generation of [OpenAPI documentation](https://swagger.io/specification/).
Creates two new endpoints: 
- A prettified one: https://example.com/docs/api/
- A JSON export in OpenAPI format: https://example.com/docs/api.json

Somewhat fixes: https://github.com/LycheeOrg/Lychee/issues/1770