### PR TITLE
Update HasRandomIDAndLegacyTimeBasedID.php - Album ID Generation

### DIFF
--- a/app/Models/Extensions/HasRandomIDAndLegacyTimeBasedID.php
+++ b/app/Models/Extensions/HasRandomIDAndLegacyTimeBasedID.php
@@ -151,7 +151,7 @@ trait HasRandomIDAndLegacyTimeBasedID
 		// The other characters (a-z, A-Z, 0-9) are legal within an URL.
 		// As the number of bytes is divisible by 3, no trailing `=` occurs.
 		try {
-			$id = strtr(base64_encode(random_bytes(3 * RandomID::ID_LENGTH / 4)), '+/', '-_');
+			$id = rtrim(strtr(base64_encode(random_bytes(3 * RandomID::ID_LENGTH / 4)), '+/', '-_'),'-');
 		} catch (\Exception $e) {
 			throw new InsufficientEntropyException($e);
 		}

--- a/app/Models/Extensions/HasRandomIDAndLegacyTimeBasedID.php
+++ b/app/Models/Extensions/HasRandomIDAndLegacyTimeBasedID.php
@@ -151,7 +151,13 @@ trait HasRandomIDAndLegacyTimeBasedID
 		// The other characters (a-z, A-Z, 0-9) are legal within an URL.
 		// As the number of bytes is divisible by 3, no trailing `=` occurs.
 		try {
-			$id = rtrim(strtr(base64_encode(random_bytes(3 * RandomID::ID_LENGTH / 4)), '+/', '-_'),'-');
+			$id = strtr(base64_encode(random_bytes(3 * RandomID::ID_LENGTH / 4)), '+/', '-_');
+			// Last character whould not be a - for some version of android.
+			// this will reduce the entropy and induce a slight bias but we are still
+			// above the birthday bounds.
+			if ($id[23] === '-') {
+				$id[23] = '0';
+			}
 		} catch (\Exception $e) {
 			throw new InsufficientEntropyException($e);
 		}


### PR DESCRIPTION
Modification of ID generation based on recommendation by associate who is a PHP developer. This will avoid having a hyphen at the end of URLs which seems to cause issues with certain apps/devices that do URL parsing.

In an exceptionally rare, but not impossible situation, an ID of "--------------" would result in "".

- Title: "Resolves an edge case where hyphens would be generated at end of album IDs"
- See discussion: https://github.com/LycheeOrg/Lychee/discussions/2551#discussioncomment-10791531
- My understanding is that the hyphen is trimmed off the end of the ID if one is present.
----

- Add a test that triggered the bug before fixing it.

I am not sure how to do this...

- Ensure it doesn't break any feature.

I received this as an input from a reliable PHP dev, is all I can say, and I have to assume based on parsing the line that it shouldn't break any feature in this case?