### PR TITLE
Add password unlocking middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -94,5 +94,6 @@ class Kernel extends HttpKernel
 		'cache_control' => \App\Http\Middleware\CacheControl::class,
 		'support' => \LycheeVerify\Http\Middleware\VerifySupporterStatus::class,
 		'config_integrity' => \App\Http\Middleware\ConfigIntegrity::class,
+		'unlock_with_password' => \App\Http\Middleware\UnlockWithPassword::class,
 	];
 }

--- a/app/Http/Middleware/UnlockWithPassword.php
+++ b/app/Http/Middleware/UnlockWithPassword.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Actions\Album\Unlock;
+use App\Enum\SmartAlbumType;
+use App\Exceptions\Internal\LycheeLogicException;
+use App\Factories\AlbumFactory;
+use App\Models\Configs;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Class LoginRequired.
+ *
+ * This middleware is ensures that only logged in users can access Lychee.
+ */
+class UnlockWithPassword
+{
+	private AlbumFactory $albumFactory;
+	private Unlock $unlock;
+
+	public function __construct(AlbumFactory $albumFactory, Unlock $unlock)
+	{
+		$this->albumFactory = $albumFactory;
+		$this->unlock = $unlock;
+	}
+
+	/**
+	 * Handle an incoming request.
+	 * If a password is provided, we try to unlock the album or fail silently.
+	 *
+	 * @param Request  $request the incoming request to serve
+	 * @param \Closure $next    the next operation to be applied to the
+	 *                          request
+	 */
+	public function handle(Request $request, \Closure $next): mixed
+	{
+		$album_id = $request->route('albumId');
+		if ($album_id === null || !is_string($album_id)) {
+			throw new LycheeLogicException('No albumId provided as url parameter.');
+		}
+
+		if (in_array($album_id, SmartAlbumType::values(), true)) {
+			return $next($request);
+		}
+
+		if (!$request->filled('password')) {
+			return $next($request);
+		}
+
+		if (!Configs::getValueAsBool('unlock_password_photos_with_url_param')) {
+			Log::warning('password provided but unlock_password_photos_with_url_param is disabled.');
+
+			return $next($request);
+		}
+
+		try {
+			$album = $this->albumFactory->findBaseAlbumOrFail($album_id);
+			$this->unlock->do($album, $request['password']);
+		} catch (\Exception) {
+			// fail silently
+		}
+
+		return $next($request);
+	}
+}

--- a/routes/web_v2.php
+++ b/routes/web_v2.php
@@ -21,8 +21,8 @@ Route::feeds();
 
 Route::get('/', [VueController::class, 'view'])->name('home')->middleware(['migration:complete']);
 Route::get('/gallery', [VueController::class, 'view'])->name('gallery')->middleware(['migration:complete']);
-Route::get('/gallery/{albumId}', [VueController::class, 'view'])->name('gallery-album')->middleware(['migration:complete']);
-Route::get('/gallery/{albumId}/{photoId}', [VueController::class, 'view'])->name('gallery-photo')->middleware(['migration:complete']);
+Route::get('/gallery/{albumId}', [VueController::class, 'view'])->name('gallery-album')->middleware(['migration:complete', 'unlock_with_password']);
+Route::get('/gallery/{albumId}/{photoId}', [VueController::class, 'view'])->name('gallery-photo')->middleware(['migration:complete', 'unlock_with_password']);
 
 Route::get('/frame', [VueController::class, 'view'])->name('frame')->middleware(['migration:complete']);
 Route::get('/frame/{albumId}', [VueController::class, 'view'])->name('frame')->middleware(['migration:complete']);


### PR DESCRIPTION
As requested in https://github.com/LycheeOrg/Lychee/discussions/2339

If a ?password=<password> is added when sharing the url of an album e.g.:
`https://lychee.test/gallery/somealbum?password=test` then Lychee will be try to use the password (here `test`) to unlock the album.
**If the password is wrong, this fails silently.**

If a password is provided but the setting is set to false in the database a warning will be raised in the logs.
