### PR TITLE
Add more statistics: punch card a la GitHub (SE).

### DIFF
--- a/app/Actions/Statistics/Counts.php
+++ b/app/Actions/Statistics/Counts.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Statistics;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * We compute the size usage from the size variants.
+ * Do note that this number may be slightly off due to the way we store pictures in the database:
+ * row are duplicates for pictures, but the file is stored only once.
+ */
+final class Counts
+{
+	/**
+	 * Return the number of photos uploaded per day over a period of time.
+	 *
+	 * @param int|null $owner_id
+	 * @param int      $min_date number of days in the past to start counting from today
+	 * @param int      $max_date number of days in the past to stop counting from today
+	 *
+	 * @return Collection<int,object{date:string,uploads:int}>
+	 */
+	public function getCreatedAtCountOverTime(?int $owner_id = null, int $min_date = 365, int $max_date = 0): Collection
+	{
+		$max_date_object = Carbon::now()->subDays($max_date);
+		$min_date_object = Carbon::now()->subDays($min_date);
+
+		/** @var Collection<int,object{date:string,uploads:int}> */
+		return DB::table('photos')->selectRaw(' DATE(created_at) date, count(*) uploads')
+			->where('created_at', '>', $min_date_object)
+			->where('created_at', '<=', $max_date_object)
+			->when($owner_id !== null, function ($query, $owner_id) {
+				return $query->where('owner_id', $owner_id);
+			})
+			->groupBy('date')
+			->orderBy('date', 'asc')
+			->get();
+	}
+
+	/**
+	 * Return the number of photos taken per day over a period of time.
+	 *
+	 * @param int|null $owner_id
+	 * @param int      $min_date number of days in the past to start counting from today
+	 * @param int      $max_date number of days in the past to stop counting from today
+	 *
+	 * @return Collection<int,object{date:string,uploads:int}>
+	 */
+	public function getTakenAtCountOverTime(?int $owner_id = null, int $min_date = 365, int $max_date = 0): Collection
+	{
+		$max_date_object = Carbon::now()->subDays($max_date);
+		$min_date_object = Carbon::now()->subDays($min_date);
+
+		/** @var Collection<int,object{date:string,uploads:int}> */
+		return DB::table('photos')->selectRaw(' DATE(taken_at) date, count(*) uploads')
+			->where('taken_at', '>', $min_date_object)
+			->where('taken_at', '<=', $max_date_object)
+			->when($owner_id !== null, function ($query, $owner_id) {
+				return $query->where('owner_id', $owner_id);
+			})
+			->groupBy('date')
+			->orderBy('date', 'asc')
+			->get();
+	}
+
+	/**
+	 * Return the minimum created_at date of all photos for a user.
+	 *
+	 * @param int|null $owner_id
+	 *
+	 * @return string
+	 */
+	public function getMinCreatedAt(?int $owner_id = null): string
+	{
+		// @phpstan-ignore-next-line Phpstan does not recognise that the result of the query has the attribute min_created_at
+		return DB::table('photos')
+			->select(DB::raw('min(created_at) as min_created_at'))
+			->when($owner_id !== null, function ($query, $owner_id) {
+				return $query->where('owner_id', $owner_id);
+			})
+			->first()?->min_created_at ?? '';
+	}
+
+	/**
+	 * Return the minimum taken_at date of all photos for a user.
+	 *
+	 * @param int|null $owner_id
+	 *
+	 * @return string
+	 */
+	public function getMinTakenAt(?int $owner_id = null): string
+	{
+		// @phpstan-ignore-next-line Phpstan does not recognise that the result of the query has the attribute min_taken_at
+		return DB::table('photos')
+			->select(DB::raw('min(taken_at) as min_taken_at'))
+			->whereNotNull('taken_at')
+			->when($owner_id !== null, function ($query, $owner_id) {
+				return $query->where('owner_id', $owner_id);
+			})
+			->first()?->min_taken_at ?? '';
+	}
+}

--- a/app/Actions/Statistics/Spaces.php
+++ b/app/Actions/Statistics/Spaces.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\DB;
  * Do note that this number may be slightly off due to the way we store pictures in the database:
  * row are duplicates for pictures, but the file is stored only once.
  */
-class Spaces
+final class Spaces
 {
 	/**
 	 * Return the amount of data stored on the server (optionally for a user).

--- a/app/Enum/CountType.php
+++ b/app/Enum/CountType.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Enum;
+
+/**
+ * Enum CountType.
+ *
+ * The type of counting for the punch card data.
+ */
+enum CountType: string
+{
+	case TAKEN_AT = 'taken_at';
+	case CREATED_AT = 'created_at';
+}

--- a/app/Http/Middleware/ConfigIntegrity.php
+++ b/app/Http/Middleware/ConfigIntegrity.php
@@ -32,6 +32,9 @@ class ConfigIntegrity
 		'cache_ttl',
 		'exif_disabled_for_all',
 		'file_name_hidden',
+		'low_number_of_shoots_per_day',
+		'medium_number_of_shoots_per_day',
+		'high_number_of_shoots_per_day',
 	];
 
 	/**

--- a/app/Http/Requests/Statistics/CountsRequest.php
+++ b/app/Http/Requests/Statistics/CountsRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Statistics;
+
+use App\Contracts\Http\Requests\HasOwnerId;
+use App\Enum\CountType;
+use App\Http\Requests\BaseApiRequest;
+use App\Http\Requests\Traits\HasOwnerIdTrait;
+use App\Models\Configs;
+use App\Policies\SettingsPolicy;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
+
+class CountsRequest extends BaseApiRequest implements HasOwnerId
+{
+	use HasOwnerIdTrait;
+
+	public int $min;
+	public int $max;
+	public CountType $type;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::check(SettingsPolicy::CAN_SEE_STATISTICS, [Configs::class]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function rules(): array
+	{
+		return [
+			'max' => ['sometimes', 'integer', 'min:0'],
+			'min' => ['sometimes', 'integer', 'min:0', 'gte:max'],
+			'type' => ['required', 'string', Rule::enum(CountType::class)],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		$this->min = intval($values['min'] ?? 365);
+		$this->max = intval($values['max'] ?? 0);
+		$this->type = CountType::from($values['type']);
+
+		// Filter only to user if user is not admin
+		if (Auth::check() && Auth::user()?->may_administrate !== true) {
+			$this->owner_id = intval(Auth::id());
+		}
+	}
+}

--- a/app/Http/Resources/Statistics/CountsData.php
+++ b/app/Http/Resources/Statistics/CountsData.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Statistics;
+
+use App\Models\Configs;
+use Illuminate\Support\Collection;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class CountsData extends Data
+{
+	/** @var DayCount[] */
+	public array $data;
+	public int $low_number_of_shoots_per_day;
+	public int $medium_number_of_shoots_per_day;
+	public int $high_number_of_shoots_per_day;
+	public string $min_created_at;
+	public string $min_taken_at;
+
+	/**
+	 * @param Collection<int,object{date:string,uploads:int}> $data
+	 *
+	 * @return void
+	 */
+	public function __construct(Collection $data, string $min_taken_at, string $min_created_at)
+	{
+		$this->data = $data->map(fn ($v) => new DayCount($v->date, $v->uploads))->all();
+		$this->low_number_of_shoots_per_day = Configs::getValueAsInt('low_number_of_shoots_per_day');
+		$this->medium_number_of_shoots_per_day = Configs::getValueAsInt('medium_number_of_shoots_per_day');
+		$this->high_number_of_shoots_per_day = Configs::getValueAsInt('high_number_of_shoots_per_day');
+		$this->min_created_at = substr($min_created_at, 0, 4); // we only need the year
+		$this->min_taken_at = substr($min_taken_at, 0, 4); // we only need the year
+	}
+}

--- a/app/Http/Resources/Statistics/DayCount.php
+++ b/app/Http/Resources/Statistics/DayCount.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Statistics;
+
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class DayCount extends Data
+{
+	/**
+	 * @param string $date  of the count
+	 * @param int    $count number
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		public string $date,
+		public int $count,
+	) {
+	}
+}

--- a/app/Metadata/Cache/RouteCacheManager.php
+++ b/app/Metadata/Cache/RouteCacheManager.php
@@ -92,6 +92,7 @@ final readonly class RouteCacheManager
 			'api/v2/Statistics::albumSpace' => new RouteCacheConfig(tag: CacheTag::STATISTICS, user_dependant: true),
 			'api/v2/Statistics::sizeVariantSpace' => new RouteCacheConfig(tag: CacheTag::STATISTICS, user_dependant: true),
 			'api/v2/Statistics::totalAlbumSpace' => new RouteCacheConfig(tag: CacheTag::STATISTICS, user_dependant: true),
+			'api/v2/Statistics::getCountsOverTime' => new RouteCacheConfig(tag: CacheTag::STATISTICS, user_dependant: true),
 			'api/v2/Statistics::userSpace' => new RouteCacheConfig(tag: CacheTag::STATISTICS, user_dependant: true),
 			'api/v2/UserManagement' => new RouteCacheConfig(tag: CacheTag::USERS, user_dependant: true),
 			'api/v2/Users' => new RouteCacheConfig(tag: CacheTag::USERS, user_dependant: true),

--- a/database/migrations/2025_02_02_220404_config_punch_card.php
+++ b/database/migrations/2025_02_02_220404_config_punch_card.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public function getConfigs(): array
+	{
+		return [
+			[
+				'key' => 'low_number_of_shoots_per_day',
+				'value' => '10',
+				'cat' => 'Gallery',
+				'type_range' => self::POSITIVE,
+				'description' => 'Number of shoots per day to be considered as low.',
+				'details' => 'This is used to determine the color in the punch card statistics.',
+				'is_secret' => false,
+				'level' => 1,
+			],
+			[
+				'key' => 'medium_number_of_shoots_per_day',
+				'value' => '50',
+				'cat' => 'Gallery',
+				'type_range' => self::POSITIVE,
+				'description' => 'Number of shoots per day to be considered as medium.',
+				'details' => 'This is used to determine the color in the punch card statistics.',
+				'is_secret' => false,
+				'level' => 1,
+			],
+			[
+				'key' => 'high_number_of_shoots_per_day',
+				'value' => '100',
+				'cat' => 'Gallery',
+				'type_range' => self::POSITIVE,
+				'description' => 'Number of shoots per day to be considered as high.',
+				'details' => 'This is used to determine the color in the punch card statistics.',
+				'is_secret' => false,
+				'level' => 1,
+			],
+		];
+	}
+};

--- a/lang/cz/statistics.php
+++ b/lang/cz/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/cz/statistics.php
+++ b/lang/cz/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/cz/statistics.php
+++ b/lang/cz/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/de/statistics.php
+++ b/lang/de/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/de/statistics.php
+++ b/lang/de/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/de/statistics.php
+++ b/lang/de/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/el/statistics.php
+++ b/lang/el/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/el/statistics.php
+++ b/lang/el/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/el/statistics.php
+++ b/lang/el/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/en/statistics.php
+++ b/lang/en/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/en/statistics.php
+++ b/lang/en/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/en/statistics.php
+++ b/lang/en/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/es/statistics.php
+++ b/lang/es/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/es/statistics.php
+++ b/lang/es/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/es/statistics.php
+++ b/lang/es/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/fr/statistics.php
+++ b/lang/fr/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/fr/statistics.php
+++ b/lang/fr/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/fr/statistics.php
+++ b/lang/fr/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/hu/statistics.php
+++ b/lang/hu/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/hu/statistics.php
+++ b/lang/hu/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/hu/statistics.php
+++ b/lang/hu/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/it/statistics.php
+++ b/lang/it/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/it/statistics.php
+++ b/lang/it/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/it/statistics.php
+++ b/lang/it/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/ja/statistics.php
+++ b/lang/ja/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/ja/statistics.php
+++ b/lang/ja/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/ja/statistics.php
+++ b/lang/ja/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/nl/statistics.php
+++ b/lang/nl/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/nl/statistics.php
+++ b/lang/nl/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/nl/statistics.php
+++ b/lang/nl/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/no/statistics.php
+++ b/lang/no/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/no/statistics.php
+++ b/lang/no/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/no/statistics.php
+++ b/lang/no/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/pl/statistics.php
+++ b/lang/pl/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/pl/statistics.php
+++ b/lang/pl/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/pl/statistics.php
+++ b/lang/pl/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/pt/statistics.php
+++ b/lang/pt/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/pt/statistics.php
+++ b/lang/pt/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/pt/statistics.php
+++ b/lang/pt/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/ru/statistics.php
+++ b/lang/ru/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/ru/statistics.php
+++ b/lang/ru/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/ru/statistics.php
+++ b/lang/ru/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/sk/statistics.php
+++ b/lang/sk/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/sk/statistics.php
+++ b/lang/sk/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/sk/statistics.php
+++ b/lang/sk/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/sv/statistics.php
+++ b/lang/sv/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/sv/statistics.php
+++ b/lang/sv/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/sv/statistics.php
+++ b/lang/sv/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/vi/statistics.php
+++ b/lang/vi/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/vi/statistics.php
+++ b/lang/vi/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/vi/statistics.php
+++ b/lang/vi/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/zh_CN/statistics.php
+++ b/lang/zh_CN/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/zh_CN/statistics.php
+++ b/lang/zh_CN/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/zh_CN/statistics.php
+++ b/lang/zh_CN/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/lang/zh_TW/statistics.php
+++ b/lang/zh_TW/statistics.php
@@ -43,5 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
+		'caption' => 'Each column represent a week.',
 	],
 ];

--- a/lang/zh_TW/statistics.php
+++ b/lang/zh_TW/statistics.php
@@ -43,6 +43,6 @@ return [
 		'tooltip' => '%d photos on %s',
 		'created_at' => 'Upload date',
 		'taken_at' => 'Exif date',
-		'caption' => 'Each column represent a week.',
+		'caption' => 'Each column represents a week.',
 	],
 ];

--- a/lang/zh_TW/statistics.php
+++ b/lang/zh_TW/statistics.php
@@ -31,4 +31,17 @@ return [
 		'descendants' => 'Children',
 		'size' => 'Size',
 	],
+	'punch_card' => [
+		'title' => 'Activity',
+		'photo-taken' => '%d photos taken',
+		'photo-taken-in' => '%d photos taken in %d',
+		'photo-uploaded' => '%d photos uploaded',
+		'photo-uploaded-in' => '%d photos uploaded in %d',
+		'with-exif' => 'with exif data',
+		'less' => 'Less',
+		'more' => 'More',
+		'tooltip' => '%d photos on %s',
+		'created_at' => 'Upload date',
+		'taken_at' => 'Exif date',
+	],
 ];

--- a/resources/js/components/statistics/Activity.vue
+++ b/resources/js/components/statistics/Activity.vue
@@ -63,7 +63,7 @@ const years = computed(() => {
 	}
 
 	const maxYear = new Date().getFullYear();
-	const minYear = isTakenAt.value ? minCreatedAt.value : minCreatedAt.value;
+	const minYear = isTakenAt.value ? minTakenAt.value : minCreatedAt.value;
 	const listYears = [];
 	for (var i = maxYear; i >= minYear; i--) {
 		listYears.push(i);

--- a/resources/js/components/statistics/Activity.vue
+++ b/resources/js/components/statistics/Activity.vue
@@ -1,0 +1,143 @@
+<template>
+	<Panel class="max-w-5xl mx-auto border-0" :header="$t('statistics.punch_card.title')" v-if="counts !== undefined">
+		<div class="flex justify-center">
+			{{ caption }}
+			<span class="ml-1" v-if="isTakenAt" v-tooltip="$t('statistics.punch_card.with-exif')">*</span>
+		</div>
+		<div class="flex items-start justify-center gap-4 w-[calc(1024px-2rem)]">
+			<div class="flex justify-center flex-col items-center">
+				<PunchCard :low="low" :medium="medium" :high="high" :data="counts" :year="year" :key="getKey(counts)" />
+				<PunchCardCaption :low="low" :medium="medium" :high="high" />
+			</div>
+			<div class="flex flex-col gap-2 w-32">
+				<div class="flex items-center">
+					<ToggleSwitch id="pp_taken_at_created_at" v-model="isTakenAt" class="mr-2" @change="load" />
+					<label class="text-sm" for="pp_taken_at_created_at">{{
+						isTakenAt ? $t("statistics.punch_card.taken_at") : $t("statistics.punch_card.created_at")
+					}}</label>
+				</div>
+				<div class="text-right">
+					<ScrollPanel class="w-32 h-24" pt:content:class="flex flex-col">
+						<span
+							v-for="y in years"
+							class="hover:text-primary cursor-pointer mr-4"
+							:class="{ 'text-primary': y === year }"
+							@click="handleYear(y)"
+							>{{ y }}</span
+						>
+					</ScrollPanel>
+				</div>
+			</div>
+		</div>
+	</Panel>
+</template>
+<script setup lang="ts">
+import StatisticsService from "@/services/statistics-service";
+import Panel from "primevue/panel";
+import { sprintf } from "sprintf-js";
+import { computed, onMounted, ref } from "vue";
+import PunchCard from "./PunchCard.vue";
+import PunchCardCaption from "./PunchCardCaption.vue";
+import ToggleSwitch from "primevue/toggleswitch";
+import { trans } from "laravel-vue-i18n";
+import ScrollPanel from "primevue/scrollpanel";
+
+const isTakenAt = ref(true);
+const min = ref(365);
+const max = ref(0);
+
+const total = ref(0);
+const low = ref(10);
+const medium = ref(50);
+const high = ref(100);
+
+const year = ref<number | undefined>(undefined);
+const caption = ref("");
+const counts = ref<App.Http.Resources.Statistics.DayCount[] | undefined>(undefined);
+const minCreatedAt = ref(new Date().getFullYear());
+const minTakenAt = ref(new Date().getFullYear());
+
+const years = computed(() => {
+	if (counts.value === undefined) {
+		return [];
+	}
+
+	const maxYear = new Date().getFullYear();
+	const minYear = isTakenAt.value ? minCreatedAt.value : minCreatedAt.value;
+	const listYears = [];
+	for (var i = maxYear; i >= minYear; i--) {
+		listYears.push(i);
+	}
+
+	return listYears;
+});
+
+function setCaption() {
+	switch (true) {
+		case isTakenAt.value === true && year.value === undefined:
+			caption.value = sprintf(trans("statistics.punch_card.photo-taken"), total.value);
+			break;
+		case isTakenAt.value === false && year.value === undefined:
+			caption.value = sprintf(trans("statistics.punch_card.photo-uploaded"), total.value);
+			break;
+		case isTakenAt.value === true && year.value !== undefined:
+			caption.value = sprintf(trans("statistics.punch_card.photo-taken-in"), total.value, year.value);
+			break;
+		case isTakenAt.value === false && year.value !== undefined:
+			caption.value = sprintf(trans("statistics.punch_card.photo-uploaded-in"), total.value, year.value);
+			break;
+		default:
+			"";
+	}
+}
+
+function load() {
+	StatisticsService.getCountsOverTime(min.value, max.value, isTakenAt.value ? "taken_at" : "created_at").then((response) => {
+		counts.value = response.data.data;
+		low.value = response.data.low_number_of_shoots_per_day;
+		medium.value = response.data.medium_number_of_shoots_per_day;
+		high.value = response.data.high_number_of_shoots_per_day;
+		minCreatedAt.value = parseInt(response.data.min_created_at, 10);
+		minTakenAt.value = parseInt(response.data.min_taken_at, 10);
+		total.value = 0;
+		for (const d of counts.value) {
+			total.value += d.count;
+		}
+
+		setCaption();
+	});
+}
+
+function handleYear(y: number) {
+	year.value = y;
+	// min is the number of days since the first day of the year till now.
+	min.value = Math.max(0, Math.floor((new Date().getTime() - new Date(y, 0, 1).getTime()) / 86400000) + 1);
+	// max is the number of days since the first day of the next year till now.
+	max.value = Math.max(0, Math.floor((new Date().getTime() - new Date(y + 1, 0, 1).getTime()) / 86400000));
+	load();
+}
+
+/**
+ * Generate a hash code for the given string.
+ * This is used to have a unique key for the data.
+ *
+ * @param str
+ */
+function hashCode(str: string) {
+	var hash = 0,
+		i = 0,
+		len = str.length;
+	while (i < len) {
+		hash = ((hash << 5) - hash + str.charCodeAt(i++)) << 0;
+	}
+	return hash;
+}
+
+function getKey(data: App.Http.Resources.Statistics.DayCount[]) {
+	return hashCode(data.map((d) => d.date + d.count).join("|"));
+}
+
+onMounted(() => {
+	load();
+});
+</script>

--- a/resources/js/components/statistics/PunchCard.vue
+++ b/resources/js/components/statistics/PunchCard.vue
@@ -37,11 +37,10 @@ const props = defineProps<{
 	low: number;
 	medium: number;
 	high: number;
-	data: DayCount[];
+	data: App.Http.Resources.Statistics.DayCount[];
 	year: number | undefined;
 }>();
 
-type DayCount = { date: string; count: number };
 type DayData = { date: Date; count: number };
 type MonthCol = { month: string; colspan: number };
 
@@ -51,7 +50,7 @@ const weeks = ref<DayData[][]>([]);
 const months = ref<MonthCol[]>([]);
 const days = ref<number[]>([0, 1, 2, 3, 4, 5, 6]);
 
-function transformData(data: DayCount[], year: number | undefined) {
+function transformData(data: App.Http.Resources.Statistics.DayCount[], year: number | undefined) {
 	weeks.value = [];
 	let startDate: Date;
 

--- a/resources/js/components/statistics/PunchCard.vue
+++ b/resources/js/components/statistics/PunchCard.vue
@@ -1,0 +1,138 @@
+<template>
+	<table class="border-separate border-spacing-0.5">
+		<thead>
+			<tr>
+				<td></td>
+				<td v-for="(m, i) in months" :key="`mo${i}${m.month}${m.colspan}`" :colspan="m.colspan" class="text-xs">{{ m.month }}</td>
+			</tr>
+		</thead>
+		<tbody>
+			<tr v-for="(d, i) in days" :key="`d${d}:${genDayKey(d)}`">
+				<td class="text-2xs w-8">{{ i % 2 ? "" : formatDay(d) }}</td>
+				<template v-for="(week, i) in weeks" :key="`week${i}:${genWeekKey(week)}`">
+					<td v-if="week[d].count < 0" class="h-3 w-3 m-0.5 rounded-xs"></td>
+					<td
+						v-else
+						v-tooltip.top="{ value: format(week[d]), dt: { maxWidth: '500px' } }"
+						:class="{
+							'h-3 w-3 m-0.5 rounded-xs border border-surface-400 dark:border-surface-700': true,
+							'bg-transparent': week[d].count === 0,
+							'bg-sky-100 dark:bg-sky-100/60': week[d].count > 0 && week[d].count < low,
+							'bg-sky-300 dark:bg-sky-300/80': week[d].count >= low && week[d].count < medium,
+							'bg-sky-500 dark:bg-sky-500/80': week[d].count >= medium && week[d].count < high,
+							'bg-sky-700 dark:bg-sky-700': week[d].count >= high,
+						}"
+					></td>
+				</template>
+			</tr>
+		</tbody>
+	</table>
+</template>
+<script setup lang="ts">
+import { trans } from "laravel-vue-i18n";
+import { sprintf } from "sprintf-js";
+import { onMounted, ref } from "vue";
+
+const props = defineProps<{
+	low: number;
+	medium: number;
+	high: number;
+	data: DayCount[];
+	year: number | undefined;
+}>();
+
+type DayCount = { date: string; count: number };
+type DayData = { date: Date; count: number };
+type MonthCol = { month: string; colspan: number };
+
+const startDay = ref(1);
+
+const weeks = ref<DayData[][]>([]);
+const months = ref<MonthCol[]>([]);
+const days = ref<number[]>([0, 1, 2, 3, 4, 5, 6]);
+
+function transformData(data: DayCount[], year: number | undefined) {
+	weeks.value = [];
+	let startDate: Date;
+
+	if (year === undefined) {
+		startDate = new Date();
+		startDate.setDate(startDate.getDate() - 7 * 52 - 1);
+	} else {
+		startDate = new Date(year, 0, 1);
+	}
+
+	// Sunday = 0, Monday = 1, ... (See below):
+	let day = startDate.getDay();
+	if (startDay.value === 1) {
+		day = (day + 6) % 7;
+	}
+	const offset = day;
+
+	for (let w = 0; w < 52; w++) {
+		let week: DayData[] = [];
+
+		// First loop to fill the week.
+		for (let d = 0; d < day; d++) {
+			let date = new Date(startDate);
+			date.setDate(startDate.getDate() + w * 7 + d);
+			week.push({ date, count: -1 });
+		}
+
+		for (let d = day; d < 7; d++) {
+			let date = new Date(startDate);
+			date.setDate(startDate.getDate() + w * 7 + d - offset);
+			const candidate = date.toISOString().slice(0, 10);
+			const count = data.find((c) => c.date === candidate)?.count ?? 0;
+			week.push({ date, count });
+		}
+		day = 0;
+		weeks.value.push(week);
+	}
+}
+
+function prepMonths() {
+	months.value = [];
+	let previous = "";
+	const formatter = new Intl.DateTimeFormat(navigator.language, { month: "short" });
+	let j = 0;
+	for (let i = 0; i < 52; i++) {
+		const candidate = formatter.format(weeks.value[i][0].date);
+		if (previous !== candidate && j > 0) {
+			months.value.push({ month: previous, colspan: j });
+			previous = candidate;
+			j = 0;
+		}
+		previous = candidate;
+		j += 1;
+	}
+	months.value.push({ month: previous, colspan: j });
+}
+
+function genWeekKey(week: DayData[]) {
+	return week.map((w) => w.count).join("|");
+}
+
+function genDayKey(day: number): string {
+	return weeks.value.map((w) => w[day].count).join("|");
+}
+
+function formatDay(dayIdx: number): string {
+	const formatter = new Intl.DateTimeFormat(navigator.language, { weekday: "short" });
+
+	var baseDate = new Date(Date.UTC(2017, 0, 1 + startDay.value)); // just a Sunday or Monday
+	baseDate.setDate(baseDate.getDate() + dayIdx);
+
+	return formatter.format(baseDate);
+}
+
+function format(d: DayData) {
+	const formatter = new Intl.DateTimeFormat(navigator.language, { month: "long", day: "numeric" });
+	return sprintf(trans("statistics.punch_card.tooltip"), d.count, formatter.format(d.date));
+}
+
+onMounted(() => {
+	transformData(props.data, props.year);
+	prepMonths();
+});
+</script>

--- a/resources/js/components/statistics/PunchCardCaption.vue
+++ b/resources/js/components/statistics/PunchCardCaption.vue
@@ -1,0 +1,30 @@
+<template>
+	<div class="text-muted-color-emphasis">
+		{{ $t("statistics.punch_card.less") }}
+		<span v-tooltip="'= 0'" class="mx-0.5 inline-block h-3 w-3 bg-transparent border border-surface-400 dark:border-surface-700"></span>
+		<span
+			v-tooltip="`0 < ${props.low}`"
+			class="mx-0.5 inline-block h-3 w-3 bg-sky-100 dark:bg-sky-100/60 border border-surface-400 dark:border-surface-700"
+		></span>
+		<span
+			v-tooltip="`${props.low} < ${props.medium}`"
+			class="mx-0.5 inline-block h-3 w-3 bg-sky-300 dark:bg-sky-300/80 border border-surface-400 dark:border-surface-700"
+		></span>
+		<span
+			v-tooltip="`${props.medium} < ${props.high}`"
+			class="mx-0.5 inline-block h-3 w-3 bg-sky-500 dark:bg-sky-500/80 border border-surface-400 dark:border-surface-700"
+		></span>
+		<span
+			v-tooltip="`≥ ${props.high}`"
+			class="mx-0.5 inline-block h-3 w-3 bg-sky-700 dark:bg-sky-700 border border-surface-400 dark:border-surface-700"
+		></span>
+		{{ $t("statistics.punch_card.more") }}
+	</div>
+</template>
+<script setup lang="ts">
+const props = defineProps<{
+	low: number;
+	medium: number;
+	high: number;
+}>();
+</script>

--- a/resources/js/components/statistics/PunchCardCaption.vue
+++ b/resources/js/components/statistics/PunchCardCaption.vue
@@ -1,24 +1,30 @@
 <template>
-	<div class="text-muted-color-emphasis">
-		{{ $t("statistics.punch_card.less") }}
-		<span v-tooltip="'= 0'" class="mx-0.5 inline-block h-3 w-3 bg-transparent border border-surface-400 dark:border-surface-700"></span>
-		<span
-			v-tooltip="`0 < ${props.low}`"
-			class="mx-0.5 inline-block h-3 w-3 bg-sky-100 dark:bg-sky-100/60 border border-surface-400 dark:border-surface-700"
-		></span>
-		<span
-			v-tooltip="`${props.low} < ${props.medium}`"
-			class="mx-0.5 inline-block h-3 w-3 bg-sky-300 dark:bg-sky-300/80 border border-surface-400 dark:border-surface-700"
-		></span>
-		<span
-			v-tooltip="`${props.medium} < ${props.high}`"
-			class="mx-0.5 inline-block h-3 w-3 bg-sky-500 dark:bg-sky-500/80 border border-surface-400 dark:border-surface-700"
-		></span>
-		<span
-			v-tooltip="`≥ ${props.high}`"
-			class="mx-0.5 inline-block h-3 w-3 bg-sky-700 dark:bg-sky-700 border border-surface-400 dark:border-surface-700"
-		></span>
-		{{ $t("statistics.punch_card.more") }}
+	<div class="flex gap-16 justify-between w-full pl-8.5 items-center">
+		<div class="text-muted-color text-sm">
+			{{ $t("statistics.punch_card.caption") }}
+		</div>
+
+		<div class="text-muted-color-emphasis">
+			{{ $t("statistics.punch_card.less") }}
+			<span v-tooltip="'= 0'" class="mx-0.5 inline-block h-3 w-3 bg-transparent border border-surface-400 dark:border-surface-700"></span>
+			<span
+				v-tooltip="`0 < ${props.low}`"
+				class="mx-0.5 inline-block h-3 w-3 bg-sky-100 dark:bg-sky-100/60 border border-surface-400 dark:border-surface-700"
+			></span>
+			<span
+				v-tooltip="`${props.low} < ${props.medium}`"
+				class="mx-0.5 inline-block h-3 w-3 bg-sky-300 dark:bg-sky-300/80 border border-surface-400 dark:border-surface-700"
+			></span>
+			<span
+				v-tooltip="`${props.medium} < ${props.high}`"
+				class="mx-0.5 inline-block h-3 w-3 bg-sky-500 dark:bg-sky-500/80 border border-surface-400 dark:border-surface-700"
+			></span>
+			<span
+				v-tooltip="`≥ ${props.high}`"
+				class="mx-0.5 inline-block h-3 w-3 bg-sky-700 dark:bg-sky-700 border border-surface-400 dark:border-surface-700"
+			></span>
+			{{ $t("statistics.punch_card.more") }}
+		</div>
 	</div>
 </template>
 <script setup lang="ts">

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -31,6 +31,7 @@ declare namespace App.Enum {
 		| "is_starred"
 		| "type";
 	export type ConfigType = "int" | "positive" | "string" | "string_required" | "0|1" | "0|1|2" | "" | "license" | "map_provider";
+	export type CountType = "taken_at" | "created_at";
 	export type DateOrderingType = "older_younger" | "younger_older";
 	export type DbDriverType = "mysql" | "pgsql" | "sqlite";
 	export type DefaultAlbumProtectionType = 1 | 2 | 3;
@@ -656,6 +657,18 @@ declare namespace App.Http.Resources.Statistics {
 		num_photos: number;
 		num_descendants: number;
 		size: number;
+	};
+	export type CountsData = {
+		data: Array<App.Http.Resources.Statistics.DayCount>;
+		low_number_of_shoots_per_day: number;
+		medium_number_of_shoots_per_day: number;
+		high_number_of_shoots_per_day: number;
+		min_created_at: string;
+		min_taken_at: string;
+	};
+	export type DayCount = {
+		date: string;
+		count: number;
 	};
 	export type Sizes = {
 		type: App.Enum.SizeVariantType;

--- a/resources/js/services/statistics-service.ts
+++ b/resources/js/services/statistics-service.ts
@@ -14,6 +14,9 @@ const StatisticsService = {
 	getTotalAlbumSpace(albumId: string | null = null): Promise<AxiosResponse<App.Http.Resources.Statistics.Album[]>> {
 		return axios.get(`${Constants.getApiUrl()}Statistics::totalAlbumSpace`, { params: { album_id: albumId }, data: {} });
 	},
+	getCountsOverTime(min: number, max: number, type: "taken_at" | "created_at"): Promise<AxiosResponse<App.Http.Resources.Statistics.CountsData>> {
+		return axios.get(`${Constants.getApiUrl()}Statistics::getCountsOverTime`, { params: { min, max, type }, data: {} });
+	},
 };
 
 export default StatisticsService;

--- a/resources/js/views/Statistics.vue
+++ b/resources/js/views/Statistics.vue
@@ -16,6 +16,7 @@
 	<Panel class="max-w-5xl mx-auto border-0">
 		<SizeVariantMeter v-if="load" :album-id="null" />
 	</Panel>
+	<Activity v-if="!is_se_preview_enabled" />
 	<Panel class="max-w-5xl mx-auto border-0" :pt:header:class="'hidden'">
 		<TotalCard v-if="total" :total="total" />
 		<div class="py-4" v-if="load && total">
@@ -40,6 +41,7 @@ import SizeVariantMeter from "@/components/statistics/SizeVariantMeter.vue";
 import TotalCard, { TotalAlbum } from "@/components/statistics/TotalCard.vue";
 import AlbumsTable from "@/components/statistics/AlbumsTable.vue";
 import OpenLeftMenu from "@/components/headers/OpenLeftMenu.vue";
+import Activity from "@/components/statistics/Activity.vue";
 
 const router = useRouter();
 const user = ref<App.Http.Resources.Models.UserResource | undefined>(undefined);

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -227,6 +227,7 @@ Route::get('/Statistics::userSpace', [StatisticsController::class, 'getSpacePerU
 Route::get('/Statistics::sizeVariantSpace', [StatisticsController::class, 'getSpacePerSizeVariantType'])->middleware(['support:se']);
 Route::get('/Statistics::albumSpace', [StatisticsController::class, 'getSpacePerAlbum'])->middleware(['support:se']);
 Route::get('/Statistics::totalAlbumSpace', [StatisticsController::class, 'getTotalSpacePerAlbum'])->middleware(['support:se']);
+Route::get('/Statistics::getCountsOverTime', [StatisticsController::class, 'getPhotoCountOverTime'])->middleware(['support:se']);
 
 /**
  * UPDATE.

--- a/tests/Feature_v2/Statistics/CountsOverTimeTest.php
+++ b/tests/Feature_v2/Statistics/CountsOverTimeTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\Statistics;
+
+use LycheeVerify\Http\Middleware\VerifySupporterStatus;
+use Tests\Feature_v2\Base\BaseApiV2Test;
+
+class CountsOverTimeTest extends BaseApiV2Test
+{
+	public function testCountsOverTimeUnauthorized(): void
+	{
+		$response = $this->getJson('Statistics::getCountsOverTime');
+		$this->assertSupporterRequired($response);
+
+		$response = $this->withoutMiddleware(VerifySupporterStatus::class)->getJson('Statistics::getCountsOverTime');
+		$this->assertUnprocessable($response);
+
+		$response = $this->withoutMiddleware(VerifySupporterStatus::class)->getJsonWithData('Statistics::getCountsOverTime', [
+			'type' => 'taken_at',
+		]);
+		$this->assertUnauthorized($response);
+	}
+
+	public function testCountsOverTimeAdmin(): void
+	{
+		$response = $this->withoutMiddleware(VerifySupporterStatus::class)->actingAs($this->admin)->getJsonWithData('Statistics::getCountsOverTime', [
+			'type' => 'created_at',
+		]);
+		$this->assertOk($response);
+		self::assertCount(6, $response->json());
+
+		$response = $this->withoutMiddleware(VerifySupporterStatus::class)->actingAs($this->admin)->getJsonWithData('Statistics::getCountsOverTime', [
+			'type' => 'taken_at',
+		]);
+		$this->assertOk($response);
+		self::assertCount(6, $response->json());
+
+		// dd($response->json());
+		// self::assertEquals($this->userMayUpload1->username(), $response->json()[0]['username']);
+	}
+}


### PR DESCRIPTION
Add more statistics: a punch card.
![image](https://github.com/user-attachments/assets/62fd2726-73d4-4b09-a654-58bdc0fb8bdd)

- Allows to filter on upload/taken date.
- Allows to look through the previous years.

The low, medium, high thresholds are configurable too (for the shading). Defaults are 10, 50, 100.