### PR TITLE
Disable snq if secret is not set

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,14 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: composer
     directory: /
     schedule:
-      interval: daily
+      interval: weekly

--- a/.github/workflows/php_no_legacy_tests.yml
+++ b/.github/workflows/php_no_legacy_tests.yml
@@ -117,6 +117,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: SonarCloud Scan
+        if: ${{ env.SONAR_TOKEN }}
         uses: SonarSource/sonarcloud-github-action@9f9bba2c7aaf7a55eac26abbac906c3021d211b2 # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -113,6 +113,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: SonarCloud Scan
+        if: ${{ env.SONAR_TOKEN }}
         uses: SonarSource/sonarcloud-github-action@9f9bba2c7aaf7a55eac26abbac906c3021d211b2 # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any


### PR DESCRIPTION
Hopefully this will prevent future dependabots PR to fail and same for contributors.