### PR TITLE
Fix S3/symlink mitigation conflation

### DIFF
--- a/app/Models/Extensions/HasUrlGenerator.php
+++ b/app/Models/Extensions/HasUrlGenerator.php
@@ -44,20 +44,20 @@ trait HasUrlGenerator
 			return 'data:image/webp;base64,' . $short_path;
 		}
 
-		if (
-			!Configs::getValueAsBool('SL_enable') ||
-			(!Configs::getValueAsBool('SL_for_admin') && Auth::user()?->may_administrate === true)
-		) {
-			/** @disregard P1013 */
-			return $image_disk->url($short_path);
-		}
-
 		/** @disregard P1013 */
 		$storage_adapter = $image_disk->getAdapter();
 		if ($storage_adapter instanceof AwsS3V3Adapter) {
 			// @codeCoverageIgnoreStart
 			return self::getAwsUrl($short_path, $storage_disk);
 			// @codeCoverageIgnoreEnd
+		}
+
+		if (
+			!Configs::getValueAsBool('SL_enable') ||
+			(!Configs::getValueAsBool('SL_for_admin') && Auth::user()?->may_administrate === true)
+		) {
+			/** @disregard P1013 */
+			return $image_disk->url($short_path);
 		}
 
 		return null;

--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -409,9 +409,17 @@ return [
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/media-src
 		'media-src' => [
 			'self' => true,
-			'allow' => [
-				'blob:', // required for "live" photos
-			],
+			'allow' => array_merge(
+				[
+					'blob:', // required for "live" photos
+				],
+				// Add the S3 URL to the list of allowed image sources
+				env('AWS_ACCESS_KEY_ID', '') === '' ? [] :
+				[
+					// @phpstan-ignore-next-line
+					str_replace(parse_url(env('AWS_URL'), PHP_URL_PATH), '', env('AWS_URL')),
+				]
+			),
 		],
 
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/navigate-to

--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -413,7 +413,7 @@ return [
 				[
 					'blob:', // required for "live" photos
 				],
-				// Add the S3 URL to the list of allowed image sources
+				// Add the S3 URL to the list of allowed media sources
 				env('AWS_ACCESS_KEY_ID', '') === '' ? [] :
 				[
 					// @phpstan-ignore-next-line


### PR DESCRIPTION
<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.

Don't worry if your code styling isn't perfect! php-cs-fixer will automatically create a pull request with any style fixes. This allows us to focus on the content of the contribution and not the code style.
-->

See #3146 for a discussion on this matter. This is the function in question:

https://github.com/LycheeOrg/Lychee/blob/98dbddf65f0c5295b530595abdfc8b4cb44f8a21/app/Models/Extensions/HasUrlGenerator.php#L39-L64

The second check in this function tests if the "Enable symbolic link protection" or "Enable symbolic links on logged in admin user" flags are turned off. (This is a security feature added as of #295.)

The third check tests if we're using S3 storage. As currently written, it's impossible to reach the third test unless both of the aforementioned symlink settings are on.

The issue is that these settings are mutually exclusive. If you're loading from an S3 bucket, there aren't any symlinks to speak of. Turning the setting on will create some anyway and bypass the second check, but then Lychee will get confused when it tries to clean them up later:

```
lychee-1         | chown: cannot dereference '/sym/a36b8f12469b51133f22a5a72db1f7b883af81085c51931e6316f7d4832a120e.jpg': No such file or directory
lychee-1         | chown: cannot dereference '/sym/33be8b6f5c8e6a122bdffb149efbf9bc797b2011570b640b54bbd093391aedfd.jpg': No such file or directory
```

And if you're using a private bucket, your pre-signed URLs achieve the same effect as the symlink mitigation.