### PR TITLE
Fix additional_footer_text setting (#2445)

### DIFF
--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -28,8 +28,8 @@
 	@isset($copyright)
 		<p class="home_copyright w-full uppercase text-text-main-400 leading-6 font-normal">{{ $copyright }}</p>
 	@endisset
-	@isset($personal_text)
-		<p class="personal_text w-full text-text-main-400 leading-6 font-normal">{{ $personal_text }}</p>
+	@isset($additional_footer_text)
+		<p class="personal_text w-full text-text-main-400 leading-6 font-normal">{{ $additional_footer_text }}</p>
 	@endisset
 	@isset($hosted_by)
 	<p class="hosted_by w-full uppercase text-text-main-400 leading-6 font-normal">


### PR DESCRIPTION
This PR addresses #2445 and fixes the page footer contents when using the `additional_footer_text`-setting.

Tested on Lychee v5.3.0.