### PR TITLE
Exclude /feed from content type check

### DIFF
--- a/app/Http/Middleware/AcceptContentType.php
+++ b/app/Http/Middleware/AcceptContentType.php
@@ -26,11 +26,12 @@ class AcceptContentType
 	public const HTML = 'html';
 
 	/**
-	 * The URIs that should be excluded from CSRF verification.
+	 * The URIs that should be excluded from AcceptContentType verification.
 	 *
 	 * @var array<int,string>
 	 */
 	protected $except = [
+		'/feed',
 	];
 
 	/**


### PR DESCRIPTION
Simpler solution. Another approach would be to require the Accept Content Type.

Fixes #3008 