### PR TITLE
Fix error appearing when clicking on + menu in Smart albums

### DIFF
--- a/resources/js/components/headers/AlbumHeader.vue
+++ b/resources/js/components/headers/AlbumHeader.vue
@@ -48,7 +48,7 @@
 			</template>
 		</template>
 	</Toolbar>
-	<ContextMenu ref="addmenu" :model="addMenu" v-if="props.album.rights.can_upload && props.config.is_model_album">
+	<ContextMenu ref="addmenu" :model="addMenu" v-if="props.album.rights.can_upload">
 		<template #item="{ item, props }">
 			<Divider v-if="item.is_divider" />
 			<a v-else v-ripple v-bind="props.action" @click="item.callback">
@@ -68,7 +68,6 @@ import Toolbar from "primevue/toolbar";
 import { computed } from "vue";
 import { useRouter } from "vue-router";
 import { onKeyStroke } from "@vueuse/core";
-import AlbumCreateDialog from "@/components/forms/album/AlbumCreateDialog.vue";
 import ContextMenu from "primevue/contextmenu";
 import { shouldIgnoreKeystroke } from "@/utils/keybindings-utils";
 import ImportFromLink from "@/components/modals/ImportFromLink.vue";
@@ -126,6 +125,7 @@ function deleteTrack() {
 
 const { addmenu, addMenu, openAddMenu } = useContextMenuAlbumAdd(
 	props.album,
+	props.config,
 	{
 		toggleUpload,
 		toggleCreateAlbum,

--- a/resources/js/composables/contextMenus/contextMenuAlbumAdd.ts
+++ b/resources/js/composables/contextMenus/contextMenuAlbumAdd.ts
@@ -26,6 +26,7 @@ export function useContextMenuAlbumAdd(
 		| App.Http.Resources.Models.AlbumResource
 		| App.Http.Resources.Models.TagAlbumResource
 		| App.Http.Resources.Models.SmartAlbumResource,
+	config: App.Http.Resources.GalleryConfigs.AlbumConfig,
 	callbacks: Callbacks,
 	dropbox_api_key: Ref<string>,
 ) {
@@ -53,11 +54,13 @@ export function useContextMenuAlbumAdd(
 			},
 			{
 				is_divider: true,
+				if: config.is_model_album,
 			},
 			{
 				label: "lychee.NEW_ALBUM",
 				icon: "pi pi-folder",
 				callback: callbacks.toggleCreateAlbum,
+				if: config.is_model_album,
 			},
 		];
 
@@ -67,14 +70,17 @@ export function useContextMenuAlbumAdd(
 				label: "lychee.DELETE_TRACK",
 				icon: "pi pi-compass",
 				callback: callbacks.deleteTrack,
+				if: config.is_model_album,
 			});
 		} else {
 			menu.push({
 				label: "lychee.UPLOAD_TRACK",
 				icon: "pi pi-compass",
 				callback: callbacks.toggleUploadTrack,
+				if: config.is_model_album,
 			});
 		}
+
 		return menu.filter((item) => item.if === undefined || item.if !== false);
 	});
 


### PR DESCRIPTION
Thanks @prbt2016

The menu was not _available_ in the DOM when in a smart album, as a result, Vue was crashing when trying to show it.

We fix this by removing unused elements in the menu for smart album. Yes this reduces the size of the menu significantly...