### PR TITLE
Support ratio

### DIFF
--- a/app/DTO/ImageDimension.php
+++ b/app/DTO/ImageDimension.php
@@ -11,11 +11,12 @@ class ImageDimension extends ArrayableDTO
 	}
 
 	/**
-	 * Return the ratio given width and height
-	 * 
-	 * @return float 
+	 * Return the ratio given width and height.
+	 *
+	 * @return float
 	 */
-	public function getRatio(): float {
+	public function getRatio(): float
+	{
 		return $this->height > 0 ? $this->width / $this->height : 0;
 	}
 }

--- a/app/DTO/ImageDimension.php
+++ b/app/DTO/ImageDimension.php
@@ -9,4 +9,13 @@ class ImageDimension extends ArrayableDTO
 		public int $height
 	) {
 	}
+
+	/**
+	 * Return the ratio given width and height
+	 * 
+	 * @return float 
+	 */
+	public function getRatio(): float {
+		return $this->height > 0 ? $this->width / $this->height : 0;
+	}
 }

--- a/app/Models/Extensions/SizeVariants.php
+++ b/app/Models/Extensions/SizeVariants.php
@@ -174,7 +174,7 @@ class SizeVariants extends AbstractDTO
 			$result->width = $dim->width;
 			$result->height = $dim->height;
 			$result->filesize = $filesize;
-			$result->ratio = $dim->getRatio(); 
+			$result->ratio = $dim->getRatio();
 			$result->save();
 			$this->add($result);
 

--- a/app/Models/Extensions/SizeVariants.php
+++ b/app/Models/Extensions/SizeVariants.php
@@ -174,6 +174,7 @@ class SizeVariants extends AbstractDTO
 			$result->width = $dim->width;
 			$result->height = $dim->height;
 			$result->filesize = $filesize;
+			$result->ratio = $dim->getRatio(); 
 			$result->save();
 			$this->add($result);
 

--- a/database/migrations/2022_12_05_195600_enable_disable_smart_albums.php
+++ b/database/migrations/2022_12_05_195600_enable_disable_smart_albums.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class() extends Migration {
 	/**

--- a/database/migrations/2022_12_26_101639_allow_username_change.php
+++ b/database/migrations/2022_12_26_101639_allow_username_change.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class() extends Migration {
 	/**

--- a/database/migrations/2023_02_23_192505_add_auto_fix_orientation_setting.php
+++ b/database/migrations/2023_02_23_192505_add_auto_fix_orientation_setting.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class() extends Migration {
 	/**

--- a/database/migrations/2023_04_05_150625_queue-processing.php
+++ b/database/migrations/2023_04_05_150625_queue-processing.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class() extends Migration {
 	/**

--- a/database/migrations/2023_05_04_193000_add_use_last_modified_date_when_no_exit_date_setting.php
+++ b/database/migrations/2023_05_04_193000_add_use_last_modified_date_when_no_exit_date_setting.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class() extends Migration {
 	/**

--- a/database/migrations/2023_07_07_143908_add_ratio_size_variants.php
+++ b/database/migrations/2023_07_07_143908_add_ratio_size_variants.php
@@ -1,5 +1,6 @@
 <?php
 
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
@@ -7,7 +8,6 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class() extends Migration {
-
 	private AbstractSchemaManager $schemaManager;
 
 	/**
@@ -28,11 +28,11 @@ return new class() extends Migration {
 			// This index is required by \App\Actions\SizeVariant\Delete::do()
 			// for `SizeVariant::query()`
 			$table->float('ratio')->after('height')->default(1);
-			$table->index(['photo_id','type','ratio']);
+			$table->index(['photo_id', 'type', 'ratio']);
 		});
 
 		DB::table('size_variants')
-			->where('height','>', 0)
+			->where('height', '>', 0)
 			->update(['ratio' => DB::raw('width / height')]);
 	}
 
@@ -41,29 +41,28 @@ return new class() extends Migration {
 	 */
 	public function down(): void
 	{
+		Schema::table('photos', function (Blueprint $table) {
+			$this->dropIndexIfExists($table, 'photo_id_type_ratio_index');
+		});
 
-	Schema::table('photos', function (Blueprint $table) {
-		$this->dropIndexIfExists($table, 'photo_id_type_ratio_index');
-	});
-
-	Schema::table('size_variants', function (Blueprint $table) {
-		$table->dropColumn('ratio');
-	});
-}
-
-/**
- * A helper function that allows to drop an index if exists.
- *
- * @param Blueprint $table
- * @param string    $indexName
- *
- * @throws DBALException
- */
-private function dropIndexIfExists(Blueprint $table, string $indexName): void
-{
-	$doctrineTable = $this->schemaManager->introspectTable($table->getTable());
-	if ($doctrineTable->hasIndex($indexName)) {
-		$table->dropIndex($indexName);
+		Schema::table('size_variants', function (Blueprint $table) {
+			$table->dropColumn('ratio');
+		});
 	}
-}
+
+	/**
+	 * A helper function that allows to drop an index if exists.
+	 *
+	 * @param Blueprint $table
+	 * @param string    $indexName
+	 *
+	 * @throws DBALException
+	 */
+	private function dropIndexIfExists(Blueprint $table, string $indexName): void
+	{
+		$doctrineTable = $this->schemaManager->introspectTable($table->getTable());
+		if ($doctrineTable->hasIndex($indexName)) {
+			$table->dropIndex($indexName);
+		}
+	}
 };

--- a/database/migrations/2023_07_07_143908_add_ratio_size_variants.php
+++ b/database/migrations/2023_07_07_143908_add_ratio_size_variants.php
@@ -1,0 +1,69 @@
+<?php
+
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+
+	private AbstractSchemaManager $schemaManager;
+
+	/**
+	 * @throws DBALException
+	 */
+	public function __construct()
+	{
+		$connection = Schema::connection(null)->getConnection();
+		$this->schemaManager = $connection->getDoctrineSchemaManager();
+	}
+
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		Schema::table('size_variants', function (Blueprint $table) {
+			// This index is required by \App\Actions\SizeVariant\Delete::do()
+			// for `SizeVariant::query()`
+			$table->float('ratio')->after('height')->default(1);
+			$table->index(['photo_id','type','ratio']);
+		});
+
+		DB::table('size_variants')
+			->where('height','>', 0)
+			->update(['ratio' => DB::raw('width / height')]);
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+
+	Schema::table('photos', function (Blueprint $table) {
+		$this->dropIndexIfExists($table, 'photo_id_type_ratio_index');
+	});
+
+	Schema::table('size_variants', function (Blueprint $table) {
+		$table->dropColumn('ratio');
+	});
+}
+
+/**
+ * A helper function that allows to drop an index if exists.
+ *
+ * @param Blueprint $table
+ * @param string    $indexName
+ *
+ * @throws DBALException
+ */
+private function dropIndexIfExists(Blueprint $table, string $indexName): void
+{
+	$doctrineTable = $this->schemaManager->introspectTable($table->getTable());
+	if ($doctrineTable->hasIndex($indexName)) {
+		$table->dropIndex($indexName);
+	}
+}
+};


### PR DESCRIPTION
This adds support for ratio inside the DB.
This will be needed by the livewire front-end to quickly choose a hero image (we want a landscape image).
Unfortunately if we do not pre-compute this, it slows down the search as it relies on file_sort.
For this reason, it is more interesting to support the data directly in the database.