### PR TITLE
If LegacyIdException is thrown provide proper solution

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -8,6 +8,7 @@ use App\Enum\SeverityType;
 use App\Exceptions\Handlers\AccessDBDenied;
 use App\Exceptions\Handlers\AdminSetterHandler;
 use App\Exceptions\Handlers\InstallationHandler;
+use App\Exceptions\Handlers\LegacyIdExceptionHandler;
 use App\Exceptions\Handlers\MigrationHandler;
 use App\Exceptions\Handlers\NoEncryptionKey;
 use App\Exceptions\Handlers\ViteManifestNotFoundHandler;
@@ -108,6 +109,7 @@ class Handler extends ExceptionHandler
 		AdminSetterHandler::class,
 		MigrationHandler::class,
 		ViteManifestNotFoundHandler::class,
+		LegacyIdExceptionHandler::class,
 	];
 
 	/** @var array<int,class-string<\Throwable>> */

--- a/app/Exceptions/Handlers/LegacyIdExceptionHandler.php
+++ b/app/Exceptions/Handlers/LegacyIdExceptionHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Exceptions\Handlers;
+
+use App\Contracts\Exceptions\Handlers\HttpExceptionHandler;
+use App\Exceptions\ModelDBException;
+use Illuminate\Database\QueryException;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface as HttpException;
+
+/**
+ * Class AccessDBDenied.
+ *
+ * If access to the DB is denied, we need to run the installation.
+ */
+class LegacyIdExceptionHandler implements HttpExceptionHandler
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function check(HttpException $e): bool
+	{
+		do {
+			if (
+				($e instanceof QueryException || $e instanceof ModelDBException) &&
+				str_contains($e->getMessage(), 'Numeric value out of range: 1264')
+			) {
+				return true;
+			}
+		} while ($e = $e->getPrevious());
+
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function renderHttpException(SymfonyResponse $defaultResponse, HttpException $e): SymfonyResponse
+	{
+		return response()->view('error.error', [
+			'code' => $e->getStatusCode(),
+			'type' => class_basename($e),
+			'message' => 'SQLSTATE: Numeric value out of range: 1264 for column \'legacy_id\'. To fix, please set <pre>force_32bit_ids</pre> to <pre>1</pre> in your config.',
+		], $e->getStatusCode(), $e->getHeaders());
+	}
+}

--- a/app/Exceptions/Handlers/LegacyIdExceptionHandler.php
+++ b/app/Exceptions/Handlers/LegacyIdExceptionHandler.php
@@ -9,9 +9,10 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface as HttpException;
 
 /**
- * Class AccessDBDenied.
+ * Class LegacyIdExceptionHandler.
  *
- * If access to the DB is denied, we need to run the installation.
+ * If SQLSTATE: Numeric value out of range: 1264 is throw it means we are interacting with 32 bit DB.
+ * Advise to set config parameter.
  */
 class LegacyIdExceptionHandler implements HttpExceptionHandler
 {
@@ -40,7 +41,7 @@ class LegacyIdExceptionHandler implements HttpExceptionHandler
 		return response()->view('error.error', [
 			'code' => $e->getStatusCode(),
 			'type' => class_basename($e),
-			'message' => 'SQLSTATE: Numeric value out of range: 1264 for column \'legacy_id\'. To fix, please set <pre>force_32bit_ids</pre> to <pre>1</pre> in your config.',
+			'message' => 'SQLSTATE: Numeric value out of range: 1264 for column \'legacy_id\'. To fix, please set `force_32bit_ids` to `1` in your config.',
 		], $e->getStatusCode(), $e->getHeaders());
 	}
 }

--- a/app/Exceptions/Handlers/LegacyIdExceptionHandler.php
+++ b/app/Exceptions/Handlers/LegacyIdExceptionHandler.php
@@ -41,7 +41,7 @@ class LegacyIdExceptionHandler implements HttpExceptionHandler
 		return response()->view('error.error', [
 			'code' => $e->getStatusCode(),
 			'type' => class_basename($e),
-			'message' => 'SQLSTATE: Numeric value out of range: 1264 for column \'legacy_id\'. To fix, please set `force_32bit_ids` to `1` in your config.',
+			'message' => 'SQLSTATE: Numeric value out of range: 1264 for column \'legacy_id\'. To fix, please set `force_32bit_ids` to `1` in your Settings => More.',
 		], $e->getStatusCode(), $e->getHeaders());
 	}
 }


### PR DESCRIPTION
Fixes #2290.

This small handler should resolve some of the exceptions we are having complaints about legacy id.
(though I think we should probably drop the legacy id completely, it is not like we are going to go back at any time. 