### PR TITLE
New Feature: Low Quality Image Placeholder

### DIFF
--- a/app/Actions/Diagnostics/Errors.php
+++ b/app/Actions/Diagnostics/Errors.php
@@ -15,6 +15,7 @@ use App\Actions\Diagnostics\Pipes\Checks\ImageOptCheck;
 use App\Actions\Diagnostics\Pipes\Checks\IniSettingsCheck;
 use App\Actions\Diagnostics\Pipes\Checks\MigrationCheck;
 use App\Actions\Diagnostics\Pipes\Checks\PHPVersionCheck;
+use App\Actions\Diagnostics\Pipes\Checks\PlaceholderExistsCheck;
 use App\Actions\Diagnostics\Pipes\Checks\SmallMediumExistsCheck;
 use App\Actions\Diagnostics\Pipes\Checks\SupporterCheck;
 use App\Actions\Diagnostics\Pipes\Checks\TimezoneCheck;
@@ -44,6 +45,7 @@ class Errors
 		ForeignKeyListInfo::class,
 		DBIntegrityCheck::class,
 		SmallMediumExistsCheck::class,
+		PlaceholderExistsCheck::class,
 		CountSizeVariantsCheck::class,
 		SupporterCheck::class,
 	];

--- a/app/Actions/Diagnostics/Pipes/Checks/PlaceholderExistsCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/PlaceholderExistsCheck.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Actions\Diagnostics\Pipes\Checks;
+
+use App\Contracts\DiagnosticPipe;
+use App\Enum\SizeVariantType;
+use App\Image\SizeVariantDimensionHelpers;
+use App\Models\SizeVariant;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Check if there are placeholders that can be generated or encoded.
+ */
+class PlaceholderExistsCheck implements DiagnosticPipe
+{
+	public const NUM_PLACEHOLDER = 'num_placeholder';
+	public const MAX_NUM_PLACEHOLDER = 'max_num_placeholder';
+	public const NUM_UNENCODED_PLACEHOLDER = 'num_unencoded_placeholder';
+	public const INFO_MSG_MISSING = 'Info: Found %d placeholders that could be generated.';
+	public const INFO_LINE_MISSING = '     You can use `php artisan lychee:generate_thumbs placeholder %d` to generate them.';
+	public const INFO_MSG_UNENCODED = 'Info: Found %d placeholder images that have not been encoded.';
+	public const INFO_LINE_UNENCODED = '     You can use `php artisan lychee:encode_placeholders %d` to encode them.';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function handle(array &$data, \Closure $next): array
+	{
+		if (!Schema::hasTable('configs') || !Schema::hasTable('size_variants')) {
+			// @codeCoverageIgnoreStart
+			return $next($data);
+			// @codeCoverageIgnoreEnd
+		}
+
+		$svHelpers = new SizeVariantDimensionHelpers();
+		if (!$svHelpers->isEnabledByConfiguration(SizeVariantType::PLACEHOLDER)) {
+			return $next($data);
+		}
+
+		$result = DB::query()
+		->selectSub(
+			SizeVariant::query()
+			->selectRaw('COUNT(*)')
+			->where('type', '=', SizeVariantType::PLACEHOLDER),
+			self::NUM_PLACEHOLDER
+		)
+		->selectSub(
+			SizeVariant::query()
+			->selectRaw('COUNT(*)')
+			->where('type', '=', SizeVariantType::ORIGINAL),
+			self::MAX_NUM_PLACEHOLDER
+		)
+		->selectSub(
+			SizeVariant::query()
+			->selectRaw('COUNT(*)')
+			->where('short_path', 'LIKE', '%placeholder/%'),
+			self::NUM_UNENCODED_PLACEHOLDER
+		)
+		->first();
+
+		$num = $result->{self::NUM_UNENCODED_PLACEHOLDER};
+		if ($num > 0) {
+			$data[] = sprintf(self::INFO_MSG_UNENCODED, $num);
+			$data[] = sprintf(self::INFO_LINE_UNENCODED, $num);
+		}
+
+		$num = $result->{self::MAX_NUM_PLACEHOLDER} - $result->{self::NUM_PLACEHOLDER};
+		if ($num > 0) {
+			$data[] = sprintf(self::INFO_MSG_MISSING, $num);
+			$data[] = sprintf(self::INFO_LINE_MISSING, $num);
+		}
+
+		return $next($data);
+	}
+}

--- a/app/Actions/Diagnostics/Pipes/Checks/PlaceholderExistsCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/PlaceholderExistsCheck.php
@@ -59,13 +59,13 @@ class PlaceholderExistsCheck implements DiagnosticPipe
 		)
 		->first();
 
-		$num = $result->{self::NUM_UNENCODED_PLACEHOLDER};
+		$num = $result->{self::NUM_UNENCODED_PLACEHOLDER}; // @phpstan-ignore-line
 		if ($num > 0) {
 			$data[] = sprintf(self::INFO_MSG_UNENCODED, $num);
 			$data[] = sprintf(self::INFO_LINE_UNENCODED, $num);
 		}
 
-		$num = $result->{self::MAX_NUM_PLACEHOLDER} - $result->{self::NUM_PLACEHOLDER};
+		$num = $result->{self::MAX_NUM_PLACEHOLDER} - $result->{self::NUM_PLACEHOLDER}; // @phpstan-ignore-line
 		if ($num > 0) {
 			$data[] = sprintf(self::INFO_MSG_MISSING, $num);
 			$data[] = sprintf(self::INFO_LINE_MISSING, $num);

--- a/app/Actions/Photo/Create.php
+++ b/app/Actions/Photo/Create.php
@@ -167,6 +167,7 @@ class Create
 			Shared\Save::class,
 			Standalone\CreateOriginalSizeVariant::class,
 			Standalone\CreateSizeVariants::class,
+			Standalone\EncodePlaceholder::class,
 			Standalone\ReplaceOriginalWithBackup::class,
 			Shared\UploadSizeVariantsToS3::class,
 		];

--- a/app/Actions/Photo/Create.php
+++ b/app/Actions/Photo/Create.php
@@ -254,6 +254,7 @@ class Create
 			Shared\Save::class,
 			Standalone\CreateOriginalSizeVariant::class,
 			Standalone\CreateSizeVariants::class,
+			Standalone\EncodePlaceholder::class,
 			Standalone\ReplaceOriginalWithBackup::class,
 			Shared\UploadSizeVariantsToS3::class,
 		];

--- a/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
+++ b/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
@@ -15,10 +15,7 @@ class EncodePlaceholder implements StandalonePipe
 			$placeholderEncoder = new PlaceholderEncoder();
 			$placeholder = $state->getPhoto()->size_variants->getPlaceholder();
 			if ($placeholder !== null) {
-				$originalFile = $placeholder->getFile();
 				$placeholderEncoder->do($placeholder);
-				// delete original file since we now have no reference to it
-				$originalFile->delete();
 			}
 
 			return $next($state);

--- a/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
+++ b/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Actions\Photo\Pipes\Standalone;
+
+use App\Contracts\PhotoCreate\StandalonePipe;
+use App\DTO\PhotoCreate\StandaloneDTO;
+use App\Exceptions\MediaFileOperationException;
+use App\Image\Files\InMemoryBuffer;
+use App\Image\Files\TemporaryLocalFile;
+use function Safe\imagecreatefromstring;
+use function Safe\imagewebp;
+use function Safe\rewind;
+use function Safe\stream_filter_append;
+use function Safe\stream_get_contents;
+
+class EncodePlaceholder implements StandalonePipe
+{
+	public function handle(StandaloneDTO $state, \Closure $next): StandaloneDTO
+	{
+		try {
+			$inMemoryBuffer = new InMemoryBuffer();
+			$placeholder = $state->getPhoto()->size_variants->getPlaceholder();
+			$file = $placeholder->getFile();
+			// Do not attempt to encode placeholders if they were not generated
+			if ($placeholder === null) {
+				return $next($state);
+			}
+
+			$originalStream = $file->read();
+			if (stream_get_meta_data($originalStream)['seekable']) {
+				$inputStream = $originalStream;
+			} else {
+				// We make an in-memory copy of the provided stream,
+				// because we must be able to seek/rewind the stream.
+				// For example, a readable stream from a remote location (i.e.
+				// a "download" stream) is only forward readable once.
+				$inMemoryBuffer->write($originalStream);
+				$inputStream = $inMemoryBuffer->read();
+			}
+			$imgBinary = stream_get_contents($inputStream);
+
+			rewind($inputStream);
+			/** @var \GdImage $referenceImage */
+			$referenceImage = imagecreatefromstring($imgBinary);
+
+			// Compress webp image to acceptable size for DB,
+			// size_variants.short_path column allows max 255B.
+			// We need a bit of breathing room because the file
+			// may expand up to 33% when we convert to base64.
+			imagewebp($referenceImage, $inMemoryBuffer->stream(), 30);
+
+			$base64 = new TemporaryLocalFile('.txt');
+
+			stream_filter_append($base64->read(), 'convert.base64-encode');
+			$base64->write($inMemoryBuffer->read());
+			$base64->close();
+
+			$placeholder->filesize = $base64->getFilesize();
+			$placeholder->short_path = stream_get_contents($base64->read());
+			// delete original file since we now have no reference to it
+			$placeholder->getFile()->delete();
+			$placeholder->save();
+
+			return $next($state);
+		} catch (\ErrorException $e) {
+			throw new MediaFileOperationException('Failed to encode placeholder to base64', $e);
+		}
+	}
+}

--- a/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
+++ b/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
@@ -20,7 +20,7 @@ class EncodePlaceholder implements StandalonePipe
 		try {
 			$inMemoryBuffer = new InMemoryBuffer();
 			$placeholder = $state->getPhoto()->size_variants->getPlaceholder();
-			$file = $placeholder->getFile();
+			$file = $placeholder?->getFile();
 			// Do not attempt to encode placeholders if they were not generated
 			if ($placeholder === null) {
 				return $next($state);

--- a/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
+++ b/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
@@ -5,61 +5,19 @@ namespace App\Actions\Photo\Pipes\Standalone;
 use App\Contracts\PhotoCreate\StandalonePipe;
 use App\DTO\PhotoCreate\StandaloneDTO;
 use App\Exceptions\MediaFileOperationException;
-use App\Image\Files\InMemoryBuffer;
-use App\Image\Files\TemporaryLocalFile;
-use function Safe\imagecreatefromstring;
-use function Safe\imagewebp;
-use function Safe\rewind;
-use function Safe\stream_filter_append;
-use function Safe\stream_get_contents;
+use App\Image\PlaceholderEncoder;
 
 class EncodePlaceholder implements StandalonePipe
 {
 	public function handle(StandaloneDTO $state, \Closure $next): StandaloneDTO
 	{
 		try {
-			$inMemoryBuffer = new InMemoryBuffer();
+			$placeholderEncoder = new PlaceholderEncoder();
 			$placeholder = $state->getPhoto()->size_variants->getPlaceholder();
-			$file = $placeholder?->getFile();
-			// Do not attempt to encode placeholders if they were not generated
-			if ($placeholder === null) {
-				return $next($state);
-			}
-
-			$originalStream = $file->read();
-			if (stream_get_meta_data($originalStream)['seekable']) {
-				$inputStream = $originalStream;
-			} else {
-				// We make an in-memory copy of the provided stream,
-				// because we must be able to seek/rewind the stream.
-				// For example, a readable stream from a remote location (i.e.
-				// a "download" stream) is only forward readable once.
-				$inMemoryBuffer->write($originalStream);
-				$inputStream = $inMemoryBuffer->read();
-			}
-			$imgBinary = stream_get_contents($inputStream);
-
-			rewind($inputStream);
-			/** @var \GdImage $referenceImage */
-			$referenceImage = imagecreatefromstring($imgBinary);
-
-			// Compress webp image to acceptable size for DB,
-			// size_variants.short_path column allows max 255B.
-			// We need a bit of breathing room because the file
-			// may expand up to 33% when we convert to base64.
-			imagewebp($referenceImage, $inMemoryBuffer->stream(), 30);
-
-			$base64 = new TemporaryLocalFile('.txt');
-
-			stream_filter_append($base64->read(), 'convert.base64-encode');
-			$base64->write($inMemoryBuffer->read());
-			$base64->close();
-
-			$placeholder->filesize = $base64->getFilesize();
-			$placeholder->short_path = stream_get_contents($base64->read());
+			$originalFile = $placeholder->getFile();
+			$placeholderEncoder->do($placeholder);
 			// delete original file since we now have no reference to it
-			$placeholder->getFile()->delete();
-			$placeholder->save();
+			$originalFile->delete();
 
 			return $next($state);
 		} catch (\ErrorException $e) {

--- a/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
+++ b/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
@@ -14,10 +14,12 @@ class EncodePlaceholder implements StandalonePipe
 		try {
 			$placeholderEncoder = new PlaceholderEncoder();
 			$placeholder = $state->getPhoto()->size_variants->getPlaceholder();
-			$originalFile = $placeholder->getFile();
-			$placeholderEncoder->do($placeholder);
-			// delete original file since we now have no reference to it
-			$originalFile->delete();
+			if ($placeholder !== null) {
+				$originalFile = $placeholder->getFile();
+				$placeholderEncoder->do($placeholder);
+				// delete original file since we now have no reference to it
+				$originalFile->delete();
+			}
 
 			return $next($state);
 		} catch (\ErrorException $e) {

--- a/app/Assets/BaseSizeVariantNamingStrategy.php
+++ b/app/Assets/BaseSizeVariantNamingStrategy.php
@@ -18,6 +18,11 @@ abstract class BaseSizeVariantNamingStrategy extends AbstractSizeVariantNamingSt
 	public const THUMB_EXTENSION = '.jpeg';
 
 	/**
+	 * The file extension which is always used by placeholder variants.
+	 */
+	public const PLACEHOLDER_EXTENSION = '.webp';
+
+	/**
 	 * Returns the file extension incl. the preceding dot.
 	 *
 	 * @throws MissingValueException
@@ -30,6 +35,10 @@ abstract class BaseSizeVariantNamingStrategy extends AbstractSizeVariantNamingSt
 			($sizeVariant !== SizeVariantType::ORIGINAL && !$this->photo->isPhoto())
 		) {
 			return self::THUMB_EXTENSION;
+		}
+
+		if ($sizeVariant === SizeVariantType::PLACEHOLDER) {
+			return self::PLACEHOLDER_EXTENSION;
 		}
 
 		if ($this->extension === '') {

--- a/app/Console/Commands/ImageProcessing/EncodePlaceholders.php
+++ b/app/Console/Commands/ImageProcessing/EncodePlaceholders.php
@@ -52,9 +52,7 @@ class EncodePlaceholders extends Command
 
 			$placeholderEncoder = new PlaceholderEncoder();
 			foreach ($placeholders as $placeholder) {
-				$file = $placeholder->getFile();
 				$placeholderEncoder->do($placeholder);
-				$file->delete();
 			}
 
 			return 0;

--- a/app/Console/Commands/ImageProcessing/EncodePlaceholders.php
+++ b/app/Console/Commands/ImageProcessing/EncodePlaceholders.php
@@ -47,7 +47,7 @@ class EncodePlaceholders extends Command
 			if (count($placeholders) === 0) {
 				$this->line('No placeholders require encoding.');
 
-				return -1;
+				return 0;
 			}
 
 			$placeholderEncoder = new PlaceholderEncoder();

--- a/app/Console/Commands/ImageProcessing/EncodePlaceholders.php
+++ b/app/Console/Commands/ImageProcessing/EncodePlaceholders.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Console\Commands\ImageProcessing;
+
+use App\Exceptions\UnexpectedException;
+use App\Image\PlaceholderEncoder;
+use App\Models\SizeVariant;
+use Illuminate\Console\Command;
+use Safe\Exceptions\InfoException;
+use function Safe\set_time_limit;
+
+class EncodePlaceholders extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'lychee:encode_placeholders {limit=5 : number of photos to encode placeholders for} {tm=600 : timeout time requirement}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Encode placeholders if size variant exists and image has not been encoded';
+
+	/**
+	 * Execute the console command.
+	 */
+	public function handle(): int
+	{
+		try {
+			$limit = (int) $this->argument('limit');
+			$timeout = (int) $this->argument('tm');
+
+			try {
+				set_time_limit($timeout);
+			} catch (InfoException) {
+				// Silently do nothing, if `set_time_limit` is denied.
+			}
+
+			$placeholders = SizeVariant::query()
+				->where('short_path', 'LIKE', '%placeholder/%')
+				->limit($limit)
+				->get();
+			if (count($placeholders) === 0) {
+				$this->line('No placeholders require encoding.');
+
+				return -1;
+			}
+
+			$placeholderEncoder = new PlaceholderEncoder();
+			foreach ($placeholders as $placeholder) {
+				$file = $placeholder->getFile();
+				$placeholderEncoder->do($placeholder);
+				$file->delete();
+			}
+
+			return 0;
+		} catch (\Throwable $e) {
+			throw new UnexpectedException($e);
+		}
+	}
+}

--- a/app/Console/Commands/ImageProcessing/GenerateThumbs.php
+++ b/app/Console/Commands/ImageProcessing/GenerateThumbs.php
@@ -7,6 +7,7 @@ use App\Contracts\Exceptions\LycheeException;
 use App\Contracts\Models\SizeVariantFactory;
 use App\Enum\SizeVariantType;
 use App\Exceptions\UnexpectedException;
+use App\Image\PlaceholderEncoder;
 use App\Models\Photo;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Builder;
@@ -99,10 +100,18 @@ class GenerateThumbs extends Command
 
 			// Initialize factory for size variants
 			$sizeVariantFactory = resolve(SizeVariantFactory::class);
+			$placeholderEncoder = new PlaceholderEncoder();
 			/** @var Photo $photo */
 			foreach ($photos as $photo) {
 				$sizeVariantFactory->init($photo);
 				$sizeVariant = $sizeVariantFactory->createSizeVariantCond($sizeVariantType);
+				if ($sizeVariant->type === SizeVariantType::PLACEHOLDER) {
+					$originalFile = $sizeVariant->getFile();
+					$placeholderEncoder->do($sizeVariant);
+					// delete original file since we now have no reference to it
+					$originalFile->delete();
+					$sizeVariant->save();
+				}
 				if ($sizeVariant !== null) {
 					$this->line('   ' . $sizeVariantName . ' (' . $sizeVariant->width . 'x' . $sizeVariant->height . ') for ' . $photo->title . ' created.');
 				} else {

--- a/app/Console/Commands/ImageProcessing/GenerateThumbs.php
+++ b/app/Console/Commands/ImageProcessing/GenerateThumbs.php
@@ -105,7 +105,8 @@ class GenerateThumbs extends Command
 			foreach ($photos as $photo) {
 				$sizeVariantFactory->init($photo);
 				$sizeVariant = $sizeVariantFactory->createSizeVariantCond($sizeVariantType);
-				if ($sizeVariant->type === SizeVariantType::PLACEHOLDER) {
+
+				if ($sizeVariant->type === SizeVariantType::PLACEHOLDER && $sizeVariant !== null) {
 					$originalFile = $sizeVariant->getFile();
 					$placeholderEncoder->do($sizeVariant);
 					// delete original file since we now have no reference to it

--- a/app/Console/Commands/ImageProcessing/GenerateThumbs.php
+++ b/app/Console/Commands/ImageProcessing/GenerateThumbs.php
@@ -7,7 +7,6 @@ use App\Contracts\Exceptions\LycheeException;
 use App\Contracts\Models\SizeVariantFactory;
 use App\Enum\SizeVariantType;
 use App\Exceptions\UnexpectedException;
-use App\Image\PlaceholderEncoder;
 use App\Models\Photo;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Builder;
@@ -100,19 +99,10 @@ class GenerateThumbs extends Command
 
 			// Initialize factory for size variants
 			$sizeVariantFactory = resolve(SizeVariantFactory::class);
-			$placeholderEncoder = new PlaceholderEncoder();
 			/** @var Photo $photo */
 			foreach ($photos as $photo) {
 				$sizeVariantFactory->init($photo);
 				$sizeVariant = $sizeVariantFactory->createSizeVariantCond($sizeVariantType);
-
-				if ($sizeVariant->type === SizeVariantType::PLACEHOLDER && $sizeVariant !== null) {
-					$originalFile = $sizeVariant->getFile();
-					$placeholderEncoder->do($sizeVariant);
-					// delete original file since we now have no reference to it
-					$originalFile->delete();
-					$sizeVariant->save();
-				}
 				if ($sizeVariant !== null) {
 					$this->line('   ' . $sizeVariantName . ' (' . $sizeVariant->width . 'x' . $sizeVariant->height . ') for ' . $photo->title . ' created.');
 				} else {

--- a/app/Console/Commands/ImageProcessing/GenerateThumbs.php
+++ b/app/Console/Commands/ImageProcessing/GenerateThumbs.php
@@ -20,6 +20,7 @@ class GenerateThumbs extends Command
 	 * @var array<string,SizeVariantType>
 	 */
 	public const SIZE_VARIANTS = [
+		'placeholder' => SizeVariantType::PLACEHOLDER,
 		'thumb' => SizeVariantType::THUMB,
 		'thumb2x' => SizeVariantType::THUMB2X,
 		'small' => SizeVariantType::SMALL,

--- a/app/Contracts/Image/ImageHandlerInterface.php
+++ b/app/Contracts/Image/ImageHandlerInterface.php
@@ -29,15 +29,16 @@ interface ImageHandlerInterface
 	/**
 	 * Save the image into the provided file.
 	 *
-	 * @param MediaFile $file               the file to write into
-	 * @param int|null  $compressionQuality Override configured compression quality
-	 * @param bool      $collectStatistics  if true, the method returns statistics about the stream
+	 * @param MediaFile $file              the file to write into
+	 * @param bool      $collectStatistics if true, the method returns statistics about the stream
 	 *
 	 * @return StreamStats|null optional statistics about the stream, if requested
 	 *
 	 * @throws MediaFileOperationException
 	 */
-	public function save(MediaFile $file, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats;
+	public function save(MediaFile $file, bool $collectStatistics = false): ?StreamStats;
+
+	public function convertAndSave(MediaFile $file, string $targetMimeType, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats;
 
 	/**
 	 * Frees all internal resources.

--- a/app/Contracts/Image/ImageHandlerInterface.php
+++ b/app/Contracts/Image/ImageHandlerInterface.php
@@ -38,8 +38,6 @@ interface ImageHandlerInterface
 	 */
 	public function save(MediaFile $file, bool $collectStatistics = false): ?StreamStats;
 
-	public function convertAndSave(MediaFile $file, string $targetMimeType, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats;
-
 	/**
 	 * Frees all internal resources.
 	 *

--- a/app/Contracts/Image/ImageHandlerInterface.php
+++ b/app/Contracts/Image/ImageHandlerInterface.php
@@ -29,14 +29,15 @@ interface ImageHandlerInterface
 	/**
 	 * Save the image into the provided file.
 	 *
-	 * @param MediaFile $file              the file to write into
-	 * @param bool      $collectStatistics if true, the method returns statistics about the stream
+	 * @param MediaFile $file               the file to write into
+	 * @param int|null  $compressionQuality Override configured compression quality
+	 * @param bool      $collectStatistics  if true, the method returns statistics about the stream
 	 *
 	 * @return StreamStats|null optional statistics about the stream, if requested
 	 *
 	 * @throws MediaFileOperationException
 	 */
-	public function save(MediaFile $file, bool $collectStatistics = false): ?StreamStats;
+	public function save(MediaFile $file, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats;
 
 	/**
 	 * Frees all internal resources.

--- a/app/Enum/SizeVariantType.php
+++ b/app/Enum/SizeVariantType.php
@@ -16,6 +16,7 @@ enum SizeVariantType: int
 	case SMALL = 4;
 	case THUMB2X = 5;
 	case THUMB = 6;
+	case PLACEHOLDER = 7;
 
 	/**
 	 * Given a sizeVariantType return the associated name.
@@ -25,6 +26,7 @@ enum SizeVariantType: int
 	public function name(): string
 	{
 		return match ($this) {
+			self::PLACEHOLDER => 'placeholder',
 			self::THUMB => 'thumb',
 			self::THUMB2X => 'thumb2x',
 			self::SMALL => 'small',
@@ -43,6 +45,7 @@ enum SizeVariantType: int
 	public function localization(): string
 	{
 		return match ($this) {
+			self::PLACEHOLDER => __('lychee.PHOTO_PLACEHOLDER'),
 			self::THUMB => __('lychee.PHOTO_THUMB'),
 			self::THUMB2X => __('lychee.PHOTO_THUMB_HIDPI'),
 			self::SMALL => __('lychee.PHOTO_SMALL'),

--- a/app/Http/Resources/Models/SizeVariantsResouce.php
+++ b/app/Http/Resources/Models/SizeVariantsResouce.php
@@ -19,6 +19,7 @@ class SizeVariantsResouce extends Data
 	public ?SizeVariantResource $small;
 	public ?SizeVariantResource $thumb2x;
 	public ?SizeVariantResource $thumb;
+	public ?SizeVariantResource $placeholder;
 
 	public function __construct(Photo $photo)
 	{
@@ -34,6 +35,7 @@ class SizeVariantsResouce extends Data
 		$small2x = $size_variants?->getSizeVariant(SizeVariantType::SMALL2X);
 		$thumb = $size_variants?->getSizeVariant(SizeVariantType::THUMB);
 		$thumb2x = $size_variants?->getSizeVariant(SizeVariantType::THUMB2X);
+		$placeholder = $size_variants?->getSizeVariant(SizeVariantType::PLACEHOLDER);
 
 		$this->medium = $medium?->toResource();
 		$this->medium2x = $medium2x?->toResource();
@@ -42,5 +44,6 @@ class SizeVariantsResouce extends Data
 		$this->small2x = $small2x?->toResource();
 		$this->thumb = $thumb?->toResource();
 		$this->thumb2x = $thumb2x?->toResource();
+		$this->placeholder = $placeholder?->toResource();
 	}
 }

--- a/app/Image/Handlers/GdHandler.php
+++ b/app/Image/Handlers/GdHandler.php
@@ -221,7 +221,7 @@ class GdHandler extends BaseImageHandler
 	/**
 	 * {@inheritDoc}
 	 */
-	public function save(MediaFile $file, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats
+	public function save(MediaFile $file, bool $collectStatistics = false): ?StreamStats
 	{
 		if ($this->gdImage === null) {
 			throw new MediaFileOperationException('No image loaded');
@@ -248,6 +248,33 @@ class GdHandler extends BaseImageHandler
 			return parent::applyLosslessOptimizationConditionally($file) ?? $streamStat;
 		} catch (\ErrorException $e) {
 			throw new MediaFileOperationException('Failed to save image', $e);
+		}
+	}
+
+	public function convertAndSave(MediaFile $file, string $targetMimeType, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats
+	{
+		if ($this->gdImage === null) {
+			throw new MediaFileOperationException('No image loaded');
+		}
+		try {
+			$inMemoryBuffer = new InMemoryBuffer();
+			$compressionQuality = $compressionQuality ?? $this->compressionQuality;
+
+			match ($targetMimeType) {
+				'image/jpeg' => imagejpeg($this->gdImage, $inMemoryBuffer->stream(), $compressionQuality),
+				'image/png' => imagepng($this->gdImage, $inMemoryBuffer->stream(), $compressionQuality),
+				'image/gif' => imagegif($this->gdImage, $inMemoryBuffer->stream()),
+				'image/webp' => imagewebp($this->gdImage, $inMemoryBuffer->stream(), $compressionQuality),
+				default => throw new \AssertionError('uncovered image type'),
+			};
+
+			$streamStat = $file->write($inMemoryBuffer->read(), $collectStatistics);
+			$file->close();
+			$inMemoryBuffer->close();
+
+			return parent::applyLosslessOptimizationConditionally($file) ?? $streamStat;
+		} catch (\ErrorException $e) {
+			throw new MediaFileOperationException('Failed to convert image', $e);
 		}
 	}
 

--- a/app/Image/Handlers/GdHandler.php
+++ b/app/Image/Handlers/GdHandler.php
@@ -221,7 +221,7 @@ class GdHandler extends BaseImageHandler
 	/**
 	 * {@inheritDoc}
 	 */
-	public function save(MediaFile $file, bool $collectStatistics = false): ?StreamStats
+	public function save(MediaFile $file, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats
 	{
 		if ($this->gdImage === null) {
 			throw new MediaFileOperationException('No image loaded');

--- a/app/Image/Handlers/GdHandler.php
+++ b/app/Image/Handlers/GdHandler.php
@@ -251,33 +251,6 @@ class GdHandler extends BaseImageHandler
 		}
 	}
 
-	public function convertAndSave(MediaFile $file, string $targetMimeType, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats
-	{
-		if ($this->gdImage === null) {
-			throw new MediaFileOperationException('No image loaded');
-		}
-		try {
-			$inMemoryBuffer = new InMemoryBuffer();
-			$compressionQuality = $compressionQuality ?? $this->compressionQuality;
-
-			match ($targetMimeType) {
-				'image/jpeg' => imagejpeg($this->gdImage, $inMemoryBuffer->stream(), $compressionQuality),
-				'image/png' => imagepng($this->gdImage, $inMemoryBuffer->stream(), $compressionQuality),
-				'image/gif' => imagegif($this->gdImage, $inMemoryBuffer->stream()),
-				'image/webp' => imagewebp($this->gdImage, $inMemoryBuffer->stream(), $compressionQuality),
-				default => throw new \AssertionError('uncovered image type'),
-			};
-
-			$streamStat = $file->write($inMemoryBuffer->read(), $collectStatistics);
-			$file->close();
-			$inMemoryBuffer->close();
-
-			return parent::applyLosslessOptimizationConditionally($file) ?? $streamStat;
-		} catch (\ErrorException $e) {
-			throw new MediaFileOperationException('Failed to convert image', $e);
-		}
-	}
-
 	/**
 	 * Rotates and flips a photo based on the designated EXIF orientation.
 	 *

--- a/app/Image/Handlers/ImageHandler.php
+++ b/app/Image/Handlers/ImageHandler.php
@@ -81,9 +81,9 @@ class ImageHandler extends BaseImageHandler implements ImageHandlerInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function save(MediaFile $file, bool $collectStatistics = false): ?StreamStats
+	public function save(MediaFile $file, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats
 	{
-		return $this->engine->save($file, $collectStatistics);
+		return $this->engine->save($file, $compressionQuality, $collectStatistics);
 	}
 
 	/**

--- a/app/Image/Handlers/ImageHandler.php
+++ b/app/Image/Handlers/ImageHandler.php
@@ -86,11 +86,6 @@ class ImageHandler extends BaseImageHandler implements ImageHandlerInterface
 		return $this->engine->save($file, $collectStatistics);
 	}
 
-	public function convertAndSave(MediaFile $file, string $targetMimeType, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats
-	{
-		return $this->engine->convertAndSave($file, $targetMimeType, $compressionQuality, $collectStatistics);
-	}
-
 	/**
 	 * {@inheritDoc}
 	 */

--- a/app/Image/Handlers/ImageHandler.php
+++ b/app/Image/Handlers/ImageHandler.php
@@ -81,9 +81,14 @@ class ImageHandler extends BaseImageHandler implements ImageHandlerInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function save(MediaFile $file, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats
+	public function save(MediaFile $file, bool $collectStatistics = false): ?StreamStats
 	{
-		return $this->engine->save($file, $compressionQuality, $collectStatistics);
+		return $this->engine->save($file, $collectStatistics);
+	}
+
+	public function convertAndSave(MediaFile $file, string $targetMimeType, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats
+	{
+		return $this->engine->convertAndSave($file, $targetMimeType, $compressionQuality, $collectStatistics);
 	}
 
 	/**

--- a/app/Image/Handlers/ImagickHandler.php
+++ b/app/Image/Handlers/ImagickHandler.php
@@ -71,13 +71,18 @@ class ImagickHandler extends BaseImageHandler
 	/**
 	 * {@inheritDoc}
 	 */
-	public function save(MediaFile $file, bool $collectStatistics = false): ?StreamStats
+	public function save(MediaFile $file, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats
 	{
 		if ($this->imImage === null) {
 			throw new MediaFileOperationException('No image loaded');
 		}
 		try {
-			$this->imImage->setImageCompressionQuality($this->compressionQuality);
+			if ($compressionQuality !== null) {
+				$this->imImage->setImageCompressionQuality($compressionQuality);
+			} else {
+				$this->imImage->setImageCompressionQuality($this->compressionQuality);
+			}
+
 			$profiles = $this->imImage->getImageProfiles('icc', true);
 			// Remove metadata to save some bytes
 			$this->imImage->stripImage();

--- a/app/Image/Handlers/ImagickHandler.php
+++ b/app/Image/Handlers/ImagickHandler.php
@@ -26,59 +26,6 @@ class ImagickHandler extends BaseImageHandler
 	}
 
 	/**
-	 * Not currently working as expected, and should not be used.
-	 *  We are limited by imagick's lack of webp compression.
-	 * This method only exists here because its GD counterpart is
-	 * working fine and {@link ImageHandlerInterface} requires it.
-	 *
-	 * @param MediaFile $file
-	 * @param string    $targetMimeType
-	 * @param int|null  $compressionQuality
-	 * @param bool      $collectStatistics
-	 *
-	 * @return StreamStats|null
-	 */
-	public function convertAndSave(MediaFile $file, string $targetMimeType, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats
-	{
-		// Nasty workaround to only use GD for this function
-		$image = new GdHandler();
-		$image->load($file);
-
-		return $image->convertAndSave($file, $targetMimeType, $compressionQuality, $collectStatistics);
-		//		if ($this->imImage === null) {
-		//			throw new MediaFileOperationException('No image loaded');
-		//		}
-		//		try {
-		//			$this->imImage->setImageFormat('WEBP');
-		//			$this->imImage->setImageCompressionQuality($compressionQuality);
-		//			$this->imImage->setOption('webp:method', '6');
-		//			$this->imImage->setOption('webp:lossless', 'false');
-		//			$this->imImage->setOption('webp:emulate-jpeg-size', 'false');
-		//
-		//			$profiles = $this->imImage->getImageProfiles('icc', true);
-		//			// Remove metadata to save some bytes
-		//			$this->imImage->stripImage();
-		//			// Re-add  color profiles
-		//			if (key_exists('icc', $profiles)) {
-		//				$this->imImage->profileImage('icc', $profiles['icc']);
-		//			}
-		//
-		//			// We write the image into a memory buffer first, because
-		//			// we don't know if the file is a local file (or hosted elsewhere)
-		//			// and if the file supports seekable streams
-		//			$inMemoryBuffer = new InMemoryBuffer();
-		//			$this->imImage->writeImageFile($inMemoryBuffer->stream(), ltrim($file->getExtension(), '.'));
-		//			$streamStat = $file->write($inMemoryBuffer->read(), $collectStatistics);
-		//			$file->close();
-		//			$inMemoryBuffer->close();
-		//
-		//			return $streamStat;
-		//		} catch (\ImagickException $e) {
-		//			throw new MediaFileOperationException('Failed to convert image', $e);
-		//		}
-	}
-
-	/**
 	 * {@inheritdoc}
 	 */
 	public function reset(): void

--- a/app/Image/Handlers/ImagickHandler.php
+++ b/app/Image/Handlers/ImagickHandler.php
@@ -78,7 +78,6 @@ class ImagickHandler extends BaseImageHandler
 		}
 		try {
 			$this->imImage->setImageCompressionQuality($this->compressionQuality);
-
 			$profiles = $this->imImage->getImageProfiles('icc', true);
 			// Remove metadata to save some bytes
 			$this->imImage->stripImage();

--- a/app/Image/Handlers/ImagickHandler.php
+++ b/app/Image/Handlers/ImagickHandler.php
@@ -26,6 +26,59 @@ class ImagickHandler extends BaseImageHandler
 	}
 
 	/**
+	 * Not currently working as expected, and should not be used.
+	 *  We are limited by imagick's lack of webp compression.
+	 * This method only exists here because its GD counterpart is
+	 * working fine and {@link ImageHandlerInterface} requires it.
+	 *
+	 * @param MediaFile $file
+	 * @param string    $targetMimeType
+	 * @param int|null  $compressionQuality
+	 * @param bool      $collectStatistics
+	 *
+	 * @return StreamStats|null
+	 */
+	public function convertAndSave(MediaFile $file, string $targetMimeType, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats
+	{
+		// Nasty workaround to only use GD for this function
+		$image = new GdHandler();
+		$image->load($file);
+
+		return $image->convertAndSave($file, $targetMimeType, $compressionQuality, $collectStatistics);
+		//		if ($this->imImage === null) {
+		//			throw new MediaFileOperationException('No image loaded');
+		//		}
+		//		try {
+		//			$this->imImage->setImageFormat('WEBP');
+		//			$this->imImage->setImageCompressionQuality($compressionQuality);
+		//			$this->imImage->setOption('webp:method', '6');
+		//			$this->imImage->setOption('webp:lossless', 'false');
+		//			$this->imImage->setOption('webp:emulate-jpeg-size', 'false');
+		//
+		//			$profiles = $this->imImage->getImageProfiles('icc', true);
+		//			// Remove metadata to save some bytes
+		//			$this->imImage->stripImage();
+		//			// Re-add  color profiles
+		//			if (key_exists('icc', $profiles)) {
+		//				$this->imImage->profileImage('icc', $profiles['icc']);
+		//			}
+		//
+		//			// We write the image into a memory buffer first, because
+		//			// we don't know if the file is a local file (or hosted elsewhere)
+		//			// and if the file supports seekable streams
+		//			$inMemoryBuffer = new InMemoryBuffer();
+		//			$this->imImage->writeImageFile($inMemoryBuffer->stream(), ltrim($file->getExtension(), '.'));
+		//			$streamStat = $file->write($inMemoryBuffer->read(), $collectStatistics);
+		//			$file->close();
+		//			$inMemoryBuffer->close();
+		//
+		//			return $streamStat;
+		//		} catch (\ImagickException $e) {
+		//			throw new MediaFileOperationException('Failed to convert image', $e);
+		//		}
+	}
+
+	/**
 	 * {@inheritdoc}
 	 */
 	public function reset(): void
@@ -71,17 +124,13 @@ class ImagickHandler extends BaseImageHandler
 	/**
 	 * {@inheritDoc}
 	 */
-	public function save(MediaFile $file, ?int $compressionQuality = null, bool $collectStatistics = false): ?StreamStats
+	public function save(MediaFile $file, bool $collectStatistics = false): ?StreamStats
 	{
 		if ($this->imImage === null) {
 			throw new MediaFileOperationException('No image loaded');
 		}
 		try {
-			if ($compressionQuality !== null) {
-				$this->imImage->setImageCompressionQuality($compressionQuality);
-			} else {
-				$this->imImage->setImageCompressionQuality($this->compressionQuality);
-			}
+			$this->imImage->setImageCompressionQuality($this->compressionQuality);
 
 			$profiles = $this->imImage->getImageProfiles('icc', true);
 			// Remove metadata to save some bytes

--- a/app/Image/PlaceholderEncoder.php
+++ b/app/Image/PlaceholderEncoder.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Image;
+
+use App\Contracts\Image\MediaFile;
+use App\Exceptions\MediaFileOperationException;
+use App\Image\Files\InMemoryBuffer;
+use App\Image\Files\TemporaryLocalFile;
+use App\Models\SizeVariant;
+use Safe\Exceptions\FilesystemException;
+use Safe\Exceptions\ImageException;
+use Safe\Exceptions\StreamException;
+use function Safe\imagecreatefromstring;
+use function Safe\imagewebp;
+use function Safe\rewind;
+use function Safe\stream_filter_append;
+use function Safe\stream_get_contents;
+
+class PlaceholderEncoder
+{
+	private const IMAGE_QUALITY = 30;
+
+	public function do(SizeVariant $sizeVariant): void
+	{
+		try {
+			$inMemoryBuffer = new InMemoryBuffer();
+			// Compress webp image to acceptable size for DB,
+			// size_variants.short_path column allows max 255 characters.
+			// We need a bit of breathing room because the file
+			// may expand up to 33% when we convert to base64.
+			imagewebp($this->createGdImage($sizeVariant->getFile()), $inMemoryBuffer->stream(), self::IMAGE_QUALITY);
+
+			$base64 = new TemporaryLocalFile('');
+
+			stream_filter_append($base64->read(), 'convert.base64-encode');
+			$base64->write($inMemoryBuffer->read());
+			$base64->close();
+
+			$sizeVariant->filesize = $base64->getFilesize();
+			$sizeVariant->short_path = stream_get_contents($base64->read());
+			$sizeVariant->save();
+		} catch (\ErrorException $e) {
+			throw new MediaFileOperationException('Failed to encode placeholder to base64', $e);
+		}
+	}
+
+	/**
+	 * Returns a GdImage object from the provided file.
+	 *
+	 * @param MediaFile $file
+	 *
+	 * @return \GdImage
+	 *
+	 * @throws FilesystemException
+	 * @throws ImageException
+	 * @throws StreamException
+	 */
+	private function createGdImage(MediaFile $file): \GdImage
+	{
+		$inMemoryBuffer = new InMemoryBuffer();
+
+		$originalStream = $file->read();
+		if (stream_get_meta_data($originalStream)['seekable']) {
+			$inputStream = $originalStream;
+		} else {
+			// We make an in-memory copy of the provided stream,
+			// because we must be able to seek/rewind the stream.
+			// For example, a readable stream from a remote location (i.e.
+			// a "download" stream) is only forward readable once.
+			$inMemoryBuffer->write($originalStream);
+			$inputStream = $inMemoryBuffer->read();
+		}
+		$imgBinary = stream_get_contents($inputStream);
+
+		rewind($inputStream);
+		/** @var \GdImage $referenceImage */
+		$referenceImage = imagecreatefromstring($imgBinary);
+
+		return $referenceImage;
+	}
+}

--- a/app/Image/PlaceholderEncoder.php
+++ b/app/Image/PlaceholderEncoder.php
@@ -93,19 +93,8 @@ class PlaceholderEncoder
 		rewind($inputStream);
 		/** @var \GdImage $referenceImage */
 		$referenceImage = imagecreatefromstring($imgBinary);
-
-		// Since gd has issues with saving gif as webp, save as jpeg first and reload
-		$imageStats = getimagesizefromstring($imgBinary);
-		if ($imageStats !== false && $imageStats[2] === IMAGETYPE_GIF) {
-			// TODO: remove if/when GdHandler save method respects naming strategy extensions and placeholders are first generated as jpegs
-			$tmpJpeg = new InMemoryBuffer();
-			\Safe\imagejpeg($referenceImage, $tmpJpeg->stream());
-
-			$imgBinary = stream_get_contents($tmpJpeg->read());
-			rewind($inputStream);
-			/** @var \GdImage $referenceImage */
-			$referenceImage = imagecreatefromstring($imgBinary);
-		}
+		// webp does not support palette images
+		imagepalettetotruecolor($referenceImage);
 
 		$this->gdImage = $referenceImage;
 	}

--- a/app/Image/PlaceholderEncoder.php
+++ b/app/Image/PlaceholderEncoder.php
@@ -18,17 +18,40 @@ use function Safe\stream_get_contents;
 
 class PlaceholderEncoder
 {
-	private const IMAGE_QUALITY = 30;
+	private const IMAGE_QUALITY = 50;
 
+	/** Character length that the encoded base64 image cannot exceed.
+	 *	The initial value 255 is determined by the max characters in size_variants.short_path DB column.
+	 *  Since base64 encodes into groups of 4 characters, with padding to fill the final
+	 *  group if it is less than 3 bytes, the actual limit can be calculated by:
+	 * 	255 - (255 % 4) = 252 characters.
+	 */
+	private const BASE64_SIZE_LIMIT = 252;
+
+	/** Filesize in bytes that the compressed image cannot exceed.
+	 * The limit is calculated using the BASE64_SIZE_LIMIT.
+	 * Base64 encodes every 3 bytes into 4 characters.
+	 *    - 252 / 4 = 63 groups of four characters
+	 *    - Since each group of 4 chars corresponds to 3 bytes of data,
+	 *      63 * 3 = 189 bytes of unencoded data.
+	 */
+	private const FILESIZE_LIMIT = 189;
+	private const MAX_COMPRESSION_RETRIES = 3;
+
+	/**
+	 * Performs the steps to encode a usable placeholder image and saves it in
+	 * the size variant's short_path column.
+	 *
+	 * @param SizeVariant $sizeVariant unencoded placeholder size variant
+	 *
+	 * @return void
+	 */
 	public function do(SizeVariant $sizeVariant): void
 	{
 		try {
 			$inMemoryBuffer = new InMemoryBuffer();
-			// Compress webp image to acceptable size for DB,
-			// size_variants.short_path column allows max 255 characters.
-			// We need a bit of breathing room because the file
-			// may expand up to 33% when we convert to base64.
-			imagewebp($this->createGdImage($sizeVariant->getFile()), $inMemoryBuffer->stream(), self::IMAGE_QUALITY);
+			$gdImage = $this->createGdImage($sizeVariant->getFile());
+			$this->compressImage($gdImage, $inMemoryBuffer);
 
 			$base64 = new TemporaryLocalFile('');
 
@@ -36,9 +59,14 @@ class PlaceholderEncoder
 			$base64->write($inMemoryBuffer->read());
 			$base64->close();
 
-			$sizeVariant->filesize = $base64->getFilesize();
-			$sizeVariant->short_path = stream_get_contents($base64->read());
-			$sizeVariant->save();
+			$base64Length = $base64->getFilesize();
+			if ($base64Length <= self::BASE64_SIZE_LIMIT) {
+				$sizeVariant->filesize = $base64->getFilesize();
+				$sizeVariant->short_path = stream_get_contents($base64->read());
+				$sizeVariant->save();
+			} else {
+				throw new MediaFileOperationException('Encoded image is too large.');
+			}
 		} catch (\ErrorException $e) {
 			throw new MediaFileOperationException('Failed to encode placeholder to base64', $e);
 		}
@@ -77,5 +105,37 @@ class PlaceholderEncoder
 		$referenceImage = imagecreatefromstring($imgBinary);
 
 		return $referenceImage;
+	}
+
+	/**
+	 * Compress webp image to acceptable size for DB.
+	 *
+	 * @param \GdImage       $source source Image
+	 * @param InMemoryBuffer $output the file to write to
+	 *
+	 * @return void
+	 *
+	 * @throws ImageException
+	 * @throws FilesystemException
+	 */
+	private function compressImage(\GdImage $source, InMemoryBuffer $output): void
+	{
+		$quality = self::IMAGE_QUALITY;
+		$retries = 0;
+		// Given a proper placeholder source image (16px x 16px) it should
+		// almost always be sufficiently compressed on the first attempt.
+		// But just in case it isn't we try to compress again.
+		do {
+			// ensure buffer is empty before trying to compress again
+			$emptyStream = \Safe\fopen('php://temp', 'w+');
+			$output->write($emptyStream);
+			\Safe\fclose($emptyStream);
+
+			imagewebp($source, $output->stream(), $quality);
+			$filesize = \Safe\fstat($output->read())['size'];
+
+			$quality -= 5;
+			$retries++;
+		} while ($filesize > self::FILESIZE_LIMIT && $retries <= self::MAX_COMPRESSION_RETRIES);
 	}
 }

--- a/app/Image/SizeVariantDefaultFactory.php
+++ b/app/Image/SizeVariantDefaultFactory.php
@@ -184,12 +184,7 @@ class SizeVariantDefaultFactory implements SizeVariantFactory
 		};
 
 		$svFile = $this->namingStrategy->createFile($sizeVariant);
-		// Placeholder must be small enough to fit in database when encoded with base64, so it needs more compression.
-		if ($sizeVariant === SizeVariantType::PLACEHOLDER) {
-			$svImage->convertAndSave($svFile, 'image/webp', self::PLACEHOLDER_COMPRESSION_QUALITY);
-		} else {
-			$svImage->save($svFile);
-		}
+		$svImage->save($svFile);
 
 		return $this->photo->size_variants->create(
 			$sizeVariant,

--- a/app/Image/SizeVariantDefaultFactory.php
+++ b/app/Image/SizeVariantDefaultFactory.php
@@ -19,7 +19,6 @@ use App\Exceptions\MediaFileUnsupportedException;
 use App\Image\Files\TemporaryLocalFile;
 use App\Image\Handlers\ImageHandler;
 use App\Image\Handlers\VideoHandler;
-use App\Models\Configs;
 use App\Models\Photo;
 use App\Models\SizeVariant;
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -143,10 +142,6 @@ class SizeVariantDefaultFactory implements SizeVariantFactory
 		if ($this->photo->isVideo() && ($sizeVariant === SizeVariantType::MEDIUM || $sizeVariant === SizeVariantType::MEDIUM2X)) {
 			return null;
 		}
-		// TODO: Remove when GD can convert supported files to webp with proper compression
-		if ($sizeVariant === SizeVariantType::PLACEHOLDER && Configs::hasImagick() === false) {
-			return null;
-		}
 		// Don't re-create existing size variant
 		if ($this->photo->size_variants->getSizeVariant($sizeVariant) !== null) {
 			return null;
@@ -191,7 +186,7 @@ class SizeVariantDefaultFactory implements SizeVariantFactory
 		$svFile = $this->namingStrategy->createFile($sizeVariant);
 		// Placeholder must be small enough to fit in database when encoded with base64, so it needs more compression.
 		if ($sizeVariant === SizeVariantType::PLACEHOLDER) {
-			$svImage->save($svFile, self::PLACEHOLDER_COMPRESSION_QUALITY);
+			$svImage->convertAndSave($svFile, 'image/webp', self::PLACEHOLDER_COMPRESSION_QUALITY);
 		} else {
 			$svImage->save($svFile);
 		}

--- a/app/Image/SizeVariantDefaultFactory.php
+++ b/app/Image/SizeVariantDefaultFactory.php
@@ -29,7 +29,6 @@ class SizeVariantDefaultFactory implements SizeVariantFactory
 	public const THUMBNAIL_DIM = 200;
 	public const THUMBNAIL2X_DIM = 400;
 	public const PLACEHOLDER_DIM = 16;
-	public const PLACEHOLDER_COMPRESSION_QUALITY = 30;
 
 	/** @var ImageHandlerInterface the image handler (gd, imagick, ...) which is used to generate image files */
 	protected ImageHandlerInterface $referenceImage;

--- a/app/Image/SizeVariantDefaultFactory.php
+++ b/app/Image/SizeVariantDefaultFactory.php
@@ -179,7 +179,7 @@ class SizeVariantDefaultFactory implements SizeVariantFactory
 	{
 		$svImage = match ($sizeVariant) {
 			SizeVariantType::THUMB, SizeVariantType::THUMB2X, SizeVariantType::PLACEHOLDER => $this->referenceImage->cloneAndCrop($maxDim),
-			default => $this->referenceImage->cloneAndScale($maxDim)
+			default => $this->referenceImage->cloneAndScale($maxDim),
 		};
 
 		$svFile = $this->namingStrategy->createFile($sizeVariant);

--- a/app/Image/SizeVariantDefaultFactory.php
+++ b/app/Image/SizeVariantDefaultFactory.php
@@ -28,6 +28,7 @@ class SizeVariantDefaultFactory implements SizeVariantFactory
 {
 	public const THUMBNAIL_DIM = 200;
 	public const THUMBNAIL2X_DIM = 400;
+	public const PLACEHOLDER_DIM = 16;
 
 	/** @var ImageHandlerInterface the image handler (gd, imagick, ...) which is used to generate image files */
 	protected ImageHandlerInterface $referenceImage;
@@ -105,6 +106,7 @@ class SizeVariantDefaultFactory implements SizeVariantFactory
 	public function createSizeVariants(): Collection
 	{
 		$allVariants = [
+			SizeVariantType::PLACEHOLDER,
 			SizeVariantType::THUMB,
 			SizeVariantType::THUMB2X,
 			SizeVariantType::SMALL,
@@ -176,8 +178,8 @@ class SizeVariantDefaultFactory implements SizeVariantFactory
 	private function createSizeVariantInternal(SizeVariantType $sizeVariant, ImageDimension $maxDim): SizeVariant
 	{
 		$svImage = match ($sizeVariant) {
-			SizeVariantType::THUMB, SizeVariantType::THUMB2X => $this->referenceImage->cloneAndCrop($maxDim),
-			default => $this->referenceImage->cloneAndScale($maxDim),
+			SizeVariantType::THUMB, SizeVariantType::THUMB2X, SizeVariantType::PLACEHOLDER => $this->referenceImage->cloneAndCrop($maxDim),
+			default => $this->referenceImage->cloneAndScale($maxDim)
 		};
 
 		$svFile = $this->namingStrategy->createFile($sizeVariant);

--- a/app/Image/SizeVariantDimensionHelpers.php
+++ b/app/Image/SizeVariantDimensionHelpers.php
@@ -60,7 +60,7 @@ class SizeVariantDimensionHelpers
 			SizeVariantType::MEDIUM2X => Configs::getValueAsBool('medium_2x'),
 			SizeVariantType::SMALL2X => Configs::getValueAsBool('small_2x'),
 			SizeVariantType::THUMB2X => Configs::getValueAsBool('thumb_2x'),
-			SizeVariantType::SMALL, SizeVariantType::MEDIUM, SizeVariantType::THUMB => true,
+			SizeVariantType::SMALL, SizeVariantType::MEDIUM, SizeVariantType::THUMB, SizeVariantType::PLACEHOLDER => true, // TODO: Add config for placeholder
 			default => throw new InvalidSizeVariantException('unknown size variant: ' . $sizeVariant->value),
 		};
 	}
@@ -78,7 +78,7 @@ class SizeVariantDimensionHelpers
 	public function isLargeEnough(ImageDimension $realDim, ImageDimension $maxDim, SizeVariantType $sizeVariant): bool
 	{
 		return match ($sizeVariant) {
-			SizeVariantType::THUMB => true,
+			SizeVariantType::THUMB, SizeVariantType::PLACEHOLDER => true,
 			SizeVariantType::THUMB2X => $realDim->width >= $maxDim->width && $realDim->height >= $maxDim->height,
 			default => ($realDim->width >= $maxDim->width && $maxDim->width !== 0) || ($realDim->height >= $maxDim->height && $maxDim->height !== 0),
 		};
@@ -98,6 +98,7 @@ class SizeVariantDimensionHelpers
 			SizeVariantType::SMALL => Configs::getValueAsInt('small_max_width'),
 			SizeVariantType::THUMB2X => SizeVariantDefaultFactory::THUMBNAIL2X_DIM,
 			SizeVariantType::THUMB => SizeVariantDefaultFactory::THUMBNAIL_DIM,
+			SizeVariantType::PLACEHOLDER => SizeVariantDefaultFactory::PLACEHOLDER_DIM,
 			default => throw new InvalidSizeVariantException('No applicable for original'),
 		};
 	}
@@ -116,6 +117,7 @@ class SizeVariantDimensionHelpers
 			SizeVariantType::SMALL => Configs::getValueAsInt('small_max_height'),
 			SizeVariantType::THUMB2X => SizeVariantDefaultFactory::THUMBNAIL2X_DIM,
 			SizeVariantType::THUMB => SizeVariantDefaultFactory::THUMBNAIL_DIM,
+			SizeVariantType::PLACEHOLDER => SizeVariantDefaultFactory::PLACEHOLDER_DIM,
 			default => throw new InvalidSizeVariantException('unknown size variant: ' . $sizeVariant->value),
 		};
 	}

--- a/app/Image/SizeVariantDimensionHelpers.php
+++ b/app/Image/SizeVariantDimensionHelpers.php
@@ -60,7 +60,8 @@ class SizeVariantDimensionHelpers
 			SizeVariantType::MEDIUM2X => Configs::getValueAsBool('medium_2x'),
 			SizeVariantType::SMALL2X => Configs::getValueAsBool('small_2x'),
 			SizeVariantType::THUMB2X => Configs::getValueAsBool('thumb_2x'),
-			SizeVariantType::SMALL, SizeVariantType::MEDIUM, SizeVariantType::THUMB, SizeVariantType::PLACEHOLDER => true, // TODO: Add config for placeholder
+			SizeVariantType::PLACEHOLDER => Configs::getValueAsBool('low_quality_image_placeholder'),
+			SizeVariantType::SMALL, SizeVariantType::MEDIUM, SizeVariantType::THUMB => true,
 			default => throw new InvalidSizeVariantException('unknown size variant: ' . $sizeVariant->value),
 		};
 	}

--- a/app/Legacy/Actions/Photo/Strategies/AddStandaloneStrategy.php
+++ b/app/Legacy/Actions/Photo/Strategies/AddStandaloneStrategy.php
@@ -22,6 +22,7 @@ use App\Image\Files\TemporaryLocalFile;
 use App\Image\Handlers\GoogleMotionPictureHandler;
 use App\Image\Handlers\ImageHandler;
 use App\Image\Handlers\VideoHandler;
+use App\Image\PlaceholderEncoder;
 use App\Image\StreamStat;
 use App\Jobs\UploadSizeVariantToS3Job;
 use App\Models\Configs;
@@ -199,6 +200,12 @@ class AddStandaloneStrategy extends AbstractAddStrategy
 				$sizeVariantFactory->init($this->photo, $this->sourceImage, $this->namingStrategy);
 				$variants = $sizeVariantFactory->createSizeVariants();
 				$variants->push($originalVariant);
+
+				$placeholder = $variants->firstWhere('type', SizeVariantType::PLACEHOLDER);
+				if ($placeholder !== null) {
+					$placeholderEncoder = new PlaceholderEncoder();
+					$placeholderEncoder->do($placeholder);
+				}
 
 				if (Features::active('use-s3')) {
 					// If enabled, upload all size variants to the remote bucket and delete the local files after that

--- a/app/Legacy/V1/Resources/ConfigurationResource.php
+++ b/app/Legacy/V1/Resources/ConfigurationResource.php
@@ -109,6 +109,7 @@ class ConfigurationResource extends JsonResource
 				'local_takestamp_video_formats' => Configs::getValueAsString('local_takestamp_video_formats'),
 				'log_max_num_line' => Configs::getValueAsInt('log_max_num_line'),
 				'lossless_optimization' => Configs::getValueAsBool('lossless_optimization'),
+				'low_quality_image_placeholder' => Configs::getValueAsBool('low_quality_image_placeholder'),
 				'medium_2x' => Configs::getValueAsBool('medium_2x'),
 				'medium_max_height' => Configs::getValueAsInt('medium_max_height'),
 				'medium_max_width' => Configs::getValueAsInt('medium_max_width'),

--- a/app/Legacy/V1/Resources/Models/PhotoResource.php
+++ b/app/Legacy/V1/Resources/Models/PhotoResource.php
@@ -59,6 +59,7 @@ class PhotoResource extends JsonResource
 		$small2x = $size_variants?->getSizeVariant(SizeVariantType::SMALL2X);
 		$thumb = $size_variants?->getSizeVariant(SizeVariantType::THUMB);
 		$thumb2x = $size_variants?->getSizeVariant(SizeVariantType::THUMB2X);
+		$placeholder = $size_variants?->getSizeVariant(SizeVariantType::PLACEHOLDER);
 
 		return [
 			'id' => $this->resource->id,
@@ -92,6 +93,7 @@ class PhotoResource extends JsonResource
 				'small2x' => $small2x === null ? null : SizeVariantResource::make($small2x)->toArray($request),
 				'thumb' => $thumb === null ? null : SizeVariantResource::make($thumb)->toArray($request),
 				'thumb2x' => $thumb2x === null ? null : SizeVariantResource::make($thumb2x)->toArray($request),
+				'placeholder' => $placeholder === null ? null : SizeVariantResource::make($placeholder)->toArray($request),
 			],
 			'tags' => $this->resource->tags,
 			'taken_at' => $this->resource->taken_at?->toIso8601String(),

--- a/app/Models/Extensions/SizeVariants.php
+++ b/app/Models/Extensions/SizeVariants.php
@@ -35,6 +35,7 @@ class SizeVariants extends AbstractDTO
 	private ?SizeVariant $small = null;
 	private ?SizeVariant $thumb2x = null;
 	private ?SizeVariant $thumb = null;
+	private ?SizeVariant $placeholder = null;
 
 	/**
 	 * SizeVariants constructor.
@@ -87,6 +88,7 @@ class SizeVariants extends AbstractDTO
 			SizeVariantType::SMALL => $this->small = $sizeVariant,
 			SizeVariantType::THUMB2X => $this->thumb2x = $sizeVariant,
 			SizeVariantType::THUMB => $this->thumb = $sizeVariant,
+			SizeVariantType::PLACEHOLDER => $this->placeholder = $sizeVariant,
 		};
 	}
 
@@ -105,6 +107,7 @@ class SizeVariants extends AbstractDTO
 			SizeVariantType::SMALL->name() => $this->small?->toArray(),
 			SizeVariantType::THUMB2X->name() => $this->thumb2x?->toArray(),
 			SizeVariantType::THUMB->name() => $this->thumb?->toArray(),
+			SizeVariantType::PLACEHOLDER->name() => $this->placeholder?->toArray(),
 		];
 	}
 
@@ -123,6 +126,7 @@ class SizeVariants extends AbstractDTO
 			$this->small,
 			$this->thumb2x,
 			$this->thumb,
+			$this->placeholder,
 		]);
 	}
 
@@ -145,6 +149,7 @@ class SizeVariants extends AbstractDTO
 			SizeVariantType::SMALL => $this->small,
 			SizeVariantType::THUMB2X => $this->thumb2x,
 			SizeVariantType::THUMB => $this->thumb,
+			SizeVariantType::PLACEHOLDER => $this->placeholder,
 		};
 	}
 
@@ -196,6 +201,11 @@ class SizeVariants extends AbstractDTO
 	public function getThumb(): ?SizeVariant
 	{
 		return $this->thumb;
+	}
+
+	public function getPlaceholder(): ?SizeVariant
+	{
+		return $this->placeholder;
 	}
 
 	/**
@@ -257,6 +267,7 @@ class SizeVariants extends AbstractDTO
 			$this->small?->id,
 			$this->thumb2x?->id,
 			$this->thumb?->id,
+			$this->placeholder?->id,
 		];
 
 		$this->original = null;
@@ -266,6 +277,7 @@ class SizeVariants extends AbstractDTO
 		$this->small = null;
 		$this->thumb2x = null;
 		$this->thumb = null;
+		$this->placeholder = null;
 
 		(new Delete())->do(array_diff($ids, [null]))->do();
 	}
@@ -284,6 +296,7 @@ class SizeVariants extends AbstractDTO
 		self::replicateSizeVariant($duplicate, $this->small);
 		self::replicateSizeVariant($duplicate, $this->thumb2x);
 		self::replicateSizeVariant($duplicate, $this->thumb);
+		self::replicateSizeVariant($duplicate, $this->placeholder);
 
 		return $duplicate;
 	}

--- a/app/Models/Extensions/Thumb.php
+++ b/app/Models/Extensions/Thumb.php
@@ -9,6 +9,7 @@ use App\Enum\ColumnSortingPhotoType;
 use App\Enum\OrderSortingType;
 use App\Enum\SizeVariantType;
 use App\Exceptions\InvalidPropertyException;
+use App\Models\Configs;
 use App\Models\Photo;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -23,13 +24,15 @@ class Thumb extends AbstractDTO
 	public string $type;
 	public ?string $thumbUrl;
 	public ?string $thumb2xUrl;
+	public ?string $placeholderUrl;
 
-	protected function __construct(string $id, string $type, string $thumbUrl, ?string $thumb2xUrl = null)
+	protected function __construct(string $id, string $type, string $thumbUrl, ?string $thumb2xUrl = null, ?string $placeholderUrl = null)
 	{
 		$this->id = $id;
 		$this->type = $type;
 		$this->thumbUrl = $thumbUrl;
 		$this->thumb2xUrl = $thumb2xUrl;
+		$this->placeholderUrl = $placeholderUrl;
 	}
 
 	/**
@@ -42,9 +45,9 @@ class Thumb extends AbstractDTO
 	 */
 	public static function sizeVariantsFilter(HasMany $relation): HasMany
 	{
-		$svAlbumThumbs = [SizeVariantType::THUMB, SizeVariantType::THUMB2X];
+		$svAlbumThumbs = [SizeVariantType::THUMB, SizeVariantType::THUMB2X, SizeVariantType::PLACEHOLDER];
 		if (Features::active('vuejs')) {
-			$svAlbumThumbs = [SizeVariantType::SMALL, SizeVariantType::SMALL2X, SizeVariantType::THUMB, SizeVariantType::THUMB2X];
+			$svAlbumThumbs = [SizeVariantType::SMALL, SizeVariantType::SMALL2X, SizeVariantType::THUMB, SizeVariantType::THUMB2X, SizeVariantType::PLACEHOLDER];
 		}
 
 		return $relation->whereIn('type', $svAlbumThumbs);
@@ -135,11 +138,16 @@ class Thumb extends AbstractDTO
 			? $photo->size_variants->getSmall2x()
 			: $photo->size_variants->getThumb2x();
 
+		$placeholder = (Configs::getValueAsBool('low_quality_image_placeholder'))
+			? $photo->size_variants->getPlaceholder()
+			: null;
+
 		return new self(
 			$photo->id,
 			$photo->type,
 			$thumb->url,
-			$thumb2x?->url
+			$thumb2x?->url,
+			$placeholder?->url,
 		);
 	}
 
@@ -155,6 +163,7 @@ class Thumb extends AbstractDTO
 			'type' => $this->type,
 			'thumb' => $this->thumbUrl,
 			'thumb2x' => $this->thumb2xUrl,
+			'placeholder' => $this->placeholderUrl,
 		];
 	}
 }

--- a/app/Models/SizeVariant.php
+++ b/app/Models/SizeVariant.php
@@ -177,14 +177,14 @@ class SizeVariant extends Model
 	{
 		$imageDisk = Storage::disk($this->storage_disk->value);
 
+		if ($this->type === SizeVariantType::PLACEHOLDER) {
+			return 'data:image/webp;base64,' . $this->short_path;
+		}
+
 		if (
 			!Configs::getValueAsBool('SL_enable') ||
 			(!Configs::getValueAsBool('SL_for_admin') && Auth::user()?->may_administrate === true)
 		) {
-			if ($this->type === SizeVariantType::PLACEHOLDER) {
-				return 'data:image/webp;base64,' . $this->short_path;
-			}
-
 			/** @disregard P1013 */
 			return $imageDisk->url($this->short_path);
 		}

--- a/app/Models/SizeVariant.php
+++ b/app/Models/SizeVariant.php
@@ -181,6 +181,10 @@ class SizeVariant extends Model
 			!Configs::getValueAsBool('SL_enable') ||
 			(!Configs::getValueAsBool('SL_for_admin') && Auth::user()?->may_administrate === true)
 		) {
+			if ($this->type === SizeVariantType::PLACEHOLDER) {
+				return 'data:image/webp;base64,' . $this->short_path;
+			}
+
 			/** @disregard P1013 */
 			return $imageDisk->url($this->short_path);
 		}

--- a/database/migrations/2024_08_15_163203_config_low_quality_image_placeholder.php
+++ b/database/migrations/2024_08_15_163203_config_low_quality_image_placeholder.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Legacy\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public function getConfigs(): array
+	{
+		return [
+			[
+				'key' => 'low_quality_image_placeholder',
+				'value' => '1',
+				'cat' => 'Image Processing',
+				'type_range' => self::BOOL,
+				'description' => 'Enable low quality image placeholders',
+			],
+		];
+	}
+};

--- a/database/migrations/2024_08_15_163203_config_low_quality_image_placeholder.php
+++ b/database/migrations/2024_08_15_163203_config_low_quality_image_placeholder.php
@@ -1,17 +1,20 @@
 <?php
 
-use App\Legacy\BaseConfigMigration;
+use App\Models\Extensions\BaseConfigMigration;
 
 return new class() extends BaseConfigMigration {
+	public const PROCESSING = 'Image Processing';
+
 	public function getConfigs(): array
 	{
 		return [
 			[
 				'key' => 'low_quality_image_placeholder',
 				'value' => '1',
-				'cat' => 'Image Processing',
+				'cat' => self::PROCESSING,
 				'type_range' => self::BOOL,
 				'description' => 'Enable low quality image placeholders',
+				'is_secret' => false,
 			],
 		];
 	}

--- a/lang/cz/lychee.php
+++ b/lang/cz/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Náhled HiDPI',
 	'PHOTO_THUMB' => 'Čtvercový náhled',
 	'PHOTO_THUMB_HIDPI' => 'Čtvercový náhled HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Zobrazení foto Lychee:',

--- a/lang/de/lychee.php
+++ b/lang/de/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Miniaturansicht HiDPI',
 	'PHOTO_THUMB' => 'Quadratische Miniaturansicht',
 	'PHOTO_THUMB_HIDPI' => 'Quadratische Miniaturansicht HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Foto-Vorschau',
 	'PHOTO_LIVE_VIDEO' => 'Video des Live-Fotos',
 	'PHOTO_VIEW' => 'Lychees Foto-Ansicht:',

--- a/lang/el/lychee.php
+++ b/lang/el/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Μικρογραφία HiDPI',
 	'PHOTO_THUMB' => 'Τετράγωνη Μικρογραφία',
 	'PHOTO_THUMB_HIDPI' => 'Τετράγωνη Μικρογραφία HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Προβολή Φωτογραφιών:',

--- a/lang/en/lychee.php
+++ b/lang/en/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Thumb HiDPI',
 	'PHOTO_THUMB' => 'Square thumb',
 	'PHOTO_THUMB_HIDPI' => 'Square thumb HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Photo View:',

--- a/lang/es/lychee.php
+++ b/lang/es/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Miniatura HiDPI',
 	'PHOTO_THUMB' => 'Cuadrado de Miniatura',
 	'PHOTO_THUMB_HIDPI' => 'Cuadrado de Miniatura HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Miniatura de la foto',
 	'PHOTO_LIVE_VIDEO' => 'Video de live-photo',
 	'PHOTO_VIEW' => 'Vista de Foto de Lychee',

--- a/lang/fr/lychee.php
+++ b/lang/fr/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Petite taille HiDPI',
 	'PHOTO_THUMB' => 'Mignature carrée',
 	'PHOTO_THUMB_HIDPI' => 'Mignature carrée HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Partie vidéo d’une live-photo',
 	'PHOTO_VIEW' => 'Vue photo de Lychee :',

--- a/lang/hu/lychee.php
+++ b/lang/hu/lychee.php
@@ -491,6 +491,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Bélyegkép HiDPI',
 	'PHOTO_THUMB' => 'Négyzetes bélyegkép',
 	'PHOTO_THUMB_HIDPI' => 'Négyzetes bélyegkép HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Kép bélyegképe',
 	'PHOTO_LIVE_VIDEO' => 'Videó része a live-fotónak',
 	'PHOTO_VIEW' => 'Lychee Kép Megtekintés:',

--- a/lang/it/lychee.php
+++ b/lang/it/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Thumb HiDPI',
 	'PHOTO_THUMB' => 'Square thumb',
 	'PHOTO_THUMB_HIDPI' => 'Square thumb HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Photo View:',

--- a/lang/ja/lychee.php
+++ b/lang/ja/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => '小 HiDPI',
 	'PHOTO_THUMB' => '正方形サムネイル',
 	'PHOTO_THUMB_HIDPI' => '正方形サムネイル HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'サムネイル',
 	'PHOTO_LIVE_VIDEO' => 'ライブフォトのビデオ部分',
 	'PHOTO_VIEW' => 'Lychee の写真表示：',

--- a/lang/nl/lychee.php
+++ b/lang/nl/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Thumb HiDPI',
 	'PHOTO_THUMB' => 'Square thumb',
 	'PHOTO_THUMB_HIDPI' => 'Square thumb HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Photo View:',

--- a/lang/no/lychee.php
+++ b/lang/no/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Miniatyr HiDPI',
 	'PHOTO_THUMB' => 'Kvadratisk miniatyr',
 	'PHOTO_THUMB_HIDPI' => 'Kvadratisk miniatyr HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Filmdel av livebilde',
 	'PHOTO_VIEW' => 'Lychee Bildevisning:',

--- a/lang/pl/lychee.php
+++ b/lang/pl/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Thumb HiDPI',
 	'PHOTO_THUMB' => 'Kwadratowa miniaturka',
 	'PHOTO_THUMB_HIDPI' => 'Square thumb HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Photo View:',

--- a/lang/pt/lychee.php
+++ b/lang/pt/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Pequena HiDPI',
 	'PHOTO_THUMB' => 'Quadrada pequena',
 	'PHOTO_THUMB_HIDPI' => 'Quadrada pequena HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video parte de fotografia ao vivo',
 	'PHOTO_VIEW' => 'Vista de Fotografia Lychee:',

--- a/lang/ru/lychee.php
+++ b/lang/ru/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Thumb HiDPI',
 	'PHOTO_THUMB' => 'Square thumb',
 	'PHOTO_THUMB_HIDPI' => 'Square thumb HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Photo View:',

--- a/lang/sk/lychee.php
+++ b/lang/sk/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Náhľad HiDPI',
 	'PHOTO_THUMB' => 'Štvorcový náhľad',
 	'PHOTO_THUMB_HIDPI' => 'Štvorcový náhľad HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Zobrazenie foto Lychee:',

--- a/lang/sv/lychee.php
+++ b/lang/sv/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Thumb HiDPI',
 	'PHOTO_THUMB' => 'Square thumb',
 	'PHOTO_THUMB_HIDPI' => 'Square thumb HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Photo View:',

--- a/lang/vi/lychee.php
+++ b/lang/vi/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Độ phân giải cho hình nhỏ HiDPI',
 	'PHOTO_THUMB' => 'Ô vuông nhỏ',
 	'PHOTO_THUMB_HIDPI' => 'Độ phân giải cho hình ô vuông nhỏ HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Hình thu nhỏ của hình ảnh gốc',
 	'PHOTO_LIVE_VIDEO' => 'Phần video của hình động live-photo',
 	'PHOTO_VIEW' => 'Khung hiển thị hình ảnh Lychee:',

--- a/lang/zh_CN/lychee.php
+++ b/lang/zh_CN/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => '缩略图 HiDPI',
 	'PHOTO_THUMB' => '方形缩略图',
 	'PHOTO_THUMB_HIDPI' => '方形缩略图 HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => '实况照片（Live-Photo）的视频部分',
 	'PHOTO_VIEW' => 'Lychee 照片查看:',

--- a/lang/zh_TW/lychee.php
+++ b/lang/zh_TW/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => '低解析度',
 	'PHOTO_THUMB' => '方形圖',
 	'PHOTO_THUMB_HIDPI' => '方形解析度',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => '實時照片的視頻部分',
 	'PHOTO_VIEW' => 'Lychee照片瀏覽：',

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -151,7 +151,7 @@ parameters:
 				- tests
 
 		-
-			message: '#Access to private property App\\Models\\Extensions\\SizeVariants::\$(original|small(2x)?|thumb(2x)?|medium(2x)?)#'
+			message: '#Access to private property App\\Models\\Extensions\\SizeVariants::\$(original|small(2x)?|thumb(2x)?|medium(2x)?|placeholder)#'
 			paths:
 				- tests
 		-

--- a/tests/Feature_v1/BasePhotosAddHandler.php
+++ b/tests/Feature_v1/BasePhotosAddHandler.php
@@ -338,6 +338,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 				'small' => ['width' => 480, 'height' => 360],
 				'thumb2x' => ['width' => 400, 'height' => 400],
 				'thumb' => ['width' => 200,	'height' => 200],
+				'placeholder' => ['width' => 16, 'height' => 16],
 			],
 			'live_photo_url' => null,
 		]);
@@ -363,6 +364,10 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 			'title' => 'gaming',
 			'type' => TestConstants::MIME_TYPE_VID_MP4,
 			'size_variants' => [
+				'placeholder' => [
+					'width' => 16,
+					'height' => 16,
+				],
 				'thumb' => [
 					'width' => 200,
 					'height' => 200,
@@ -422,6 +427,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 				'small' => null,
 				'thumb2x' => null,
 				'thumb' => null,
+				'placeholder' => null,
 			],
 		]);
 
@@ -464,6 +470,7 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 			'shutter' => '1/250 s',
 			'type' => TestConstants::MIME_TYPE_IMG_JPEG,
 			'size_variants' => [
+				'placeholder' => ['width' => 16, 'height' => 16],
 				'thumb' => ['width' => 200, 'height' => 200],
 				'thumb2x' => ['width' => 400, 'height' => 400],
 				'small' => ['width' => 529,	'height' => 360],

--- a/tests/Feature_v1/BasePhotosAddHandler.php
+++ b/tests/Feature_v1/BasePhotosAddHandler.php
@@ -15,6 +15,7 @@ namespace Tests\Feature_v1;
 use App\Models\Configs;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Testing\Assert;
 use function Safe\date;
 use function Safe\file_get_contents;
 use function Safe\file_put_contents;
@@ -71,6 +72,40 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 				'original' => ['width' => 6720,	'height' => 4480, 'filesize' => 21106422],
 			],
 		]);
+	}
+
+	/**
+	 * Tests that a placeholder for the source image was encoded.
+	 *
+	 * @return void
+	 */
+	public function testUploadWithPlaceholder(): void
+	{
+		$init_config_value1 = Configs::getValue('low_quality_image_placeholder');
+
+		try {
+			Configs::set('low_quality_image_placeholder', '1');
+			static::assertEquals('1', Configs::getValue('low_quality_image_placeholder'));
+
+			$response = $this->photos_tests->upload(
+				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
+			);
+			$response->assertJson([
+				'size_variants' => [
+					'placeholder' => ['width' => 16, 'height' => 16],
+				],
+			]);
+			$responseContent = $response->getContent();
+			if ($responseContent !== false) {
+				$photo = \Safe\json_decode($responseContent)->size_variants->placeholder;
+				// Because image compression is non-deterministic, we can only reliably
+				// check for the file signature in the decoded base64 data.
+				Assert::assertStringContainsString('WEBPVP8', \Safe\base64_decode($photo->url));
+				Assert::assertLessThan(190, $photo->filesize);
+			}
+		} finally {
+			Configs::set('low_quality_image_placeholder', $init_config_value1);
+		}
 	}
 
 	/**

--- a/tests/Feature_v1/BasePhotosAddHandler.php
+++ b/tests/Feature_v1/BasePhotosAddHandler.php
@@ -82,30 +82,26 @@ abstract class BasePhotosAddHandler extends BasePhotoTest
 	public function testUploadWithPlaceholder(): void
 	{
 		$init_config_value1 = Configs::getValue('low_quality_image_placeholder');
+		Configs::set('low_quality_image_placeholder', '1');
+		static::assertEquals('1', Configs::getValue('low_quality_image_placeholder'));
 
-		try {
-			Configs::set('low_quality_image_placeholder', '1');
-			static::assertEquals('1', Configs::getValue('low_quality_image_placeholder'));
-
-			$response = $this->photos_tests->upload(
-				AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
-			);
-			$response->assertJson([
-				'size_variants' => [
-					'placeholder' => ['width' => 16, 'height' => 16],
-				],
-			]);
-			$responseContent = $response->getContent();
-			if ($responseContent !== false) {
-				$photo = \Safe\json_decode($responseContent)->size_variants->placeholder;
-				// Because image compression is non-deterministic, we can only reliably
-				// check for the file signature in the decoded base64 data.
-				Assert::assertStringContainsString('WEBPVP8', \Safe\base64_decode($photo->url));
-				Assert::assertLessThan(190, $photo->filesize);
-			}
-		} finally {
-			Configs::set('low_quality_image_placeholder', $init_config_value1);
+		$response = $this->photos_tests->upload(
+			AbstractTestCase::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
+		);
+		$response->assertJson([
+			'size_variants' => [
+				'placeholder' => ['width' => 16, 'height' => 16],
+			],
+		]);
+		$responseContent = $response->getContent();
+		if ($responseContent !== false) {
+			$photo = \Safe\json_decode($responseContent)->size_variants->placeholder;
+			// check for the file signature in the decoded base64 data.
+			Assert::assertStringContainsString('WEBPVP8', \Safe\base64_decode($photo->url));
+			Assert::assertLessThan(190, $photo->filesize);
 		}
+
+		Configs::set('low_quality_image_placeholder', $init_config_value1);
 	}
 
 	/**

--- a/tests/Feature_v1/CommandEncodePlaceholdersTest.php
+++ b/tests/Feature_v1/CommandEncodePlaceholdersTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v1;
+
+use App\Enum\SizeVariantType;
+use App\Models\Configs;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Testing\Assert;
+use Tests\Constants\TestConstants;
+use Tests\Feature_v1\Base\BasePhotoTest;
+
+class CommandEncodePlaceholdersTest extends BasePhotoTest
+{
+	public const COMMAND = 'lychee:encode_placeholders';
+	public const GENERATE_THUMBS_COMMAND = 'lychee:generate_thumbs';
+
+	public function testNoPlaceholdersUnencoded(): void
+	{
+		$this->artisan(self::COMMAND)
+			->expectsOutput('No placeholders require encoding.')
+			->assertExitCode(0);
+	}
+
+	public function testPlaceholderEncoding(): void
+	{
+		$originalConfig = Configs::getValueAsBool('low_quality_image_placeholder');
+		Configs::set('low_quality_image_placeholder', true);
+
+		/** @var \App\Models\Photo $photo1 */
+		$photo1 = static::convertJsonToObject($this->photos_tests->upload(
+			static::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
+		));
+
+		// Remove the size variant "placeholder" from DB
+		DB::table('size_variants')
+			->where('photo_id', '=', $photo1->id)
+			->where('type', '=', SizeVariantType::PLACEHOLDER)
+			->delete();
+
+		// Re-create it without encoding
+		$this->artisan(self::GENERATE_THUMBS_COMMAND, ['type' => 'placeholder'])
+			->assertExitCode(0);
+
+		// Attempt to encode using command
+		$this->artisan(self::COMMAND)
+			->assertExitCode(0);
+
+		// Get updated photo and check if placeholder was encoded
+		/** @var \App\Models\Photo $photo2 */
+		$photo2 = static::convertJsonToObject($this->photos_tests->get($photo1->id));
+		// check for the file signature in the decoded base64 data.
+		Assert::assertStringContainsString('WEBPVP8', \Safe\base64_decode($photo2->size_variants->placeholder->url));
+
+		Configs::set('low_quality_image_placeholder', $originalConfig);
+	}
+}

--- a/tests/Feature_v1/CommandGenerateThumbsTest.php
+++ b/tests/Feature_v1/CommandGenerateThumbsTest.php
@@ -32,7 +32,7 @@ class CommandGenerateThumbsTest extends BasePhotoTest
 	public function testInvalidSizeVariantArgument(): void
 	{
 		$this->artisan(self::COMMAND, ['type' => 'smally'])
-			->expectsOutput('Type smally is not one of thumb, thumb2x, small, small2x, medium, medium2x')
+			->expectsOutput('Type smally is not one of placeholder, thumb, thumb2x, small, small2x, medium, medium2x')
 			->assertExitCode(1);
 	}
 


### PR DESCRIPTION
Implements backend for #2258 

Adds low quality image placeholder to be displayed while album covers are downloading. 
Improves perceived loading times.


Approach:
- Adds new size variant of type 7 called 'placeholder'
- Adds PlaceholderEncoder class to compress image to usable size, convert to base64 and save to db
- Adds new standalone pipe to process the placeholder
- Adds step in legacy code path to process the placeholder
- Adds command to handle placeholders that exist but have not been encoded yet
- Adds diagnostic info check for determining number of missing and unencoded placeholders
- Modifies SizeVariant getUrlAttribute to use data URI instead of app url for placeholders
- Modifies Thumb to include generated placeholder


**Notes for implementing the frontend**

- requires either a `filter: blur();` or `backdrop-filter: blur();`. I've found that between 8-15px looks best.