### PR TITLE
Exit with error for unsupported S3 backend

### DIFF
--- a/app/Console/Commands/ImageProcessing/GenerateThumbs.php
+++ b/app/Console/Commands/ImageProcessing/GenerateThumbs.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands\ImageProcessing;
 
+use App\Assets\Features;
 use App\Contracts\Exceptions\ExternalLycheeException;
 use App\Contracts\Exceptions\LycheeException;
 use App\Contracts\Models\SizeVariantFactory;
@@ -60,6 +61,13 @@ class GenerateThumbs extends Command
 
 				return 1;
 			}
+
+			if (Features::active('use-s3')) {
+				$this->error('This tool does not support S3 file storage.');
+
+				return 1;
+			}
+
 			$sizeVariantType = self::SIZE_VARIANTS[$sizeVariantName];
 
 			$amount = (int) $this->argument('amount');


### PR DESCRIPTION
The `lychee:generate_thumbs` command does not support the S3 backend. This commit outputs an error message and exits the tool when the command is invoked with such a backend, avoiding incorrect behaviour such as writing images to the filesystem.

<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.

Don't worry if your code styling isn't perfect! php-cs-fixer will automatically create a pull request with any style fixes. This allows us to focus on the content of the contribution and not the code style.
-->