### PR TITLE
Add support for Feature flags.

### DIFF
--- a/app/Actions/Diagnostics/Pipes/Infos/InstallTypeInfo.php
+++ b/app/Actions/Diagnostics/Pipes/Infos/InstallTypeInfo.php
@@ -30,8 +30,8 @@ class InstallTypeInfo implements DiagnosticPipe
 		$data[] = Diagnostics::line('APP_DEBUG:', config('app.debug') === true ? 'true' : 'false'); // check if debug is on (will help in case of error 500)
 		$data[] = Diagnostics::line('APP_URL:', config('app.url') !== 'http://localhost' ? 'set' : 'default'); // Some people leave that value by default... It is now breaking their visual.
 		$data[] = Diagnostics::line('APP_DIR:', config('app.dir_url') !== '' ? 'set' : 'default'); // Some people leave that value by default... It is now breaking their visual.
-		$data[] = Diagnostics::line('LOG_VIEWER_ENABLED:', Features::whenConst('log-viewer', 'true', 'false'));
-		$data[] = Diagnostics::line('LIVEWIRE_ENABLED:', Features::whenConst('livewire', 'true', 'false'));
+		$data[] = Diagnostics::line('LOG_VIEWER_ENABLED:', Features::when('log-viewer', 'true', 'false'));
+		$data[] = Diagnostics::line('LIVEWIRE_ENABLED:', Features::when('livewire', 'true', 'false'));
 		$data[] = '';
 
 		return $next($data);

--- a/app/Actions/Diagnostics/Pipes/Infos/InstallTypeInfo.php
+++ b/app/Actions/Diagnostics/Pipes/Infos/InstallTypeInfo.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Diagnostics\Pipes\Infos;
 
 use App\Actions\Diagnostics\Diagnostics;
+use App\Assets\Features;
 use App\Contracts\DiagnosticPipe;
 use App\Metadata\Versions\InstalledVersion;
 
@@ -29,8 +30,8 @@ class InstallTypeInfo implements DiagnosticPipe
 		$data[] = Diagnostics::line('APP_DEBUG:', config('app.debug') === true ? 'true' : 'false'); // check if debug is on (will help in case of error 500)
 		$data[] = Diagnostics::line('APP_URL:', config('app.url') !== 'http://localhost' ? 'set' : 'default'); // Some people leave that value by default... It is now breaking their visual.
 		$data[] = Diagnostics::line('APP_DIR:', config('app.dir_url') !== '' ? 'set' : 'default'); // Some people leave that value by default... It is now breaking their visual.
-		$data[] = Diagnostics::line('LOG_VIEWER_ENABLED:', config('log-viewer.enabled', true) === true ? 'true' : 'false');
-		$data[] = Diagnostics::line('LIVEWIRE_ENABLED:', config('app.livewire', true) === true ? 'true' : 'false');
+		$data[] = Diagnostics::line('LOG_VIEWER_ENABLED:', Features::whenConst('log-viewer', 'true', 'false'));
+		$data[] = Diagnostics::line('LIVEWIRE_ENABLED:', Features::whenConst('livewire', 'true', 'false'));
 		$data[] = '';
 
 		return $next($data);

--- a/app/Assets/Features.php
+++ b/app/Assets/Features.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Assets;
+
+use App\Exceptions\Internal\FeaturesDoesNotExistsException;
+
+/**
+ * Manage enabled and disabled features.
+ */
+final class Features
+{
+	/**
+	 * Determine whether a feature is active.
+	 *
+	 * @param string $featureName to check
+	 *
+	 * @return bool is active
+	 */
+	public static function active(string $featureName): bool
+	{
+		self::exists($featureName);
+
+		return config('features.' . $featureName) === true;
+	}
+
+	/**
+	 * Determine whether a feature is inactive.
+	 *
+	 * @param string $featureName to check
+	 *
+	 * @return bool is inactive
+	 */
+	public static function inactive(string $featureName): bool
+	{
+		self::exists($featureName);
+
+		return config('features.' . $featureName) === false;
+	}
+
+	/**
+	 * Determine if all of the given features are active.
+	 *
+	 * @param array<int,string> $featureNames to check
+	 *
+	 * @return bool is inactive
+	 */
+	public static function allAreActive(array $featureNames): bool
+	{
+		return array_reduce(
+			$featureNames,
+			fn ($bool, $featureName) => $bool && self::active($featureName),
+			true);
+	}
+
+	/**
+	 * Determine if any of the given features are active.
+	 *
+	 * @param array<int,string> $featureNames to check
+	 *
+	 * @return bool is inactive
+	 */
+	public static function someAreActive(array $featureNames): bool
+	{
+		return array_reduce(
+			$featureNames,
+			fn (bool $bool, string $featureName) => $bool || self::active($featureName),
+			false);
+	}
+
+	/**
+	 * Determine if all of the given features are inactive.
+	 *
+	 * @param array<int,string> $featureNames to check
+	 *
+	 * @return bool is inactive
+	 */
+	public static function allAreInactive(array $featureNames): bool
+	{
+		return array_reduce(
+			$featureNames,
+			fn (bool $bool, string $featureName) => $bool && self::inactive($featureName),
+			true);
+	}
+
+	/**
+	 * Determine if any of the given features are inactive.
+	 *
+	 * @param array<int,string> $featureNames to check
+	 *
+	 * @return bool is inactive
+	 */
+	public static function someAreInactive(array $featureNames): bool
+	{
+		return array_reduce(
+			$featureNames,
+			fn (bool $bool, string $featureName) => $bool || self::inactive($featureName),
+			false);
+	}
+
+	/**
+	 * Determine whether a feature is active.
+	 *
+	 * @template T
+	 *
+	 * @param string|array<int,string> $featureNames  to check
+	 * @param \Closure(): T            $callbackTrue  what happens if we features are enabled
+	 * @param \Closure(): T            $callbackFalse what happens if we features are disabled
+	 *
+	 * @return T
+	 */
+	public static function when(string|array $featureNames, \Closure $callbackTrue, \Closure $callbackFalse): mixed
+	{
+		if (is_array($featureNames)) {
+			return self::allAreActive($featureNames) ? $callbackTrue() : $callbackFalse();
+		}
+
+		return self::active($featureNames) ? $callbackTrue() : $callbackFalse();
+	}
+
+	/**
+	 * Determine whether a feature is active.
+	 *
+	 * @template T
+	 *
+	 * @param string|array<int,string> $featureNames to check
+	 * @param T                        $valIfTrue    Value if we features are enabled
+	 * @param T                        $valIfFalse   Value if we features are disabled
+	 *
+	 * @return T
+	 */
+	public static function whenConst(string|array $featureNames, mixed $valIfTrue, mixed $valIfFalse): mixed
+	{
+		if (is_array($featureNames)) {
+			return self::allAreActive($featureNames) ? $valIfTrue : $valIfFalse;
+		}
+
+		return self::active($featureNames) ? $valIfTrue : $valIfFalse;
+	}
+
+	/**
+	 * Assert whether the feature exists or not.
+	 * Throws an exception if not.
+	 *
+	 * @param string $featureName name of the feature to check
+	 *
+	 * @return void
+	 *
+	 * @throws FeaturesDoesNotExistsException
+	 */
+	private static function exists(string $featureName): void
+	{
+		if (!is_bool(config('features.' . $featureName))) {
+			throw new FeaturesDoesNotExistsException(sprintf('No feature with name %s found.', $featureName));
+		}
+	}
+}

--- a/app/Exceptions/Internal/FeaturesDoesNotExistsException.php
+++ b/app/Exceptions/Internal/FeaturesDoesNotExistsException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Exceptions\Internal;
+
+class FeaturesDoesNotExistsException extends LycheeLogicException
+{
+	public function __construct(string $msg)
+	{
+		parent::__construct($msg);
+	}
+}

--- a/app/Http/Controllers/RedirectController.php
+++ b/app/Http/Controllers/RedirectController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Album\Unlock;
+use App\Assets\Features;
 use App\Contracts\Exceptions\LycheeException;
 use App\Exceptions\Internal\FrameworkException;
 use App\Factories\AlbumFactory;
@@ -75,7 +76,7 @@ class RedirectController extends Controller
 			}
 
 			// If we are using livewire by default, we redirect to Livewire url intead.
-			if (config('app.livewire') === true) {
+			if (Features::active('livewire')) {
 				return $photoID === null ?
 					redirect(route('livewire-gallery-album', ['albumId' => $albumID])) :
 					redirect(route('livewire-gallery-photo', ['albumId' => $albumID, 'photoId' => $photoID]));
@@ -98,7 +99,7 @@ class RedirectController extends Controller
 	public function view(): View|SymfonyResponse
 	{
 		$base_route = Configs::getValueAsBool('landing_page_enable') ? route('landing') : route('livewire-gallery');
-		if (config('app.legacy_v4_redirect') === false) {
+		if (Features::active('legacy_v4_redirect') === false) {
 			return redirect($base_route);
 		}
 

--- a/app/Http/Middleware/DisableCSP.php
+++ b/app/Http/Middleware/DisableCSP.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Assets\Features;
 use App\Contracts\Exceptions\LycheeException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Http\Request;
@@ -49,7 +50,7 @@ class DisableCSP
 		}
 
 		// disable unsafe-eval if we are on a Livewire page
-		if (config('app.livewire', false) === true || Str::startsWith($request->getRequestUri(), $dir_url . '/livewire/')) {
+		if (Features::active('livewire') || Str::startsWith($request->getRequestUri(), $dir_url . '/livewire/')) {
 			$this->handleLivewire();
 		}
 

--- a/app/Livewire/Components/Menus/LeftMenu.php
+++ b/app/Livewire/Components/Menus/LeftMenu.php
@@ -35,7 +35,6 @@ class LeftMenu extends Component implements Openable
 	use InteractWithModal;
 	use UseOpenable;
 
-	#[Locked] public bool $has_log_viewer = false;
 	#[Locked] public bool $has_dev_tools = false;
 	#[Locked] public ?string $clockwork_url = null;
 	#[Locked] public ?string $doc_api_url = null;
@@ -62,7 +61,6 @@ class LeftMenu extends Component implements Openable
 	public function render(): View
 	{
 		$this->loadDevMenu();
-		$this->has_log_viewer = config('log-viewer.enabled', true);
 
 		return view('livewire.components.left-menu');
 	}

--- a/app/Models/Extensions/Thumb.php
+++ b/app/Models/Extensions/Thumb.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Extensions;
 
+use App\Assets\Features;
 use App\DTO\AbstractDTO;
 use App\DTO\SortingCriterion;
 use App\Enum\ColumnSortingPhotoType;
@@ -39,7 +40,7 @@ class Thumb extends AbstractDTO
 	public static function sizeVariantsFilter(HasMany $relation): HasMany
 	{
 		$svAlbumThumbs = [SizeVariantType::THUMB, SizeVariantType::THUMB2X];
-		if (config('app.livewire', true) === true) {
+		if (Features::active('livewire')) {
 			$svAlbumThumbs = [SizeVariantType::SMALL, SizeVariantType::SMALL2X, SizeVariantType::THUMB, SizeVariantType::THUMB2X];
 		}
 
@@ -88,14 +89,14 @@ class Thumb extends AbstractDTO
 	 */
 	public static function createFromPhoto(?Photo $photo): ?Thumb
 	{
-		$thumb = (config('app.livewire', true) === true && $photo?->size_variants->getSmall() !== null)
+		$thumb = (Features::active('livewire') && $photo?->size_variants->getSmall() !== null)
 			? $photo->size_variants->getSmall()
 			: $photo?->size_variants->getThumb();
 		if ($thumb === null) {
 			return null;
 		}
 
-		$thumb2x = (config('app.livewire', true) === true && $photo?->size_variants->getSmall() !== null)
+		$thumb2x = (Features::active('livewire') && $photo?->size_variants->getSmall() !== null)
 			? $photo->size_variants->getSmall2x()
 			: $photo?->size_variants->getThumb2x();
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -109,7 +109,7 @@ class AppServiceProvider extends ServiceProvider
 		/**
 		 * We force URL to HTTPS if requested in .env via APP_FORCE_HTTPS.
 		 */
-		if (config('app.force_https') === true) {
+		if (config('features.force_https') === true) {
 			URL::forceScheme('https');
 		}
 

--- a/config/app.php
+++ b/config/app.php
@@ -48,18 +48,6 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
-	| Application Environment
-	|--------------------------------------------------------------------------
-	|
-	| This value determines whether livewire front-end is enabled as it is
-	| currently under development.
-	|
-	*/
-
-	'livewire' => (bool) env('LIVEWIRE_ENABLED', true),
-
-	/*
-	|--------------------------------------------------------------------------
 	| Application Debug Mode
 	|--------------------------------------------------------------------------
 	|
@@ -91,20 +79,6 @@ return [
 	'dir_url' => env('APP_DIR', '') === '' ? '' : ('/' . trim(env('APP_DIR'), '/')),
 
 	'asset_url' => null,
-
-	'legacy_v4_redirect' => env('LEGACY_V4_REDIRECT', false),
-
-	/*
-	|--------------------------------------------------------------------------
-	| Application URL
-	|--------------------------------------------------------------------------
-	|
-	| When running behind a proxy, it may be necessary for the urls to be
-	| set as https for the reverse translation. You should set this if you
-	| want to force the https scheme.
-	*/
-
-	'force_https' => (bool) env('APP_FORCE_HTTPS', false),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -280,6 +254,7 @@ return [
 	'aliases' => Facade::defaultAliases()->merge([
 		'DebugBar' => Barryvdh\Debugbar\Facades\Debugbar::class,
 		'Helpers' => App\Facades\Helpers::class,
+		'Features' => App\Assets\Features::class,
 		// Aliases for easier access in the blade templates
 		'Configs' => App\Models\Configs::class,
 		'AlbumPolicy' => App\Policies\AlbumPolicy::class,

--- a/config/features.php
+++ b/config/features.php
@@ -31,7 +31,7 @@ return [
 	| When using new front-end old links to /#albumID/PhotoID are broken.
 	| This provides here a way to avoid those.
 	*/
-	'legacy_v4_redirect' => env('LEGACY_V4_REDIRECT', false),
+	'legacy_v4_redirect' => (bool) env('LEGACY_V4_REDIRECT', false),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -40,5 +40,5 @@ return [
 	| Log Viewer can be disabled, so it's no longer accessible via browser.
 	|
 	*/
-	'log-viewer' => env('LOG_VIEWER_ENABLED', true),
+	'log-viewer' => (bool) env('LOG_VIEWER_ENABLED', true),
 ];

--- a/config/features.php
+++ b/config/features.php
@@ -1,0 +1,44 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Use Livewire Front-end
+	|--------------------------------------------------------------------------
+	|
+	| This value determines whether livewire front-end is enabled as it is
+	| currently under development.
+	|
+	*/
+	'livewire' => (bool) env('LIVEWIRE_ENABLED', true),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Force HTTPS
+	|--------------------------------------------------------------------------
+	|
+	| When running behind a proxy, it may be necessary for the urls to be
+	| set as https for the reverse translation. You should set this if you
+	| want to force the https scheme.
+	*/
+	'force_https' => (bool) env('APP_FORCE_HTTPS', false),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Enable v4 redirections
+	|--------------------------------------------------------------------------
+	|
+	| When using new front-end old links to /#albumID/PhotoID are broken.
+	| This provides here a way to avoid those.
+	*/
+	'legacy_v4_redirect' => env('LEGACY_V4_REDIRECT', false),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Log Viewer
+	|--------------------------------------------------------------------------
+	| Log Viewer can be disabled, so it's no longer accessible via browser.
+	|
+	*/
+	'log-viewer' => env('LOG_VIEWER_ENABLED', true),
+];

--- a/resources/views/install/setup-success.blade.php
+++ b/resources/views/install/setup-success.blade.php
@@ -7,7 +7,7 @@ active
 @section('content')
 	<strong>Admin account has been created.</strong>
 	<div class="buttons">
-	<a href="{{ config('app.livewire') !== true ? route('home') : route('livewire-index') }}" class="button" >
+	<a href="{{ Features::when('livewire', fn () => route('livewire-index'), fn () => route('home')) }}" class="button" >
 			Open Lychee <i class="fa fa-angle-right fa-fw" aria-hidden="true"></i>
 		</a>
 	</div>

--- a/resources/views/livewire/components/left-menu.blade.php
+++ b/resources/views/livewire/components/left-menu.blade.php
@@ -30,7 +30,7 @@
                     {{ __('lychee.SHARING') }}</x-leftbar.leftbar-item>
             @endcan
             @can(SettingsPolicy::CAN_SEE_LOGS, [App\Models\Configs::class])
-                @if($has_log_viewer)
+                @if(Features::active('log-viewer'))
                 <x-leftbar.leftbar-item href="{{ route('log-viewer.index') }}" icon="excerpt">
                     {{ __('lychee.LOGS') }}
                 </x-leftbar.leftbar-item>

--- a/routes/web-livewire.php
+++ b/routes/web-livewire.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Components\Pages;
 
+use App\Assets\Features;
 use App\Enum\OauthProvidersType;
 use App\Http\Controllers\Oauth;
 use App\Http\Controllers\RedirectController;
@@ -20,14 +21,14 @@ use Illuminate\Support\Facades\Route;
 | contains the "web" middleware group. Now create something great!
 |
 */
-Route::prefix(config('app.livewire') === true ? '' : 'livewire')
+Route::prefix(Features::whenConst('livewire', '', 'livewire'))// config('features.livewire') === true ? '' : 'livewire')
 	->group(function () {
 		Route::get('/diagnostics', Diagnostics::class)->name('diagnostics');
 	});
 
 Route::middleware(['installation:complete', 'migration:complete'])
 	->group(function () {
-		Route::prefix(config('app.livewire') === true ? '' : 'livewire')
+		Route::prefix(config('features.livewire') === true ? '' : 'livewire')
 		->group(function () {
 			// Oauth routes.
 			Route::get('/auth/{provider}/redirect', [Oauth::class, 'redirected'])->whereIn('provider', OauthProvidersType::values());

--- a/routes/web-livewire.php
+++ b/routes/web-livewire.php
@@ -21,14 +21,14 @@ use Illuminate\Support\Facades\Route;
 | contains the "web" middleware group. Now create something great!
 |
 */
-Route::prefix(Features::whenConst('livewire', '', 'livewire'))
+Route::prefix(Features::when('livewire', '', 'livewire'))
 	->group(function () {
 		Route::get('/diagnostics', Diagnostics::class)->name('diagnostics');
 	});
 
 Route::middleware(['installation:complete', 'migration:complete'])
 	->group(function () {
-		Route::prefix(Features::whenConst('livewire', '', 'livewire'))
+		Route::prefix(Features::when('livewire', '', 'livewire'))
 		->group(function () {
 			// Oauth routes.
 			Route::get('/auth/{provider}/redirect', [Oauth::class, 'redirected'])->whereIn('provider', OauthProvidersType::values());

--- a/routes/web-livewire.php
+++ b/routes/web-livewire.php
@@ -21,14 +21,14 @@ use Illuminate\Support\Facades\Route;
 | contains the "web" middleware group. Now create something great!
 |
 */
-Route::prefix(Features::whenConst('livewire', '', 'livewire'))// config('features.livewire') === true ? '' : 'livewire')
+Route::prefix(Features::whenConst('livewire', '', 'livewire'))
 	->group(function () {
 		Route::get('/diagnostics', Diagnostics::class)->name('diagnostics');
 	});
 
 Route::middleware(['installation:complete', 'migration:complete'])
 	->group(function () {
-		Route::prefix(config('features.livewire') === true ? '' : 'livewire')
+		Route::prefix(Features::whenConst('livewire', '', 'livewire'))
 		->group(function () {
 			// Oauth routes.
 			Route::get('/auth/{provider}/redirect', [Oauth::class, 'redirected'])->whereIn('provider', OauthProvidersType::values());

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\URL;
 Route::feeds();
 
 // If we are using Livewire by default, we no longer need those routes.
-if (config('app.livewire') !== true) {
+if (config('features.livewire') !== true) {
 	Route::get('/', [IndexController::class, 'show'])->name('home')->middleware(['migration:complete']);
 	Route::get('/gallery', [IndexController::class, 'gallery'])->name('gallery')->middleware(['migration:complete']);
 	Route::get('/view', [IndexController::class, 'view'])->name('view')->middleware(['redirect-legacy-id']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Assets\Features;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 
@@ -18,7 +19,7 @@ use Illuminate\Support\Facades\URL;
 Route::feeds();
 
 // If we are using Livewire by default, we no longer need those routes.
-if (config('features.livewire') !== true) {
+if (!Features::active('livewire')) {
 	Route::get('/', [IndexController::class, 'show'])->name('home')->middleware(['migration:complete']);
 	Route::get('/gallery', [IndexController::class, 'gallery'])->name('gallery')->middleware(['migration:complete']);
 	Route::get('/view', [IndexController::class, 'view'])->name('view')->middleware(['redirect-legacy-id']);


### PR DESCRIPTION
This pull request reuse a similar interface of [pennant](https://laravel.com/docs/10.x/pennant) but in a much lighter version.

:warning: For this specific one, we do not make use of Facade as this breaks the route creations during the initial loading and phpstan parsing.

Using Features will also ensure that flags are well defined, an exception will be thrown if a flag is not found in the configuration. As usual flags are usually mapped to an optional ENV variable. This will allow us to integrates different code path and functionalities without relying too heavily on databases queries.
