### PR TITLE
only owner users with upload rights are allowed to edit albums

### DIFF
--- a/app/Policies/AlbumPolicy.php
+++ b/app/Policies/AlbumPolicy.php
@@ -228,7 +228,7 @@ class AlbumPolicy extends BasePolicy
 		}
 
 		if ($album instanceof BaseAlbum) {
-			return $this->isOwner($user, $album) ||
+			return ($this->isOwner($user, $album) && $user->may_upload) ||
 				$album->current_user_permissions()?->grants_edit === true ||
 				$album->public_permissions()?->grants_edit === true;
 		}


### PR DESCRIPTION
Fixes #2302

The problem was that in the case of ownership, we forgot to check whether the user had upload rights.