### PR TITLE
Drop middleware not existing to avoid a 500

### DIFF
--- a/routes/web_v1.php
+++ b/routes/web_v1.php
@@ -28,7 +28,7 @@ Route::feeds();
 // If we are using Livewire by default, we no longer need those routes.
 Route::get('/', [IndexController::class, 'show'])->name('home')->middleware(['migration:complete']);
 Route::get('/gallery', [IndexController::class, 'gallery'])->name('gallery')->middleware(['migration:complete']);
-Route::get('/view', [IndexController::class, 'view'])->name('view')->middleware(['redirect-legacy-id']);
+Route::get('/view', [IndexController::class, 'view'])->name('view');
 Route::get('/frame', [IndexController::class, 'frame'])->name('frame')->middleware(['migration:complete']);
 Route::match(['get', 'post'], '/migrate', [UpdateController::class, 'migrate'])
 	->name('migrate')


### PR DESCRIPTION
This is part of legacy code base, that middleware was in charge of redirecting if the id was in the legacy table and you where using `/view` end point. This is v3 like photo sharing. Dropping the middleware.

Will not be fixed further as this is part of legacy code base and aimed to be dropped completely at some point.