### PR TITLE
Fixes the delete button text

### DIFF
--- a/resources/js/components/forms/gallery-dialogs/DeleteDialog.vue
+++ b/resources/js/components/forms/gallery-dialogs/DeleteDialog.vue
@@ -11,7 +11,7 @@
 						{{ $t("dialogs.button.cancel") }}
 					</Button>
 					<Button severity="danger" class="w-full border-none rounded-none rounded-br-xl font-bold" @click="execute">
-						{{ $t("dialog.button.delete") }}
+						{{ $t("dialogs.button.delete") }}
 					</Button>
 				</div>
 			</div>


### PR DESCRIPTION
This will fix the text shown on the delete button when deleting a photo.

This doesn't have an existing issue item. Would you like me to create one?

This fixes the issue by properly referencing `dialogs` (variable) instead of `dialog` (undefined). 

- Add a test that triggered the bug before fixing it.
I wasn't able to find any tests that would address .vue files (like the one edited here). If you could point me in the right direction though, I'd be happy to add one.


Before: As seen on test site ([link](https://lychee-demo.fly.dev/gallery/sA6G20o96-EfTYUqHwk4UjLl/jfctlT-Ut4owNhhCEJoTxw8F))
![firefox_je37oCr87g](https://github.com/user-attachments/assets/cee313e8-0249-418d-9bc1-70562a4e4ee6)


After:
![firefox_DKpzGCW6ei](https://github.com/user-attachments/assets/215c0475-d739-4f97-a023-073a40c5bd71)
