### PR TITLE
Fix hidden gallery footer social icons

### DIFF
--- a/resources/js/components/footers/GalleryFooter.vue
+++ b/resources/js/components/footers/GalleryFooter.vue
@@ -5,11 +5,11 @@
 			The height of the footer is always the natural height
 			of its child elements
 			-->
-		<div id="home_socials" class="w-full" style="display: none" v-if="footerData.footer_show_social_media">
+		<div id="home_socials" class="w-full" v-if="footerData.footer_show_social_media">
 			<a
 				v-if="footerData.sm_facebook_url !== ''"
 				:href="footerData.sm_facebook_url"
-				class="socialicons"
+				class="socials socialicons"
 				id="facebook"
 				target="_blank"
 				rel="noopener"
@@ -17,7 +17,7 @@
 			<a
 				v-if="footerData.sm_flickr_url !== ''"
 				:href="footerData.sm_flickr_url"
-				class="socialicons"
+				class="socials socialicons"
 				id="flickr"
 				target="_blank"
 				rel="noopener"
@@ -25,7 +25,7 @@
 			<a
 				v-if="footerData.sm_twitter_url !== ''"
 				:href="footerData.sm_twitter_url"
-				class="socialicons"
+				class="socials socialicons"
 				id="twitter"
 				target="_blank"
 				rel="noopener"
@@ -33,7 +33,7 @@
 			<a
 				v-if="footerData.sm_instagram_url !== ''"
 				:href="footerData.sm_instagram_url"
-				class="socialicons"
+				class="socials socialicons"
 				id="instagram"
 				target="_blank"
 				rel="noopener"
@@ -41,7 +41,7 @@
 			<a
 				v-if="footerData.sm_youtube_url !== ''"
 				:href="footerData.sm_youtube_url"
-				class="socialicons"
+				class="socials socialicons"
 				id="youtube"
 				target="_blank"
 				rel="noopener"


### PR DESCRIPTION
<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.

Don't worry if your code styling isn't perfect! php-cs-fixer will automatically create a pull request with any style fixes. This allows us to focus on the content of the contribution and not the code style.
-->
Fixes #2501 

The linked issue is reproducible for me in v6.1.2. The icons are visible in the landing page footer, but not in the gallery footer.

I think there's 2 issues with the gallery footer:
https://github.com/LycheeOrg/Lychee/blob/2e873f3a1aea07f41dd1b821f7d550da6679d3c0/resources/js/components/footers/GalleryFooter.vue#L8-L16

The first is that the div has `style="display: none"`. This hides the entire div even when `footer_show_social_media` is enabled. If I override the style to display the div in chrome devtools, I can see the div, but get the square boxes as shown in the original report.

The second issue is that the font with the icons is tied to the `socials` class, but the gallery footer links only set `socialicons`. (This is what causes the square boxes)

https://github.com/LycheeOrg/Lychee/blob/2e873f3a1aea07f41dd1b821f7d550da6679d3c0/resources/sass/fonts.css#L46-L48

You can see that the correctly working landing page footer sets both `socials` and `socialicons` classes:
https://github.com/LycheeOrg/Lychee/blob/2e873f3a1aea07f41dd1b821f7d550da6679d3c0/resources/js/components/footers/LandingFooter.vue#L3-L11