### PR TITLE
Fixes Displayed Times in Jobs page

### DIFF
--- a/resources/js/views/Jobs.vue
+++ b/resources/js/views/Jobs.vue
@@ -13,7 +13,7 @@
 	<Panel class="max-w-5xl mx-auto border-none">
 		<div v-if="jobs.length === 0" class="text-center">{{ $t("jobs.no_data") }}</div>
 		<div class="flex text-xs sm:text-base flex-wrap sm:flex-nowrap" v-for="job in jobs">
-			<span class="hidden sm:inline-block sm:w-1/4 text-muted-color">{{ prettyDate(job.created_at) }}</span>
+			<span class="hidden sm:inline-block sm:w-2/5 text-muted-color">{{ prettyDate(job.created_at) }}</span>
 			<span class="w-1/6 sm:w-1/4" :class="textCss(job.status)">{{ job.status }}</span>
 			<span class="w-5/6 sm:w-1/4">{{ job.username }}</span>
 			<span class="w-1/6 sm:hidden text-muted-color">{{ prettyDate(job.created_at) }}</span>
@@ -51,12 +51,7 @@ function textCss(status: string) {
 }
 
 function prettyDate(iso8601: string): string {
-	const date = iso8601.substring(0, 10).split("-");
-	const time = iso8601
-		.substring(11, 19)
-		.split(":")
-		.map((x) => parseInt(x));
-	return `${date[2]}/${date[1]}/${date[0]} ${time[0]}:${time[1]}`;
+	return new Date(iso8601).toLocaleString();
 }
 
 load();


### PR DESCRIPTION
Change from using substring to instead having JS parse the date.

Previously entries would've appeared as such:
![firefox_ubKiz7fc2z](https://github.com/user-attachments/assets/d25e052f-14d3-4fa3-b99f-da290793a99e)
Take note of the last one, which is at 4:9, not how anyone would write 04:09 (or 4:09 AM even). 

This was due to us parsing the string into numbers, and forgetting to place leading 0s as appropriate. 

This has been fixed now, as seen in this preview:
![firefox_m2sZoQKf95](https://github.com/user-attachments/assets/dae86619-8654-49a0-8b17-bac79a414d1a)
It does so by letting the Javascript DateTime object do all the heavy lifting and work. 

Furthermore, this change has a "feature" addition to it as well, as now datetimes are shown in the local datetime of the user instead of GMT, which will help keep it more readable. Furthermore respecting the users' locale, so Europeans will get DD MM YYYY and Americans MM DD YYYY, etc.
![chrome_BYZnTxUHas](https://github.com/user-attachments/assets/9c3fc5be-ab26-435c-b60f-5068480f670d)
(Note the changing datetime formats based off Locale, as well as changing hours when GMT is converted to "local" timezone).
