### PR TITLE
Fixes "Videos not loading when going consecutively"

### DIFF
--- a/resources/js/composables/photo/basePhoto.ts
+++ b/resources/js/composables/photo/basePhoto.ts
@@ -1,6 +1,6 @@
 import { computed, Ref, ref } from "vue";
 
-export function usePhotoBaseFunction(photoId: Ref<string>) {
+export function usePhotoBaseFunction(photoId: Ref<string>, videoElement: Ref<HTMLVideoElement | null>) {
 	const photo = ref<App.Http.Resources.Models.PhotoResource | undefined>(undefined);
 	const album = ref<App.Http.Resources.Models.AbstractAlbumResource | null>(null);
 	const photos = ref<App.Http.Resources.Models.PhotoResource[]>([]);
@@ -87,6 +87,13 @@ export function usePhotoBaseFunction(photoId: Ref<string>) {
 
 	function refresh(): void {
 		photo.value = photos.value.find((p: App.Http.Resources.Models.PhotoResource) => p.id === photoId.value);
+
+		// handle videos.
+		const videoElementValue = videoElement.value;
+		if (photo.value?.precomputed?.is_video && videoElementValue) {
+			videoElementValue.src = photo.value?.size_variants?.original?.url ?? "";
+			videoElementValue.load();
+		}
 	}
 
 	return {

--- a/resources/js/views/gallery-panels/Photo.vue
+++ b/resources/js/views/gallery-panels/Photo.vue
@@ -187,8 +187,10 @@ const { is_full_screen, is_edit_open, are_details_open, is_slideshow_active } = 
 const { isDeleteVisible, toggleDelete, isMoveVisible, toggleMove } = useGalleryModals(togglableStore);
 
 const photoId = ref(props.photoid);
-const { photo, album, photos, previousStyle, nextStyle, srcSetMedium, style, imageViewMode, refresh, hasPrevious, hasNext } =
-	usePhotoBaseFunction(photoId);
+const { photo, album, photos, previousStyle, nextStyle, srcSetMedium, style, imageViewMode, refresh, hasPrevious, hasNext } = usePhotoBaseFunction(
+	photoId,
+	videoElement,
+);
 const { getPlaceholderIcon } = useImageHelpers();
 
 const { slideshow_timeout } = storeToRefs(lycheeStore);
@@ -314,19 +316,6 @@ function scrollTo(event: WheelEvent) {
 		previous(true);
 	}
 }
-
-watch(
-	() => photo.value,
-	(newPhoto) => {
-		if (newPhoto) {
-			const videoElementValue = videoElement.value;
-			if (newPhoto.precomputed?.is_video && videoElementValue) {
-				videoElementValue.src = newPhoto.size_variants?.original?.url ?? "";
-				videoElementValue.load();
-			}
-		}
-	},
-);
 
 useSwipe(swipe, {
 	onSwipe(_e: TouchEvent) {},

--- a/resources/js/views/gallery-panels/Photo.vue
+++ b/resources/js/views/gallery-panels/Photo.vue
@@ -19,6 +19,7 @@
 					width="auto"
 					height="auto"
 					id="image"
+					ref="videoElement"
 					controls
 					class="absolute m-auto w-auto h-auto"
 					:class="is_full_screen || is_slideshow_active ? 'max-w-full max-h-full' : 'max-wh-full-56'"
@@ -169,7 +170,7 @@ import { useImageHelpers } from "@/utils/Helpers";
 import { useTogglablesStateStore } from "@/stores/ModalsState";
 
 const swipe = ref<HTMLElement | null>(null);
-
+const videoElement = ref<HTMLVideoElement | null>(null);
 const props = defineProps<{
 	albumid: string;
 	photoid: string;
@@ -313,6 +314,19 @@ function scrollTo(event: WheelEvent) {
 		previous(true);
 	}
 }
+
+watch(
+	() => photo.value,
+	(newPhoto) => {
+		if (newPhoto) {
+			const videoElementValue = videoElement.value;
+			if (newPhoto.precomputed?.is_video && videoElementValue) {
+				videoElementValue.src = newPhoto.size_variants?.original?.url ?? "";
+				videoElementValue.load();
+			}
+		}
+	},
+);
 
 useSwipe(swipe, {
 	onSwipe(_e: TouchEvent) {},


### PR DESCRIPTION
<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.

Don't worry if your code styling isn't perfect! php-cs-fixer will automatically create a pull request with any style fixes. This allows us to focus on the content of the contribution and not the code style.
-->

Fixes #2878 by monitoring the current photo type and if it is video triggers the video loading.

This fix will allow users to navigate through consecutive videos without needing to refresh page manually to load the current video. Hence, this fix should enhance user experience when navigating through an album.
