### PR TITLE
Fix clipped form content when editing photo's 'about' information

### DIFF
--- a/resources/views/components/gallery/view/photo.blade.php
+++ b/resources/views/components/gallery/view/photo.blade.php
@@ -117,7 +117,7 @@
 			</template>
 		</div>
 		<template x-if="photo.rights.can_edit">
-			<div class="h-full relative overflow-clip w-0 bg-bg-800 transition-all"
+			<div class="h-full relative overflow-x-clip overflow-y-auto w-0 bg-bg-800 transition-all"
 				x-bind:class="photoFlags.isEditOpen ? 'w-full' : 'w-0 translate-x-full'">
 				<x-gallery.photo.properties />
 			</div>


### PR DESCRIPTION
The `overflow-clip` class on the form container for editing a photo's 'about' information prevented scrolling, resulting in content being cut off on some screen sizes. This commit adjusts the overflow property to clip only the x-axis, while setting the y-axis overflow to `auto`, ensuring the entire form content remains accessible.