### PR TITLE
Fixes HTTP 500 "Attempt to read property "photo_id" on null" on album page when no photo is found for header

### DIFF
--- a/app/Livewire/Components/Pages/Gallery/Album.php
+++ b/app/Livewire/Components/Pages/Gallery/Album.php
@@ -211,7 +211,7 @@ class Album extends BaseAlbumComponent implements Reloadable
 			->inRandomOrder()
 			->first();
 
-		if (!$photo) {
+		if ($photo === null) {
 			return null;
 		}
 

--- a/app/Livewire/Components/Pages/Gallery/Album.php
+++ b/app/Livewire/Components/Pages/Gallery/Album.php
@@ -211,6 +211,10 @@ class Album extends BaseAlbumComponent implements Reloadable
 			->inRandomOrder()
 			->first();
 
+		if (!$photo) {
+			return null;
+		}
+
 		return SizeVariant::query()
 			->where('photo_id', '=', $photo->photo_id)
 			->where('type', '>', 1)


### PR DESCRIPTION
It appears that `\App\Livewire\Components\Pages\Gallery\Album::fetchHeaderUrl()` does not properly handle the situation when no photo of the right ratio/type combination can be found in the content of the album.

And in this case, the result is pretty ugly :confused: 

![image](https://github.com/LycheeOrg/Lychee/assets/4866761/b54142df-d96f-4fbf-9046-86884839502c)

The quick and dirty solution here is just to return `null`, at least until a better way to handle the case is found.