### PR TITLE
Fix missing include in `hook-redirection.blade.php`

### DIFF
--- a/resources/views/hook-redirection.blade.php
+++ b/resources/views/hook-redirection.blade.php
@@ -1,4 +1,3 @@
-<x-layouts.app>
 <div 
 	id="redirectData"
 	data-gallery="{{ $gallery }}"
@@ -21,4 +20,3 @@
 		window.location = base;
 	}
 </script>
-</x-layouts.app>


### PR DESCRIPTION
In commit b560ff5, the `layouts.app` base template was added to `hook-redirection.blade.php`. However, in commit b156ec4, the base template was removed, leaving a broken include reference.

This causes commands like `php artisan view:cache` to fail due to the missing template.

This commit removes the invalid include, restoring the file to its state prior to b560ff5 and resolving the issue.

<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.

Don't worry if your code styling isn't perfect! php-cs-fixer will automatically create a pull request with any style fixes. This allows us to focus on the content of the contribution and not the code style.
-->