### PR TITLE
Resolve route name clashes to enable cache generation

### DIFF
--- a/routes/web_v2.php
+++ b/routes/web_v2.php
@@ -25,15 +25,15 @@ Route::get('/gallery/{albumId}', [VueController::class, 'view'])->name('gallery-
 Route::get('/gallery/{albumId}/{photoId}', [VueController::class, 'view'])->name('gallery-photo')->middleware(['migration:complete', 'unlock_with_password']);
 
 Route::get('/frame', [VueController::class, 'view'])->name('frame')->middleware(['migration:complete']);
-Route::get('/frame/{albumId}', [VueController::class, 'view'])->name('frame')->middleware(['migration:complete']);
+Route::get('/frame/{albumId}', [VueController::class, 'view'])->name('frame-album')->middleware(['migration:complete']);
 
 Route::get('/map', [VueController::class, 'view'])->name('map')->middleware(['migration:complete']);
-Route::get('/map/{albumId}', [VueController::class, 'view'])->name('map')->middleware(['migration:complete']);
+Route::get('/map/{albumId}', [VueController::class, 'view'])->name('map-album')->middleware(['migration:complete']);
 
 // later
-Route::get('/search', [VueController::class, 'view'])->middleware(['migration:complete']);
-Route::get('/search/{albumId}', [VueController::class, 'view'])->middleware(['migration:complete']);
-Route::get('/search/{albumId}/{photoId}', [VueController::class, 'view'])->middleware(['migration:complete']);
+Route::get('/search', [VueController::class, 'view'])->name("search")->middleware(['migration:complete']);
+Route::get('/search/{albumId}', [VueController::class, 'view'])->name("search-album")->middleware(['migration:complete']);
+Route::get('/search/{albumId}/{photoId}', [VueController::class, 'view'])->name("search-photo")->middleware(['migration:complete']);
 
 Route::get('/profile', [VueController::class, 'view'])->name('profile')->middleware(['migration:complete']);
 Route::get('/users', [VueController::class, 'view'])->middleware(['migration:complete']);

--- a/routes/web_v2.php
+++ b/routes/web_v2.php
@@ -31,9 +31,9 @@ Route::get('/map', [VueController::class, 'view'])->name('map')->middleware(['mi
 Route::get('/map/{albumId}', [VueController::class, 'view'])->name('map-album')->middleware(['migration:complete']);
 
 // later
-Route::get('/search', [VueController::class, 'view'])->name("search")->middleware(['migration:complete']);
-Route::get('/search/{albumId}', [VueController::class, 'view'])->name("search-album")->middleware(['migration:complete']);
-Route::get('/search/{albumId}/{photoId}', [VueController::class, 'view'])->name("search-photo")->middleware(['migration:complete']);
+Route::get('/search', [VueController::class, 'view'])->name('search')->middleware(['migration:complete']);
+Route::get('/search/{albumId}', [VueController::class, 'view'])->name('search-album')->middleware(['migration:complete']);
+Route::get('/search/{albumId}/{photoId}', [VueController::class, 'view'])->name('search-photo')->middleware(['migration:complete']);
 
 Route::get('/profile', [VueController::class, 'view'])->name('profile')->middleware(['migration:complete']);
 Route::get('/users', [VueController::class, 'view'])->middleware(['migration:complete']);


### PR DESCRIPTION
Clashing route names in `routes/web_v2.php` caused the error:

```
Unable to prepare route [X/Y] for serialization. Another route has already been assigned name [X].
```

when running `php artisan route:cache`.

This commit ensures that all routes have unique names, allowing the artisan command to successfully generate the route cache.

<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.

Don't worry if your code styling isn't perfect! php-cs-fixer will automatically create a pull request with any style fixes. This allows us to focus on the content of the contribution and not the code style.
-->