### PR TITLE
Sharing propagation backend.

### DIFF
--- a/app/Actions/Sharing/Propagate.php
+++ b/app/Actions/Sharing/Propagate.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Sharing;
+
+use App\Constants\AccessPermissionConstants as APC;
+use App\Models\AccessPermission;
+use App\Models\Album;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\DB;
+
+class Propagate
+{
+	/**
+	 * Update all descendants with the current album access permissions.
+	 *
+	 * @param Album $album
+	 *
+	 * @return void
+	 */
+	public function update(Album $album): void
+	{
+		if (!App::runningUnitTests()) {
+			// @codeCoverageIgnoreStart
+			DB::beginTransaction();
+			// @codeCoverageIgnoreEnd
+		}
+		// for each descendant, create a new permission if it does not exist.
+		// or update the existing permission.
+		/** @var Collection<int,Album> $descendants */
+		$descendants = $album->descendants()->get();
+		$permissions = $album->access_permissions()->whereNotNull('user_id')->get();
+
+		// This is super inefficient.
+		// It would be better to do it in a single query...
+		// But how?
+		$descendants->each(function (Album $descendant, int|string $idx) use ($permissions) {
+			$permissions->each(function (AccessPermission $permission) use ($descendant) {
+				AccessPermission::updateOrCreate([
+					APC::BASE_ALBUM_ID => $descendant->id,
+					APC::USER_ID => $permission->user_id,
+				], [
+					APC::GRANTS_FULL_PHOTO_ACCESS => $permission->grants_full_photo_access,
+					APC::GRANTS_DOWNLOAD => $permission->grants_download,
+					APC::GRANTS_UPLOAD => $permission->grants_upload,
+					APC::GRANTS_EDIT => $permission->grants_edit,
+					APC::GRANTS_DELETE => $permission->grants_delete,
+				]);
+			});
+		});
+
+		if (!App::runningUnitTests()) {
+			// @codeCoverageIgnoreStart
+			DB::commit();
+			// @codeCoverageIgnoreEnd
+		}
+	}
+
+	/**
+	 * Overwrite all descendants with the current album access permissions.
+	 *
+	 * @param Album $album
+	 *
+	 * @return void
+	 */
+	public function overwrite(Album $album): void
+	{
+		if (!App::runningUnitTests()) {
+			// @codeCoverageIgnoreStart
+			DB::beginTransaction();
+			// @codeCoverageIgnoreEnd
+		}
+
+		// override permission for all descendants albums.
+		// Faster done by:
+		// 1. clearing all the permissions.
+		// 2. applying the new permissions.
+
+		DB::table(APC::ACCESS_PERMISSIONS)
+			->whereNotNull('user_id')
+			->whereIn(
+				'base_album_id',
+				DB::table('albums')
+					->select('id')
+					->where('_lft', '>', $album->_lft)
+					->where('_rgt', '<', $album->_rgt)
+			)
+			->delete();
+
+		$descendant_ids = DB::table('albums')
+			->select('id')
+			->where('_lft', '>', $album->_lft)
+			->where('_rgt', '<', $album->_rgt)
+			->pluck('id');
+
+		$access_permissions = $album->access_permissions()->whereNotNull('user_id')->get();
+
+		$new_perm = $access_permissions->reduce(
+			fn (?array $acc, AccessPermission $permission) => array_merge(
+				$acc ?? [],
+				$descendant_ids->map(
+					fn ($descendant_id) => [
+						APC::BASE_ALBUM_ID => $descendant_id,
+						APC::USER_ID => $permission->user_id,
+						APC::GRANTS_FULL_PHOTO_ACCESS => $permission->grants_full_photo_access,
+						APC::GRANTS_DOWNLOAD => $permission->grants_download,
+						APC::GRANTS_UPLOAD => $permission->grants_upload,
+						APC::GRANTS_EDIT => $permission->grants_edit,
+						APC::GRANTS_DELETE => $permission->grants_delete,
+					]
+				)->all()
+			)
+		);
+
+		DB::table(APC::ACCESS_PERMISSIONS)->insert($new_perm);
+
+		if (!App::runningUnitTests()) {
+			// @codeCoverageIgnoreStart
+			DB::commit();
+			// @codeCoverageIgnoreEnd
+		}
+	}
+}

--- a/app/Http/Controllers/Gallery/SharingController.php
+++ b/app/Http/Controllers/Gallery/SharingController.php
@@ -10,6 +10,7 @@ namespace App\Http\Controllers\Gallery;
 
 use App\Actions\Sharing\Share;
 use App\Constants\AccessPermissionConstants as APC;
+use App\Exceptions\Internal\LycheeLogicException;
 use App\Http\Requests\Sharing\AddSharingRequest;
 use App\Http\Requests\Sharing\DeleteSharingRequest;
 use App\Http\Requests\Sharing\EditSharingRequest;
@@ -18,6 +19,7 @@ use App\Http\Requests\Sharing\ListSharingRequest;
 use App\Http\Requests\Sharing\PropagateSharingRequest;
 use App\Http\Resources\Models\AccessPermissionResource;
 use App\Models\AccessPermission;
+use App\Models\Album;
 use App\Models\BaseAlbumImpl;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Collection;
@@ -124,10 +126,23 @@ class SharingController extends Controller
 		AccessPermission::query()->where('id', '=', $request->perm()->id)->delete();
 	}
 
+	/**
+	 * Propagate sharing permissions.
+	 *
+	 * @param PropagateSharingRequest $request
+	 *
+	 * @return void
+	 */
 	public function propagate(PropagateSharingRequest $request): void
 	{
 		$album = $request->album();
+		if (!$album instanceof Album) {
+			throw new LycheeLogicException('Only albums can have any descandants.');
+		}
+
+		$descendants = $album->descendants()->get();
 		$permissions = $album->accessPermissions()->whereNotNull('user_id')->get();
+
 		if ($request->shallOverride) {
 			// override permission for all descendants albums.
 			// Faster done by:

--- a/app/Http/Controllers/Gallery/SharingController.php
+++ b/app/Http/Controllers/Gallery/SharingController.php
@@ -15,6 +15,7 @@ use App\Http\Requests\Sharing\DeleteSharingRequest;
 use App\Http\Requests\Sharing\EditSharingRequest;
 use App\Http\Requests\Sharing\ListAllSharingRequest;
 use App\Http\Requests\Sharing\ListSharingRequest;
+use App\Http\Requests\Sharing\PropagateSharingRequest;
 use App\Http\Resources\Models\AccessPermissionResource;
 use App\Models\AccessPermission;
 use App\Models\BaseAlbumImpl;
@@ -121,5 +122,20 @@ class SharingController extends Controller
 	public function delete(DeleteSharingRequest $request): void
 	{
 		AccessPermission::query()->where('id', '=', $request->perm()->id)->delete();
+	}
+
+	public function propagate(PropagateSharingRequest $request): void
+	{
+		$album = $request->album();
+		$permissions = $album->accessPermissions()->whereNotNull('user_id')->get();
+		if ($request->shallOverride) {
+			// override permission for all descendants albums.
+			// Faster done by:
+			// 1. clearing all the permissions.
+			// 2. applying the new permissions.
+		} else {
+			// for each descendant, create a new permission if it does not exist.
+			// or update the existing permission.
+		}
 	}
 }

--- a/app/Http/Controllers/Gallery/SharingController.php
+++ b/app/Http/Controllers/Gallery/SharingController.php
@@ -8,6 +8,7 @@
 
 namespace App\Http\Controllers\Gallery;
 
+use App\Actions\Sharing\Propagate;
 use App\Actions\Sharing\Share;
 use App\Constants\AccessPermissionConstants as APC;
 use App\Exceptions\Internal\LycheeLogicException;
@@ -133,24 +134,17 @@ class SharingController extends Controller
 	 *
 	 * @return void
 	 */
-	public function propagate(PropagateSharingRequest $request): void
+	public function propagate(PropagateSharingRequest $request, Propagate $propagate): void
 	{
 		$album = $request->album();
 		if (!$album instanceof Album) {
 			throw new LycheeLogicException('Only albums can have any descandants.');
 		}
 
-		$descendants = $album->descendants()->get();
-		$permissions = $album->accessPermissions()->whereNotNull('user_id')->get();
-
 		if ($request->shallOverride) {
-			// override permission for all descendants albums.
-			// Faster done by:
-			// 1. clearing all the permissions.
-			// 2. applying the new permissions.
+			$propagate->overwrite($album);
 		} else {
-			// for each descendant, create a new permission if it does not exist.
-			// or update the existing permission.
+			$propagate->update($album);
 		}
 	}
 }

--- a/app/Http/Requests/Sharing/PropagateSharingRequest.php
+++ b/app/Http/Requests/Sharing/PropagateSharingRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Sharing;
+
+use App\Contracts\Http\Requests\HasBaseAlbum;
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Models\AbstractAlbum;
+use App\Http\Requests\BaseApiRequest;
+use App\Http\Requests\Traits\HasBaseAlbumTrait;
+use App\Policies\AlbumPolicy;
+use App\Rules\RandomIDRule;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Represents a request for listing the shares of a specific album.
+ *
+ * Only the owner of the album (or the admin) can set the shares.
+ */
+class PropagateSharingRequest extends BaseApiRequest implements HasBaseAlbum
+{
+	use HasBaseAlbumTrait;
+
+	public bool $shallOverride;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::check(AlbumPolicy::CAN_SHARE_WITH_USERS, [AbstractAlbum::class, $this->album]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::SHALL_OVERRIDE_ATTRIBUTE => ['required', 'boolean'],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		$this->album = $this->albumFactory->findBaseAlbumOrFail($values[RequestAttribute::ALBUM_ID_ATTRIBUTE]);
+		$this->shallOverride = static::toBoolean($values[RequestAttribute::SHALL_OVERRIDE_ATTRIBUTE]);
+	}
+}

--- a/lang/cz/sharing.php
+++ b/lang/cz/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/de/sharing.php
+++ b/lang/de/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/el/sharing.php
+++ b/lang/el/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/en/sharing.php
+++ b/lang/en/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/es/sharing.php
+++ b/lang/es/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/fr/sharing.php
+++ b/lang/fr/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/hu/sharing.php
+++ b/lang/hu/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/it/sharing.php
+++ b/lang/it/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/ja/sharing.php
+++ b/lang/ja/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/nl/sharing.php
+++ b/lang/nl/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/no/sharing.php
+++ b/lang/no/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/pl/sharing.php
+++ b/lang/pl/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/pt/sharing.php
+++ b/lang/pt/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/ru/sharing.php
+++ b/lang/ru/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/sk/sharing.php
+++ b/lang/sk/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/sv/sharing.php
+++ b/lang/sv/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/vi/sharing.php
+++ b/lang/vi/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/zh_CN/sharing.php
+++ b/lang/zh_CN/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/lang/zh_TW/sharing.php
+++ b/lang/zh_TW/sharing.php
@@ -19,6 +19,7 @@ return [
 	'username' => 'Username',
 	'no_data' => 'Sharing list is empty.',
 	'share' => 'Share',
+	'add_new_access_permission' => 'Add a new access permission',
 	'permission_deleted' => 'Permission deleted!',
 	'permission_created' => 'Permission created!',
 

--- a/resources/js/components/forms/album/AlbumCreateShareDialog.vue
+++ b/resources/js/components/forms/album/AlbumCreateShareDialog.vue
@@ -2,7 +2,7 @@
 	<Dialog v-model:visible="visible" pt:root:class="border-none" modal :dismissable-mask="true" @close="visible = false">
 		<template #container="{ closeCallback }">
 			<div class="flex flex-col relative md:w-[500px] max-w-[500px] text-sm rounded-md pt-9">
-				<div class="flex text-muted-color-emphasis w-full px-9">
+				<div class="flex text-muted-color-emphasis w-full px-9 pb-2">
 					<div class="w-1/2">
 						<span class="w-full">{{ $t("sharing.username") }}</span>
 					</div>

--- a/resources/js/components/forms/album/AlbumCreateShareDialog.vue
+++ b/resources/js/components/forms/album/AlbumCreateShareDialog.vue
@@ -1,0 +1,120 @@
+<template>
+	<Dialog v-model:visible="visible" pt:root:class="border-none" modal :dismissable-mask="true" @close="visible = false">
+		<template #container="{ closeCallback }">
+			<div class="flex flex-col relative md:w-[500px] max-w-[500px] text-sm rounded-md pt-9">
+				<div class="flex text-muted-color-emphasis w-full px-9">
+					<div class="w-1/2">
+						<span class="w-full">{{ $t("sharing.username") }}</span>
+					</div>
+					<div class="w-1/2 flex justify-around items-center">
+						<i class="pi pi-eye" v-tooltip.top="$t('sharing.grants.read')" />
+						<i class="pi pi-window-maximize" v-tooltip.top="$t('sharing.grants.original')" />
+						<i class="pi pi-cloud-download" v-tooltip.top="$t('sharing.grants.download')" />
+						<i class="pi pi-upload" v-tooltip.top="$t('sharing.grants.upload')" />
+						<i class="pi pi-file-edit" v-tooltip.top="$t('sharing.grants.edit')" />
+						<i class="pi pi-trash" v-tooltip.top="$t('sharing.grants.delete')" />
+					</div>
+				</div>
+				<div class="flex text-muted-color-emphasis w-full px-9">
+					<div class="w-1/2 flex items-center" v-if="newShareUser">
+						<span class="w-full">{{ newShareUser.username }}</span>
+						<span @click="newShareUser = undefined"><i class="pi pi-times" /></span>
+					</div>
+					<div class="w-1/2" v-if="!newShareUser">
+						<SearchTargetUser @selected="selectUser" :filtered-users-ids="props.filteredUsersIds" />
+					</div>
+					<div class="w-1/2 flex items-center justify-around">
+						<Checkbox v-model="grantsReadAccess" :binary="true" disabled />
+						<Checkbox v-model="grantsFullPhotoAccess" :binary="true" />
+						<Checkbox v-model="grantsDownload" :binary="true" />
+						<Checkbox v-model="grantsUpload" :binary="true" />
+						<Checkbox v-model="grantsEdit" :binary="true" />
+						<Checkbox v-model="grantsDelete" :binary="true" />
+					</div>
+				</div>
+				<div class="flex items-center mt-9 w-full">
+					<Button @click="closeCallback" severity="secondary" class="w-full font-bold border-none rounded-bl-xl">
+						{{ $t("dialogs.button.cancel") }}
+					</Button>
+					<Button
+						@click="create"
+						:disabled="!newShareUser"
+						class="font-bold w-full border-none rounded-none bg-surface text-create-600 hover:bg-create-600 hover:text-white rounded-br-xl"
+					>
+						<i class="pi pi-user-plus" /><span class="hidden md:inline">{{ $t("sharing.share") }}</span>
+					</Button>
+				</div>
+			</div>
+		</template>
+	</Dialog>
+</template>
+<script setup lang="ts">
+import SharingService from "@/services/sharing-service";
+import { trans } from "laravel-vue-i18n";
+import Dialog from "primevue/dialog";
+import { useToast } from "primevue/usetoast";
+import { ref } from "vue";
+import SearchTargetUser from "./SearchTargetUser.vue";
+import Checkbox from "primevue/checkbox";
+import Button from "primevue/button";
+
+const props = withDefaults(
+	defineProps<{
+		album: App.Http.Resources.Models.AlbumResource | App.Http.Resources.Models.TagAlbumResource;
+		filteredUsersIds?: number[];
+	}>(),
+	{
+		filteredUsersIds: () => [],
+	},
+);
+
+const visible = defineModel("visible", { type: Boolean, required: true });
+
+const toast = useToast();
+const emits = defineEmits<{
+	createdPermission: [];
+}>();
+
+const newShareUser = ref<App.Http.Resources.Models.LightUserResource | undefined>(undefined);
+const grantsFullPhotoAccess = ref(false);
+const grantsDownload = ref(false);
+const grantsUpload = ref(false);
+const grantsEdit = ref(false);
+const grantsDelete = ref(false);
+const grantsReadAccess = ref(true);
+
+function selectUser(target: App.Http.Resources.Models.LightUserResource) {
+	newShareUser.value = target;
+}
+
+function reset() {
+	newShareUser.value = undefined;
+	grantsFullPhotoAccess.value = false;
+	grantsDownload.value = false;
+	grantsUpload.value = false;
+	grantsEdit.value = false;
+	grantsDelete.value = false;
+}
+
+function create() {
+	if (newShareUser.value === undefined) {
+		return;
+	}
+	const data = {
+		album_ids: [props.album.id],
+		user_ids: [newShareUser.value.id],
+		grants_download: grantsDownload.value,
+		grants_full_photo_access: grantsFullPhotoAccess.value,
+		grants_upload: grantsUpload.value,
+		grants_edit: grantsEdit.value,
+		grants_delete: grantsDelete.value,
+	};
+
+	SharingService.add(data).then(() => {
+		toast.add({ severity: "success", summary: trans("toasts.success"), detail: trans("sharing.permission_created"), life: 3000 });
+		visible.value = false;
+		reset();
+		emits("createdPermission");
+	});
+}
+</script>

--- a/resources/js/components/forms/album/AlbumProperties.vue
+++ b/resources/js/components/forms/album/AlbumProperties.vue
@@ -266,7 +266,7 @@
 						<label for="tags">{{ $t("gallery.album.properties.show_tags") }}</label>
 					</FloatLabel>
 				</div>
-				<Button class="p-3 mt-4 w-full font-bold border-none text-white hover:bg-primary-500 hover:text-surface-0 flex-shrink" @click="save">
+				<Button class="p-3 mt-4 w-full font-bold border-none flex-shrink" @click="save">
 					{{ $t("dialogs.button.save") }}
 				</Button>
 			</form>

--- a/resources/js/components/forms/album/AlbumShare.vue
+++ b/resources/js/components/forms/album/AlbumShare.vue
@@ -16,9 +16,21 @@
 				<div class="w-1/6"></div>
 			</div>
 			<ShareLine v-for="perm in perms" :perm="perm" @delete="deletePermission" :with-album="props.withAlbum" />
-			<CreateSharing :withAlbum="props.withAlbum" :album="props.album" @createdPermission="load" :filtered-users-ids="sharedUserIds" />
+			<div v-if="perms.length === 0">
+				<p class="text-muted-color text-center py-3">{{ $t("sharing.no_data") }}</p>
+			</div>
+			<Button @click="dialogVisible = true" class="p-3 mt-4 w-full font-bold border-none rounded-bl-xl">
+				{{ $t("sharing.share") }}
+			</Button>
 		</template>
 	</Card>
+	<AlbumCreateShareDialog
+		v-if="!props.withAlbum"
+		v-model:visible="dialogVisible"
+		:album="props.album"
+		@createdPermission="load"
+		:filtered-users-ids="sharedUserIds"
+	/>
 </template>
 
 <script setup lang="ts">
@@ -27,8 +39,9 @@ import Card from "primevue/card";
 import { useToast } from "primevue/usetoast";
 import SharingService from "@/services/sharing-service";
 import ShareLine from "@/components/forms/sharing/ShareLine.vue";
-import CreateSharing from "../sharing/CreateSharing.vue";
 import { trans } from "laravel-vue-i18n";
+import AlbumCreateShareDialog from "./AlbumCreateShareDialog.vue";
+import Button from "primevue/button";
 
 const props = defineProps<{
 	withAlbum: boolean;
@@ -38,6 +51,8 @@ const props = defineProps<{
 const toast = useToast();
 
 const perms = ref<App.Http.Resources.Models.AccessPermissionResource[] | undefined>(undefined);
+
+const dialogVisible = ref(false);
 
 function load() {
 	SharingService.get(props.album.id).then((response) => {

--- a/resources/js/components/forms/album/AlbumShare.vue
+++ b/resources/js/components/forms/album/AlbumShare.vue
@@ -1,27 +1,30 @@
 <template>
-	<Card class="sm:p-4 xl:px-9 max-w-3xl w-full py-0" v-if="perms !== undefined" pt:body:class="p-0">
+	<Card class="sm:p-4 xl:px-9 max-w-3xl w-full py-0" pt:body:class="p-0" pt:content:class="flex justify-center flex-col">
 		<template #content>
-			<div class="flex text-muted-color-emphasis">
-				<div class="w-5/12 flex">
-					<span class="w-full">{{ $t("sharing.username") }}</span>
+			<ProgressSpinner v-if="perms === undefined" />
+			<template v-else>
+				<div class="flex text-muted-color-emphasis">
+					<div class="w-5/12 flex">
+						<span class="w-full">{{ $t("sharing.username") }}</span>
+					</div>
+					<div class="w-1/2 flex justify-around items-center">
+						<i class="pi pi-eye" v-tooltip.top="$t('sharing.grants.read')" />
+						<i class="pi pi-window-maximize" v-tooltip.top="$t('sharing.grants.original')" />
+						<i class="pi pi-cloud-download" v-tooltip.top="$t('sharing.grants.download')" />
+						<i class="pi pi-upload" v-tooltip.top="$t('sharing.grants.upload')" />
+						<i class="pi pi-file-edit" v-tooltip.top="$t('sharing.grants.edit')" />
+						<i class="pi pi-trash" v-tooltip.top="$t('sharing.grants.delete')" />
+					</div>
+					<div class="w-1/6"></div>
 				</div>
-				<div class="w-1/2 flex justify-around items-center">
-					<i class="pi pi-eye" v-tooltip.top="$t('sharing.grants.read')" />
-					<i class="pi pi-window-maximize" v-tooltip.top="$t('sharing.grants.original')" />
-					<i class="pi pi-cloud-download" v-tooltip.top="$t('sharing.grants.download')" />
-					<i class="pi pi-upload" v-tooltip.top="$t('sharing.grants.upload')" />
-					<i class="pi pi-file-edit" v-tooltip.top="$t('sharing.grants.edit')" />
-					<i class="pi pi-trash" v-tooltip.top="$t('sharing.grants.delete')" />
+				<ShareLine v-for="perm in perms" :perm="perm" @delete="deletePermission" :with-album="props.withAlbum" />
+				<div v-if="perms.length === 0">
+					<p class="text-muted-color text-center py-3">{{ $t("sharing.no_data") }}</p>
 				</div>
-				<div class="w-1/6"></div>
-			</div>
-			<ShareLine v-for="perm in perms" :perm="perm" @delete="deletePermission" :with-album="props.withAlbum" />
-			<div v-if="perms.length === 0">
-				<p class="text-muted-color text-center py-3">{{ $t("sharing.no_data") }}</p>
-			</div>
-			<Button @click="dialogVisible = true" severity="contrast" class="p-3 w-full mt-4 font-bold border-none rounded-xl">
-				{{ $t("sharing.add_new_access_permission") }}
-			</Button>
+				<Button @click="dialogVisible = true" severity="contrast" class="p-3 w-full mt-4 font-bold border-none rounded-xl">
+					{{ $t("sharing.add_new_access_permission") }}
+				</Button>
+			</template>
 		</template>
 	</Card>
 	<AlbumCreateShareDialog
@@ -42,6 +45,7 @@ import ShareLine from "@/components/forms/sharing/ShareLine.vue";
 import { trans } from "laravel-vue-i18n";
 import AlbumCreateShareDialog from "./AlbumCreateShareDialog.vue";
 import Button from "primevue/button";
+import ProgressSpinner from "primevue/progressspinner";
 
 const props = defineProps<{
 	withAlbum: boolean;

--- a/resources/js/components/forms/album/AlbumShare.vue
+++ b/resources/js/components/forms/album/AlbumShare.vue
@@ -1,5 +1,5 @@
 <template>
-	<Card class="sm:p-4 xl:px-9 max-w-3xl w-full" v-if="perms !== undefined">
+	<Card class="sm:p-4 xl:px-9 max-w-3xl w-full py-0" v-if="perms !== undefined" pt:body:class="p-0">
 		<template #content>
 			<div class="flex text-muted-color-emphasis">
 				<div class="w-5/12 flex">
@@ -19,8 +19,8 @@
 			<div v-if="perms.length === 0">
 				<p class="text-muted-color text-center py-3">{{ $t("sharing.no_data") }}</p>
 			</div>
-			<Button @click="dialogVisible = true" class="p-3 mt-4 w-full font-bold border-none rounded-bl-xl">
-				{{ $t("sharing.share") }}
+			<Button @click="dialogVisible = true" severity="contrast" class="p-3 w-full mt-4 font-bold border-none rounded-xl">
+				{{ $t("sharing.add_new_access_permission") }}
 			</Button>
 		</template>
 	</Card>

--- a/resources/js/components/forms/album/SearchTargetUser.vue
+++ b/resources/js/components/forms/album/SearchTargetUser.vue
@@ -18,14 +18,13 @@
 		</template>
 		<template #option="slotProps">
 			<div class="flex items-center">
-				<!-- <img :src="slotProps.option.thumb" alt="poster" class="w-4 rounded-sm" /> -->
 				<span class="text-left">{{ slotProps.option.username }}</span>
 			</div>
 		</template>
 	</Select>
 </template>
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { onMounted, ref, watch } from "vue";
 import Select from "primevue/select";
 import UsersService from "@/services/users-service";
 
@@ -53,8 +52,6 @@ function load() {
 	});
 }
 
-load();
-
 function selected() {
 	if (selectedTarget.value === undefined) {
 		return;
@@ -73,6 +70,8 @@ function filterUsers() {
 		emits("no-target");
 	}
 }
+
+onMounted(load);
 
 watch(() => props.filteredUsersIds, filterUsers);
 </script>

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -74,6 +74,7 @@ Route::get('/Map::provider', [Gallery\MapController::class, 'getProvider'])->mid
  */
 Route::get('/Sharing', [Gallery\SharingController::class, 'list']);
 Route::post('/Sharing', [Gallery\SharingController::class, 'create']);
+Route::put('/Sharing', [Gallery\SharingController::class, 'propagate']);
 Route::patch('/Sharing', [Gallery\SharingController::class, 'edit']);
 Route::delete('/Sharing', [Gallery\SharingController::class, 'delete']);
 Route::get('/Sharing::all', [Gallery\SharingController::class, 'listAll']);

--- a/tests/Feature_v2/Album/SharingTest.php
+++ b/tests/Feature_v2/Album/SharingTest.php
@@ -183,7 +183,6 @@ class SharingTest extends BaseApiV2Test
 			'shall_override' => true,
 		]);
 		$this->assertNoContent($response);
-		// self::assertEquals(2, AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->count());
 		self::assertEquals(0,
 			AccessPermission::query()
 				->where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)

--- a/tests/Feature_v2/Album/SharingTest.php
+++ b/tests/Feature_v2/Album/SharingTest.php
@@ -18,6 +18,9 @@
 
 namespace Tests\Feature_v2\Album;
 
+use App\Constants\AccessPermissionConstants as APC;
+use App\Models\AccessPermission;
+use App\Models\Album;
 use Tests\Feature_v2\Base\BaseApiV2Test;
 
 class SharingTest extends BaseApiV2Test
@@ -73,5 +76,128 @@ class SharingTest extends BaseApiV2Test
 
 		$response = $this->actingAs($this->userMayUpload2)->deleteJson('Sharing', ['perm_id' => $id]);
 		$this->assertNoContent($response);
+	}
+
+	public function testUpdateOverrideForbidden(): void
+	{
+		$response = $this->putJson('Sharing', []);
+		$this->assertUnprocessable($response);
+
+		$response = $this->putJson('Sharing', [
+			'album_id' => $this->album1->id,
+			'shall_override' => true,
+		]);
+		$this->assertUnauthorized($response);
+
+		$response = $this->actingAs($this->userMayUpload2)->putJson('Sharing', []);
+		$this->assertUnprocessable($response);
+
+		$response = $this->actingAs($this->userMayUpload2)->putJson('Sharing', [
+			'album_id' => $this->album1->id,
+			'shall_override' => true,
+		]);
+		$this->assertForbidden($response);
+	}
+
+	public function testUpdate(): void
+	{
+		$response = $this->actingAs($this->userMayUpload1)->putJson('Sharing', []);
+		$this->assertUnprocessable($response);
+
+		// Update sub album permission.
+		$response = $this->actingAs($this->userMayUpload1)->putJson('Sharing', [
+			'album_id' => $this->album1->id,
+			'shall_override' => false,
+		]);
+		$this->assertNoContent($response);
+		self::assertEquals(1, AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->count());
+		$perm = AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->first();
+
+		// Update the permission with false
+		$response = $this->actingAs($this->userMayUpload1)->patchJson('Sharing', [
+			'perm_id' => $perm->id,
+			'grants_edit' => false,
+			'grants_delete' => false,
+			'grants_download' => false,
+			'grants_full_photo_access' => false,
+			'grants_upload' => false,
+		]);
+		$this->assertOk($response);
+
+		// Verify the permission
+		$perm = AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->first();
+		self::assertFalse($perm->grants_edit);
+		self::assertFalse($perm->grants_delete);
+		self::assertFalse($perm->grants_download);
+		self::assertFalse($perm->grants_full_photo_access);
+		self::assertFalse($perm->grants_upload);
+
+		// Apply update again
+		$response = $this->actingAs($this->userMayUpload1)->putJson('Sharing', [
+			'album_id' => $this->album1->id,
+			'shall_override' => false,
+		]);
+		$this->assertNoContent($response);
+		// Verify the count is still 1.
+		self::assertEquals(1, AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->count());
+
+		// Verify the permission
+		$perm = AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->first();
+		self::assertTrue($perm->grants_edit);
+		self::assertTrue($perm->grants_delete);
+		self::assertTrue($perm->grants_download);
+		self::assertTrue($perm->grants_full_photo_access);
+		self::assertTrue($perm->grants_upload);
+	}
+
+	public function testOverride(): void
+	{
+		// Set up the permission in subSlbum
+		$response = $this->actingAs($this->userMayUpload1)->postJson('Sharing', [
+			'user_ids' => [$this->userLocked->id],
+			'album_ids' => [$this->subAlbum1->id],
+			'grants_edit' => true,
+			'grants_delete' => true,
+			'grants_download' => true,
+			'grants_full_photo_access' => true,
+			'grants_upload' => true,
+		]);
+		$this->assertOk($response);
+		self::assertEquals(1, AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->count());
+
+		$response = $this->actingAs($this->userMayUpload1)->postJson('Sharing', [
+			'user_ids' => [$this->userNoUpload->id],
+			'album_ids' => [$this->album1->id],
+			'grants_edit' => true,
+			'grants_delete' => true,
+			'grants_download' => true,
+			'grants_full_photo_access' => true,
+			'grants_upload' => true,
+		]);
+		$this->assertOk($response);
+		self::assertEquals(2, AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->album1->id)->count());
+
+		// Update sub album permission.
+		$response = $this->actingAs($this->userMayUpload1)->putJson('Sharing', [
+			'album_id' => $this->album1->id,
+			'shall_override' => true,
+		]);
+		$this->assertNoContent($response);
+		// self::assertEquals(2, AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->count());
+		self::assertEquals(0,
+			AccessPermission::query()
+				->where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)
+				->where(APC::USER_ID, '=', $this->userLocked->id)
+				->count());
+		self::assertEquals(1,
+			AccessPermission::query()
+				->where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)
+				->where(APC::USER_ID, '=', $this->userMayUpload2->id)
+				->count());
+		self::assertEquals(1,
+			AccessPermission::query()
+				->where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)
+				->where(APC::USER_ID, '=', $this->userNoUpload->id)
+				->count());
 	}
 }

--- a/tests/Feature_v2/Base/BaseApiV2Test.php
+++ b/tests/Feature_v2/Base/BaseApiV2Test.php
@@ -115,6 +115,21 @@ abstract class BaseApiV2Test extends BaseV2Test
 	}
 
 	/**
+	 * Visit the given URI with a PUT request, expecting a JSON response.
+	 *
+	 * @param Uri|string $uri
+	 * @param array      $data
+	 * @param array      $headers
+	 * @param int        $options
+	 *
+	 * @return TestResponse<\Illuminate\Http\JsonResponse>
+	 */
+	public function putJson($uri, array $data = [], array $headers = [], $options = 0)
+	{
+		return $this->json('PUT', self::API_PREFIX . ltrim($uri, '/'), $data, $headers, $options);
+	}
+
+	/**
 	 * Visit the given URI with a DELETE request, expecting a JSON response.
 	 *
 	 * @param Uri|string $uri


### PR DESCRIPTION
Adds a single end-point (PUT) on Sharing to support propagation.
a boolean is required to define whether the overwritten or update strategy is chosen.

Contains #2938 

Fixes #292