### PR TITLE
Fix functionality to hide back button when configuration is set

### DIFF
--- a/resources/js/components/headers/BackLinkButton.vue
+++ b/resources/js/components/headers/BackLinkButton.vue
@@ -1,5 +1,12 @@
 <template>
-	<Button as="a" :href="props.config.back_button_url" severity="secondary" text class="border-none">
+	<Button
+		as="a"
+		:href="props.config.back_button_url"
+		severity="secondary"
+		text
+		class="border-none"
+		:class="props.config.back_button_enabled ? '' : 'hidden'"
+	>
 		<i class="pi pi-home sm:hidden" />
 		<span class="hidden sm:inline">{{ props.config.back_button_text }}</span>
 	</Button>


### PR DESCRIPTION
In version 5, the option to hide the back button functioned correctly, ensuring the button was not displayed when configured to be hidden. However, this behaviour regressed in the new UI. This commit reinstates the original functionality, ensuring the back button is properly hidden when the corresponding option is enabled.

<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.

Don't worry if your code styling isn't perfect! php-cs-fixer will automatically create a pull request with any style fixes. This allows us to focus on the content of the contribution and not the code style.
-->