### PR TITLE
Add latency middleware to see loading times in development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,10 @@ LOG_VIEWER_ENABLED=true
 # enable or disable clockwork. By default it is disabled (and not provided on non-dev build).
 CLOCKWORK_ENABLE=false
 
+# enable or disable latency debug: adds a specific amount of time in milliseconds to wait before processing requests.
+# Always disabled on production environment.
+# APP_DEBUG_LATENCY=0
+
 # enable s3 bucket (required in addition to needing AWS_ACCESS_KEY_ID)
 # S3_ENABLED=true
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -76,6 +76,7 @@ class Kernel extends HttpKernel
 			\Illuminate\View\Middleware\ShareErrorsFromSession::class,
 			\App\Http\Middleware\VerifyCsrfToken::class,
 			\Illuminate\Routing\Middleware\SubstituteBindings::class,
+			\App\Http\Middleware\Latency::class,
 		],
 	];
 

--- a/app/Http/Middleware/Latency.php
+++ b/app/Http/Middleware/Latency.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Request;
+
+/**
+ * Add middleware that introduces latency to the request.
+ *
+ * It is possible to enable network throttling in web browsers.
+ * However this applies to all requests, including loading images, css, js, etc.
+ *
+ * We want to be able to test the front-end when API is slow but other components are already loaded.
+ * This middleware adds a small delay before executing the request.
+ */
+class Latency
+{
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @param \Illuminate\Http\Request                                                                          $request
+	 * @param \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse) $next
+	 *
+	 * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+	 */
+	public function handle(Request $request, \Closure $next)
+	{
+		$latency = config('features.latency');
+
+		if ($latency > 0) {
+			usleep($latency * 1000);
+		}
+
+		return $next($request);
+	}
+}

--- a/config/features.php
+++ b/config/features.php
@@ -82,4 +82,12 @@ return [
 	|--------------------------------------------------------------------------
 	*/
 	'hide-lychee-SE' => (bool) env('HIDE_LYCHEE_SE_CONFIG', false),
+
+	/*
+	 |--------------------------------------------------------------------------
+	 | Add latency on requests to simulate slower network. Time in ms.
+	 | Disabled on production environment.
+	 |--------------------------------------------------------------------------
+	 */
+	'latency' => env('APP_ENV', 'production') === 'production' ? 0 : (int) env('APP_DEBUG_LATENCY', 0),
 ];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -129,3 +129,9 @@ parameters:
 			message: '#Dynamic call to static method Illuminate\\Http\\Response::getContent\(\)#'
 			paths:
 				- tests
+		
+		-	# for the tests we need to pass a closure, but we really don't care about it.
+			message: '#Parameter \#2 \$next of method App\\Http\\Middleware\\.*::handle\(\) expects Closure\(Illuminate\\Http\\Request\): \(Illuminate\\Http\\RedirectResponse\|Illuminate\\Http\\Response\), Closure\(\): .* given\.#'
+			paths:
+				- tests
+		

--- a/tests/Unit/Middleware/LatencyTest.php
+++ b/tests/Unit/Middleware/LatencyTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Unit\Middleware;
+
+use App\Http\Middleware\Latency;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\Request;
+use Tests\AbstractTestCase;
+
+class LatencyTest extends AbstractTestCase
+{
+	use DatabaseTransactions;
+
+	public function testLatencyRequired(): void
+	{
+		config(['features.latency' => 1000]);
+		$request = $this->mock(Request::class);
+		$middleware = new Latency();
+
+		$start = microtime(true);
+		$middleware->handle($request, fn () => 1);
+		$end = microtime(true);
+		self::assertGreaterThan(1, $end - $start);
+	}
+
+	public function testNoLatency(): void
+	{
+		config(['features.latency' => 0]);
+		$request = $this->mock(Request::class);
+		$middleware = new Latency();
+
+		$start = microtime(true);
+		$middleware->handle($request, fn () => 1);
+		$end = microtime(true);
+		self::assertLessThan(1, $end - $start);
+	}
+}

--- a/tests/Unit/Middleware/LatencyTest.php
+++ b/tests/Unit/Middleware/LatencyTest.php
@@ -34,6 +34,8 @@ class LatencyTest extends AbstractTestCase
 		$middleware = new Latency();
 
 		$start = microtime(true);
+		// Parameter #2 $next of method App\Http\Middleware\Latency::handle() expects Closure(Illuminate\Http\Request): (Illuminate\Http\RedirectResponse|Illuminate\Http\Response), Closure(): 1 given.
+		// @phpstan-ignore-next-line
 		$middleware->handle($request, fn () => 1);
 		$end = microtime(true);
 		self::assertGreaterThan(1, $end - $start);
@@ -46,6 +48,8 @@ class LatencyTest extends AbstractTestCase
 		$middleware = new Latency();
 
 		$start = microtime(true);
+		// Parameter #2 $next of method App\Http\Middleware\Latency::handle() expects Closure(Illuminate\Http\Request): (Illuminate\Http\RedirectResponse|Illuminate\Http\Response), Closure(): 1 given.
+		// @phpstan-ignore-next-line
 		$middleware->handle($request, fn () => 1);
 		$end = microtime(true);
 		self::assertLessThan(1, $end - $start);

--- a/tests/Unit/Middleware/LatencyTest.php
+++ b/tests/Unit/Middleware/LatencyTest.php
@@ -34,8 +34,6 @@ class LatencyTest extends AbstractTestCase
 		$middleware = new Latency();
 
 		$start = microtime(true);
-		// Parameter #2 $next of method App\Http\Middleware\Latency::handle() expects Closure(Illuminate\Http\Request): (Illuminate\Http\RedirectResponse|Illuminate\Http\Response), Closure(): 1 given.
-		// @phpstan-ignore-next-line
 		$middleware->handle($request, fn () => 1);
 		$end = microtime(true);
 		self::assertGreaterThan(1, $end - $start);
@@ -48,8 +46,6 @@ class LatencyTest extends AbstractTestCase
 		$middleware = new Latency();
 
 		$start = microtime(true);
-		// Parameter #2 $next of method App\Http\Middleware\Latency::handle() expects Closure(Illuminate\Http\Request): (Illuminate\Http\RedirectResponse|Illuminate\Http\Response), Closure(): 1 given.
-		// @phpstan-ignore-next-line
 		$middleware->handle($request, fn () => 1);
 		$end = microtime(true);
 		self::assertLessThan(1, $end - $start);


### PR DESCRIPTION
Add environment variable:
```sh
# enable or disable latency debug: adds a specific amount of time in milliseconds to wait before processing requests.
# Always disabled on production environment.
# APP_DEBUG_LATENCY=0
```