### PR TITLE
Fixes RSS Feed's URL

### DIFF
--- a/app/Actions/RSS/Generate.php
+++ b/app/Actions/RSS/Generate.php
@@ -25,7 +25,7 @@ class Generate
 	private function create_link_to_page(Photo $photo_model): string
 	{
 		if ($photo_model->album_id !== null) {
-			return url('/gallery#' . $photo_model->album_id . '/' . $photo_model->id);
+			return url('/gallery/' . $photo_model->album_id . '/' . $photo_model->id);
 		}
 
 		return url('/view?p=' . $photo_model->id);


### PR DESCRIPTION
<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.

Don't worry if your code styling isn't perfect! php-cs-fixer will automatically create a pull request with any style fixes. This allows us to focus on the content of the contribution and not the code style.
-->

This simple PR fixes the URLs given by an RSS feed, which was changed from `<base>/gallery#` to `<base>/gallery/`

Tested it on my local instance, and works