### PR TITLE
Add check and execute npm only if the package.json exists.

### DIFF
--- a/scripts/post-merge
+++ b/scripts/post-merge
@@ -17,8 +17,13 @@ else
         echo "composer install"
         composer install
         if command -v npm > /dev/null; then
-        	echo "npm install --no-audit --no-fund"
-        	npm install --no-audit --no-fund
+            printf "\n${ORANGE}npm detected${NO_COLOR}\n"
+            if  [ -f "package.json" ]; then
+                echo "npm install --no-audit --no-fund"
+                npm install --no-audit --no-fund
+            else
+                printf "${GREEN}no package.json found${NO_COLOR}\n"
+            fi
         fi
     else
         printf "\n${ORANGE}--no-dev mode detected${NO_COLOR}\n"

--- a/scripts/post-merge
+++ b/scripts/post-merge
@@ -16,15 +16,6 @@ else
         printf "\n${ORANGE}Dev mode detected${NO_COLOR}\n"
         echo "composer install"
         composer install
-        if command -v npm > /dev/null; then
-            printf "\n${ORANGE}npm detected${NO_COLOR}\n"
-            if  [ -f "package.json" ]; then
-                echo "npm install --no-audit --no-fund"
-                npm install --no-audit --no-fund
-            else
-                printf "${GREEN}no package.json found${NO_COLOR}\n"
-            fi
-        fi
     else
         printf "\n${ORANGE}--no-dev mode detected${NO_COLOR}\n"
         echo "composer install --no-dev --prefer-dist"


### PR DESCRIPTION
Fixes #2063

This is a _temporary_ change as with Livewire the package.json will come back hence why I did not remove the command completely but added a simple check.