### PR TITLE
Add a feature flag to disable the content-type verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,14 @@ CLOCKWORK_ENABLE=false
 # Always disabled on production environment.
 # APP_DEBUG_LATENCY=0
 
+# All API requests to have the header "content-type: application/json"
+# or "content-type: multipart/form-data" depending on the type.
+#
+# If you want to disable this requirement, set this to false.
+#
+# This requirement prevents the use of the API from the API documentation page.
+REQUIRE_CONTENT_TYPE_ENABLED=true
+
 # enable s3 bucket (required in addition to needing AWS_ACCESS_KEY_ID)
 # S3_ENABLED=true
 
@@ -208,3 +216,4 @@ VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 ###################################################################
 # VITE_LOCAL_DEV=true
 # VITE_HTTP_PROXY_TARGET=http://localhost:8000
+

--- a/app/Http/Middleware/ContentType.php
+++ b/app/Http/Middleware/ContentType.php
@@ -40,6 +40,11 @@ class ContentType
 	 */
 	public function handle(Request $request, \Closure $next, string $contentType): mixed
 	{
+		// Skip if check is disabled
+		if (config('features.require-content-type') === false) {
+			return $next($request);
+		}
+
 		if ($contentType === self::JSON) {
 			if (!$request->isJson()) {
 				throw new UnexpectedContentType(self::JSON);

--- a/config/features.php
+++ b/config/features.php
@@ -90,4 +90,14 @@ return [
 	 |--------------------------------------------------------------------------
 	 */
 	'latency' => env('APP_ENV', 'production') === 'production' ? 0 : (int) env('APP_DEBUG_LATENCY', 0),
+
+	/*
+	 |--------------------------------------------------------------------------
+	 | Require the API requests to have the header "content-type: application/json"
+	 | or "content-type: multipart/form-data" depending on the type.
+	 |
+	 | Note that this prevents the use of the API from the API documentation page.
+	 |--------------------------------------------------------------------------
+	 */
+	'require-content-type' => (bool) env('REQUIRE_CONTENT_TYPE_ENABLED', true),
 ];

--- a/config/scramble.php
+++ b/config/scramble.php
@@ -29,7 +29,9 @@ return [
 		/*
 		 * Description rendered on the home page of the API documentation (`/docs/api`).
 		 */
-		'description' => '',
+		'description' => '**NOTE:** In order to use the API from this page (with the Send API Request button), you will need to disable the _"content-type"_ middleware.<br>
+		This is done by setting your `REQUIRE_CONTENT_TYPE_ENABLED=false` in your `.env`.<br>
+		After testing, we recommend setting back this value to `true` and adding the content-type header to your requests.',
 	],
 
 	/*


### PR DESCRIPTION
The middleware was preventing requests to go through when testing from the `/docs/api` page.
This allows to do the requests.