### PR TITLE
More missing dialog strings.

### DIFF
--- a/resources/js/components/forms/album/AlbumProperties.vue
+++ b/resources/js/components/forms/album/AlbumProperties.vue
@@ -430,7 +430,7 @@ function saveAlbum() {
 		photo_timeline: photoTimeline.value?.value ?? null,
 	};
 	AlbumService.updateAlbum(data).then(() => {
-		toast.add({ severity: "success", summary: trans("toast.success"), life: 3000 });
+		toast.add({ severity: "success", summary: trans("toasts.success"), life: 3000 });
 		AlbumService.clearCache(albumId.value);
 	});
 }

--- a/resources/js/components/forms/gallery-dialogs/MoveDialog.vue
+++ b/resources/js/components/forms/gallery-dialogs/MoveDialog.vue
@@ -80,15 +80,15 @@ const headIds = computed(() => {
 
 const question = computed(() => {
 	if (props.photoIds && props.photoIds?.length > 1) {
-		return sprintf(trans("dialog.move_photo.move_multiple"), props.photoIds?.length);
+		return sprintf(trans("dialogs.move_photo.move_multiple"), props.photoIds?.length);
 	}
 	if (props.albumIds && props.albumIds?.length > 1) {
-		return sprintf(trans("dialog.move_album.move_to_multiple"), props.albumIds?.length);
+		return sprintf(trans("dialogs.move_album.move_to_multiple"), props.albumIds?.length);
 	}
 	if (props.photo) {
-		return sprintf(trans("dialog.move_photo.move_single"), props.photo.title);
+		return sprintf(trans("dialogs.move_photo.move_single"), props.photo.title);
 	}
-	return sprintf(trans("dialog.move_album.move_to_single"), props.album?.title);
+	return sprintf(trans("dialogs.move_album.move_to_single"), props.album?.title);
 });
 
 const confirmation = computed(() => {
@@ -100,9 +100,9 @@ const confirmation = computed(() => {
 
 function moveConfirmationPhoto() {
 	if (props.photo) {
-		return sprintf(trans("dialog.move_photo.confirm"), props.photo.title, titleMovedTo.value);
+		return sprintf(trans("dialogs.move_photo.confirm"), props.photo.title, titleMovedTo.value);
 	}
-	return sprintf(trans("dialog.move_photo.confirm_multiple"), props.photoIds?.length, titleMovedTo.value);
+	return sprintf(trans("dialogs.move_photo.confirm_multiple"), props.photoIds?.length, titleMovedTo.value);
 }
 
 function moveConfirmationAlbum() {


### PR DESCRIPTION
A follow up to #2977 , I found a handful of more places with the same mistake, easy enough to do since it's just missing an `s`.


A handful of before/afters:

| Before | After |
|-|-|
| ![firefox_umgILObZU8](https://github.com/user-attachments/assets/5061d033-1830-42e6-8795-c6411be019af) | ![firefox_LMDOiJKIin](https://github.com/user-attachments/assets/cabb05c1-81c5-4cc8-a670-bb6ccce0100b) |
| ![firefox_P5kU9Gvhpc](https://github.com/user-attachments/assets/df0c2dac-9c9f-4d0e-b359-9be606ed35a7) | ![firefox_OpUHKQfOjz](https://github.com/user-attachments/assets/4d3c5947-66dc-4071-afde-a88624c08e17) |
| ![firefox_w5QwfdpH4z](https://github.com/user-attachments/assets/bce80c18-37b8-4c19-8256-55b2d0deac37) | ![firefox_zIs7oDe8uV](https://github.com/user-attachments/assets/cdc6557a-478f-408c-bde0-dd10ccda825e) |

