### PR TITLE
fix max/min_taken_at

### DIFF
--- a/app/Http/Resources/Models/AlbumResource.php
+++ b/app/Http/Resources/Models/AlbumResource.php
@@ -58,8 +58,8 @@ class AlbumResource extends JsonResource
 			// timestamps
 			'created_at' => $this->resource->created_at->toIso8601String(),
 			'updated_at' => $this->resource->updated_at->toIso8601String(),
-			'max_taken_at' => $this->resource->min_taken_at?->toIso8601String(),
-			'min_taken_at' => $this->resource->max_taken_at?->toIso8601String(),
+			'max_taken_at' => $this->resource->max_taken_at?->toIso8601String(),
+			'min_taken_at' => $this->resource->min_taken_at?->toIso8601String(),
 
 			// security
 			'policy' => AlbumProtectionPolicy::ofBaseAlbum($this->resource),


### PR DESCRIPTION
Fixes #2004.

When retrieving `max_taken_at` and `min_taken_at` from server the two values were mismatched.

Again kudos to @ildyria for instantly pointing me in the right direction!