### PR TITLE
Code cleanup, resort imports

### DIFF
--- a/resources/js/views/Error.vue
+++ b/resources/js/views/Error.vue
@@ -37,10 +37,10 @@
 import { ref } from "vue";
 import Divider from "primevue/divider";
 import Message from "primevue/message";
+import Button from "primevue/button";
 import Panel from "primevue/panel";
 import { useLycheeStateStore } from "@/stores/LycheeState";
 import { storeToRefs } from "pinia";
-import Button from "primevue/button";
 
 type Trace = {
 	class: string;

--- a/resources/js/views/FixTree.vue
+++ b/resources/js/views/FixTree.vue
@@ -87,19 +87,19 @@
 import { ref, onMounted } from "vue";
 import MaintenanceService from "@/services/maintenance-service";
 import Toolbar from "primevue/toolbar";
-import OpenLeftMenu from "@/components/headers/OpenLeftMenu.vue";
 import ProgressBar from "primevue/progressbar";
 import Button from "primevue/button";
+import ScrollTop from "primevue/scrolltop";
+import VirtualScroller from "primevue/virtualscroller";
+import { useToast } from "primevue/usetoast";
 import AlbumService from "@/services/album-service";
 import { AugmentedAlbum, useTreeOperations } from "@/composables/album/treeOperations";
-import { useToast } from "primevue/usetoast";
+import OpenLeftMenu from "@/components/headers/OpenLeftMenu.vue";
 import FixTreeLine from "@/components/maintenance/FixTreeLine.vue";
 import Left from "@/components/maintenance/mini/Left.vue";
 import Right from "@/components/maintenance/mini/Right.vue";
 import LeftWarn from "@/components/maintenance/mini/LeftWarn.vue";
 import RightWarn from "@/components/maintenance/mini/RightWarn.vue";
-import ScrollTop from "primevue/scrolltop";
-import VirtualScroller from "primevue/virtualscroller";
 
 const albums = ref<AugmentedAlbum[] | undefined>(undefined);
 const originalAlbums = ref<App.Http.Resources.Diagnostics.AlbumTree[] | undefined>(undefined);

--- a/resources/js/views/Landing.vue
+++ b/resources/js/views/Landing.vue
@@ -67,7 +67,7 @@
 	</main>
 </template>
 <script setup lang="ts">
-import { Ref, ref } from "vue";
+import { ref } from "vue";
 import { RouterLink, useRouter } from "vue-router";
 import InitService from "@/services/init-service";
 import LandingFooter from "@/components/footers/LandingFooter.vue";

--- a/resources/js/views/Profile.vue
+++ b/resources/js/views/Profile.vue
@@ -17,7 +17,6 @@
 	</div>
 </template>
 <script setup lang="ts">
-import Button from "primevue/button";
 import Toolbar from "primevue/toolbar";
 import SetLogin from "@/components/forms/profile/SetLogin.vue";
 import SetSecondFactor from "@/components/forms/profile/SetSecondFactor.vue";

--- a/resources/js/views/Sharing.vue
+++ b/resources/js/views/Sharing.vue
@@ -36,13 +36,13 @@
 	</Panel>
 </template>
 <script setup lang="ts">
+import { ref } from "vue";
 import ShareLine from "@/components/forms/sharing/ShareLine.vue";
 import OpenLeftMenu from "@/components/headers/OpenLeftMenu.vue";
 import SharingService from "@/services/sharing-service";
 import Panel from "primevue/panel";
 import Toolbar from "primevue/toolbar";
 import { useToast } from "primevue/usetoast";
-import { ref } from "vue";
 
 const perms = ref<App.Http.Resources.Models.AccessPermissionResource[] | undefined>(undefined);
 const toast = useToast();

--- a/resources/js/views/Statistics.vue
+++ b/resources/js/views/Statistics.vue
@@ -27,10 +27,10 @@
 	</Panel>
 </template>
 <script setup lang="ts">
+import { ref } from "vue";
 import Toolbar from "primevue/toolbar";
 import Panel from "primevue/panel";
 import { useAuthStore } from "@/stores/Auth";
-import { ref } from "vue";
 import { useLycheeStateStore } from "@/stores/LycheeState";
 import { storeToRefs } from "pinia";
 import { useRouter } from "vue-router";


### PR DESCRIPTION
This pull request includes several changes to the import statements in various Vue component files to improve code organization and readability. The most important changes involve reordering and cleaning up the import statements.

Changes to import statements:

* [`resources/js/views/Error.vue`](diffhunk://#diff-a4d0a46f6fa776dda37ca9b76e9274015b812c995be6730348cc049d1f0952baR40-L43): Reordered the import of `Button` from "primevue/button" to be consistent with other imports.
* [`resources/js/views/FixTree.vue`](diffhunk://#diff-014818059c0ed595a9501b9387d1ee76a1e0715d64acd4b890a0600d65991eb9L90-L102): Reorganized multiple import statements to ensure a logical order and avoid duplication.
* [`resources/js/views/Landing.vue`](diffhunk://#diff-2b98095a7dfa60d778451af97b64df0c593fc838a7ece51b9790b979653c17d1L70-R70): Removed an unused import of `Ref` from "vue".
* [`resources/js/views/Profile.vue`](diffhunk://#diff-904f91fb81810c4beac885be79ed720a2b9bb2e677a8c9f9e6c26d61b0f14486L20): Removed an unused import of `Button` from "primevue/button".
* `resources/js/views/Sharing.vue` and `resources/js/views/Statistics.vue`: Moved the import of `ref` from "vue" to the top of the import list for consistency. [[1]](diffhunk://#diff-8c4afe432daf4c469b267898ae4263200f641b5a38977c86fcab7a84afefad92R39-L45) [[2]](diffhunk://#diff-77b2e7d88c4b57f58de57018dc206f69376d3b22389a204eea334e6529aa624bR30-L33)