### PR TITLE
Fix errors on access rights

### DIFF
--- a/resources/views/components/gallery/album/menu/menu.blade.php
+++ b/resources/views/components/gallery/album/menu/menu.blade.php
@@ -1,4 +1,4 @@
-@props(['album', 'userCount' => 0])
+@props(['album', 'rights', 'userCount' => 0])
 <div class="w-full flex justify-center flex-wrap flex-row-reverse" x-cloak x-show="albumFlags.isDetailsOpen" x-collapse.duration.300ms >
     <ul class="
         sm:mt-7 sm:px-7 mb-4
@@ -6,28 +6,31 @@
         max-xl:w-full max-xl:flex max-xl:justify-center
         ">
         <x-gallery.album.menu.item tab='0' >{{ __('lychee.ABOUT_ALBUM') }}</x-gallery.album.menu.item>
-        @if ($userCount > 1 && ($album instanceof \App\Models\Album))
+        @if ($rights->can_share_with_users === true && $userCount > 1 && ($album instanceof \App\Models\Album))
         <x-gallery.album.menu.item tab='1' >{{ __('lychee.SHARE_ALBUM') }}</x-gallery.album.menu.item>
         @endif
-        @if($album instanceof \App\Models\Album)
+        @if($album instanceof \App\Models\Album && $rights->can_delete === true)
         <x-gallery.album.menu.item tab='2' >{{ __('lychee.MOVE_ALBUM') }}</x-gallery.album.menu.item>
         @endif
+        @if($rights->can_delete === true)
         <x-gallery.album.menu.danger tab='3' >{{ "DANGER ZONE" }}</x-gallery.album.menu.danger>
+        @endif
     </ul>
     <div class="w-full xl:w-5/6 flex justify-center flex-wrap mb-4 sm:mt-7 pl-7" x-cloak x-show="albumFlags.activeTab === 0">
         <livewire:forms.album.properties :album="$album" />
         <livewire:forms.album.visibility :album="$album" />
     </div>
-    @if ($userCount > 1 && ($album instanceof \App\Models\Album))
+    @if ($rights->can_share_with_users === true && $userCount > 1 && ($album instanceof \App\Models\Album))
     <div class="w-full xl:w-5/6 flex justify-center flex-wrap mb-4 sm:mt-7 pl-7" x-cloak x-show="albumFlags.activeTab === 1">
         <livewire:forms.album.share-with :album="$album" />
     </div>
     @endif
-    @if($album instanceof \App\Models\Album)
+    @if($album instanceof \App\Models\Album && $rights->can_delete === true)
     <div class="w-full xl:w-5/6 flex justify-center flex-wrap mb-4 sm:mt-7 pl-7" x-cloak x-show="albumFlags.activeTab === 2">
         <livewire:forms.album.move-panel :album="$album" />
     </div>
     @endif
+    @if($rights->can_delete === true)
     <div class="w-full xl:w-5/6 flex justify-center flex-wrap mb-4 sm:mt-7 pl-7" x-cloak x-show="albumFlags.activeTab === 3">
             {{-- We only display this menu if there are more than 1 user, it does not make sense otherwise --}}
             @if ($userCount > 1)
@@ -35,4 +38,5 @@
             @endif
             <livewire:forms.album.delete-panel :album="$album" />
     </div>
+    @endif
 </div>

--- a/resources/views/livewire/pages/gallery/album.blade.php
+++ b/resources/views/livewire/pages/gallery/album.blade.php
@@ -32,7 +32,7 @@
             class="relative flex flex-wrap content-start w-full justify-start overflow-y-auto"
             x-bind:class="isFullscreen ? 'h-[calc(100vh-3px)]' : 'h-[calc(100vh-56px)]'">
             @if ($rights->can_edit && $flags->is_base_album)
-                <x-gallery.album.menu.menu :album="$this->album" :userCount="$this->num_users" />
+                <x-gallery.album.menu.menu :album="$this->album" :rights="$this->rights" :userCount="$this->num_users" />
             @endif
             @if ($this->albumFormatted !== null && ($num_albums > 0 || $num_photos > 0))
                 <x-gallery.album.hero x-show="! albumFlags.isDetailsOpen" />


### PR DESCRIPTION
Loading some components with high security in the mount would obviously fail and throw a 403.
We now avoid to mount those when we don't have the rights already.

Fixes #2164