### PR TITLE
Fix building artifact in Integrate workflow

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -190,7 +190,6 @@ jobs:
       - name: Build Dist
         run: |
           make clean dist
-          mv Lychee-Dist.zip Lychee.zip
 
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3


### PR DESCRIPTION
The artifact was being uploaded (in the next step) as `Lychee-Dist.zip`, but the Makefile only creates `Lychee.zip`, so we should be able to stick with that throughout.