### PR TITLE
Fix album decorations

### DIFF
--- a/app/Http/Resources/ConfigurationResource.php
+++ b/app/Http/Resources/ConfigurationResource.php
@@ -4,6 +4,8 @@ namespace App\Http\Resources;
 
 use App\DTO\AlbumSortingCriterion;
 use App\DTO\PhotoSortingCriterion;
+use App\Enum\AlbumDecorationType;
+use App\Enum\AlbumDecorationOrientation;
 use App\Enum\DefaultAlbumProtectionType;
 use App\Enum\ThumbAlbumSubtitleType;
 use App\Exceptions\Handler;
@@ -118,6 +120,8 @@ class ConfigurationResource extends JsonResource
 				],
 			]),
 
+			'album_decoration' => Configs::getValueAsEnum('album_decoration', AlbumDecorationType::class),
+			'album_decoration_orientation' => Configs::getValueAsEnum('album_decoration_orientation', AlbumDecorationOrientation::class),
 			'album_subtitle_type' => Configs::getValueAsEnum('album_subtitle_type', ThumbAlbumSubtitleType::class),
 			'check_for_updates' => Configs::getValueAsBool('check_for_updates'),
 			'default_album_protection' => Configs::getValueAsEnum('default_album_protection', DefaultAlbumProtectionType::class),

--- a/app/Http/Resources/ConfigurationResource.php
+++ b/app/Http/Resources/ConfigurationResource.php
@@ -4,8 +4,8 @@ namespace App\Http\Resources;
 
 use App\DTO\AlbumSortingCriterion;
 use App\DTO\PhotoSortingCriterion;
-use App\Enum\AlbumDecorationType;
 use App\Enum\AlbumDecorationOrientation;
+use App\Enum\AlbumDecorationType;
 use App\Enum\DefaultAlbumProtectionType;
 use App\Enum\ThumbAlbumSubtitleType;
 use App\Exceptions\Handler;


### PR DESCRIPTION
Fixes #2002. Restores album decorations to their former glory 😄 

An accompanying PR for Lychee-front addresses the minor (and unrelated) issue with the zero or undefined photo count.

Thanks to @ildyria to pointing me right to ConfigurationResource.php!