### PR TITLE
fix complaints in Diagnostics when no migrations has been run

### DIFF
--- a/app/Actions/Diagnostics/Configuration.php
+++ b/app/Actions/Diagnostics/Configuration.php
@@ -4,6 +4,7 @@ namespace App\Actions\Diagnostics;
 
 use App\Exceptions\Internal\QueryBuilderException;
 use App\Models\Configs;
+use Illuminate\Support\Facades\Schema;
 
 class Configuration
 {
@@ -17,6 +18,10 @@ class Configuration
 	 */
 	public function get(): array
 	{
+		if (!Schema::hasTable('configs')) {
+			return ['Error: migration has not been run yet.'];
+		}
+
 		// Load settings
 		$settings = Configs::query()
 			->where('confidentiality', '<=', 2)

--- a/app/Actions/Diagnostics/Pipes/Checks/AdminUserExistsCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/AdminUserExistsCheck.php
@@ -4,6 +4,7 @@ namespace App\Actions\Diagnostics\Pipes\Checks;
 
 use App\Contracts\DiagnosticPipe;
 use App\Models\User;
+use Illuminate\Support\Facades\Schema;
 
 class AdminUserExistsCheck implements DiagnosticPipe
 {
@@ -12,6 +13,10 @@ class AdminUserExistsCheck implements DiagnosticPipe
 	 */
 	public function handle(array &$data, \Closure $next): array
 	{
+		if (!Schema::hasTable('users')) {
+			return $next($data);
+		}
+
 		$numberOfAdmin = User::query()->where('may_administrate', '=', true)->count();
 		if ($numberOfAdmin === 0) {
 			$data[] = 'Error: User Admin not found in database. Please run: "php lychee:create_user {username} {password}"';

--- a/app/Actions/Diagnostics/Pipes/Checks/ConfigSanityCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/ConfigSanityCheck.php
@@ -4,6 +4,7 @@ namespace App\Actions\Diagnostics\Pipes\Checks;
 
 use App\Contracts\DiagnosticPipe;
 use App\Models\Configs;
+use Illuminate\Support\Facades\Schema;
 
 /**
  * Small checks on the content of the config database.
@@ -18,6 +19,10 @@ class ConfigSanityCheck implements DiagnosticPipe
 	 */
 	public function handle(array &$data, \Closure $next): array
 	{
+		if (!Schema::hasTable('configs')) {
+			return $next($data);
+		}
+
 		// Load settings
 		$this->settings = Configs::get();
 

--- a/app/Actions/Diagnostics/Pipes/Checks/DBIntegrityCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/DBIntegrityCheck.php
@@ -5,6 +5,7 @@ namespace App\Actions\Diagnostics\Pipes\Checks;
 use App\Contracts\DiagnosticPipe;
 use App\Models\Photo;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 /**
  * This checks the Database integrity.
@@ -19,6 +20,10 @@ class DBIntegrityCheck implements DiagnosticPipe
 	 */
 	public function handle(array &$data, \Closure $next): array
 	{
+		if (!Schema::hasTable('size_variants') || !Schema::hasTable('photos')) {
+			return $next($data);
+		}
+
 		$subJoin = DB::table('size_variants')->where('size_variants.type', '=', 0);
 		$photos = Photo::query()
 			->with(['album'])

--- a/app/Actions/Diagnostics/Pipes/Checks/ImageOptCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/ImageOptCheck.php
@@ -5,6 +5,7 @@ namespace App\Actions\Diagnostics\Pipes\Checks;
 use App\Contracts\DiagnosticPipe;
 use App\Facades\Helpers;
 use App\Models\Configs;
+use Illuminate\Support\Facades\Schema;
 use function Safe\exec;
 use Spatie\ImageOptimizer\Optimizers\Cwebp;
 use Spatie\ImageOptimizer\Optimizers\Gifsicle;
@@ -23,6 +24,10 @@ class ImageOptCheck implements DiagnosticPipe
 	 */
 	public function handle(array &$data, \Closure $next): array
 	{
+		if (!Schema::hasTable('configs')) {
+			return $next($data);
+		}
+
 		$tools = [];
 		$tools[] = new Cwebp();
 		$tools[] = new Gifsicle();

--- a/app/Actions/Diagnostics/Pipes/Checks/UpdatableCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/UpdatableCheck.php
@@ -11,6 +11,7 @@ use App\Facades\Helpers;
 use App\Metadata\Versions\GitHubVersion;
 use App\Metadata\Versions\InstalledVersion;
 use App\Models\Configs;
+use Illuminate\Support\Facades\Schema;
 use function Safe\exec;
 
 /**
@@ -63,6 +64,9 @@ class UpdatableCheck implements DiagnosticPipe
 			// @codeCoverageIgnoreStart
 			return;
 			// @codeCoverageIgnoreEnd
+		}
+		if (!Schema::hasTable('configs')) {
+			throw new ConfigurationException('Migration is not run');
 		}
 
 		if (!Configs::getValueAsBool('allow_online_git_pull')) {

--- a/app/Metadata/Versions/InstalledVersion.php
+++ b/app/Metadata/Versions/InstalledVersion.php
@@ -8,6 +8,7 @@ use App\DTO\Version;
 use App\Exceptions\ConfigurationKeyMissingException;
 use App\Models\Configs;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
 
 /**
  * InstalledVersion contains the following info:
@@ -61,6 +62,10 @@ class InstalledVersion implements HasVersion, HasIsRelease
 	 */
 	public function getVersion(): Version
 	{
+		if (!Schema::hasTable('configs')) {
+			return Version::createFromInt(10000);
+		}
+
 		return Version::createFromInt(Configs::getValueAsInt('version'));
 	}
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -96,9 +96,15 @@ class AppServiceProvider extends ServiceProvider
 			DB::listen(fn ($q) => $this->logSQL($q));
 		}
 
-		if (Schema::hasTable('configs')) {
+		try {
 			$lang = Configs::getValueAsString('lang');
 			app()->setLocale($lang);
+		} catch (\Throwable $e) {
+			/** Ignore.
+			 * This is necessary so that we can continue:
+			 * - if Configs table do not exists (no install),
+			 * - if the value does not exists in configs (no install),.
+			 */
 		}
 
 		/**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -30,6 +30,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Opcodes\LogViewer\Facades\LogViewer;
@@ -95,16 +96,9 @@ class AppServiceProvider extends ServiceProvider
 			DB::listen(fn ($q) => $this->logSQL($q));
 		}
 
-		try {
+		if (Schema::hasTable('configs')) {
 			$lang = Configs::getValueAsString('lang');
 			app()->setLocale($lang);
-		} catch (\Throwable $e) {
-			/** log and ignore.
-			 * This is necessary so that we can continue:
-			 * - if Configs table do not exists (no install),
-			 * - if the value does not exists in configs (no install),.
-			 */
-			logger($e);
 		}
 
 		/**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -30,7 +30,6 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Opcodes\LogViewer\Facades\LogViewer;


### PR DESCRIPTION
Fixes complaint seen in #1988
>Output of the diagnostics [REQUIRED]
>```
> /crashplan/www/lychee# php artisan lychee:diagnostics
>
>In Connection.php line 795:
>
>SQLSTATE[42S22]: Column not found: 1054 Unknown column 'may_administrate' in 'where clause' (Connection: mysql, >SQL: select count(*) as aggregate
>from users where may_administrate = 1)
>
>In Connection.php line 416:
>
>SQLSTATE[42S22]: Column not found: 1054 Unknown column 'may_administrate' in 'where clause'
>```

Basically skip any check that requires a DB interaction.
