### PR TITLE
Fixes upload fails for non-existent partner video upload to S3

### DIFF
--- a/app/Jobs/UploadSizeVariantToS3Job.php
+++ b/app/Jobs/UploadSizeVariantToS3Job.php
@@ -86,6 +86,10 @@ class UploadSizeVariantToS3Job implements ShouldQueue
 
 		$photo = Photo::query()->where('id', '=', $this->variant->photo_id)->first();
 
+		if ($photo->live_photo_short_path === null) {
+			return;
+		}
+
 		Storage::disk(StorageDiskType::S3->value)->writeStream(
 			$photo->live_photo_short_path,
 			Storage::disk(StorageDiskType::LOCAL->value)->readStream($photo->live_photo_short_path)


### PR DESCRIPTION
Previously, the S3 upload flow attempted to upload a partner video regardless of its existence, resulting in an error when the video was missing. This error prevented the job responsible for uploading the original variant to S3 from completing successfully.

This commit adds a check to ensure the partner video exists before attempting to upload, resolving the issue and allowing the job to complete as expected.

Fixes one of the bugs described here: https://github.com/LycheeOrg/Lychee/discussions/2521.

<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.

Don't worry if your code styling isn't perfect! php-cs-fixer will automatically create a pull request with any style fixes. This allows us to focus on the content of the contribution and not the code style.
-->