### PR TITLE
feat: `npm run build-dev` to build js/css etc... assets without minif…

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
         "check": "vue-tsc --noEmit -p tsconfig.json --composite false --skipLibCheck",
         "dev": "vite",
         "build": "vite build",
+		"build-dev": "vite build --mode development",
         "check-formatting": "prettier --check resources/js/ resources/sass/",
         "format": "prettier --write resources/js/ resources/sass/",
         "vca": "vca -- --dir resources/js"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -111,7 +111,17 @@ function getCorsSettings(env: Record<string, string>) {
 
 /** @type {import('vite').UserConfig} */
 export default defineConfig(({ command, mode, isSsrBuild, isPreview } : ConfigEnv) : UserConfig => {
-	const config = baseConfig;
+	const config = { ...baseConfig };
+
+	if (mode === 'development') {
+		console.log("DEVELOPMENT MODE detected");
+		config.build.sourcemap = true;
+		config.build.minify = false; // Ensure no minification in development
+		config.define = {
+			__VUE_OPTIONS_API__: true,
+			__VUE_PROD_DEVTOOLS__: true,
+		};
+	}
 	const env = loadEnv(mode, process.cwd(), "");
 
 	if (config.server === undefined) {


### PR DESCRIPTION
I wanted to make a development build of js files, so that I can see vue componenets, but since I was running the application itself in the docker container, when I run `npm run dev` it did not pick up correct host values. 

so I wanted a way to work on the app with development build of assets. something small but will be useful if you dont want to use the vite HMR server but still want development build

<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.

Don't worry if your code styling isn't perfect! php-cs-fixer will automatically create a pull request with any style fixes. This allows us to focus on the content of the contribution and not the code style.
-->