### PR TITLE
Add Diagnostics cache checks

### DIFF
--- a/app/Actions/Diagnostics/Errors.php
+++ b/app/Actions/Diagnostics/Errors.php
@@ -11,6 +11,7 @@ namespace App\Actions\Diagnostics;
 use App\Actions\Diagnostics\Pipes\Checks\AdminUserExistsCheck;
 use App\Actions\Diagnostics\Pipes\Checks\AppUrlMatchCheck;
 use App\Actions\Diagnostics\Pipes\Checks\BasicPermissionCheck;
+use App\Actions\Diagnostics\Pipes\Checks\CachePasswordCheck;
 use App\Actions\Diagnostics\Pipes\Checks\ConfigSanityCheck;
 use App\Actions\Diagnostics\Pipes\Checks\CountSizeVariantsCheck;
 use App\Actions\Diagnostics\Pipes\Checks\DBIntegrityCheck;
@@ -54,6 +55,7 @@ class Errors
 		SmallMediumExistsCheck::class,
 		PlaceholderExistsCheck::class,
 		CountSizeVariantsCheck::class,
+		CachePasswordCheck::class,
 		SupporterCheck::class,
 	];
 

--- a/app/Actions/Diagnostics/Pipes/Checks/CachePasswordCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/CachePasswordCheck.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Diagnostics\Pipes\Checks;
+
+use App\Constants\AccessPermissionConstants as APC;
+use App\Contracts\DiagnosticPipe;
+use App\DTO\DiagnosticData;
+use App\Models\Configs;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * We check wether the config is set to use Cache and if there are password sets for albums.
+ */
+class CachePasswordCheck implements DiagnosticPipe
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function handle(array &$data, \Closure $next): array
+	{
+		if (!Schema::hasTable('configs')) {
+			return $next($data);
+		}
+
+		if (Configs::getValueAsBool('cache_enabled') && DB::table(APC::ACCESS_PERMISSIONS)->whereNotNull('password')->count() > 0) {
+			$data[] = DiagnosticData::warn('Response cache is enabled and some albums are password protected.', self::class, ['Due to response caching, unlocking those albums will reveal their content to other annonymous users.']);
+		}
+
+		return $next($data);
+	}
+}

--- a/app/Http/Resources/Rights/AlbumRightsResource.php
+++ b/app/Http/Resources/Rights/AlbumRightsResource.php
@@ -10,6 +10,7 @@ namespace App\Http\Resources\Rights;
 
 use App\Contracts\Models\AbstractAlbum;
 use App\Models\Album;
+use App\Models\Configs;
 use App\Policies\AlbumPolicy;
 use Illuminate\Support\Facades\Gate;
 use Spatie\LaravelData\Data;
@@ -27,6 +28,7 @@ class AlbumRightsResource extends Data
 	public bool $can_delete = false;
 	public bool $can_transfer = false;
 	public bool $can_access_original = false;
+	public bool $can_pasword_protect = false;
 
 	/**
 	 * Given an album, returns the access rights associated to it.
@@ -42,5 +44,6 @@ class AlbumRightsResource extends Data
 		$this->can_delete = Gate::check(AlbumPolicy::CAN_DELETE, [AbstractAlbum::class, $abstractAlbum]);
 		$this->can_transfer = Gate::check(AlbumPolicy::CAN_TRANSFER, [AbstractAlbum::class, $abstractAlbum]);
 		$this->can_access_original = Gate::check(AlbumPolicy::CAN_ACCESS_FULL_PHOTO, [AbstractAlbum::class, $abstractAlbum]);
+		$this->can_pasword_protect = !Configs::getValueAsBool('cache_enabled');
 	}
 }

--- a/lang/cz/dialogs.php
+++ b/lang/cz/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/cz/settings.php
+++ b/lang/cz/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/de/dialogs.php
+++ b/lang/de/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/el/dialogs.php
+++ b/lang/el/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/el/settings.php
+++ b/lang/el/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/en/dialogs.php
+++ b/lang/en/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/es/dialogs.php
+++ b/lang/es/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/es/settings.php
+++ b/lang/es/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/fr/dialogs.php
+++ b/lang/fr/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/hu/dialogs.php
+++ b/lang/hu/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/hu/settings.php
+++ b/lang/hu/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/it/dialogs.php
+++ b/lang/it/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/it/settings.php
+++ b/lang/it/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/ja/dialogs.php
+++ b/lang/ja/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/ja/settings.php
+++ b/lang/ja/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/nl/dialogs.php
+++ b/lang/nl/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/nl/settings.php
+++ b/lang/nl/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/no/dialogs.php
+++ b/lang/no/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/no/settings.php
+++ b/lang/no/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/pl/dialogs.php
+++ b/lang/pl/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/pl/settings.php
+++ b/lang/pl/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/pt/dialogs.php
+++ b/lang/pt/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/pt/settings.php
+++ b/lang/pt/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/ru/dialogs.php
+++ b/lang/ru/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/ru/settings.php
+++ b/lang/ru/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/sk/dialogs.php
+++ b/lang/sk/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/sk/settings.php
+++ b/lang/sk/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/sv/dialogs.php
+++ b/lang/sv/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/sv/settings.php
+++ b/lang/sv/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/vi/dialogs.php
+++ b/lang/vi/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/vi/settings.php
+++ b/lang/vi/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/zh_CN/dialogs.php
+++ b/lang/zh_CN/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/zh_CN/settings.php
+++ b/lang/zh_CN/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/lang/zh_TW/dialogs.php
+++ b/lang/zh_TW/dialogs.php
@@ -107,6 +107,7 @@ return [
 		'password' => 'Password',
 		'password_prot' => 'Password protected',
 		'password_prot_expl' => 'Anonymous users need a shared password to access this album.',
+		'password_prop_not_compatible' => 'Response cache is conflicting with this setting.<br>Due to response caching, unlocking this album will<br>also reveal its content to other annonymous users.',
 		'nsfw' => 'Sensitive',
 		'nsfw_expl' => 'Album contains sensitive content.',
 		'visibility_updated' => 'Visibility updated.',

--- a/lang/zh_TW/settings.php
+++ b/lang/zh_TW/settings.php
@@ -35,6 +35,8 @@ return [
 		'language' => 'Language used by Lychee',
 		'nsfw_album_visibility' => 'Make Sensitive albums visible by default.',
 		'nsfw_album_explanation' => 'If the album is public, it is still accessible, just hidden from the view and <b>can be revealed by pressing <kbd>H</kbd></b>.',
+		'cache_enabled' => 'Enable caching of responses.',
+		'cache_enabled_details' => 'This will significantly speed up the response time of Lychee.<br> <i class="pi pi-exclamation-triangle text-warning-600 mr-2"></i>If you are using password protected albums, you should not enable this.',
 	],
 	'lychee_se' => [
 		'header' => 'Lychee <span class="text-primary-emphasis">SE</span>',

--- a/resources/js/components/forms/album/AlbumVisibility.vue
+++ b/resources/js/components/forms/album/AlbumVisibility.vue
@@ -13,9 +13,8 @@
 						:class="is_public ? 'text-muted-color-emphasis' : 'text-muted-color'"
 					>
 						<ToggleSwitch
-							id="pp_dialog_full_check"
+							input-id="pp_dialog_full_check"
 							v-model="grants_full_photo_access"
-							:disabled="!is_public"
 							class="-ml-10 mr-2 translate-y-1"
 							@change="save"
 						/>
@@ -26,13 +25,7 @@
 						class="relative h-12 my-4 pl-9 transition-color duration-300"
 						:class="is_public ? 'text-muted-color-emphasis' : 'text-muted-color'"
 					>
-						<ToggleSwitch
-							id="pp_dialog_link_check"
-							v-model="is_link_required"
-							:disabled="!is_public"
-							class="-ml-10 mr-2 translate-y-1"
-							@change="save"
-						/>
+						<ToggleSwitch input-id="pp_dialog_link_check" v-model="is_link_required" class="-ml-10 mr-2 translate-y-1" @change="save" />
 						<label class="font-bold" for="pp_dialog_link_check">{{ $t("dialogs.visibility.hidden") }}</label>
 						<p class="my-1.5">{{ $t("dialogs.visibility.hidden_expl") }}</p>
 					</div>
@@ -41,9 +34,8 @@
 						:class="is_public ? 'text-muted-color-emphasis' : 'text-muted-color'"
 					>
 						<ToggleSwitch
-							id="pp_dialog_downloadable_check"
+							input-id="pp_dialog_downloadable_check"
 							v-model="grants_download"
-							:disabled="!is_public"
 							class="-ml-10 mr-2 translate-y-1"
 							@change="save"
 						/>
@@ -51,13 +43,31 @@
 						<p class="my-1.5">{{ $t("dialogs.visibility.downloadable_expl") }}</p>
 					</div>
 					<div
+						v-if="!can_pasword_protect && is_password_required"
 						class="relative my-4 pl-9 transition-color duration-300"
 						:class="is_public ? 'text-muted-color-emphasis' : 'text-muted-color'"
 					>
 						<ToggleSwitch
-							id="pp_dialog_password_check"
+							input-id="pp_dialog_password_check_2"
 							v-model="is_password_required"
-							:disabled="!is_public"
+							class="-ml-10 mr-2 translate-y-1 group"
+							:pt:slider:class="'group-has-checked:bg-danger-700'"
+							@change="save"
+						/>
+						<label class="font-bold inline-flex items-center gap-2" for="pp_dialog_password_check_2">
+							<span class="border-b border-dashed border-danger-700">{{ $t("dialogs.visibility.password_prot") }}</span>
+							<i class="pi pi-exclamation-triangle text-danger-700" />
+						</label>
+						<p class="mt-1.5 mb-4 text-danger-600/80" v-html="$t('dialogs.visibility.password_prop_not_compatible')"></p>
+					</div>
+					<div
+						v-else-if="can_pasword_protect"
+						class="relative my-4 pl-9 transition-color duration-300"
+						:class="is_public ? 'text-muted-color-emphasis' : 'text-muted-color'"
+					>
+						<ToggleSwitch
+							input-id="pp_dialog_password_check"
+							v-model="is_password_required"
 							class="-ml-10 mr-2 translate-y-1"
 							@change="save"
 						/>
@@ -75,7 +85,7 @@
 				<form>
 					<div class="relative h-12 my-4 transition-color duration-300">
 						<ToggleSwitch
-							id="pp_dialog_nsfw_check"
+							input-id="pp_dialog_nsfw_check"
 							v-model="is_nsfw"
 							class="mr-2 translate-y-1"
 							style="
@@ -96,7 +106,7 @@
 	</Card>
 </template>
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref } from "vue";
 import Card from "primevue/card";
 import ToggleSwitch from "primevue/toggleswitch";
 import FloatLabel from "primevue/floatlabel";
@@ -119,6 +129,7 @@ const grants_full_photo_access = ref<boolean>(props.album.policy.grants_full_pho
 const grants_download = ref<boolean>(props.album.policy.grants_download);
 const is_password_required = ref<boolean>(props.album.policy.is_password_required);
 const password = ref<string>("");
+const can_pasword_protect = ref<boolean>(props.album.rights.can_pasword_protect);
 
 function save() {
 	const data: UpdateProtectionPolicyData = {
@@ -128,7 +139,7 @@ function save() {
 		is_nsfw: is_nsfw.value,
 		grants_full_photo_access: grants_full_photo_access.value,
 		grants_download: grants_download.value,
-		password: password.value,
+		password: is_password_required.value ? password.value : undefined,
 	};
 
 	AlbumService.updateProtectionPolicy(data).then(() => {

--- a/resources/js/components/settings/EasySettings.vue
+++ b/resources/js/components/settings/EasySettings.vue
@@ -10,10 +10,17 @@
 				/>
 				<SelectLang v-if="lang !== undefined" :label="$t('settings.system.language')" :config="lang" />
 				<div class="flex flex-wrap justify-between">
-					<label for="pp_dialog_nsfw_visible">{{ $t("settings.system.nsfw_album_visibility") }}</label>
+					<label for="pp_dialog_nsfw_visible" class="text-muted-color-emphasis">{{ $t("settings.system.nsfw_album_visibility") }}</label>
 					<ToggleSwitch id="pp_dialog_nsfw_visible" v-model="nsfwVisible" class="text-sm" @update:model-value="updateNSFW" />
 					<p class="my-1.5 text-muted-color w-full" v-html="$t('settings.system.nsfw_album_explanation')"></p>
 				</div>
+				<BoolField
+					v-if="cache_enabled !== undefined"
+					:label="$t('settings.system.cache_enabled')"
+					:config="cache_enabled"
+					:details="$t('settings.system.cache_enabled_details')"
+					@filled="save"
+				/>
 			</div>
 		</Fieldset>
 		<Fieldset class="border-b-0 border-r-0 rounded-r-none rounded-b-none" v-if="!is_se_enabled && !is_se_info_hidden">
@@ -311,6 +318,7 @@ const layout = ref<App.Http.Resources.Models.ConfigResource | undefined>(undefin
 const nsfwVisible = ref<boolean | undefined>(undefined);
 
 const dark_mode_enabled = ref<App.Http.Resources.Models.ConfigResource | undefined>(undefined);
+const cache_enabled = ref<App.Http.Resources.Models.ConfigResource | undefined>(undefined);
 
 const map_display = ref<App.Http.Resources.Models.ConfigResource | undefined>(undefined);
 const map_display_public = ref<App.Http.Resources.Models.ConfigResource | undefined>(undefined);
@@ -362,6 +370,7 @@ function load() {
 		dark_mode_enabled.value = configurations.find((config) => config.key === "dark_mode_enabled");
 		nsfwVisible.value = configurations.find((config) => config.key === "nsfw_visible")?.value === "1";
 		dropbox_key.value = configurations.find((config) => config.key === "dropbox_key")?.value ?? "";
+		cache_enabled.value = configurations.find((config) => config.key === "cache_enabled");
 
 		photoSortingColumn.value = configurations.find((config) => config.key === "sorting_photos_col");
 		photoSortingOrder.value = configurations.find((config) => config.key === "sorting_photos_order");

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -573,6 +573,7 @@ declare namespace App.Http.Resources.Rights {
 		can_delete: boolean;
 		can_transfer: boolean;
 		can_access_original: boolean;
+		can_pasword_protect: boolean;
 	};
 	export type GlobalRightsResource = {
 		root_album: App.Http.Resources.Rights.RootAlbumRightsResource;


### PR DESCRIPTION
- Add diagnostic cache checks
- Disable password albums when cache is enabled (do not force it but make it not possible to set a new password)
- Add cache into the easy settings.
