### PR TITLE
fixes #1686 by providing absolute path if not set

### DIFF
--- a/app/Console/Commands/PhotosAddedNotification.php
+++ b/app/Console/Commands/PhotosAddedNotification.php
@@ -9,6 +9,8 @@ use App\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
 
 class PhotosAddedNotification extends Command
 {
@@ -58,6 +60,12 @@ class PhotosAddedNotification extends Command
 					}
 
 					$thumbUrl = $photo->size_variants->getThumb()?->url;
+
+					// Mail clients do not like relative paths.
+					// if url does not start with 'http', it is not absolute...
+					if (!Str::startsWith('http', $thumbUrl)) {
+						$thumbUrl = URL::asset($thumbUrl);
+					}
 
 					// If the url config doesn't contain a trailing slash then add it
 					if (str_ends_with(config('app.url'), '/')) {

--- a/app/Models/SizeVariant.php
+++ b/app/Models/SizeVariant.php
@@ -21,6 +21,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\URL;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 
 // TODO: Uncomment the following line, if Lychee really starts to support AWS s3.


### PR DESCRIPTION
Fixes #1686

> I believe this is because the value of LYCHEE_UPLOADS_URL is not set in your .env
> By default the value is `upload/` but if you load this in a mail client, I believe this will not be working.