### PR TITLE
Php 32bit - Zip-stream with version 2.1 instead of 3.1

### DIFF
--- a/app/Actions/Album/Archive32.php
+++ b/app/Actions/Album/Archive32.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Album;
+
+use App\Services\Archives\Zip21Trait;
+
+final class Archive32 extends BaseArchive
+{
+	use Zip21Trait;
+}

--- a/app/Actions/Album/Archive64.php
+++ b/app/Actions/Album/Archive64.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Album;
+
+use App\Services\Archives\Zip31Trait;
+
+final class Archive64 extends BaseArchive
+{
+	use Zip31Trait;
+}

--- a/app/Actions/Photo/Archive32.php
+++ b/app/Actions/Photo/Archive32.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Photo;
+
+use App\Services\Archives\Zip21Trait;
+
+final class Archive32 extends BaseArchive
+{
+	use Zip21Trait;
+}

--- a/app/Actions/Photo/Archive64.php
+++ b/app/Actions/Photo/Archive64.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Photo;
+
+use App\Services\Archives\Zip31Trait;
+
+final class Archive64 extends BaseArchive
+{
+	use Zip31Trait;
+}

--- a/app/Http/Controllers/Gallery/AlbumController.php
+++ b/app/Http/Controllers/Gallery/AlbumController.php
@@ -8,7 +8,7 @@
 
 namespace App\Http\Controllers\Gallery;
 
-use App\Actions\Album\Archive as AlbumArchive;
+use App\Actions\Album\BaseArchive as AlbumBaseArchive;
 use App\Actions\Album\Create;
 use App\Actions\Album\CreateTagAlbum;
 use App\Actions\Album\Delete;
@@ -20,7 +20,7 @@ use App\Actions\Album\SetProtectionPolicy;
 use App\Actions\Album\SetSmartProtectionPolicy;
 use App\Actions\Album\Transfer;
 use App\Actions\Album\Unlock;
-use App\Actions\Photo\Archive as PhotoArchive;
+use App\Actions\Photo\BaseArchive as PhotoBaseArchive;
 use App\Events\AlbumRouteCacheUpdated;
 use App\Exceptions\Internal\LycheeLogicException;
 use App\Exceptions\UnauthenticatedException;
@@ -350,19 +350,17 @@ class AlbumController extends Controller
 	/**
 	 * Return the archive of the pictures of the album and its sub-albums.
 	 *
-	 * @param ZipRequest   $request
-	 * @param AlbumArchive $album_archive
-	 * @param PhotoArchive $photo_archive
+	 * @param ZipRequest $request
 	 *
 	 * @return StreamedResponse
 	 */
-	public function getArchive(ZipRequest $request, AlbumArchive $album_archive, PhotoArchive $photo_archive): StreamedResponse
+	public function getArchive(ZipRequest $request): StreamedResponse
 	{
 		if ($request->albums()->count() > 0) {
-			return $album_archive->do($request->albums());
+			return AlbumBaseArchive::resolve()->do($request->albums());
 		}
 
-		return $photo_archive->do($request->photos(), $request->sizeVariant());
+		return PhotoBaseArchive::resolve()->do($request->photos(), $request->sizeVariant());
 	}
 
 	/**

--- a/app/Legacy/V1/Controllers/AlbumController.php
+++ b/app/Legacy/V1/Controllers/AlbumController.php
@@ -9,6 +9,7 @@
 namespace App\Legacy\V1\Controllers;
 
 use App\Actions\Album\Archive;
+use App\Actions\Album\BaseArchive;
 use App\Actions\Album\Create;
 use App\Actions\Album\CreateTagAlbum;
 use App\Actions\Album\Delete;
@@ -387,14 +388,13 @@ final class AlbumController extends Controller
 	 * Return the archive of the pictures of the album and its sub-albums.
 	 *
 	 * @param ArchiveAlbumsRequest $request
-	 * @param Archive              $archive
 	 *
 	 * @return StreamedResponse
 	 *
 	 * @throws LycheeException
 	 */
-	public function getArchive(ArchiveAlbumsRequest $request, Archive $archive): StreamedResponse
+	public function getArchive(ArchiveAlbumsRequest $request): StreamedResponse
 	{
-		return $archive->do($request->albums());
+		return BaseArchive::resolve()->do($request->albums());
 	}
 }

--- a/app/Legacy/V1/Controllers/PhotoController.php
+++ b/app/Legacy/V1/Controllers/PhotoController.php
@@ -9,6 +9,7 @@
 namespace App\Legacy\V1\Controllers;
 
 use App\Actions\Photo\Archive;
+use App\Actions\Photo\BaseArchive;
 use App\Actions\Photo\Delete;
 use App\Actions\Photo\Duplicate;
 use App\Actions\Photo\Move;
@@ -313,15 +314,14 @@ final class PhotoController extends Controller
 	 * Return the archive of pictures or just a picture if only one.
 	 *
 	 * @param ArchivePhotosRequest $request
-	 * @param Archive              $archive
 	 *
 	 * @return SymfonyResponse
 	 *
 	 * @throws LycheeException
 	 */
-	public function getArchive(ArchivePhotosRequest $request, Archive $archive): SymfonyResponse
+	public function getArchive(ArchivePhotosRequest $request): SymfonyResponse
 	{
-		return $archive->do($request->photos(), $request->sizeVariant());
+		return BaseArchive::resolve()->do($request->photos(), $request->sizeVariant());
 	}
 
 	/**

--- a/app/Services/Archives/Zip21Trait.php
+++ b/app/Services/Archives/Zip21Trait.php
@@ -29,6 +29,7 @@ trait Zip21Trait
 	{
 		if (InstalledVersions::satisfies(new VersionParser(), 'maennchen/zipstream-php', '^2.1')) {
 			$options = new \ZipStream\Option\Archive();
+			$options->setContentType('application/octet-stream');
 			$options->setDeflateLevel($this->deflateLevel);
 			$options->setZeroHeader(true);
 			$options->setEnableZip64(Configs::getValueAsBool('zip64'));
@@ -50,7 +51,7 @@ trait Zip21Trait
 
 		$options = new \ZipStream\Option\File();
 		$options->setComment($photo->title);
-		$options->setTime($photo->taken_at);
+		$options->setTime($photo->taken_at ?? $photo->created_at);
 		$zip->addFileFromStream(name: $fileName, stream: $file->read(), options: $options);
 	}
 }

--- a/app/Services/Archives/Zip21Trait.php
+++ b/app/Services/Archives/Zip21Trait.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Services\Archives;
+
+use App\Exceptions\ConfigurationKeyMissingException;
+use App\Exceptions\Internal\LycheeLogicException;
+use App\Image\Files\BaseMediaFile;
+use App\Image\Files\FlysystemFile;
+use App\Models\Configs;
+use App\Models\Photo;
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
+use ZipStream\ZipStream;
+
+trait Zip21Trait
+{
+	/**
+	 * @return ZipStream
+	 *
+	 * @throws ConfigurationKeyMissingException
+	 */
+	protected function createZip(): ZipStream
+	{
+		if (InstalledVersions::satisfies(new VersionParser(), 'maennchen/zipstream-php', '^2.1')) {
+			$options = new \ZipStream\Option\Archive();
+			$options->setDeflateLevel($this->deflateLevel);
+			$options->setZeroHeader(true);
+			$options->setEnableZip64(Configs::getValueAsBool('zip64'));
+			$options->setSendHttpHeaders(false);
+
+			return new ZipStream('archive.zip', $options);
+		}
+
+		throw new LycheeLogicException('Unsupported version of maennchen/zipstream-php');
+	}
+
+	protected function addFileToZip(ZipStream $zip, string $fileName, FlysystemFile|BaseMediaFile $file, Photo|null $photo): void
+	{
+		if ($photo === null) {
+			$zip->addFileFromStream(name: $fileName, stream: $file->read());
+
+			return;
+		}
+
+		$options = new \ZipStream\Option\File();
+		$options->setComment($photo->title);
+		$options->setTime($photo->taken_at);
+		$zip->addFileFromStream(name: $fileName, stream: $file->read(), options: $options);
+	}
+}

--- a/app/Services/Archives/Zip31Trait.php
+++ b/app/Services/Archives/Zip31Trait.php
@@ -49,6 +49,6 @@ trait Zip31Trait
 		}
 
 		/** @disregard */
-		$zip->addFileFromStream(fileName: $fileName, stream: $file->read(), comment: $photo->title, lastModificationDateTime: $photo->taken_at);
+		$zip->addFileFromStream(fileName: $fileName, stream: $file->read(), comment: $photo->title, lastModificationDateTime: $photo->taken_at ?? $photo->created_at);
 	}
 }

--- a/app/Services/Archives/Zip31Trait.php
+++ b/app/Services/Archives/Zip31Trait.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Services\Archives;
+
+use App\Exceptions\ConfigurationKeyMissingException;
+use App\Exceptions\Internal\LycheeLogicException;
+use App\Image\Files\BaseMediaFile;
+use App\Image\Files\FlysystemFile;
+use App\Models\Configs;
+use App\Models\Photo;
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
+use ZipStream\ZipStream;
+
+trait Zip31Trait
+{
+	/**
+	 * @return ZipStream
+	 *
+	 * @throws ConfigurationKeyMissingException
+	 */
+	protected function createZip(): ZipStream
+	{
+		if (InstalledVersions::satisfies(new VersionParser(), 'maennchen/zipstream-php', '^3.1')) {
+			/** @disregard */
+			return new ZipStream(defaultCompressionMethod: $this->deflateLevel === -1 ? ZipMethod::STORE : ZipMethod::DEFLATE,
+				defaultDeflateLevel: $this->deflateLevel,
+				enableZip64: Configs::getValueAsBool('zip64'),
+				defaultEnableZeroHeader: true, sendHttpHeaders: false);
+		}
+
+		throw new LycheeLogicException('Unsupported version of maennchen/zipstream-php');
+	}
+
+	protected function addFileToZip(ZipStream $zip, string $fileName, FlysystemFile|BaseMediaFile $file, Photo|null $photo): void
+	{
+		if ($photo === null) {
+			/** @disregard */
+			$zip->addFileFromStream(fileName: $fileName, stream: $file->read());
+
+			return;
+		}
+
+		/** @disregard */
+		$zip->addFileFromStream(fileName: $fileName, stream: $file->read(), comment: $photo->title, lastModificationDateTime: $photo->taken_at);
+	}
+}

--- a/app/Services/Archives/Zip31Trait.php
+++ b/app/Services/Archives/Zip31Trait.php
@@ -16,6 +16,7 @@ use App\Models\Configs;
 use App\Models\Photo;
 use Composer\InstalledVersions;
 use Composer\Semver\VersionParser;
+use ZipStream\CompressionMethod as ZipMethod;
 use ZipStream\ZipStream;
 
 trait Zip31Trait

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "lychee-org/lycheeverify": "^1.0.2",
         "lychee-org/nestedset": "^9.0",
         "lychee-org/php-exif": "^1.0.4",
-        "maennchen/zipstream-php": "^3.1",
+        "maennchen/zipstream-php": "^2.1 || ^3.1",
         "mavinoo/laravel-batch": "^2.4",
         "opcodesio/log-viewer": "dev-lycheeOrg",
         "php-ffmpeg/php-ffmpeg": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f41ced356c6370d5be9ded929153c875",
+    "content-hash": "1a2560159b62b9323bed923ac6da746b",
     "packages": [
         {
             "name": "amphp/amp",
@@ -870,16 +870,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.339.0",
+            "version": "3.339.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "41bcd4a555649d276c8fbc0bc1738e59fda2221d"
+                "reference": "e443779facb8cd0bba30383753a7a451db83acd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/41bcd4a555649d276c8fbc0bc1738e59fda2221d",
-                "reference": "41bcd4a555649d276c8fbc0bc1738e59fda2221d",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/e443779facb8cd0bba30383753a7a451db83acd6",
+                "reference": "e443779facb8cd0bba30383753a7a451db83acd6",
                 "shasum": ""
             },
             "require": {
@@ -905,7 +905,6 @@
                 "ext-openssl": "*",
                 "ext-pcntl": "*",
                 "ext-sockets": "*",
-                "paragonie/random_compat": ">= 2",
                 "phpunit/phpunit": "^5.6.3 || ^8.5 || ^9.5",
                 "psr/cache": "^2.0 || ^3.0",
                 "psr/simple-cache": "^2.0 || ^3.0",
@@ -962,9 +961,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.339.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.339.9"
             },
-            "time": "2025-01-27T19:25:50+00:00"
+            "time": "2025-02-07T19:14:31+00:00"
         },
         {
             "name": "bepsvpt/secure-headers",
@@ -1286,16 +1285,16 @@
         },
         {
             "name": "dedoc/scramble",
-            "version": "v0.12.2",
+            "version": "v0.12.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dedoc/scramble.git",
-                "reference": "9482d3c6285ebb16a067bd28b01e94899e1fddd8"
+                "reference": "544fa3407eaa9a157401d65e9b4737ae9d3147a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dedoc/scramble/zipball/9482d3c6285ebb16a067bd28b01e94899e1fddd8",
-                "reference": "9482d3c6285ebb16a067bd28b01e94899e1fddd8",
+                "url": "https://api.github.com/repos/dedoc/scramble/zipball/544fa3407eaa9a157401d65e9b4737ae9d3147a0",
+                "reference": "544fa3407eaa9a157401d65e9b4737ae9d3147a0",
                 "shasum": ""
             },
             "require": {
@@ -1350,7 +1349,7 @@
             ],
             "support": {
                 "issues": "https://github.com/dedoc/scramble/issues",
-                "source": "https://github.com/dedoc/scramble/tree/v0.12.2"
+                "source": "https://github.com/dedoc/scramble/tree/v0.12.6"
             },
             "funding": [
                 {
@@ -1358,7 +1357,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-03T12:23:33+00:00"
+            "time": "2025-02-08T10:46:30+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -3726,16 +3725,16 @@
         },
         {
             "name": "lcobucci/jwt",
-            "version": "5.4.2",
+            "version": "5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "ea1ce71cbf9741e445a5914e2f67cdbb484ff712"
+                "reference": "a835af59b030d3f2967725697cf88300f579088e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/ea1ce71cbf9741e445a5914e2f67cdbb484ff712",
-                "reference": "ea1ce71cbf9741e445a5914e2f67cdbb484ff712",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/a835af59b030d3f2967725697cf88300f579088e",
+                "reference": "a835af59b030d3f2967725697cf88300f579088e",
                 "shasum": ""
             },
             "require": {
@@ -3783,7 +3782,7 @@
             ],
             "support": {
                 "issues": "https://github.com/lcobucci/jwt/issues",
-                "source": "https://github.com/lcobucci/jwt/tree/5.4.2"
+                "source": "https://github.com/lcobucci/jwt/tree/5.5.0"
             },
             "funding": [
                 {
@@ -3795,7 +3794,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2024-11-07T12:54:35+00:00"
+            "time": "2025-01-26T21:29:45+00:00"
         },
         {
             "name": "league/commonmark",
@@ -8390,27 +8389,27 @@
         },
         {
             "name": "spatie/laravel-package-tools",
-            "version": "1.18.3",
+            "version": "1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-package-tools.git",
-                "reference": "ba67eee37d86ed775dab7dad58a7cbaf9a6cfe78"
+                "reference": "1c9c30ac6a6576b8d15c6c37b6cf23d748df2faa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/ba67eee37d86ed775dab7dad58a7cbaf9a6cfe78",
-                "reference": "ba67eee37d86ed775dab7dad58a7cbaf9a6cfe78",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/1c9c30ac6a6576b8d15c6c37b6cf23d748df2faa",
+                "reference": "1c9c30ac6a6576b8d15c6c37b6cf23d748df2faa",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^9.28|^10.0|^11.0",
+                "illuminate/contracts": "^9.28|^10.0|^11.0|^12.0",
                 "php": "^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.5",
-                "orchestra/testbench": "^7.7|^8.0|^9.0",
-                "pestphp/pest": "^1.22|^2",
-                "phpunit/phpunit": "^9.5.24|^10.5",
+                "orchestra/testbench": "^7.7|^8.0|^9.0|^10.0",
+                "pestphp/pest": "^1.23|^2.1|^3.1",
+                "phpunit/phpunit": "^9.5.24|^10.5|^11.5",
                 "spatie/pest-plugin-test-time": "^1.1|^2.2"
             },
             "type": "library",
@@ -8438,7 +8437,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-package-tools/issues",
-                "source": "https://github.com/spatie/laravel-package-tools/tree/1.18.3"
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.19.0"
             },
             "funding": [
                 {
@@ -8446,7 +8445,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-22T08:51:18+00:00"
+            "time": "2025-02-06T14:58:20+00:00"
         },
         {
             "name": "spatie/laravel-typescript-transformer",
@@ -12159,16 +12158,16 @@
         },
         {
             "name": "composer/class-map-generator",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/class-map-generator.git",
-                "reference": "4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915"
+                "reference": "ffe442c5974c44a9343e37a0abcb1cc37319f5b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915",
-                "reference": "4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/ffe442c5974c44a9343e37a0abcb1cc37319f5b9",
+                "reference": "ffe442c5974c44a9343e37a0abcb1cc37319f5b9",
                 "shasum": ""
             },
             "require": {
@@ -12212,7 +12211,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/class-map-generator/issues",
-                "source": "https://github.com/composer/class-map-generator/tree/1.5.0"
+                "source": "https://github.com/composer/class-map-generator/tree/1.6.0"
             },
             "funding": [
                 {
@@ -12228,7 +12227,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-25T16:11:06+00:00"
+            "time": "2025-02-05T10:05:34+00:00"
         },
         {
             "name": "composer/composer",
@@ -13335,16 +13334,16 @@
         },
         {
             "name": "larastan/larastan",
-            "version": "v2.9.12",
+            "version": "v2.9.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/larastan/larastan.git",
-                "reference": "19012b39fbe4dede43dbe0c126d9681827a5e908"
+                "reference": "78f7f8da613e54edb2ab4afa5bede045228fb843"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/19012b39fbe4dede43dbe0c126d9681827a5e908",
-                "reference": "19012b39fbe4dede43dbe0c126d9681827a5e908",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/78f7f8da613e54edb2ab4afa5bede045228fb843",
+                "reference": "78f7f8da613e54edb2ab4afa5bede045228fb843",
                 "shasum": ""
             },
             "require": {
@@ -13358,7 +13357,7 @@
                 "illuminate/support": "^9.52.16 || ^10.28.0 || ^11.16",
                 "php": "^8.0.2",
                 "phpmyadmin/sql-parser": "^5.9.0",
-                "phpstan/phpstan": "^1.12.11"
+                "phpstan/phpstan": "^1.12.17"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^12.0",
@@ -13416,7 +13415,7 @@
             ],
             "support": {
                 "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/v2.9.12"
+                "source": "https://github.com/larastan/larastan/tree/v2.9.14"
             },
             "funding": [
                 {
@@ -13424,7 +13423,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-26T23:09:02+00:00"
+            "time": "2025-02-06T21:03:14+00:00"
         },
         {
             "name": "lychee-org/phpstan-lychee",
@@ -14058,16 +14057,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.16",
+            "version": "1.12.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9"
+                "reference": "7027b3b0270bf392de0cfba12825979768d728bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e0bb5cb78545aae631220735aa706eac633a6be9",
-                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7027b3b0270bf392de0cfba12825979768d728bf",
+                "reference": "7027b3b0270bf392de0cfba12825979768d728bf",
                 "shasum": ""
             },
             "require": {
@@ -14112,7 +14111,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-21T14:50:05+00:00"
+            "time": "2025-02-07T15:01:57+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -14533,16 +14532,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.41",
+            "version": "10.5.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e76586fa3d49714f230221734b44892e384109d7"
+                "reference": "bd68a781d8e30348bc297449f5234b3458267ae8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e76586fa3d49714f230221734b44892e384109d7",
-                "reference": "e76586fa3d49714f230221734b44892e384109d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bd68a781d8e30348bc297449f5234b3458267ae8",
+                "reference": "bd68a781d8e30348bc297449f5234b3458267ae8",
                 "shasum": ""
             },
             "require": {
@@ -14614,7 +14613,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.41"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.45"
             },
             "funding": [
                 {
@@ -14630,7 +14629,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-13T09:33:05+00:00"
+            "time": "2025-02-06T16:08:12+00:00"
         },
         {
             "name": "react/cache",
@@ -16400,16 +16399,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v7.2.0",
+            "version": "v7.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "b176e1f1f550ef44c94eb971bf92488de08f7c6b"
+                "reference": "700a880e5089280c7cf3ca1ccf9d9de6630f5d25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/b176e1f1f550ef44c94eb971bf92488de08f7c6b",
-                "reference": "b176e1f1f550ef44c94eb971bf92488de08f7c6b",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/700a880e5089280c7cf3ca1ccf9d9de6630f5d25",
+                "reference": "700a880e5089280c7cf3ca1ccf9d9de6630f5d25",
                 "shasum": ""
             },
             "require": {
@@ -16447,7 +16446,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v7.2.0"
+                "source": "https://github.com/symfony/dom-crawler/tree/v7.2.3"
             },
             "funding": [
                 {
@@ -16463,7 +16462,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-13T16:15:23+00:00"
+            "time": "2025-01-27T11:08:17+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -17051,5 +17050,5 @@
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,7 @@ parameters:
 		- config
 	excludePaths:
 		- database/migrations/2021_12_04_181200_refactor_models.php
+		- app/Services/Archives # This is creating errors depending if version 2.1 or 3.1 is installed...
 	stubFiles:
 		# these can be removed after https://github.com/thecodingmachine/safe/issues/283 has been merged
 		- phpstan/stubs/Wireable.stub


### PR DESCRIPTION
Fixes #2933

We leverage 2 traits one for each implementation of ZipStream.
The code is moved to a BaseArchive class and the installation decides which class to use.