### PR TITLE
Fixes #1950 : Do not enforce strict model when downloading

### DIFF
--- a/app/Actions/Album/Archive.php
+++ b/app/Actions/Album/Archive.php
@@ -13,6 +13,7 @@ use App\Models\TagAlbum;
 use App\Policies\AlbumPolicy;
 use App\Policies\PhotoPolicy;
 use App\SmartAlbums\BaseSmartAlbum;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
 use Safe\Exceptions\InfoException;
@@ -49,6 +50,9 @@ class Archive extends Action
 	 */
 	public function do(Collection $albums): StreamedResponse
 	{
+		// For this specific case we must allow lazy loading.
+		Model::shouldBeStrict(false);
+
 		$this->deflateLevel = Configs::getValueAsInt('zip_deflate_level');
 
 		$responseGenerator = function () use ($albums) {

--- a/app/Actions/Album/Archive.php
+++ b/app/Actions/Album/Archive.php
@@ -50,7 +50,13 @@ class Archive extends Action
 	 */
 	public function do(Collection $albums): StreamedResponse
 	{
-		// For this specific case we must allow lazy loading.
+		// Issue #1950: Setting Model::shouldBeStrict(); in /app/Providers/AppServiceProvider.php breaks recursive album download.
+		// 
+		// From my understanding it is because when we query an album with it's relations (photos & children),
+		// the relations of the children are not populated.
+		// As a result, when we try to query the picture list of those, it breaks.
+		// In that specific case, it is better to simply disable Model::shouldBeStrict() and eat the recursive SQL queries:
+		// for this specific case we must allow lazy loading.
 		Model::shouldBeStrict(false);
 
 		$this->deflateLevel = Configs::getValueAsInt('zip_deflate_level');

--- a/app/Actions/Album/Archive.php
+++ b/app/Actions/Album/Archive.php
@@ -51,7 +51,7 @@ class Archive extends Action
 	public function do(Collection $albums): StreamedResponse
 	{
 		// Issue #1950: Setting Model::shouldBeStrict(); in /app/Providers/AppServiceProvider.php breaks recursive album download.
-		// 
+		//
 		// From my understanding it is because when we query an album with it's relations (photos & children),
 		// the relations of the children are not populated.
 		// As a result, when we try to query the picture list of those, it breaks.


### PR DESCRIPTION
Fixes #1950

> From my understanding it is because when we query a model with it's relations, the subsequent relations are not populated. Because an albums has sub albums (children). When we try to query the picture list of those, it breaks.
> 
> In that specific case, it might be better to simply disable the `Model::shouldBeStrict()` and eat the recursive SQL queries.
