### PR TITLE
Activate Focus on Input elements

### DIFF
--- a/resources/js/components/forms/basic/InputText.vue
+++ b/resources/js/components/forms/basic/InputText.vue
@@ -20,20 +20,23 @@ import InputText, { InputTextPassThroughOptions } from "primevue/inputtext";
 import type { PassThroughOptions } from "primevue/passthrough";
 import type { DesignToken, Nullable, PassThrough } from "@primevue/core";
 
-const props = withDefaults(defineProps<{
-	size?: "small" | "large" | undefined;
-	invalid?: boolean | undefined;
-	variant?: "outlined" | "filled" | undefined;
-	fluid?: boolean;
-	dt?: DesignToken<any>;
-	pt?: PassThrough<InputTextPassThroughOptions>;
-	ptOptions?: PassThroughOptions;
-	unstyled?: boolean;
-	class?: string;
-	autofocus?: boolean;
-}>(), {
-	autofocus: false
-});
+const props = withDefaults(
+	defineProps<{
+		size?: "small" | "large" | undefined;
+		invalid?: boolean | undefined;
+		variant?: "outlined" | "filled" | undefined;
+		fluid?: boolean;
+		dt?: DesignToken<any>;
+		pt?: PassThrough<InputTextPassThroughOptions>;
+		ptOptions?: PassThroughOptions;
+		unstyled?: boolean;
+		class?: string;
+		autofocus?: boolean;
+	}>(),
+	{
+		autofocus: false,
+	},
+);
 
 const emits = defineEmits(["updated"]);
 const modelValue = defineModel<Nullable<string>>();

--- a/resources/js/components/forms/basic/InputText.vue
+++ b/resources/js/components/forms/basic/InputText.vue
@@ -10,6 +10,7 @@
 		:pt="props.pt"
 		:ptOptions="props.ptOptions"
 		:unstyled="props.unstyled"
+		:autofocus="props.autofocus"
 		@update:modelValue="($event) => emits('updated', $event)"
 	/>
 </template>
@@ -19,7 +20,7 @@ import InputText, { InputTextPassThroughOptions } from "primevue/inputtext";
 import type { PassThroughOptions } from "primevue/passthrough";
 import type { DesignToken, Nullable, PassThrough } from "@primevue/core";
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
 	size?: "small" | "large" | undefined;
 	invalid?: boolean | undefined;
 	variant?: "outlined" | "filled" | undefined;
@@ -29,7 +30,10 @@ const props = defineProps<{
 	ptOptions?: PassThroughOptions;
 	unstyled?: boolean;
 	class?: string;
-}>();
+	autofocus?: boolean;
+}>(), {
+	autofocus: false
+});
 
 const emits = defineEmits(["updated"]);
 const modelValue = defineModel<Nullable<string>>();

--- a/resources/js/components/forms/users/CreateEditUser.vue
+++ b/resources/js/components/forms/users/CreateEditUser.vue
@@ -1,9 +1,9 @@
 <template>
-	<Dialog v-model:visible="visible" class="border-none max-w-lg w-full">
+	<Dialog v-model:visible="visible" modal class="border-none max-w-lg w-full">
 		<template #container="{ closeCallback }">
 			<div class="p-9 w-full flex flex-col gap-2 justify-center">
 				<FloatLabel class="w-full" variant="on">
-					<InputText id="username" v-model="username" aria-label="Username" />
+					<InputText id="username" v-model="username" aria-label="Username" :autofocus="true"/>
 					<label class="" for="username">{{ $t("lychee.USERNAME") }}</label>
 				</FloatLabel>
 				<FloatLabel class="w-full" variant="on">
@@ -60,6 +60,7 @@
 </template>
 <script setup lang="ts">
 import { Ref, ref, watch } from "vue";
+import Dialog from "primevue/dialog";
 import Button from "primevue/button";
 import Checkbox from "primevue/checkbox";
 import FloatLabel from "primevue/floatlabel";
@@ -67,7 +68,6 @@ import { useToast } from "primevue/usetoast";
 import InputText from "@/components/forms/basic/InputText.vue";
 import InputPassword from "@/components/forms/basic/InputPassword.vue";
 import UserManagementService from "@/services/user-management-service";
-import Dialog from "primevue/dialog";
 import { useLycheeStateStore } from "@/stores/LycheeState";
 import { storeToRefs } from "pinia";
 import Textarea from "../basic/Textarea.vue";
@@ -82,6 +82,7 @@ const props = defineProps<{
 	isEdit: boolean;
 }>();
 
+const usernameInputRef = ref<HTMLInputElement>()
 const id = ref<number | undefined>(props.user?.id);
 const username = ref<string | undefined>(props.user?.username);
 const note = ref<string | undefined>(props.user?.note ?? undefined);

--- a/resources/js/components/forms/users/CreateEditUser.vue
+++ b/resources/js/components/forms/users/CreateEditUser.vue
@@ -3,7 +3,7 @@
 		<template #container="{ closeCallback }">
 			<div class="p-9 w-full flex flex-col gap-2 justify-center">
 				<FloatLabel class="w-full" variant="on">
-					<InputText id="username" v-model="username" aria-label="Username" :autofocus="true"/>
+					<InputText id="username" v-model="username" aria-label="Username" :autofocus="true" />
 					<label class="" for="username">{{ $t("lychee.USERNAME") }}</label>
 				</FloatLabel>
 				<FloatLabel class="w-full" variant="on">

--- a/resources/js/components/forms/users/CreateEditUser.vue
+++ b/resources/js/components/forms/users/CreateEditUser.vue
@@ -82,7 +82,6 @@ const props = defineProps<{
 	isEdit: boolean;
 }>();
 
-const usernameInputRef = ref<HTMLInputElement>()
 const id = ref<number | undefined>(props.user?.id);
 const username = ref<string | undefined>(props.user?.username);
 const note = ref<string | undefined>(props.user?.note ?? undefined);

--- a/resources/js/components/modals/LoginModal.vue
+++ b/resources/js/components/modals/LoginModal.vue
@@ -23,7 +23,7 @@
 				</div>
 				<div class="inline-flex flex-col gap-2 px-9">
 					<FloatLabel variant="on">
-						<InputText id="username" v-model="username" autocomplete="username" />
+						<InputText id="username" v-model="username" autocomplete="username" :autofocus="true" />
 						<label class="" for="username">{{ $t("lychee.USERNAME") }}</label>
 					</FloatLabel>
 				</div>


### PR DESCRIPTION
This pull request includes several changes to improve the user experience by adding an autofocus feature to input fields and making minor refactors to the codebase. The most important changes include adding the autofocus prop to the `InputText` component, updating the `CreateEditUser` and `LoginModal` components to use this new prop, and refactoring imports.

Enhancements to input fields:

* [`resources/js/components/forms/basic/InputText.vue`](diffhunk://#diff-081332863544ae7e5b8130ae0fbf77f467cae2d16f877fba3e9185278edd7824R13): Added `autofocus` prop to the `InputText` component and set its default value to `false`. [[1]](diffhunk://#diff-081332863544ae7e5b8130ae0fbf77f467cae2d16f877fba3e9185278edd7824R13) [[2]](diffhunk://#diff-081332863544ae7e5b8130ae0fbf77f467cae2d16f877fba3e9185278edd7824L22-R23) [[3]](diffhunk://#diff-081332863544ae7e5b8130ae0fbf77f467cae2d16f877fba3e9185278edd7824L32-R36)

Updates to user-related components:

* [`resources/js/components/forms/users/CreateEditUser.vue`](diffhunk://#diff-f0c03656c831c1a2e7635b6fdca2f12aa63fb5a23738c321287efe8fa6669a37L2-R6): Updated the `InputText` component for the username field to use the new `autofocus` prop.
* [`resources/js/components/modals/LoginModal.vue`](diffhunk://#diff-03c1b746d1b1e808f4568e9413c9d0577fa8ca42356454056b7a2a17573b096dL26-R26): Updated the `InputText` component for the username field to use the new `autofocus` prop.

Codebase refactoring:

* [`resources/js/components/forms/users/CreateEditUser.vue`](diffhunk://#diff-f0c03656c831c1a2e7635b6fdca2f12aa63fb5a23738c321287efe8fa6669a37R63-L70): Refactored imports to improve code organization.
* [`resources/js/components/forms/users/CreateEditUser.vue`](diffhunk://#diff-f0c03656c831c1a2e7635b6fdca2f12aa63fb5a23738c321287efe8fa6669a37R85): Added a reference for the username input field.