### PR TITLE
New Feature: Low Quality Image Placeholder cont.

### DIFF
--- a/app/Actions/Diagnostics/Errors.php
+++ b/app/Actions/Diagnostics/Errors.php
@@ -15,6 +15,7 @@ use App\Actions\Diagnostics\Pipes\Checks\ImageOptCheck;
 use App\Actions\Diagnostics\Pipes\Checks\IniSettingsCheck;
 use App\Actions\Diagnostics\Pipes\Checks\MigrationCheck;
 use App\Actions\Diagnostics\Pipes\Checks\PHPVersionCheck;
+use App\Actions\Diagnostics\Pipes\Checks\PlaceholderExistsCheck;
 use App\Actions\Diagnostics\Pipes\Checks\SmallMediumExistsCheck;
 use App\Actions\Diagnostics\Pipes\Checks\SupporterCheck;
 use App\Actions\Diagnostics\Pipes\Checks\TimezoneCheck;
@@ -44,6 +45,7 @@ class Errors
 		ForeignKeyListInfo::class,
 		DBIntegrityCheck::class,
 		SmallMediumExistsCheck::class,
+		PlaceholderExistsCheck::class,
 		CountSizeVariantsCheck::class,
 		SupporterCheck::class,
 	];

--- a/app/Actions/Diagnostics/Pipes/Checks/PlaceholderExistsCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/PlaceholderExistsCheck.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Actions\Diagnostics\Pipes\Checks;
+
+use App\Contracts\DiagnosticPipe;
+use App\Enum\SizeVariantType;
+use App\Image\SizeVariantDimensionHelpers;
+use App\Models\SizeVariant;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Check if there are placeholders that can be generated or encoded.
+ */
+class PlaceholderExistsCheck implements DiagnosticPipe
+{
+	public const INFO_MSG_MISSING = 'Info: Found %d placeholders that could be generated.';
+	public const INFO_LINE_MISSING = '     You can use `php artisan lychee:generate_thumbs placeholder %d` to generate them.';
+	public const INFO_MSG_UNENCODED = 'Info: Found %d placeholder images that have not been encoded.';
+	public const INFO_LINE_UNENCODED = '     You can use `php artisan lychee:encode_placeholders %d` to encode them.';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function handle(array &$data, \Closure $next): array
+	{
+		if (!Schema::hasTable('configs') || !Schema::hasTable('size_variants')) {
+			// @codeCoverageIgnoreStart
+			return $next($data);
+			// @codeCoverageIgnoreEnd
+		}
+
+		$svHelpers = new SizeVariantDimensionHelpers();
+		if (!$svHelpers->isEnabledByConfiguration(SizeVariantType::PLACEHOLDER)) {
+			return $next($data);
+		}
+
+		/** @var object{num_placeholder:int,max_num_placeholder:int,num_unencoded_placeholder:int}> $result */
+		$result = DB::query()
+		->selectSub(
+			SizeVariant::query()
+			->selectRaw('COUNT(*)')
+			->where('type', '=', SizeVariantType::PLACEHOLDER),
+			'num_placeholder'
+		)
+		->selectSub(
+			SizeVariant::query()
+			->selectRaw('COUNT(*)')
+			->where('type', '=', SizeVariantType::ORIGINAL),
+			'max_num_placeholder'
+		)
+		->selectSub(
+			SizeVariant::query()
+			->selectRaw('COUNT(*)')
+			->where('short_path', 'LIKE', '%placeholder/%'),
+			'num_unencoded_placeholder'
+		)
+		->first();
+
+		$num = $result->num_unencoded_placeholder;
+		if ($num > 0) {
+			$data[] = sprintf(self::INFO_MSG_UNENCODED, $num);
+			$data[] = sprintf(self::INFO_LINE_UNENCODED, $num);
+		}
+
+		$num = $result->max_num_placeholder - $result->num_placeholder;
+		if ($num > 0) {
+			$data[] = sprintf(self::INFO_MSG_MISSING, $num);
+			$data[] = sprintf(self::INFO_LINE_MISSING, $num);
+		}
+
+		return $next($data);
+	}
+}

--- a/app/Actions/Photo/Create.php
+++ b/app/Actions/Photo/Create.php
@@ -167,6 +167,7 @@ class Create
 			Shared\Save::class,
 			Standalone\CreateOriginalSizeVariant::class,
 			Standalone\CreateSizeVariants::class,
+			Standalone\EncodePlaceholder::class,
 			Standalone\ReplaceOriginalWithBackup::class,
 			Shared\UploadSizeVariantsToS3::class,
 		];
@@ -253,6 +254,7 @@ class Create
 			Shared\Save::class,
 			Standalone\CreateOriginalSizeVariant::class,
 			Standalone\CreateSizeVariants::class,
+			Standalone\EncodePlaceholder::class,
 			Standalone\ReplaceOriginalWithBackup::class,
 			Shared\UploadSizeVariantsToS3::class,
 		];

--- a/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
+++ b/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Actions\Photo\Pipes\Standalone;
+
+use App\Contracts\PhotoCreate\StandalonePipe;
+use App\DTO\PhotoCreate\StandaloneDTO;
+use App\Exceptions\MediaFileOperationException;
+use App\Image\PlaceholderEncoder;
+
+class EncodePlaceholder implements StandalonePipe
+{
+	public function handle(StandaloneDTO $state, \Closure $next): StandaloneDTO
+	{
+		try {
+			$placeholderEncoder = new PlaceholderEncoder();
+			$placeholder = $state->getPhoto()->size_variants->getPlaceholder();
+			if ($placeholder !== null) {
+				$placeholderEncoder->do($placeholder);
+			}
+
+			return $next($state);
+		} catch (\ErrorException $e) {
+			throw new MediaFileOperationException('Failed to encode placeholder to base64', $e);
+		}
+	}
+}

--- a/app/Assets/BaseSizeVariantNamingStrategy.php
+++ b/app/Assets/BaseSizeVariantNamingStrategy.php
@@ -18,6 +18,11 @@ abstract class BaseSizeVariantNamingStrategy extends AbstractSizeVariantNamingSt
 	public const THUMB_EXTENSION = '.jpeg';
 
 	/**
+	 * The file extension which is always used by placeholder variants.
+	 */
+	public const PLACEHOLDER_EXTENSION = '.webp';
+
+	/**
 	 * Returns the file extension incl. the preceding dot.
 	 *
 	 * @throws MissingValueException
@@ -30,6 +35,10 @@ abstract class BaseSizeVariantNamingStrategy extends AbstractSizeVariantNamingSt
 			($sizeVariant !== SizeVariantType::ORIGINAL && !$this->photo->isPhoto())
 		) {
 			return self::THUMB_EXTENSION;
+		}
+
+		if ($sizeVariant === SizeVariantType::PLACEHOLDER) {
+			return self::PLACEHOLDER_EXTENSION;
 		}
 
 		if ($this->extension === '') {

--- a/app/Console/Commands/ImageProcessing/EncodePlaceholders.php
+++ b/app/Console/Commands/ImageProcessing/EncodePlaceholders.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Console\Commands\ImageProcessing;
+
+use App\Exceptions\UnexpectedException;
+use App\Image\PlaceholderEncoder;
+use App\Models\SizeVariant;
+use Illuminate\Console\Command;
+use Safe\Exceptions\InfoException;
+use function Safe\set_time_limit;
+
+class EncodePlaceholders extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'lychee:encode_placeholders {limit=5 : number of photos to encode placeholders for} {tm=600 : timeout time requirement}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Encode placeholders if size variant exists and image has not been encoded';
+
+	/**
+	 * Execute the console command.
+	 */
+	public function handle(): int
+	{
+		try {
+			$limit = (int) $this->argument('limit');
+			$timeout = (int) $this->argument('tm');
+
+			try {
+				set_time_limit($timeout);
+			} catch (InfoException) {
+				// Silently do nothing, if `set_time_limit` is denied.
+			}
+
+			$placeholders = SizeVariant::query()
+				->where('short_path', 'LIKE', '%placeholder/%')
+				->limit($limit)
+				->get();
+			if (count($placeholders) === 0) {
+				$this->line('No placeholders require encoding.');
+
+				return 0;
+			}
+
+			$placeholderEncoder = new PlaceholderEncoder();
+			foreach ($placeholders as $placeholder) {
+				$placeholderEncoder->do($placeholder);
+			}
+
+			return 0;
+		} catch (\Throwable $e) {
+			throw new UnexpectedException($e);
+		}
+	}
+}

--- a/app/Console/Commands/ImageProcessing/GenerateThumbs.php
+++ b/app/Console/Commands/ImageProcessing/GenerateThumbs.php
@@ -20,6 +20,7 @@ class GenerateThumbs extends Command
 	 * @var array<string,SizeVariantType>
 	 */
 	public const SIZE_VARIANTS = [
+		'placeholder' => SizeVariantType::PLACEHOLDER,
 		'thumb' => SizeVariantType::THUMB,
 		'thumb2x' => SizeVariantType::THUMB2X,
 		'small' => SizeVariantType::SMALL,

--- a/app/Enum/SizeVariantType.php
+++ b/app/Enum/SizeVariantType.php
@@ -16,6 +16,7 @@ enum SizeVariantType: int
 	case SMALL = 4;
 	case THUMB2X = 5;
 	case THUMB = 6;
+	case PLACEHOLDER = 7;
 
 	/**
 	 * Given a sizeVariantType return the associated name.
@@ -25,6 +26,7 @@ enum SizeVariantType: int
 	public function name(): string
 	{
 		return match ($this) {
+			self::PLACEHOLDER => 'placeholder',
 			self::THUMB => 'thumb',
 			self::THUMB2X => 'thumb2x',
 			self::SMALL => 'small',
@@ -43,6 +45,7 @@ enum SizeVariantType: int
 	public function localization(): string
 	{
 		return match ($this) {
+			self::PLACEHOLDER => __('lychee.PHOTO_PLACEHOLDER'),
 			self::THUMB => __('lychee.PHOTO_THUMB'),
 			self::THUMB2X => __('lychee.PHOTO_THUMB_HIDPI'),
 			self::SMALL => __('lychee.PHOTO_SMALL'),

--- a/app/Http/Controllers/Admin/Maintenance/GenSizeVariants.php
+++ b/app/Http/Controllers/Admin/Maintenance/GenSizeVariants.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin\Maintenance;
 use App\Contracts\Models\SizeVariantFactory;
 use App\Enum\SizeVariantType;
 use App\Http\Requests\Maintenance\CreateThumbsRequest;
+use App\Image\PlaceholderEncoder;
 use App\Image\SizeVariantDimensionHelpers;
 use App\Models\Photo;
 use App\Models\SizeVariant;
@@ -24,7 +25,7 @@ class GenSizeVariants extends Controller
 	 *
 	 * @return void
 	 */
-	public function do(CreateThumbsRequest $request, SizeVariantFactory $sizeVariantFactory): void
+	public function do(CreateThumbsRequest $request, SizeVariantFactory $sizeVariantFactory, PlaceholderEncoder $placeholderEncoder): void
 	{
 		$photos = Photo::query()
 			->where('type', 'like', 'image/%')
@@ -41,6 +42,9 @@ class GenSizeVariants extends Controller
 			// @codeCoverageIgnoreStart
 			$sizeVariantFactory->init($photo);
 			$sizeVariant = $sizeVariantFactory->createSizeVariantCond($request->kind());
+			if ($request->kind() === SizeVariantType::PLACEHOLDER && $sizeVariant !== null) {
+				$placeholderEncoder->do($sizeVariant);
+			}
 			if ($sizeVariant !== null) {
 				$generated++;
 				Log::notice($request->kind()->value . ' (' . $sizeVariant->width . 'x' . $sizeVariant->height . ') for ' . $photo->title . ' created.');

--- a/app/Http/Requests/Maintenance/CreateThumbsRequest.php
+++ b/app/Http/Requests/Maintenance/CreateThumbsRequest.php
@@ -20,6 +20,7 @@ class CreateThumbsRequest extends BaseApiRequest
 			RequestAttribute::SIZE_VARIANT_ATTRIBUTE => [
 				'required',
 				Rule::in([
+					SizeVariantType::PLACEHOLDER,
 					SizeVariantType::SMALL->value,
 					SizeVariantType::SMALL2X->value,
 					SizeVariantType::MEDIUM->value,

--- a/app/Http/Resources/Models/AlbumResource.php
+++ b/app/Http/Resources/Models/AlbumResource.php
@@ -75,7 +75,7 @@ class AlbumResource extends Data
 
 		// thumb
 		$this->cover_id = $album->cover_id;
-		$this->thumb = ThumbResource::make($album->thumb?->id, $album->thumb?->type, $album->thumb?->thumbUrl, $album->thumb?->thumb2xUrl);
+		$this->thumb = ThumbResource::make($album->thumb?->id, $album->thumb?->type, $album->thumb?->thumbUrl, $album->thumb?->thumb2xUrl, $album->thumb?->placeholderUrl);
 
 		// security
 		$this->policy = AlbumProtectionPolicy::ofBaseAlbum($album);

--- a/app/Http/Resources/Models/SizeVariantsResouce.php
+++ b/app/Http/Resources/Models/SizeVariantsResouce.php
@@ -19,6 +19,7 @@ class SizeVariantsResouce extends Data
 	public ?SizeVariantResource $small;
 	public ?SizeVariantResource $thumb2x;
 	public ?SizeVariantResource $thumb;
+	public ?SizeVariantResource $placeholder;
 
 	public function __construct(Photo $photo)
 	{
@@ -34,6 +35,7 @@ class SizeVariantsResouce extends Data
 		$small2x = $size_variants?->getSizeVariant(SizeVariantType::SMALL2X);
 		$thumb = $size_variants?->getSizeVariant(SizeVariantType::THUMB);
 		$thumb2x = $size_variants?->getSizeVariant(SizeVariantType::THUMB2X);
+		$placeholder = $size_variants?->getSizeVariant(SizeVariantType::PLACEHOLDER);
 
 		$this->medium = $medium?->toResource();
 		$this->medium2x = $medium2x?->toResource();
@@ -42,5 +44,6 @@ class SizeVariantsResouce extends Data
 		$this->small2x = $small2x?->toResource();
 		$this->thumb = $thumb?->toResource();
 		$this->thumb2x = $thumb2x?->toResource();
+		$this->placeholder = $placeholder?->toResource();
 	}
 }

--- a/app/Http/Resources/Models/SmartAlbumResource.php
+++ b/app/Http/Resources/Models/SmartAlbumResource.php
@@ -37,7 +37,7 @@ class SmartAlbumResource extends Data
 		$this->photos = $smartAlbum->relationLoaded('photos') ? PhotoResource::collect($smartAlbum->getPhotos()) : null;
 		$this->prepPhotosCollection();
 
-		$this->thumb = ThumbResource::make($smartAlbum->thumb?->id, $smartAlbum->thumb?->type, $smartAlbum->thumb?->thumbUrl, $smartAlbum->thumb?->thumb2xUrl);
+		$this->thumb = ThumbResource::make($smartAlbum->thumb?->id, $smartAlbum->thumb?->type, $smartAlbum->thumb?->thumbUrl, $smartAlbum->thumb?->thumb2xUrl, $smartAlbum->thumb?->placeholderUrl);
 		$this->policy = AlbumProtectionPolicy::ofSmartAlbum($smartAlbum);
 		$this->rights = new AlbumRightsResource($smartAlbum);
 		$url = $this->getHeaderUrl($smartAlbum);

--- a/app/Http/Resources/Models/TagAlbumResource.php
+++ b/app/Http/Resources/Models/TagAlbumResource.php
@@ -58,7 +58,7 @@ class TagAlbumResource extends Data
 		$this->prepPhotosCollection();
 
 		// thumb
-		$this->thumb = ThumbResource::make($tagAlbum->thumb?->id, $tagAlbum->thumb?->type, $tagAlbum->thumb?->thumbUrl, $tagAlbum->thumb?->thumb2xUrl);
+		$this->thumb = ThumbResource::make($tagAlbum->thumb?->id, $tagAlbum->thumb?->type, $tagAlbum->thumb?->thumbUrl, $tagAlbum->thumb?->thumb2xUrl, $tagAlbum->thumb?->placeholderUrl);
 
 		// security
 		$this->policy = AlbumProtectionPolicy::ofBaseAlbum($tagAlbum);

--- a/app/Http/Resources/Models/ThumbAlbumResource.php
+++ b/app/Http/Resources/Models/ThumbAlbumResource.php
@@ -46,7 +46,7 @@ class ThumbAlbumResource extends Data
 		$date_format = Configs::getValueAsString('date_format_album_thumb');
 
 		$this->id = $data->id;
-		$this->thumb = $data->thumb === null ? null : new ThumbResource($data->thumb->id, $data->thumb->type, $data->thumb->thumbUrl, $data->thumb->thumb2xUrl);
+		$this->thumb = $data->thumb === null ? null : new ThumbResource($data->thumb->id, $data->thumb->type, $data->thumb->thumbUrl, $data->thumb->thumb2xUrl, $data->thumb->placeholderUrl);
 		$this->title = $data->title;
 
 		if ($data instanceof BaseSmartAlbum) {

--- a/app/Http/Resources/Models/ThumbResource.php
+++ b/app/Http/Resources/Models/ThumbResource.php
@@ -12,13 +12,15 @@ class ThumbResource extends Data
 	public string $type;
 	public ?string $thumb;
 	public ?string $thumb2x;
+	public ?string $placeholder;
 
-	public function __construct(string $id, string $type, string $thumbUrl, ?string $thumb2xUrl = null)
+	public function __construct(string $id, string $type, string $thumbUrl, ?string $thumb2xUrl = null, ?string $placeholderUrl = null)
 	{
 		$this->id = $id;
 		$this->type = $type;
 		$this->thumb = $thumbUrl;
 		$this->thumb2x = $thumb2xUrl;
+		$this->placeholder = $placeholderUrl;
 	}
 
 	/**
@@ -26,10 +28,11 @@ class ThumbResource extends Data
 	 * @param string|null $type
 	 * @param string|null $thumbUrl
 	 * @param string|null $thumb2xUrl
+	 * @param string|null $placeholderUrl
 	 *
 	 * @return ($id is null ? null : ThumbResource)
 	 */
-	public static function make(?string $id, ?string $type, ?string $thumbUrl, ?string $thumb2xUrl = null): ?self
+	public static function make(?string $id, ?string $type, ?string $thumbUrl, ?string $thumb2xUrl = null, ?string $placeholderUrl = null): ?self
 	{
 		if ($id === null) {
 			return null;
@@ -38,6 +41,7 @@ class ThumbResource extends Data
 		/** @var string $id */
 		/** @var string $type */
 		/** @var string $thumbUrl */
-		return new self($id, $type, $thumbUrl, $thumb2xUrl);
+		/** @var string $placeholderUrl */
+		return new self($id, $type, $thumbUrl, $thumb2xUrl, $placeholderUrl);
 	}
 }

--- a/app/Image/PlaceholderEncoder.php
+++ b/app/Image/PlaceholderEncoder.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace App\Image;
+
+use App\Contracts\Image\MediaFile;
+use App\Exceptions\MediaFileOperationException;
+use App\Image\Files\InMemoryBuffer;
+use App\Models\SizeVariant;
+use Safe\Exceptions\FilesystemException;
+use Safe\Exceptions\ImageException;
+use Safe\Exceptions\StreamException;
+use function Safe\imagecreatefromstring;
+use function Safe\imagewebp;
+use function Safe\rewind;
+use function Safe\stream_filter_append;
+use function Safe\stream_get_contents;
+
+class PlaceholderEncoder
+{
+	private const IMAGE_QUALITY = 30;
+
+	/** Character length that the encoded base64 image cannot exceed.
+	 *	The initial value 255 is determined by the max characters in size_variants.short_path DB column.
+	 *  Since base64 encodes into groups of 4 characters, with padding to fill the final
+	 *  group if it is less than 3 bytes, the actual limit can be calculated by:
+	 * 	255 - (255 % 4) = 252 characters.
+	 */
+	private const BASE64_SIZE_LIMIT = 252;
+
+	/** Filesize in bytes that the compressed image cannot exceed.
+	 * The limit is calculated using the BASE64_SIZE_LIMIT.
+	 * Base64 encodes every 3 bytes into 4 characters.
+	 *    - 252 / 4 = 63 groups of four characters
+	 *    - Since each group of 4 chars corresponds to 3 bytes of data,
+	 *      63 * 3 = 189 bytes of unencoded data.
+	 */
+	private const COMPRESSION_SIZE_LIMIT = 189;
+	private const MAX_COMPRESSION_RETRIES = 3;
+
+	private ?\GdImage $gdImage = null;
+
+	/**
+	 * @param SizeVariant $sizeVariant unencoded placeholder size variant
+	 *
+	 * @return void
+	 */
+	public function do(SizeVariant $sizeVariant): void
+	{
+		try {
+			$originalFile = $sizeVariant->getFile();
+			$workingImage = new InMemoryBuffer();
+
+			$this->createGdImage($sizeVariant->getFile());
+			$this->compressImage($this->gdImage, $workingImage);
+			$this->encodeBase64Placeholder($workingImage);
+			$this->savePlaceholder($workingImage, $sizeVariant);
+
+			// delete original file since we now have no reference to it
+			$originalFile->delete();
+		} catch (\ErrorException $e) {
+			throw new MediaFileOperationException('Failed to encode placeholder to base64', $e);
+		}
+	}
+
+	/**
+	 * Returns a GdImage object from the provided file.
+	 *
+	 * @param MediaFile $file
+	 *
+	 * @return void
+	 *
+	 * @throws FilesystemException
+	 * @throws ImageException
+	 * @throws StreamException
+	 */
+	private function createGdImage(MediaFile $file): void
+	{
+		$inMemoryBuffer = new InMemoryBuffer();
+
+		$originalStream = $file->read();
+		if (stream_get_meta_data($originalStream)['seekable']) {
+			$inputStream = $originalStream;
+		} else {
+			// We make an in-memory copy of the provided stream,
+			// because we must be able to seek/rewind the stream.
+			// For example, a readable stream from a remote location (i.e.
+			// a "download" stream) is only forward readable once.
+			$inMemoryBuffer->write($originalStream);
+			$inputStream = $inMemoryBuffer->read();
+		}
+		$imgBinary = stream_get_contents($inputStream);
+
+		rewind($inputStream);
+		/** @var \GdImage $referenceImage */
+		$referenceImage = imagecreatefromstring($imgBinary);
+		// webp does not support palette images
+		imagepalettetotruecolor($referenceImage);
+
+		$this->gdImage = $referenceImage;
+	}
+
+	/**
+	 * Compress webp image to acceptable size for DB.
+	 *
+	 * @param \GdImage       $source source Image
+	 * @param InMemoryBuffer $output the file to write to
+	 *
+	 * @return void
+	 *
+	 * @throws ImageException
+	 * @throws FilesystemException
+	 */
+	private function compressImage(\GdImage $source, InMemoryBuffer $output): void
+	{
+		$quality = self::IMAGE_QUALITY;
+		$retries = 0;
+		// Given a proper placeholder source image (16px x 16px) it should
+		// almost always be sufficiently compressed on the first attempt.
+		// But just in case it isn't we try to compress again.
+		do {
+			// ensure buffer is empty before trying to compress again
+			$emptyStream = \Safe\fopen('php://temp', 'w+');
+			$output->write($emptyStream);
+			\Safe\fclose($emptyStream);
+
+			imagewebp($source, $output->stream(), $quality);
+			$filesize = \Safe\fstat($output->read())['size'];
+
+			$quality -= 5;
+			$retries++;
+		} while ($filesize > self::COMPRESSION_SIZE_LIMIT && $retries <= self::MAX_COMPRESSION_RETRIES);
+	}
+
+	/**
+	 * Encodes provided image file to base64.
+	 *
+	 * @param InMemoryBuffer $file
+	 *
+	 * @return void
+	 *
+	 * @throws StreamException
+	 */
+	private function encodeBase64Placeholder(InMemoryBuffer $file): void
+	{
+		$inMemoryBuffer = new InMemoryBuffer();
+
+		stream_filter_append($inMemoryBuffer->read(), 'convert.base64-encode', STREAM_FILTER_WRITE);
+		$inMemoryBuffer->write($file->read());
+
+		$file->write($inMemoryBuffer->read());
+		$inMemoryBuffer->close();
+	}
+
+	/**
+	 * Saves base64 string and size to DB.
+	 *
+	 * @param InMemoryBuffer $file
+	 * @param SizeVariant    $sizeVariant
+	 *
+	 * @return void
+	 *
+	 * @throws FilesystemException
+	 * @throws StreamException
+	 */
+	private function savePlaceholder(InMemoryBuffer $file, SizeVariant $sizeVariant): void
+	{
+		$base64Length = \Safe\fstat($file->read())['size'];
+		if ($base64Length <= self::BASE64_SIZE_LIMIT) {
+			$sizeVariant->filesize = $base64Length;
+			$sizeVariant->short_path = stream_get_contents($file->read());
+			$sizeVariant->save();
+		} else {
+			throw new MediaFileOperationException('Encoded image is too large.');
+		}
+	}
+}

--- a/app/Image/SizeVariantDefaultFactory.php
+++ b/app/Image/SizeVariantDefaultFactory.php
@@ -28,6 +28,7 @@ class SizeVariantDefaultFactory implements SizeVariantFactory
 {
 	public const THUMBNAIL_DIM = 200;
 	public const THUMBNAIL2X_DIM = 400;
+	public const PLACEHOLDER_DIM = 16;
 
 	/** @var ImageHandlerInterface the image handler (gd, imagick, ...) which is used to generate image files */
 	protected ImageHandlerInterface $referenceImage;
@@ -105,6 +106,7 @@ class SizeVariantDefaultFactory implements SizeVariantFactory
 	public function createSizeVariants(): Collection
 	{
 		$allVariants = [
+			SizeVariantType::PLACEHOLDER,
 			SizeVariantType::THUMB,
 			SizeVariantType::THUMB2X,
 			SizeVariantType::SMALL,
@@ -176,7 +178,7 @@ class SizeVariantDefaultFactory implements SizeVariantFactory
 	private function createSizeVariantInternal(SizeVariantType $sizeVariant, ImageDimension $maxDim): SizeVariant
 	{
 		$svImage = match ($sizeVariant) {
-			SizeVariantType::THUMB, SizeVariantType::THUMB2X => $this->referenceImage->cloneAndCrop($maxDim),
+			SizeVariantType::THUMB, SizeVariantType::THUMB2X, SizeVariantType::PLACEHOLDER => $this->referenceImage->cloneAndCrop($maxDim),
 			default => $this->referenceImage->cloneAndScale($maxDim),
 		};
 

--- a/app/Image/SizeVariantDimensionHelpers.php
+++ b/app/Image/SizeVariantDimensionHelpers.php
@@ -60,6 +60,7 @@ class SizeVariantDimensionHelpers
 			SizeVariantType::MEDIUM2X => Configs::getValueAsBool('medium_2x'),
 			SizeVariantType::SMALL2X => Configs::getValueAsBool('small_2x'),
 			SizeVariantType::THUMB2X => Configs::getValueAsBool('thumb_2x'),
+			SizeVariantType::PLACEHOLDER => Configs::getValueAsBool('low_quality_image_placeholder'),
 			SizeVariantType::SMALL, SizeVariantType::MEDIUM, SizeVariantType::THUMB => true,
 			default => throw new InvalidSizeVariantException('unknown size variant: ' . $sizeVariant->value),
 		};
@@ -78,7 +79,7 @@ class SizeVariantDimensionHelpers
 	public function isLargeEnough(ImageDimension $realDim, ImageDimension $maxDim, SizeVariantType $sizeVariant): bool
 	{
 		return match ($sizeVariant) {
-			SizeVariantType::THUMB => true,
+			SizeVariantType::THUMB, SizeVariantType::PLACEHOLDER => true,
 			SizeVariantType::THUMB2X => $realDim->width >= $maxDim->width && $realDim->height >= $maxDim->height,
 			default => ($realDim->width >= $maxDim->width && $maxDim->width !== 0) || ($realDim->height >= $maxDim->height && $maxDim->height !== 0),
 		};
@@ -98,6 +99,7 @@ class SizeVariantDimensionHelpers
 			SizeVariantType::SMALL => Configs::getValueAsInt('small_max_width'),
 			SizeVariantType::THUMB2X => SizeVariantDefaultFactory::THUMBNAIL2X_DIM,
 			SizeVariantType::THUMB => SizeVariantDefaultFactory::THUMBNAIL_DIM,
+			SizeVariantType::PLACEHOLDER => SizeVariantDefaultFactory::PLACEHOLDER_DIM,
 			default => throw new InvalidSizeVariantException('No applicable for original'),
 		};
 	}
@@ -116,6 +118,7 @@ class SizeVariantDimensionHelpers
 			SizeVariantType::SMALL => Configs::getValueAsInt('small_max_height'),
 			SizeVariantType::THUMB2X => SizeVariantDefaultFactory::THUMBNAIL2X_DIM,
 			SizeVariantType::THUMB => SizeVariantDefaultFactory::THUMBNAIL_DIM,
+			SizeVariantType::PLACEHOLDER => SizeVariantDefaultFactory::PLACEHOLDER_DIM,
 			default => throw new InvalidSizeVariantException('unknown size variant: ' . $sizeVariant->value),
 		};
 	}

--- a/app/Legacy/Actions/Photo/Strategies/AddStandaloneStrategy.php
+++ b/app/Legacy/Actions/Photo/Strategies/AddStandaloneStrategy.php
@@ -22,6 +22,7 @@ use App\Image\Files\TemporaryLocalFile;
 use App\Image\Handlers\GoogleMotionPictureHandler;
 use App\Image\Handlers\ImageHandler;
 use App\Image\Handlers\VideoHandler;
+use App\Image\PlaceholderEncoder;
 use App\Image\StreamStat;
 use App\Jobs\UploadSizeVariantToS3Job;
 use App\Models\Configs;
@@ -199,6 +200,12 @@ class AddStandaloneStrategy extends AbstractAddStrategy
 				$sizeVariantFactory->init($this->photo, $this->sourceImage, $this->namingStrategy);
 				$variants = $sizeVariantFactory->createSizeVariants();
 				$variants->push($originalVariant);
+
+				$placeholder = $variants->firstWhere('type', SizeVariantType::PLACEHOLDER);
+				if ($placeholder !== null) {
+					$placeholderEncoder = new PlaceholderEncoder();
+					$placeholderEncoder->do($placeholder);
+				}
 
 				if (Features::active('use-s3')) {
 					// If enabled, upload all size variants to the remote bucket and delete the local files after that

--- a/app/Legacy/V1/Resources/Models/PhotoResource.php
+++ b/app/Legacy/V1/Resources/Models/PhotoResource.php
@@ -59,6 +59,7 @@ class PhotoResource extends JsonResource
 		$small2x = $size_variants?->getSizeVariant(SizeVariantType::SMALL2X);
 		$thumb = $size_variants?->getSizeVariant(SizeVariantType::THUMB);
 		$thumb2x = $size_variants?->getSizeVariant(SizeVariantType::THUMB2X);
+		$placeholder = $size_variants?->getSizeVariant(SizeVariantType::PLACEHOLDER);
 
 		return [
 			'id' => $this->resource->id,
@@ -92,6 +93,7 @@ class PhotoResource extends JsonResource
 				'small2x' => $small2x === null ? null : SizeVariantResource::make($small2x)->toArray($request),
 				'thumb' => $thumb === null ? null : SizeVariantResource::make($thumb)->toArray($request),
 				'thumb2x' => $thumb2x === null ? null : SizeVariantResource::make($thumb2x)->toArray($request),
+				'placeholder' => $placeholder === null ? null : SizeVariantResource::make($placeholder)->toArray($request),
 			],
 			'tags' => $this->resource->tags,
 			'taken_at' => $this->resource->taken_at?->toIso8601String(),

--- a/app/Models/Extensions/SizeVariants.php
+++ b/app/Models/Extensions/SizeVariants.php
@@ -35,6 +35,7 @@ class SizeVariants extends AbstractDTO
 	private ?SizeVariant $small = null;
 	private ?SizeVariant $thumb2x = null;
 	private ?SizeVariant $thumb = null;
+	private ?SizeVariant $placeholder = null;
 
 	/**
 	 * SizeVariants constructor.
@@ -87,6 +88,7 @@ class SizeVariants extends AbstractDTO
 			SizeVariantType::SMALL => $this->small = $sizeVariant,
 			SizeVariantType::THUMB2X => $this->thumb2x = $sizeVariant,
 			SizeVariantType::THUMB => $this->thumb = $sizeVariant,
+			SizeVariantType::PLACEHOLDER => $this->placeholder = $sizeVariant,
 		};
 	}
 
@@ -105,6 +107,7 @@ class SizeVariants extends AbstractDTO
 			SizeVariantType::SMALL->name() => $this->small?->toArray(),
 			SizeVariantType::THUMB2X->name() => $this->thumb2x?->toArray(),
 			SizeVariantType::THUMB->name() => $this->thumb?->toArray(),
+			SizeVariantType::PLACEHOLDER->name() => $this->placeholder?->toArray(),
 		];
 	}
 
@@ -123,6 +126,7 @@ class SizeVariants extends AbstractDTO
 			$this->small,
 			$this->thumb2x,
 			$this->thumb,
+			$this->placeholder,
 		]);
 	}
 
@@ -145,6 +149,7 @@ class SizeVariants extends AbstractDTO
 			SizeVariantType::SMALL => $this->small,
 			SizeVariantType::THUMB2X => $this->thumb2x,
 			SizeVariantType::THUMB => $this->thumb,
+			SizeVariantType::PLACEHOLDER => $this->placeholder,
 		};
 	}
 
@@ -196,6 +201,11 @@ class SizeVariants extends AbstractDTO
 	public function getThumb(): ?SizeVariant
 	{
 		return $this->thumb;
+	}
+
+	public function getPlaceholder(): ?SizeVariant
+	{
+		return $this->placeholder;
 	}
 
 	/**
@@ -257,6 +267,7 @@ class SizeVariants extends AbstractDTO
 			$this->small?->id,
 			$this->thumb2x?->id,
 			$this->thumb?->id,
+			$this->placeholder?->id,
 		];
 
 		$this->original = null;
@@ -266,6 +277,7 @@ class SizeVariants extends AbstractDTO
 		$this->small = null;
 		$this->thumb2x = null;
 		$this->thumb = null;
+		$this->placeholder = null;
 
 		(new Delete())->do(array_diff($ids, [null]))->do();
 	}
@@ -284,6 +296,7 @@ class SizeVariants extends AbstractDTO
 		self::replicateSizeVariant($duplicate, $this->small);
 		self::replicateSizeVariant($duplicate, $this->thumb2x);
 		self::replicateSizeVariant($duplicate, $this->thumb);
+		self::replicateSizeVariant($duplicate, $this->placeholder);
 
 		return $duplicate;
 	}

--- a/app/Models/SizeVariant.php
+++ b/app/Models/SizeVariant.php
@@ -177,6 +177,10 @@ class SizeVariant extends Model
 	{
 		$imageDisk = Storage::disk($this->storage_disk->value);
 
+		if ($this->type === SizeVariantType::PLACEHOLDER) {
+			return 'data:image/webp;base64,' . $this->short_path;
+		}
+
 		if (
 			!Configs::getValueAsBool('SL_enable') ||
 			(!Configs::getValueAsBool('SL_for_admin') && Auth::user()?->may_administrate === true)

--- a/database/migrations/2024_08_15_163203_config_low_quality_image_placeholder.php
+++ b/database/migrations/2024_08_15_163203_config_low_quality_image_placeholder.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const PROCESSING = 'Image Processing';
+
+	public function getConfigs(): array
+	{
+		return [
+			[
+				'key' => 'low_quality_image_placeholder',
+				'value' => '1',
+				'cat' => self::PROCESSING,
+				'type_range' => self::BOOL,
+				'description' => 'Enable low quality image placeholders',
+				'is_secret' => false,
+			],
+		];
+	}
+};

--- a/lang/cz/lychee.php
+++ b/lang/cz/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Náhled HiDPI',
 	'PHOTO_THUMB' => 'Čtvercový náhled',
 	'PHOTO_THUMB_HIDPI' => 'Čtvercový náhled HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Zobrazení foto Lychee:',

--- a/lang/de/lychee.php
+++ b/lang/de/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Miniaturansicht HiDPI',
 	'PHOTO_THUMB' => 'Quadratische Miniaturansicht',
 	'PHOTO_THUMB_HIDPI' => 'Quadratische Miniaturansicht HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Foto-Vorschau',
 	'PHOTO_LIVE_VIDEO' => 'Video des Live-Fotos',
 	'PHOTO_VIEW' => 'Lychees Foto-Ansicht:',

--- a/lang/el/lychee.php
+++ b/lang/el/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Μικρογραφία HiDPI',
 	'PHOTO_THUMB' => 'Τετράγωνη Μικρογραφία',
 	'PHOTO_THUMB_HIDPI' => 'Τετράγωνη Μικρογραφία HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Προβολή Φωτογραφιών:',

--- a/lang/en/lychee.php
+++ b/lang/en/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Thumb HiDPI',
 	'PHOTO_THUMB' => 'Square thumb',
 	'PHOTO_THUMB_HIDPI' => 'Square thumb HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Photo View:',

--- a/lang/es/lychee.php
+++ b/lang/es/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Miniatura HiDPI',
 	'PHOTO_THUMB' => 'Cuadrado de Miniatura',
 	'PHOTO_THUMB_HIDPI' => 'Cuadrado de Miniatura HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Miniatura de la foto',
 	'PHOTO_LIVE_VIDEO' => 'Video de live-photo',
 	'PHOTO_VIEW' => 'Vista de Foto de Lychee',

--- a/lang/fr/lychee.php
+++ b/lang/fr/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Petite taille HiDPI',
 	'PHOTO_THUMB' => 'Mignature carrée',
 	'PHOTO_THUMB_HIDPI' => 'Mignature carrée HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Partie vidéo d’une live-photo',
 	'PHOTO_VIEW' => 'Vue photo de Lychee :',

--- a/lang/hu/lychee.php
+++ b/lang/hu/lychee.php
@@ -491,6 +491,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Bélyegkép HiDPI',
 	'PHOTO_THUMB' => 'Négyzetes bélyegkép',
 	'PHOTO_THUMB_HIDPI' => 'Négyzetes bélyegkép HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Kép bélyegképe',
 	'PHOTO_LIVE_VIDEO' => 'Videó része a live-fotónak',
 	'PHOTO_VIEW' => 'Lychee Kép Megtekintés:',

--- a/lang/it/lychee.php
+++ b/lang/it/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Thumb HiDPI',
 	'PHOTO_THUMB' => 'Square thumb',
 	'PHOTO_THUMB_HIDPI' => 'Square thumb HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Photo View:',

--- a/lang/ja/lychee.php
+++ b/lang/ja/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => '小 HiDPI',
 	'PHOTO_THUMB' => '正方形サムネイル',
 	'PHOTO_THUMB_HIDPI' => '正方形サムネイル HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'サムネイル',
 	'PHOTO_LIVE_VIDEO' => 'ライブフォトのビデオ部分',
 	'PHOTO_VIEW' => 'Lychee の写真表示：',

--- a/lang/nl/lychee.php
+++ b/lang/nl/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Thumb HiDPI',
 	'PHOTO_THUMB' => 'Square thumb',
 	'PHOTO_THUMB_HIDPI' => 'Square thumb HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Photo View:',

--- a/lang/no/lychee.php
+++ b/lang/no/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Miniatyr HiDPI',
 	'PHOTO_THUMB' => 'Kvadratisk miniatyr',
 	'PHOTO_THUMB_HIDPI' => 'Kvadratisk miniatyr HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Filmdel av livebilde',
 	'PHOTO_VIEW' => 'Lychee Bildevisning:',

--- a/lang/pl/lychee.php
+++ b/lang/pl/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Thumb HiDPI',
 	'PHOTO_THUMB' => 'Kwadratowa miniaturka',
 	'PHOTO_THUMB_HIDPI' => 'Square thumb HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Photo View:',

--- a/lang/pt/lychee.php
+++ b/lang/pt/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Pequena HiDPI',
 	'PHOTO_THUMB' => 'Quadrada pequena',
 	'PHOTO_THUMB_HIDPI' => 'Quadrada pequena HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video parte de fotografia ao vivo',
 	'PHOTO_VIEW' => 'Vista de Fotografia Lychee:',

--- a/lang/ru/lychee.php
+++ b/lang/ru/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Thumb HiDPI',
 	'PHOTO_THUMB' => 'Square thumb',
 	'PHOTO_THUMB_HIDPI' => 'Square thumb HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Photo View:',

--- a/lang/sk/lychee.php
+++ b/lang/sk/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Náhľad HiDPI',
 	'PHOTO_THUMB' => 'Štvorcový náhľad',
 	'PHOTO_THUMB_HIDPI' => 'Štvorcový náhľad HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Zobrazenie foto Lychee:',

--- a/lang/sv/lychee.php
+++ b/lang/sv/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Thumb HiDPI',
 	'PHOTO_THUMB' => 'Square thumb',
 	'PHOTO_THUMB_HIDPI' => 'Square thumb HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => 'Video part of live-photo',
 	'PHOTO_VIEW' => 'Lychee Photo View:',

--- a/lang/vi/lychee.php
+++ b/lang/vi/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => 'Độ phân giải cho hình nhỏ HiDPI',
 	'PHOTO_THUMB' => 'Ô vuông nhỏ',
 	'PHOTO_THUMB_HIDPI' => 'Độ phân giải cho hình ô vuông nhỏ HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Hình thu nhỏ của hình ảnh gốc',
 	'PHOTO_LIVE_VIDEO' => 'Phần video của hình động live-photo',
 	'PHOTO_VIEW' => 'Khung hiển thị hình ảnh Lychee:',

--- a/lang/zh_CN/lychee.php
+++ b/lang/zh_CN/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => '缩略图 HiDPI',
 	'PHOTO_THUMB' => '方形缩略图',
 	'PHOTO_THUMB_HIDPI' => '方形缩略图 HiDPI',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => '实况照片（Live-Photo）的视频部分',
 	'PHOTO_VIEW' => 'Lychee 照片查看:',

--- a/lang/zh_TW/lychee.php
+++ b/lang/zh_TW/lychee.php
@@ -493,6 +493,7 @@ return [
 	'PHOTO_SMALL_HIDPI' => '低解析度',
 	'PHOTO_THUMB' => '方形圖',
 	'PHOTO_THUMB_HIDPI' => '方形解析度',
+	'PHOTO_PLACEHOLDER' => 'Low Quality Image Placeholder',
 	'PHOTO_THUMBNAIL' => 'Photo thumbnail',
 	'PHOTO_LIVE_VIDEO' => '實時照片的視頻部分',
 	'PHOTO_VIEW' => 'Lychee照片瀏覽：',

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -151,7 +151,7 @@ parameters:
 				- tests
 
 		-
-			message: '#Access to private property App\\Models\\Extensions\\SizeVariants::\$(original|small(2x)?|thumb(2x)?|medium(2x)?)#'
+			message: '#Access to private property App\\Models\\Extensions\\SizeVariants::\$(original|small(2x)?|thumb(2x)?|medium(2x)?|placeholder)#'
 			paths:
 				- tests
 		-

--- a/resources/js/components/gallery/thumbs/AlbumThumbImage.vue
+++ b/resources/js/components/gallery/thumbs/AlbumThumbImage.vue
@@ -1,14 +1,25 @@
 <template>
 	<span
-		class="thumbimg absolute w-full h-full bg-neutral-800 shadow-md shadow-black/25 border-solid border border-neutral-400 ease-out transition-transform"
+		class="thumbimg absolute w-full h-full bg-neutral-800 shadow-md shadow-black/25 border-solid border border-neutral-400 ease-out transition-transform overflow-hidden"
 		:class="props.class"
 	>
 		<img
+			v-show="placeholderSrc"
+			:alt="$t('lychee.PHOTO_PLACEHOLDER')"
+			class="absolute w-full h-full top-0 left-0 blur-md"
+			:class="{ 'animate-fadeout animate-fill-forwards': isImageLoaded }"
+			:src="placeholderSrc"
+			data-overlay="false"
+			draggable="false"
+			loading="lazy"
+		/>
+		<img
 			:alt="$t('lychee.PHOTO_THUMBNAIL')"
 			class="w-full h-full m-0 p-0 border-0 object-cover"
-			:class="classList"
+			:class="classObject"
 			:src="src"
 			:srcset="srcSet"
+			@load="onImageLoad"
 			data-overlay="false"
 			draggable="false"
 			loading="lazy"
@@ -25,16 +36,24 @@ const props = defineProps<{
 	isPasswordProtected: boolean;
 }>();
 
+const isImageLoaded = ref(false);
 const src = ref("");
 const srcSet = ref("");
-const classList = computed(() => {
-	if (src.value === Constants.BASE_URL + "/img/no_images.svg" || src.value === Constants.BASE_URL + "/img/password.svg") {
-		return "invert brightness-25 dark:invert-0 dark:brightness-100";
-	}
-	return "";
-});
+const placeholderSrc = ref("");
+const classObject = computed(() => ({
+	"invert brightness-25 dark:invert-0 dark:brightness-100":
+		src.value === Constants.BASE_URL + "/img/no_images.svg" || src.value === Constants.BASE_URL + "/img/password.svg",
+	invisible: !isImageLoaded.value,
+}));
+
+function onImageLoad() {
+	isImageLoaded.value = true;
+}
 
 function load(thumb: App.Http.Resources.Models.ThumbResource | undefined | null, isPasswordProtected: boolean) {
+	if (isNotEmpty(thumb?.placeholder)) {
+		placeholderSrc.value = thumb?.placeholder as string;
+	}
 	if (thumb?.thumb === "uploads/thumb/") {
 		src.value = Constants.BASE_URL + "/img/placeholder.png";
 		if (thumb.type.includes("video")) {

--- a/resources/js/components/maintenance/MaintenanceGenSizevariants.vue
+++ b/resources/js/components/maintenance/MaintenanceGenSizevariants.vue
@@ -47,6 +47,8 @@ const description = computed(() => {
 
 function getName(sv: App.Enum.SizeVariantType): string {
 	switch (sv) {
+		case 7:
+			return "placeholder";
 		case 6:
 			return "thumb";
 		case 5:

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -76,7 +76,7 @@ declare namespace App.Enum {
 	export type OrderSortingType = "ASC" | "DESC";
 	export type PhotoLayoutType = "square" | "justified" | "unjustified" | "masonry" | "grid";
 	export type SeverityType = "emergency" | "alert" | "critical" | "error" | "warning" | "notice" | "info" | "debug";
-	export type SizeVariantType = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+	export type SizeVariantType = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
 	export type SmartAlbumType = "unsorted" | "starred" | "recent" | "on_this_day";
 	export type StorageDiskType = "images" | "s3";
 	export type ThumbAlbumSubtitleType = "description" | "takedate" | "creation" | "oldstyle";
@@ -367,6 +367,7 @@ declare namespace App.Http.Resources.Models {
 		small: App.Http.Resources.Models.SizeVariantResource | null;
 		thumb2x: App.Http.Resources.Models.SizeVariantResource | null;
 		thumb: App.Http.Resources.Models.SizeVariantResource | null;
+		placeholder: App.Http.Resources.Models.SizeVariantResource | null;
 	};
 	export type SmartAlbumResource = {
 		id: string;
@@ -421,6 +422,7 @@ declare namespace App.Http.Resources.Models {
 		type: string;
 		thumb: string | null;
 		thumb2x: string | null;
+		placeholder: string | null;
 	};
 	export type UserManagementResource = {
 		id: number;

--- a/resources/js/utils/StatsSizeVariantToColours.ts
+++ b/resources/js/utils/StatsSizeVariantToColours.ts
@@ -23,6 +23,9 @@ export function sizeVariantToColour(sv: App.Enum.SizeVariantType): string {
 		// thumb
 		case 6:
 			return documentStyle.getPropertyValue("--p-sky-100");
+		// placeholder
+		case 7:
+			return documentStyle.getPropertyValue("--p-sky-50");
 	}
 }
 

--- a/resources/js/views/Maintenance.vue
+++ b/resources/js/views/Maintenance.vue
@@ -22,6 +22,7 @@
 		<MaintenanceGenSizevariants :sv="2" />
 		<MaintenanceGenSizevariants :sv="3" />
 		<MaintenanceGenSizevariants :sv="4" />
+		<MaintenanceGenSizevariants :sv="7" />
 		<MaintenanceFixJobs />
 		<MaintenanceFixTree />
 		<MaintenanceFilesize />

--- a/tests/Feature_v1/CommandEncodePlaceholdersTest.php
+++ b/tests/Feature_v1/CommandEncodePlaceholdersTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v1;
+
+use App\Enum\SizeVariantType;
+use App\Models\Configs;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Testing\Assert;
+use Tests\Constants\TestConstants;
+use Tests\Feature_v1\Base\BasePhotoTest;
+
+class CommandEncodePlaceholdersTest extends BasePhotoTest
+{
+	public const COMMAND = 'lychee:encode_placeholders';
+	public const GENERATE_THUMBS_COMMAND = 'lychee:generate_thumbs';
+
+	public function testNoPlaceholdersUnencoded(): void
+	{
+		$this->artisan(self::COMMAND)
+			->expectsOutput('No placeholders require encoding.')
+			->assertExitCode(0);
+	}
+
+	public function testPlaceholderEncoding(): void
+	{
+		$originalConfig = Configs::getValueAsBool('low_quality_image_placeholder');
+		Configs::set('low_quality_image_placeholder', true);
+
+		/** @var \App\Models\Photo $photo1 */
+		$photo1 = static::convertJsonToObject($this->photos_tests->upload(
+			static::createUploadedFile(TestConstants::SAMPLE_FILE_NIGHT_IMAGE)
+		));
+
+		// Remove the size variant "placeholder" from DB
+		DB::table('size_variants')
+			->where('photo_id', '=', $photo1->id)
+			->where('type', '=', SizeVariantType::PLACEHOLDER)
+			->delete();
+
+		// Re-create it without encoding
+		$this->artisan(self::GENERATE_THUMBS_COMMAND, ['type' => 'placeholder'])
+			->assertExitCode(0);
+
+		// Attempt to encode using command
+		$this->artisan(self::COMMAND)
+			->assertExitCode(0);
+
+		// Get updated photo and check if placeholder was encoded
+		/** @var \App\Models\Photo $photo2 */
+		$photo2 = static::convertJsonToObject($this->photos_tests->get($photo1->id));
+		// check for the file signature in the decoded base64 data.
+		Assert::assertStringContainsString('WEBPVP8', \Safe\base64_decode($photo2->size_variants->placeholder->url));
+
+		Configs::set('low_quality_image_placeholder', $originalConfig);
+	}
+}

--- a/tests/Feature_v1/CommandGenerateThumbsTest.php
+++ b/tests/Feature_v1/CommandGenerateThumbsTest.php
@@ -32,7 +32,7 @@ class CommandGenerateThumbsTest extends BasePhotoTest
 	public function testInvalidSizeVariantArgument(): void
 	{
 		$this->artisan(self::COMMAND, ['type' => 'smally'])
-			->expectsOutput('Type smally is not one of thumb, thumb2x, small, small2x, medium, medium2x')
+			->expectsOutput('Type smally is not one of placeholder, thumb, thumb2x, small, small2x, medium, medium2x')
 			->assertExitCode(1);
 	}
 


### PR DESCRIPTION
Continues #2558 for #2258 including new frontend implementation.

Adds low quality image placeholder to be displayed while album covers are downloading. 
Improves perceived loading times.


Approach:
- Adds new size variant of type 7 called 'placeholder'
- Adds PlaceholderEncoder class to compress image to usable size, convert to base64 and save to db
- Adds new standalone pipe to process the placeholder
- Adds step in legacy code path to process the placeholder
- Adds command to handle placeholders that exist but have not been encoded yet
- Adds diagnostic info check for determining number of missing and unencoded placeholders
- Adds maintenance option to generate missing placeholders
- Modifies SizeVariant getUrlAttribute to use data URI instead of app url for placeholders
- Modifies Thumb to include generated placeholder


**Demo**

![lqip-demo](https://github.com/user-attachments/assets/bc6ff0c5-576f-46b6-a96e-ce403012e880)

