### PR TITLE
Diagnostics: Info are displayed in blue

### DIFF
--- a/app/Livewire/Components/Modules/Diagnostics/Errors.php
+++ b/app/Livewire/Components/Modules/Diagnostics/Errors.php
@@ -39,6 +39,12 @@ class Errors extends Component
 				$arr['line'] = Str::substr($line, 9);
 			}
 
+			if (Str::startsWith($line, 'Info: ')) {
+				$arr['color'] = 'text-primary-400';
+				$arr['type'] = 'Info:';
+				$arr['line'] = Str::substr($line, 6);
+			}
+
 			if (Str::startsWith($line, 'Error: ')) {
 				// @codeCoverageIgnoreStart
 				$arr['color'] = 'text-danger-600';


### PR DESCRIPTION
Before:
![image](https://github.com/LycheeOrg/Lychee/assets/627094/14cb93d8-1d50-4630-a7e6-92bf91e01415)


After:
![image](https://github.com/LycheeOrg/Lychee/assets/627094/eb219732-6c69-49fe-95dd-ffc8592ca590)
