### PR TITLE
Add preg_quote before doing glob() to escape regex characters

### DIFF
--- a/app/Actions/Import/Exec.php
+++ b/app/Actions/Import/Exec.php
@@ -271,7 +271,7 @@ class Exec
 
 			// TODO: Consider to use a modern OO-approach using [`DirectoryIterator`](https://www.php.net/manual/en/class.directoryiterator.php) and [`SplFileInfo`](https://www.php.net/manual/en/class.splfileinfo.php)
 			/** @var string[] $files */
-			$files = glob($path . '/*');
+			$files = glob(preg_quote($path) . '/*');
 
 			$filesTotal = count($files);
 			$filesCount = 0;


### PR DESCRIPTION
Fixes #2316 
Closes #2315

Some folders contain the regex special characters such as `[]` or `*` or `.` etc...
This would break the files search.

`preg_quote()` documentation [here](https://www.php.net/manual/en/function.preg-quote.php).