### PR TITLE
Make fileTimeModified parameter optional in Photo::add 

### DIFF
--- a/app/Http/Requests/Photo/AddPhotoRequest.php
+++ b/app/Http/Requests/Photo/AddPhotoRequest.php
@@ -15,7 +15,7 @@ class AddPhotoRequest extends BaseApiRequest implements HasAbstractAlbum
 	use HasAbstractAlbumTrait;
 	use AuthorizeCanEditAlbumTrait;
 
-	protected int $fileLastModifiedTime;
+	protected ?int $fileLastModifiedTime;
 	protected UploadedFile $file;
 
 	/**
@@ -36,7 +36,7 @@ class AddPhotoRequest extends BaseApiRequest implements HasAbstractAlbum
 			null :
 			$this->albumFactory->findAbstractAlbumOrFail($albumID);
 		// Convert the File Last Modified to seconds instead of milliseconds
-		$this->fileLastModifiedTime = $values[RequestAttribute::FILE_LAST_MODIFIED_TIME] / 1000;
+		$this->fileLastModifiedTime = $values[RequestAttribute::FILE_LAST_MODIFIED_TIME] ?? null;
 		$this->file = $files[RequestAttribute::FILE_ATTRIBUTE];
 	}
 
@@ -45,8 +45,8 @@ class AddPhotoRequest extends BaseApiRequest implements HasAbstractAlbum
 		return $this->file;
 	}
 
-	public function fileLastModifiedTime(): int
+	public function fileLastModifiedTime(): ?int
 	{
-		return $this->fileLastModifiedTime;
+		return $this->fileLastModifiedTime !== null ? intval($this->fileLastModifiedTime / 1000) : null;
 	}
 }

--- a/app/Http/RuleSets/Photo/AddPhotoRuleSet.php
+++ b/app/Http/RuleSets/Photo/AddPhotoRuleSet.php
@@ -18,7 +18,7 @@ class AddPhotoRuleSet implements RuleSet
 	{
 		return [
 			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['present', new AlbumIDRule(true)],
-			RequestAttribute::FILE_LAST_MODIFIED_TIME => 'required|numeric',
+			RequestAttribute::FILE_LAST_MODIFIED_TIME => 'sometimes|nullable|numeric',
 			RequestAttribute::FILE_ATTRIBUTE => 'required|file',
 		];
 	}

--- a/app/Jobs/ProcessImageJob.php
+++ b/app/Jobs/ProcessImageJob.php
@@ -38,7 +38,7 @@ class ProcessImageJob implements ShouldQueue
 	public string $originalBaseName;
 	public ?string $albumId;
 	public int $userId;
-	public int $fileLastModifiedTime;
+	public ?int $fileLastModifiedTime;
 
 	/**
 	 * Create a new job instance.
@@ -46,7 +46,7 @@ class ProcessImageJob implements ShouldQueue
 	public function __construct(
 		ProcessableJobFile $file,
 		?AbstractAlbum $albumId,
-		int $fileLastModifiedTime,
+		?int $fileLastModifiedTime,
 	) {
 		$this->filePath = $file->getPath();
 		$this->originalBaseName = $file->getOriginalBasename();

--- a/tests/Feature/LibUnitTests/PhotosUnitTest.php
+++ b/tests/Feature/LibUnitTests/PhotosUnitTest.php
@@ -46,7 +46,6 @@ class PhotosUnitTest
 	): TestResponse {
 		$params = [
 			'albumID' => $albumID,
-			'fileLastModifiedTime' => $fileLastModifiedTime,
 			'file' => $file,
 		];
 

--- a/tests/Feature/LibUnitTests/PhotosUnitTest.php
+++ b/tests/Feature/LibUnitTests/PhotosUnitTest.php
@@ -44,12 +44,18 @@ class PhotosUnitTest
 		?string $assertSee = null,
 		?int $fileLastModifiedTime = 1678824303000
 	): TestResponse {
+		$params = [
+			'albumID' => $albumID,
+			'fileLastModifiedTime' => $fileLastModifiedTime,
+			'file' => $file,
+		];
+
+		if ($fileLastModifiedTime !== null) {
+			$params['fileLastModifiedTime'] = $fileLastModifiedTime;
+		}
+
 		$response = $this->testCase->post(
-			'/api/Photo::add', [
-				'albumID' => $albumID,
-				'fileLastModifiedTime' => $fileLastModifiedTime,
-				'file' => $file,
-			], [
+			'/api/Photo::add', $params, [
 				'CONTENT_TYPE' => 'multipart/form-data',
 				'Accept' => 'application/json',
 			]

--- a/tests/Feature/LibUnitTests/PhotosUnitTest.php
+++ b/tests/Feature/LibUnitTests/PhotosUnitTest.php
@@ -107,26 +107,6 @@ class PhotosUnitTest
 	}
 
 	/**
-	 * Try uploading a picture without the file's last modified time.
-	 */
-	public function wrong_upload3(UploadedFile $file): void
-	{
-		$response = $this->testCase->post(
-			'/api/Photo::add',
-			[
-				'albumID' => null,
-				'file' => $file,
-			], [
-				'CONTENT_TYPE' => 'multipart/form-data',
-				'Accept' => 'application/json',
-			]
-		);
-
-		$response->assertUnprocessable();
-		$response->assertSee('The file last modified time field is required.');
-	}
-
-	/**
 	 * Get a photo given a photo id.
 	 *
 	 * @param string      $photo_id

--- a/tests/Feature/PhotosAddNegativeTest.php
+++ b/tests/Feature/PhotosAddNegativeTest.php
@@ -39,7 +39,6 @@ class PhotosAddNegativeTest extends BasePhotoTest
 	{
 		$this->photos_tests->wrong_upload();
 		$this->photos_tests->wrong_upload2();
-		$this->photos_tests->wrong_upload3(AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_SUNSET_IMAGE));
 	}
 
 	public function testImportViaDeniedMove(): void

--- a/tests/Feature/PhotosOperationsTest.php
+++ b/tests/Feature/PhotosOperationsTest.php
@@ -540,4 +540,18 @@ class PhotosOperationsTest extends BasePhotoTest
 		$photo = new Photo();
 		$photo->live_photo_full_path = 'Something';
 	}
+
+	/**
+	 * Test uploading without timeData.
+	 */
+	public function testUploadTimeFromFileTimeNull(): void
+	{
+		Auth::loginUsingId(1);
+		$this->photos_tests->upload(
+			self::createUploadedFile(TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE),
+			albumID: null,
+			expectedStatusCode: 201,
+			assertSee: null,
+			fileLastModifiedTime: null);
+	}
 }


### PR DESCRIPTION
This should solve problems when this value is not available to the user by restriction of the browser.