### PR TITLE
Bump dependencies with Vite 5 & prevent some more type errors

### DIFF
--- a/app/Actions/Diagnostics/Pipes/Checks/IniSettingsCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/IniSettingsCheck.php
@@ -69,7 +69,7 @@ class IniSettingsCheck implements DiagnosticPipe
 		if (extension_loaded('xdebug')) {
 			// @codeCoverageIgnoreStart
 			$msg = config('app.debug') !== true
-			? 'Errror: xdebug is enabled although Lychee is not in debug mode. Outside of debugging, xdebug will generate significant slowdown on your application.'
+			? 'Error: xdebug is enabled although Lychee is not in debug mode. Outside of debugging, xdebug will generate significant slowdown on your application.'
 			: 'Warning: xdebug is enabled. This will generate significant slowdown on your application.';
 			$data[] = $msg;
 			// @codeCoverageIgnoreEnd

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,27 +7,27 @@
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^6.5.1",
                 "@types/justified-layout": "^4.1.4",
-                "autoprefixer": "^10.4.16",
+                "autoprefixer": "^10.4.17",
                 "justified-layout": "^4.1.0",
-                "laravel-vite-plugin": "^0.8.1",
+                "laravel-vite-plugin": "^1.0.1",
                 "lazysizes": "^5.3.2",
                 "leaflet": "^1.9.4",
                 "leaflet-gpx": "^1.7.0",
                 "leaflet-rotatedmarker": "^0.2.0",
-                "leaflet.markercluster": "^1.4.1",
-                "postcss": "^8.4.32",
-                "prettier": "^3.1.1",
+                "leaflet.markercluster": "^1.5.3",
+                "postcss": "^8.4.33",
+                "prettier": "^3.2.4",
                 "qrcode": "^1.5.3",
-                "tailwindcss": "^3.3.6",
+                "tailwindcss": "^3.4.1",
                 "ts-loader": "^9.5.1",
                 "typescript": "^5.3.3",
-                "vite": "^4.5.2",
+                "vite": "^5.0.12",
                 "vite-plugin-checker": "^0.6.2",
-                "vite-plugin-commonjs": "^0.10.0"
+                "vite-plugin-commonjs": "^0.10.1"
             },
             "devDependencies": {
                 "@lychee-org/leaflet.photo": "^1.0.0",
-                "@types/alpinejs": "^3.13.5",
+                "@types/alpinejs": "^3.13.6",
                 "@types/leaflet": "^1.9.8",
                 "@types/leaflet-rotatedmarker": "^0.2.5",
                 "@types/leaflet.markercluster": "^1.5.4",
@@ -192,10 +192,25 @@
                 "node": ">=4"
             }
         },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.11.tgz",
+            "integrity": "sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==",
+            "cpu": [
+                "ppc64"
+            ],
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-            "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.11.tgz",
+            "integrity": "sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==",
             "cpu": [
                 "arm"
             ],
@@ -208,9 +223,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-            "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.11.tgz",
+            "integrity": "sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==",
             "cpu": [
                 "arm64"
             ],
@@ -223,9 +238,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-            "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.11.tgz",
+            "integrity": "sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==",
             "cpu": [
                 "x64"
             ],
@@ -238,9 +253,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-            "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.11.tgz",
+            "integrity": "sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==",
             "cpu": [
                 "arm64"
             ],
@@ -253,9 +268,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-            "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.11.tgz",
+            "integrity": "sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==",
             "cpu": [
                 "x64"
             ],
@@ -268,9 +283,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-            "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.11.tgz",
+            "integrity": "sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==",
             "cpu": [
                 "arm64"
             ],
@@ -283,9 +298,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-            "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.11.tgz",
+            "integrity": "sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==",
             "cpu": [
                 "x64"
             ],
@@ -298,9 +313,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-            "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.11.tgz",
+            "integrity": "sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==",
             "cpu": [
                 "arm"
             ],
@@ -313,9 +328,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-            "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.11.tgz",
+            "integrity": "sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==",
             "cpu": [
                 "arm64"
             ],
@@ -328,9 +343,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-            "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.11.tgz",
+            "integrity": "sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==",
             "cpu": [
                 "ia32"
             ],
@@ -343,9 +358,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-            "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.11.tgz",
+            "integrity": "sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==",
             "cpu": [
                 "loong64"
             ],
@@ -358,9 +373,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-            "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.11.tgz",
+            "integrity": "sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==",
             "cpu": [
                 "mips64el"
             ],
@@ -373,9 +388,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-            "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.11.tgz",
+            "integrity": "sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==",
             "cpu": [
                 "ppc64"
             ],
@@ -388,9 +403,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-            "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.11.tgz",
+            "integrity": "sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -403,9 +418,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-            "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.11.tgz",
+            "integrity": "sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==",
             "cpu": [
                 "s390x"
             ],
@@ -418,9 +433,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-            "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.11.tgz",
+            "integrity": "sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==",
             "cpu": [
                 "x64"
             ],
@@ -433,9 +448,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.11.tgz",
+            "integrity": "sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==",
             "cpu": [
                 "x64"
             ],
@@ -448,9 +463,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.11.tgz",
+            "integrity": "sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==",
             "cpu": [
                 "x64"
             ],
@@ -463,9 +478,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-            "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.11.tgz",
+            "integrity": "sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==",
             "cpu": [
                 "x64"
             ],
@@ -478,9 +493,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-            "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.11.tgz",
+            "integrity": "sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==",
             "cpu": [
                 "arm64"
             ],
@@ -493,9 +508,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-            "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.11.tgz",
+            "integrity": "sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==",
             "cpu": [
                 "ia32"
             ],
@@ -508,9 +523,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-            "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.11.tgz",
+            "integrity": "sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==",
             "cpu": [
                 "x64"
             ],
@@ -592,9 +607,9 @@
             "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.20",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-            "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+            "version": "0.3.22",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+            "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -647,16 +662,172 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.6.tgz",
+            "integrity": "sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.6.tgz",
+            "integrity": "sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.6.tgz",
+            "integrity": "sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.6.tgz",
+            "integrity": "sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.6.tgz",
+            "integrity": "sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.6.tgz",
+            "integrity": "sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.6.tgz",
+            "integrity": "sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.6.tgz",
+            "integrity": "sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.6.tgz",
+            "integrity": "sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.6.tgz",
+            "integrity": "sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.6.tgz",
+            "integrity": "sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.6.tgz",
+            "integrity": "sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.6.tgz",
+            "integrity": "sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@types/alpinejs": {
-            "version": "3.13.5",
-            "resolved": "https://registry.npmjs.org/@types/alpinejs/-/alpinejs-3.13.5.tgz",
-            "integrity": "sha512-BSNTroRhmBkNiyd7ELK/5Boja92hnQMST6H4z1BqXKeMVzHjp9o1j5poqd5Tyhjd8oMFwxYC4I00eghfg2xrTA==",
+            "version": "3.13.6",
+            "resolved": "https://registry.npmjs.org/@types/alpinejs/-/alpinejs-3.13.6.tgz",
+            "integrity": "sha512-BMi1/2uQz7mp30VFn69SzjN7YwQ0QzE4Hn3RMBt4iMpQeasdbMiImv1f5yvK1bYmvjIyG/YFg+CgPxbjIXZk0g==",
             "dev": true
         },
         "node_modules/@types/eslint": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.0.tgz",
-            "integrity": "sha512-FlsN0p4FhuYRjIxpbdXovvHQhtlG05O1GG/RNWvdAxTboR438IOTwmrY/vLA+Xfgg06BTkP045M3vpFwTMv1dg==",
+            "version": "8.56.2",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.2.tgz",
+            "integrity": "sha512-uQDwm1wFHmbBbCZCqAlq6Do9LYwByNZHWzXppSnay9SuwJ+VRbjkbLABer54kcPnMSlG6Fdiy2yaFXm/z9Z5gw==",
             "peer": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -676,8 +847,7 @@
         "node_modules/@types/estree": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-            "peer": true
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
         },
         "node_modules/@types/geojson": {
             "version": "7946.0.13",
@@ -730,9 +900,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.10.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
-            "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+            "version": "20.11.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+            "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -911,9 +1081,9 @@
             "peer": true
         },
         "node_modules/acorn": {
-            "version": "8.11.2",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-            "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1017,9 +1187,9 @@
             "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
         },
         "node_modules/autoprefixer": {
-            "version": "10.4.16",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
-            "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
+            "version": "10.4.17",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
+            "integrity": "sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1035,9 +1205,9 @@
                 }
             ],
             "dependencies": {
-                "browserslist": "^4.21.10",
-                "caniuse-lite": "^1.0.30001538",
-                "fraction.js": "^4.3.6",
+                "browserslist": "^4.22.2",
+                "caniuse-lite": "^1.0.30001578",
+                "fraction.js": "^4.3.7",
                 "normalize-range": "^0.1.2",
                 "picocolors": "^1.0.0",
                 "postcss-value-parser": "^4.2.0"
@@ -1138,9 +1308,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001571",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001571.tgz",
-            "integrity": "sha512-tYq/6MoXhdezDLFZuCO/TKboTzuQ/xR5cFdgXPfDtM7/kchBO3b4VWghE/OAi/DV7tTdhmLjZiZBZi1fA/GheQ==",
+            "version": "1.0.30001579",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
+            "integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1359,9 +1529,9 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.616",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.616.tgz",
-            "integrity": "sha512-1n7zWYh8eS0L9Uy+GskE0lkBUNK83cXTVJI0pU3mGprFsbfSdAc15VTFbo+A+Bq4pwstmL30AVcEU3Fo463lNg=="
+            "version": "1.4.642",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.642.tgz",
+            "integrity": "sha512-M4+u22ZJGpk4RY7tne6W+APkZhnnhmAH48FNl8iEFK2lEgob+U5rUQsIqQhvAwCXYpfd3H20pHK/ENsCvwTbsA=="
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
@@ -1391,9 +1561,9 @@
             "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w=="
         },
         "node_modules/esbuild": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-            "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+            "version": "0.19.11",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.11.tgz",
+            "integrity": "sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==",
             "hasInstallScript": true,
             "bin": {
                 "esbuild": "bin/esbuild"
@@ -1402,28 +1572,29 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/android-arm": "0.18.20",
-                "@esbuild/android-arm64": "0.18.20",
-                "@esbuild/android-x64": "0.18.20",
-                "@esbuild/darwin-arm64": "0.18.20",
-                "@esbuild/darwin-x64": "0.18.20",
-                "@esbuild/freebsd-arm64": "0.18.20",
-                "@esbuild/freebsd-x64": "0.18.20",
-                "@esbuild/linux-arm": "0.18.20",
-                "@esbuild/linux-arm64": "0.18.20",
-                "@esbuild/linux-ia32": "0.18.20",
-                "@esbuild/linux-loong64": "0.18.20",
-                "@esbuild/linux-mips64el": "0.18.20",
-                "@esbuild/linux-ppc64": "0.18.20",
-                "@esbuild/linux-riscv64": "0.18.20",
-                "@esbuild/linux-s390x": "0.18.20",
-                "@esbuild/linux-x64": "0.18.20",
-                "@esbuild/netbsd-x64": "0.18.20",
-                "@esbuild/openbsd-x64": "0.18.20",
-                "@esbuild/sunos-x64": "0.18.20",
-                "@esbuild/win32-arm64": "0.18.20",
-                "@esbuild/win32-ia32": "0.18.20",
-                "@esbuild/win32-x64": "0.18.20"
+                "@esbuild/aix-ppc64": "0.19.11",
+                "@esbuild/android-arm": "0.19.11",
+                "@esbuild/android-arm64": "0.19.11",
+                "@esbuild/android-x64": "0.19.11",
+                "@esbuild/darwin-arm64": "0.19.11",
+                "@esbuild/darwin-x64": "0.19.11",
+                "@esbuild/freebsd-arm64": "0.19.11",
+                "@esbuild/freebsd-x64": "0.19.11",
+                "@esbuild/linux-arm": "0.19.11",
+                "@esbuild/linux-arm64": "0.19.11",
+                "@esbuild/linux-ia32": "0.19.11",
+                "@esbuild/linux-loong64": "0.19.11",
+                "@esbuild/linux-mips64el": "0.19.11",
+                "@esbuild/linux-ppc64": "0.19.11",
+                "@esbuild/linux-riscv64": "0.19.11",
+                "@esbuild/linux-s390x": "0.19.11",
+                "@esbuild/linux-x64": "0.19.11",
+                "@esbuild/netbsd-x64": "0.19.11",
+                "@esbuild/openbsd-x64": "0.19.11",
+                "@esbuild/sunos-x64": "0.19.11",
+                "@esbuild/win32-arm64": "0.19.11",
+                "@esbuild/win32-ia32": "0.19.11",
+                "@esbuild/win32-x64": "0.19.11"
             }
         },
         "node_modules/escalade": {
@@ -1844,18 +2015,21 @@
             "integrity": "sha512-M5FimNMXgiOYerVRGsXZ2YK9YNCaTtwtYp7Hb2308U1Q9TXXHx5G0p08mcVR5O53qf8bWY4NJcPBxE6zuayXSg=="
         },
         "node_modules/laravel-vite-plugin": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-0.8.1.tgz",
-            "integrity": "sha512-fxzUDjOA37kOsYq8dP+3oPIlw8/kJVXwu0hOXLun82R1LpV02shGeWGYKx2lbpKffL5I0sfPPjfqbYxuqBluAA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-1.0.1.tgz",
+            "integrity": "sha512-laLEZUnSskIDZtLb2FNRdcjsRUhh1VOVvapbVGVTeaBPJTCF/b6gbPiX2dZdcH1RKoOE0an7L+2gnInk6K33Zw==",
             "dependencies": {
                 "picocolors": "^1.0.0",
-                "vite-plugin-full-reload": "^1.0.5"
+                "vite-plugin-full-reload": "^1.1.0"
+            },
+            "bin": {
+                "clean-orphaned-assets": "bin/clean.js"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.0.0 || >=20.0.0"
             },
             "peerDependencies": {
-                "vite": "^3.0.0 || ^4.0.0"
+                "vite": "^5.0.0"
             }
         },
         "node_modules/lazysizes": {
@@ -2208,9 +2382,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.32",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-            "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+            "version": "8.4.33",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+            "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2329,9 +2503,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.0.13",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
-            "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+            "version": "6.0.15",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
+            "integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -2346,9 +2520,9 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
         },
         "node_modules/prettier": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
-            "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+            "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -2471,17 +2645,33 @@
             }
         },
         "node_modules/rollup": {
-            "version": "3.29.4",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-            "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.6.tgz",
+            "integrity": "sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==",
+            "dependencies": {
+                "@types/estree": "1.0.5"
+            },
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
             "engines": {
-                "node": ">=14.18.0",
+                "node": ">=18.0.0",
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.9.6",
+                "@rollup/rollup-android-arm64": "4.9.6",
+                "@rollup/rollup-darwin-arm64": "4.9.6",
+                "@rollup/rollup-darwin-x64": "4.9.6",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.9.6",
+                "@rollup/rollup-linux-arm64-gnu": "4.9.6",
+                "@rollup/rollup-linux-arm64-musl": "4.9.6",
+                "@rollup/rollup-linux-riscv64-gnu": "4.9.6",
+                "@rollup/rollup-linux-x64-gnu": "4.9.6",
+                "@rollup/rollup-linux-x64-musl": "4.9.6",
+                "@rollup/rollup-win32-arm64-msvc": "4.9.6",
+                "@rollup/rollup-win32-ia32-msvc": "4.9.6",
+                "@rollup/rollup-win32-x64-msvc": "4.9.6",
                 "fsevents": "~2.3.2"
             }
         },
@@ -2571,9 +2761,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-            "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "peer": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
@@ -2781,9 +2971,9 @@
             }
         },
         "node_modules/tailwindcss": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.0.tgz",
-            "integrity": "sha512-VigzymniH77knD1dryXbyxR+ePHihHociZbXnLZHUyzf2MMs2ZVqlUrZ3FvpXP8pno9JzmILt1sZPD19M3IxtA==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
+            "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -2825,9 +3015,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.26.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
-            "integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
+            "version": "5.27.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.27.0.tgz",
+            "integrity": "sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==",
             "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
@@ -2843,16 +3033,16 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.9",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
-            "integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
+            "version": "5.3.10",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
+            "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
             "peer": true,
             "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.17",
+                "@jridgewell/trace-mapping": "^0.3.20",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.1",
-                "terser": "^5.16.8"
+                "terser": "^5.26.0"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -3021,28 +3211,28 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
         "node_modules/vite": {
-            "version": "4.5.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
-            "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
+            "version": "5.0.12",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+            "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
             "dependencies": {
-                "esbuild": "^0.18.10",
-                "postcss": "^8.4.27",
-                "rollup": "^3.27.1"
+                "esbuild": "^0.19.3",
+                "postcss": "^8.4.32",
+                "rollup": "^4.2.0"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^14.18.0 || >=16.0.0"
+                "node": "^18.0.0 || >=20.0.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
             },
             "optionalDependencies": {
-                "fsevents": "~2.3.2"
+                "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": ">= 14",
+                "@types/node": "^18.0.0 || >=20.0.0",
                 "less": "*",
                 "lightningcss": "^1.21.0",
                 "sass": "*",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     },
     "devDependencies": {
         "@lychee-org/leaflet.photo": "^1.0.0",
-        "@types/alpinejs": "^3.13.5",
+        "@types/alpinejs": "^3.13.6",
         "@types/leaflet": "^1.9.8",
         "@types/leaflet-rotatedmarker": "^0.2.5",
         "@types/leaflet.markercluster": "^1.5.4",
@@ -21,23 +21,23 @@
     "dependencies": {
         "@fortawesome/fontawesome-free": "^6.5.1",
         "@types/justified-layout": "^4.1.4",
-        "autoprefixer": "^10.4.16",
+        "autoprefixer": "^10.4.17",
         "justified-layout": "^4.1.0",
-        "laravel-vite-plugin": "^0.8.1",
+        "laravel-vite-plugin": "^1.0.1",
         "lazysizes": "^5.3.2",
         "leaflet": "^1.9.4",
         "leaflet-gpx": "^1.7.0",
         "leaflet-rotatedmarker": "^0.2.0",
-        "leaflet.markercluster": "^1.4.1",
-        "postcss": "^8.4.32",
-        "prettier": "^3.1.1",
+        "leaflet.markercluster": "^1.5.3",
+        "postcss": "^8.4.33",
+        "prettier": "^3.2.4",
         "qrcode": "^1.5.3",
-        "tailwindcss": "^3.3.6",
+        "tailwindcss": "^3.4.1",
         "ts-loader": "^9.5.1",
         "typescript": "^5.3.3",
-        "vite": "^4.5.2",
+        "vite": "^5.0.12",
         "vite-plugin-checker": "^0.6.2",
-        "vite-plugin-commonjs": "^0.10.0"
+        "vite-plugin-commonjs": "^0.10.1"
     },
     "browserslist": [
         "defaults and fully supports es6-module"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,4 @@
+/** @type {import('postcss-load-config').Config} */
 export default {
   plugins: {
     tailwindcss: {},

--- a/resources/js/data/panel/photoListingPanel.ts
+++ b/resources/js/data/panel/photoListingPanel.ts
@@ -3,8 +3,8 @@ import Selection from "@/lycheeOrg/actions/selection";
 import { Photo } from "@/lycheeOrg/backend";
 
 export type PhotoListingPanel = AlpineComponent<{
-	select: Selection;
 	photos: Photo[];
+	select: Selection;
 }>;
 
 /**
@@ -14,7 +14,6 @@ export type PhotoListingPanel = AlpineComponent<{
 export const photoListingPanel = (Alpine: Alpine) =>
 	Alpine.data(
 		"photoListingPanel",
-		// @ts-expect-error
 		(photos: Photo[], select: Selection): PhotoListingPanel => ({
 			photos: photos,
 			select: select,

--- a/resources/js/data/panel/searchPanel.ts
+++ b/resources/js/data/panel/searchPanel.ts
@@ -13,7 +13,6 @@ export type SearchPanel = AlpineComponent<{
 export const searchPanel = (Alpine: Alpine) =>
 	Alpine.data(
 		"searchPanel",
-		// @ts-expect-error
 		(searchQuery: string, minLength: number, select: Selection): SearchPanel => ({
 			searchQuery: searchQuery,
 			hideMessage: false,

--- a/resources/js/data/views/albumView.ts
+++ b/resources/js/data/views/albumView.ts
@@ -11,7 +11,6 @@ import PhotoLayout from "@/lycheeOrg/layouts/PhotoLayout";
 export const albumView = (Alpine: Alpine) =>
 	Alpine.data(
 		"albumView",
-		// @ts-expect-error
 		(
 			base_url: string,
 			nsfwAlbumsVisible: boolean,

--- a/resources/js/data/views/albumView.ts
+++ b/resources/js/data/views/albumView.ts
@@ -87,14 +87,17 @@ export const albumView = (Alpine: Alpine) =>
 			},
 
 			handleContextPhoto(event: MouseEvent) {
+				// @ts-expect-error
 				this.actions.handleContextPhoto(event, this);
 			},
 
 			handleClickPhoto(event: MouseEvent) {
+				// @ts-expect-error
 				this.actions.handleClickPhoto(event, this);
 			},
 
 			handleContextAlbum(event: MouseEvent) {
+				// @ts-expect-error
 				this.actions.handleContextAlbum(event, this);
 			},
 
@@ -121,6 +124,7 @@ export const albumView = (Alpine: Alpine) =>
 				// [l] login
 				// [?] keybinds
 				// [esc] back
+				// @ts-expect-error
 				if (this.keybinds.handleGlobalKeydown(event, this)) {
 					return;
 				}
@@ -135,6 +139,7 @@ export const albumView = (Alpine: Alpine) =>
 				// [s] Star
 				// [ctrl + ->] rotate CW
 				// [ctrl + <-] rotate CCW
+				// @ts-expect-error
 				if (this.photo_id !== null && this.keybinds.handlePhotoKeyDown(event, this)) {
 					return;
 				}
@@ -152,6 +157,7 @@ export const albumView = (Alpine: Alpine) =>
 				// [i] info
 				// [m] move (without select)
 				// [r] rename (without select)
+				// @ts-expect-error
 				this.keybinds.handleAlbumKeydown(event, this);
 			},
 

--- a/resources/js/data/views/dropboxView.ts
+++ b/resources/js/data/views/dropboxView.ts
@@ -15,7 +15,6 @@ type DropboxFile = {
 export const dropboxView = (Alpine: Alpine) =>
 	Alpine.data(
 		"dropboxView",
-		// @ts-expect-error
 		(urlArea_: string, progress_: string): DropboxView => ({
 			urlArea: urlArea_,
 			progress: progress_,

--- a/resources/js/data/views/photoView.ts
+++ b/resources/js/data/views/photoView.ts
@@ -42,7 +42,6 @@ export const photoView = (Alpine: Alpine) =>
 			mode: 0,
 
 			init() {
-				// @ts-expect-errror
 				console.log("init photoView!");
 
 				const photo = Alpine.store("photo") as Photo | undefined;

--- a/resources/js/data/views/photoView.ts
+++ b/resources/js/data/views/photoView.ts
@@ -27,7 +27,6 @@ export type PhotoView = AlpineComponent<{
 export const photoView = (Alpine: Alpine) =>
 	Alpine.data(
 		"photoView",
-		// @ts-expect-error
 		(
 			// photo_id: string,
 			photoFlags: PhotoFlagsView,

--- a/resources/js/data/views/uploadView.ts
+++ b/resources/js/data/views/uploadView.ts
@@ -4,7 +4,6 @@ import { UploadView, Livewire, UploadEvent } from "./types";
 export const uploadView = (Alpine: Alpine) =>
 	Alpine.data(
 		"upload",
-		// @ts-expect-error
 		(chunkSize_val: number, parallelism_val: number = 3): UploadView => ({
 			isDropping: false,
 			chunkSize: chunkSize_val,

--- a/resources/js/data/webauthn/loginWebAuthn.ts
+++ b/resources/js/data/webauthn/loginWebAuthn.ts
@@ -20,7 +20,6 @@ type LoginWebAuthn = AlpineComponent<{
 export const loginWebAuthn = (Alpine: Alpine) =>
 	Alpine.data(
 		"loginWebAuthn",
-		// @ts-expect-error
 		(success_msg_val: string = "U2F_AUTHENTIFICATION_SUCCESS", error_msg_val: string = "ERROR_TEXT"): LoginWebAuthn => ({
 			webAuthnOpen: false,
 			success_msg: success_msg_val,

--- a/resources/js/data/webauthn/registerWebAuthn.ts
+++ b/resources/js/data/webauthn/registerWebAuthn.ts
@@ -11,7 +11,6 @@ type RegisterWebAuthn = AlpineComponent<{
 export const registerWebAuthn = (Alpine: Alpine) =>
 	Alpine.data(
 		"registerWebAuthn",
-		// @ts-expect-error
 		(success_msg_val: string = "U2F_REGISTRATION_SUCCESS", error_msg_val: string = "ERROR_TEXT"): RegisterWebAuthn => ({
 			success_msg: success_msg_val,
 			error_msg: error_msg_val,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   safelist: [
     'opacity-0',
     'group-hover:opacity-100',

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import laravel from 'laravel-vite-plugin';
 import commonjs from 'vite-plugin-commonjs'
 import checker from 'vite-plugin-checker'
 
+/** @type {import('vite').UserConfig} */
 export default defineConfig({
   plugins: [
     commonjs(/* options */),


### PR DESCRIPTION
Hello, this is a small PR that aims to bump to Vite 5. It has received some extra speed and is part of several improvements as well as dropping CJS.

I also added a few `ts-expect-error` directives in albumView as the type was not exactly the same and remove one unneeded. I have a doubt if the script "check" was throwing some `Unused '@ts-expect-error' directive` before, but in some `Alpine.data` types, it is not needed as the type is already correctly casted :) (I was not sure about removing this useless directive)

Also I added the type hint on 2 config files.

Feel free to ask me to split this PR if needed or ask for some changes before merging :)