### PR TITLE
Enhance URL import to support files without extension

### DIFF
--- a/app/Actions/Import/FromUrl.php
+++ b/app/Actions/Import/FromUrl.php
@@ -6,7 +6,6 @@ use App\Actions\Photo\Create;
 use App\Actions\Photo\Strategies\ImportMode;
 use App\Exceptions\Handler;
 use App\Exceptions\MassImportException;
-use App\Image\Files\BaseMediaFile;
 use App\Image\Files\DownloadedFile;
 use App\Models\Album;
 use App\Models\Configs;
@@ -14,7 +13,6 @@ use App\Models\Photo;
 use Illuminate\Support\Collection;
 use Safe\Exceptions\InfoException;
 use function Safe\ini_get;
-use function Safe\parse_url;
 use function Safe\set_time_limit;
 
 class FromUrl
@@ -49,15 +47,6 @@ class FromUrl
 				} catch (InfoException) {
 					// Silently do nothing, if `set_time_limit` is denied.
 				}
-
-				// If the component parameter is specified, this function returns a string (or int in case of PHP_URL_PORT)
-				/** @var string $path */
-				$path = parse_url($url, PHP_URL_PATH);
-				$extension = '.' . pathinfo($path, PATHINFO_EXTENSION);
-
-				// Validate photo extension even when `$create->add()` will do later.
-				// This prevents us from downloading unsupported files.
-				BaseMediaFile::assertIsSupportedOrAcceptedFileExtension($extension);
 
 				// Download file
 				$downloadedFile = new DownloadedFile($url);

--- a/app/Image/Files/BaseMediaFile.php
+++ b/app/Image/Files/BaseMediaFile.php
@@ -76,6 +76,24 @@ abstract class BaseMediaFile extends AbstractBinaryBlob implements MediaFile
 		'application/octet-stream', // Some mp4 files; will be corrected by the metadata extractor
 	];
 
+	public const MIME_TYPES_TO_FILE_EXTENSIONS = [
+		'image/gif' => '.gif',
+		'image/jpeg' => 'jpg',
+		'image/png' => '.png',
+		'image/webp' => '.webp',
+		'video/mp4' => '.mp4',
+		'video/mpeg' => '.mpg',
+		'image/x-tga' => '.mpg',
+		'video/ogg' => '.ogv',
+		'video/webm' => '.webm',
+		'video/quicktime' => '.mov',
+		'video/x-ms-asf' => '.wmv',
+		'video/x-ms-wmv' => '.wmv',
+		'video/x-msvideo' => '.avi',
+		'video/x-m4v' => '.avi',
+		'application/octet-stream' => '.mp4',
+	];
+
 	/** @var string[] the accepted raw file extensions minus supported extensions */
 	private static array $cachedAcceptedRawFileExtensions = [];
 
@@ -324,6 +342,22 @@ abstract class BaseMediaFile extends AbstractBinaryBlob implements MediaFile
 	{
 		if (!self::isSupportedOrAcceptedFileExtension($extension)) {
 			throw new MediaFileUnsupportedException(MediaFileUnsupportedException::DEFAULT_MESSAGE . ' (bad extension: ' . $extension . ')');
+		}
+	}
+
+	/**
+	 * Returns the default file extension for the given MIME type or an empty string if there is no default extension.
+	 *
+	 * @param string $mimeType a MIME type
+	 *
+	 * @return string the default file extension for the given MIME type
+	 */
+	public static function getDefaultFileExtensionForMimeType(string $mimeType): string
+	{
+		if (array_key_exists(strtolower($mimeType), self::MIME_TYPES_TO_FILE_EXTENSIONS)) {
+			return self::MIME_TYPES_TO_FILE_EXTENSIONS[strtolower($mimeType)];
+		} else {
+			return '';
 		}
 	}
 }

--- a/app/Image/Files/BaseMediaFile.php
+++ b/app/Image/Files/BaseMediaFile.php
@@ -346,6 +346,18 @@ abstract class BaseMediaFile extends AbstractBinaryBlob implements MediaFile
 	}
 
 	/**
+	 * @param string $mimeType
+	 *
+	 * @return bool
+	 */
+	public static function isSupportedMimeType(string $mimeType): bool
+	{
+		return
+			self::isSupportedImageMimeType($mimeType) ||
+			self::isSupportedVideoMimeType($mimeType);
+	}
+
+	/**
 	 * Returns the default file extension for the given MIME type or an empty string if there is no default extension.
 	 *
 	 * @param string $mimeType a MIME type

--- a/app/Image/Files/DownloadedFile.php
+++ b/app/Image/Files/DownloadedFile.php
@@ -59,7 +59,7 @@ class DownloadedFile extends TemporaryLocalFile
 			// will try to guess the file type.
 			// File extension > Content-Type > Inferred MIME type
 
-			if (self::isSupportedFileExtension($extension)) {
+			if (self::isSupportedOrAcceptedFileExtension($extension)) {
 				parent::__construct($extension, $basename);
 				if (isset($originalMimeType)) {
 					$this->originalMimeType = $originalMimeType;

--- a/tests/Feature/Constants/TestConstants.php
+++ b/tests/Feature/Constants/TestConstants.php
@@ -17,6 +17,7 @@ class TestConstants
 	public const MIME_TYPE_VID_QUICKTIME = 'video/quicktime';
 
 	public const SAMPLE_DOWNLOAD_JPG = 'https://github.com/LycheeOrg/Lychee/raw/master/tests/Samples/mongolia.jpeg';
+	public const SAMPLE_DOWNLOAD_JPG_WITHOUT_EXTENSION = 'https://github.com/LycheeOrg/Lychee/raw/master/tests/Samples/mongolia';
 	public const SAMPLE_DOWNLOAD_TIFF = 'https://github.com/LycheeOrg/Lychee/raw/master/tests/Samples/tiff.tif';
 
 	public const SAMPLE_FILE_AARHUS = 'tests/Samples/aarhus.jpg';

--- a/tests/Feature/PhotosAddMethodsTest.php
+++ b/tests/Feature/PhotosAddMethodsTest.php
@@ -214,6 +214,24 @@ class PhotosAddMethodsTest extends BasePhotoTest
 		]]);
 	}
 
+	public function testImportFromUrlWithoutExtension(): void
+	{
+		$response = $this->photos_tests->importFromUrl([TestConstants::SAMPLE_DOWNLOAD_JPG_WITHOUT_EXTENSION]);
+
+		$response->assertJson([[
+			'album_id' => null,
+			'title' => 'mongolia',
+			'type' => TestConstants::MIME_TYPE_IMG_JPEG,
+			'size_variants' => [
+				'original' => [
+					'width' => 1280,
+					'height' => 850,
+					'filesize' => 201316,
+				],
+			],
+		]]);
+	}
+
 	/**
 	 * Test import from URL of a supported raw image.
 	 *


### PR DESCRIPTION
Fixes #1652.
A mapping between MIME types and file extensions was added. When the file extension can't be extracted from the URL, a default extension is take from this mapping. 

In order for the test to run, #1863 needs to be merged first.