### PR TITLE
Change the plaintext-field to a password-field in AlbumUnlock

### DIFF
--- a/resources/js/components/forms/album/Unlock.vue
+++ b/resources/js/components/forms/album/Unlock.vue
@@ -5,7 +5,7 @@
 				<p class="mb-5 px-9">{{ $t("lychee.ALBUM_PASSWORD_REQUIRED") }}</p>
 				<div class="inline-flex flex-col gap-2 px-9">
 					<FloatLabel variant="on">
-						<InputText id="albumPassword" v-model="password" @keydown.enter="unlock" />
+						<InputPassword id="albumPassword" v-model="password" @keydown.enter="unlock" />
 						<label class="" for="albumPassword">{{ $t("lychee.PASSWORD") }}</label>
 					</FloatLabel>
 				</div>
@@ -32,7 +32,7 @@ import Button from "primevue/button";
 import Dialog from "primevue/dialog";
 import FloatLabel from "primevue/floatlabel";
 import { computed, ref } from "vue";
-import InputText from "../basic/InputText.vue";
+import InputPassword from "../basic/InputPassword.vue";
 
 const props = defineProps<{
 	albumid: string;


### PR DESCRIPTION
During my investigations regarding #2696 I noticed that the input field in the album unlock window is a plaintext field and not a password field, so the entered text is not hidden (●●●).

![field](https://github.com/user-attachments/assets/f79bb991-2a4d-43d3-83ba-cc917ddbbad0)

This PR changes this behavoir and replaces the text-field with a password-field.