### PR TITLE
map providers are now specified in an Enum

### DIFF
--- a/app/Enum/MapProviders.php
+++ b/app/Enum/MapProviders.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Enum;
+
+/**
+ * Define the possible Map providers and their layer & attributions.
+ * (will be used later in Livewire).
+ */
+enum MapProviders: string
+{
+	case Wikimedia = 'Wikimedia';
+	case OpenStreetMapOrg = 'OpenStreetMap.org';
+	case OpenStreetMapDe = 'OpenStreetMap.de';
+	case OpenStreetMapFr = 'OpenStreetMap.fr';
+	case RRZE = 'RRZE';
+
+	public function getLayer(): string
+	{
+		return match ($this) {
+			self::Wikimedia => 'https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}{r}.png',
+			self::OpenStreetMapOrg => 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+			self::OpenStreetMapDe => 'https://tile.openstreetmap.de/{z}/{x}/{y}.png ',
+			self::OpenStreetMapFr => 'https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png ',
+			self::RRZE => 'https://{s}.osm.rrze.fau.de/osmhd/{z}/{x}/{y}.png',
+		};
+	}
+
+	public function getAtributionHtml(): string
+	{
+		return match ($this) {
+			self::Wikimedia => '<a href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia</a>',
+			self::OpenStreetMapOrg => '&copy; <a href="https://openstreetmap.org/copyright">' . __('lychee.OSM_CONTRIBUTORS') . '</a>',
+			self::OpenStreetMapDe => '&copy; <a href="https://openstreetmap.org/copyright">' . __('lychee.OSM_CONTRIBUTORS') . '</a>',
+			self::OpenStreetMapFr => '&copy; <a href="https://openstreetmap.org/copyright">' . __('lychee.OSM_CONTRIBUTORS') . '</a>',
+			self::RRZE => '&copy; <a href="https://openstreetmap.org/copyright">' . __('lychee.OSM_CONTRIBUTORS') . '</a>',
+		};
+	}
+}

--- a/app/Http/Requests/Settings/SetMapProviderSettingRequest.php
+++ b/app/Http/Requests/Settings/SetMapProviderSettingRequest.php
@@ -2,7 +2,8 @@
 
 namespace App\Http\Requests\Settings;
 
-use Illuminate\Validation\Rule;
+use App\Enum\MapProviders;
+use Illuminate\Validation\Rules\Enum;
 
 class SetMapProviderSettingRequest extends AbstractSettingRequest
 {
@@ -11,19 +12,13 @@ class SetMapProviderSettingRequest extends AbstractSettingRequest
 	public function rules(): array
 	{
 		return [
-			self::ATTRIBUTE => ['required', 'string', Rule::in([
-				'Wikimedia',
-				'OpenStreetMap.org',
-				'OpenStreetMap.de',
-				'OpenStreetMap.fr',
-				'RRZE',
-			])],
+			self::ATTRIBUTE => ['required', new Enum(MapProviders::class)],
 		];
 	}
 
 	protected function processValidatedValues(array $values, array $files): void
 	{
 		$this->name = self::ATTRIBUTE;
-		$this->value = $values[self::ATTRIBUTE];
+		$this->value = MapProviders::from($values[self::ATTRIBUTE]);
 	}
 }

--- a/app/Http/Resources/ConfigurationResource.php
+++ b/app/Http/Resources/ConfigurationResource.php
@@ -10,6 +10,7 @@ use App\Enum\AlbumLayoutType;
 use App\Enum\DefaultAlbumProtectionType;
 use App\Enum\ImageOverlayType;
 use App\Enum\LicenseType;
+use App\Enum\MapProviders;
 use App\Enum\ThumbAlbumSubtitleType;
 use App\Exceptions\Handler;
 use App\Metadata\Versions\InstalledVersion;
@@ -147,7 +148,7 @@ class ConfigurationResource extends JsonResource
 			'map_display_direction' => Configs::getValueAsString('map_display_direction'),
 			'map_display_public' => Configs::getValueAsBool('map_display_public'),
 			'map_include_subalbums' => Configs::getValueAsBool('map_include_subalbums'),
-			'map_provider' => Configs::getValueAsString('map_provider'),
+			'map_provider' => Configs::getValueAsEnum('map_provider', MapProviders::class),
 			'mod_frame_enabled' => Configs::getValueAsBool('mod_frame_enabled'),
 			'mod_frame_refresh' => Configs::getValueAsInt('mod_frame_refresh'),
 			'new_photos_notification' => Configs::getValueAsBool('new_photos_notification'),

--- a/app/Models/Configs.php
+++ b/app/Models/Configs.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enum\LicenseType;
+use App\Enum\MapProviders;
 use App\Exceptions\ConfigurationKeyMissingException;
 use App\Exceptions\Internal\InvalidConfigOption;
 use App\Exceptions\Internal\LycheeAssertionError;
@@ -61,6 +62,7 @@ class Configs extends Model
 	protected const TERNARY = '0|1|2';
 	protected const DISABLED = '';
 	protected const LICENSE = 'license';
+	protected const MAP_PROVIDER = 'map_provider';
 
 	/**
 	 * The attributes that are mass assignable.
@@ -132,6 +134,11 @@ class Configs extends Model
 			case self::LICENSE:
 				if (LicenseType::tryFrom($candidateValue) === null) {
 					$message = sprintf($message_template, 'a valid license');
+				}
+				break;
+			case self::MAP_PROVIDER:
+				if (MapProviders::tryFrom($candidateValue) === null) {
+					$message = sprintf($message_template, 'a valid map provider');
 				}
 				break;
 			default:

--- a/database/migrations/2023_10_01_143159_config_map_provider.php
+++ b/database/migrations/2023_10_01_143159_config_map_provider.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class() extends Migration {
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		DB::table('configs')->where('key', '=', 'map_provider')->update(['type_range' => 'map_provider']);
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		DB::table('configs')->where('key', '=', 'map_provider')->update(['type_range' => 'Wikimedia|OpenStreetMap.org|OpenStreetMap.de|OpenStreetMap.fr|RRZE']);
+	}
+};


### PR DESCRIPTION
The migrations does not have impact with running the code.
For this reason I would suggest to keep that one also in 4.13.1.