### PR TITLE
Fix NSFW not toggling via Protection Panel

### DIFF
--- a/app/Actions/Album/SetProtectionPolicy.php
+++ b/app/Actions/Album/SetProtectionPolicy.php
@@ -30,6 +30,8 @@ class SetProtectionPolicy extends Action
 	public function do(BaseAlbum $album, AlbumProtectionPolicy $protectionPolicy, bool $shallSetPassword, ?string $password): void
 	{
 		$album->is_nsfw = $protectionPolicy->is_nsfw;
+		$album->save();
+		
 		$active_permissions = $album->public_permissions();
 
 		if (!$protectionPolicy->is_public) {

--- a/app/Actions/Album/SetProtectionPolicy.php
+++ b/app/Actions/Album/SetProtectionPolicy.php
@@ -31,7 +31,7 @@ class SetProtectionPolicy extends Action
 	{
 		$album->is_nsfw = $protectionPolicy->is_nsfw;
 		$album->save();
-		
+
 		$active_permissions = $album->public_permissions();
 
 		if (!$protectionPolicy->is_public) {

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -964,13 +964,13 @@ class AlbumTest extends AbstractTestCase
 		Auth::loginUsingId(1);
 		$albumID1 = $this->albums_tests->add(null, 'Test Album')->offsetGet('id');
 		$res = $this->albums_tests->get($albumID1);
-		$res->assertJson(["policy" => ['is_nsfw' => false]]);
+		$res->assertJson(['policy' => ['is_nsfw' => false]]);
 		$this->albums_tests->set_protection_policy(id: $albumID1, is_nsfw: true);
 		$res = $this->albums_tests->get($albumID1);
-		$res->assertJson(["policy" => ['is_nsfw' => true]]);
+		$res->assertJson(['policy' => ['is_nsfw' => true]]);
 		$this->albums_tests->set_protection_policy(id: $albumID1, is_nsfw: false);
 		$res = $this->albums_tests->get($albumID1);
-		$res->assertJson(["policy" => ['is_nsfw' => false]]);
+		$res->assertJson(['policy' => ['is_nsfw' => false]]);
 		Auth::logout();
 	}
 }

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -964,13 +964,13 @@ class AlbumTest extends AbstractTestCase
 		Auth::loginUsingId(1);
 		$albumID1 = $this->albums_tests->add(null, 'Test Album')->offsetGet('id');
 		$res = $this->albums_tests->get($albumID1);
-		$res->assertJson(['is_nsfw' => false]);
+		$res->assertJson(["policy" => ['is_nsfw' => false]]);
 		$this->albums_tests->set_protection_policy(id: $albumID1, is_nsfw: true);
 		$res = $this->albums_tests->get($albumID1);
-		$res->assertJson(['is_nsfw' => true]);
+		$res->assertJson(["policy" => ['is_nsfw' => true]]);
 		$this->albums_tests->set_protection_policy(id: $albumID1, is_nsfw: false);
 		$res = $this->albums_tests->get($albumID1);
-		$res->assertJson(['is_nsfw' => false]);
+		$res->assertJson(["policy" => ['is_nsfw' => false]]);
 		Auth::logout();
 	}
 }

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -23,6 +23,9 @@ use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Session;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\AssertionFailedError;
+use Illuminate\Testing\Exceptions\InvalidArgumentException;
 use Tests\AbstractTestCase;
 use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\LibUnitTests\AlbumsUnitTest;
@@ -34,6 +37,7 @@ use Tests\Feature\Traits\InteractWithSmartAlbums;
 use Tests\Feature\Traits\RequiresEmptyAlbums;
 use Tests\Feature\Traits\RequiresEmptyPhotos;
 use Tests\Feature\Traits\RequiresEmptyUsers;
+use Throwable;
 
 class AlbumTest extends AbstractTestCase
 {
@@ -946,5 +950,32 @@ class AlbumTest extends AbstractTestCase
 		$album1->assertDontSee($albumID3);
 
 		Configs::set(TestConstants::CONFIG_DEFAULT_ALBUM_PROTECTION, $defaultProtectionType);
+	}
+
+	/**
+	 * Test that setting NSFW via the Protection Policy works.
+	 * 1. Create album
+	 * 2. check nsfw is false
+	 * 3. set nsfw to true
+	 * 4. check nsfw is true
+	 * 5. set nsfw to false
+	 * 6. check nsfw is false
+	 * 
+	 * 
+	 * @return void 
+	 */
+	public function testNSFWViaProtectionPolicy(): void
+	{
+		Auth::loginUsingId(1);
+		$albumID1 = $this->albums_tests->add(null, 'Test Album')->offsetGet('id');
+		$res = $this->albums_tests->get($albumID1);
+		$res->assertJson(['is_nsfw' => false]);
+		$this->albums_tests->set_protection_policy(id: $albumID1, is_nsfw:true);
+		$res = $this->albums_tests->get($albumID1);
+		$res->assertJson(['is_nsfw' => true]);
+		$this->albums_tests->set_protection_policy(id: $albumID1, is_nsfw:false);
+		$res = $this->albums_tests->get($albumID1);
+		$res->assertJson(['is_nsfw' => false]);
+		Auth::logout();
 	}
 }

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -23,9 +23,6 @@ use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Session;
-use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\AssertionFailedError;
-use Illuminate\Testing\Exceptions\InvalidArgumentException;
 use Tests\AbstractTestCase;
 use Tests\Feature\Constants\TestConstants;
 use Tests\Feature\LibUnitTests\AlbumsUnitTest;
@@ -37,7 +34,6 @@ use Tests\Feature\Traits\InteractWithSmartAlbums;
 use Tests\Feature\Traits\RequiresEmptyAlbums;
 use Tests\Feature\Traits\RequiresEmptyPhotos;
 use Tests\Feature\Traits\RequiresEmptyUsers;
-use Throwable;
 
 class AlbumTest extends AbstractTestCase
 {
@@ -959,10 +955,9 @@ class AlbumTest extends AbstractTestCase
 	 * 3. set nsfw to true
 	 * 4. check nsfw is true
 	 * 5. set nsfw to false
-	 * 6. check nsfw is false
-	 * 
-	 * 
-	 * @return void 
+	 * 6. check nsfw is false.
+	 *
+	 * @return void
 	 */
 	public function testNSFWViaProtectionPolicy(): void
 	{
@@ -970,10 +965,10 @@ class AlbumTest extends AbstractTestCase
 		$albumID1 = $this->albums_tests->add(null, 'Test Album')->offsetGet('id');
 		$res = $this->albums_tests->get($albumID1);
 		$res->assertJson(['is_nsfw' => false]);
-		$this->albums_tests->set_protection_policy(id: $albumID1, is_nsfw:true);
+		$this->albums_tests->set_protection_policy(id: $albumID1, is_nsfw: true);
 		$res = $this->albums_tests->get($albumID1);
 		$res->assertJson(['is_nsfw' => true]);
-		$this->albums_tests->set_protection_policy(id: $albumID1, is_nsfw:false);
+		$this->albums_tests->set_protection_policy(id: $albumID1, is_nsfw: false);
 		$res = $this->albums_tests->get($albumID1);
 		$res->assertJson(['is_nsfw' => false]);
 		Auth::logout();


### PR DESCRIPTION
- [x] Step 1. Create breaking tests.
- [x] Step 2. Fix code.

:)
```diff
Failed asserting that an array has the subset Array &0 (
    'policy' => Array &1 (
        'is_nsfw' => true
    )
).
--- Expected
+++ Actual
@@ @@
   array (
     'is_public' => true,
     'is_link_required' => false,
-    'is_nsfw' => true,
+    'is_nsfw' => false,
     'grants_full_photo_access' => true,
     'grants_download' => true,
     'is_password_required' => false,
```