### PR TITLE
Fixes #1942 "Content-Security-Policy blocks blob requests required for Google Motion Pictures images" 

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -388,6 +388,7 @@ return [
 				'https://b.osm.rrze.fau.de/osmhd/',
 				'https://c.osm.rrze.fau.de/osmhd/',
 				'data:', // required by openstreetmap
+				'blob:', // required for "live" photos
 			],
 		],
 
@@ -398,6 +399,9 @@ return [
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/media-src
 		'media-src' => [
 			'self' => true,
+			'allow' => [
+				'blob:', // required for "live" photos
+			],
 		],
 
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/navigate-to


### PR DESCRIPTION
Fixes #1942

Live photos make "blob:" requests, currently that results in an error: Content-Security-Policy: The page’s settings blocked the loading of a resource at blob:https://xxx.com/48d5c8e8-8bac-43af-92d0-b13eda3f6eb6 (“media-src”). and
Content-Security-Policy: The page’s settings blocked the loading of a resource at blob:https://xxx.com/f8d5c8e8-8bac-43af-92d0-b13eda3f6eb6 (“img-src”).

This change fixes that.