### PR TITLE
Fix 500 error when opcache_get_config is not available

### DIFF
--- a/app/Actions/Diagnostics/Pipes/Checks/IniSettingsCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/IniSettingsCheck.php
@@ -123,21 +123,21 @@ class IniSettingsCheck implements DiagnosticPipe
 				$data[] = DiagnosticData::error('tmpfile() is disabled, this will prevent you from uploading pictures.', self::class);
 				// @codeCoverageIgnoreEnd
 			}
-
-			$path = sys_get_temp_dir();
-			if (!is_writable($path)) {
-				// @codeCoverageIgnoreStart
-				$data[] = DiagnosticData::error('sys_get_temp_dir() is not writable, this will prevent you from uploading pictures.', self::class);
-				// @codeCoverageIgnoreEnd
-			}
-			if (!is_readable($path)) {
-				// @codeCoverageIgnoreStart
-				$data[] = DiagnosticData::error('sys_get_temp_dir() is not readable, this will prevent you from uploading pictures.', self::class);
-				// @codeCoverageIgnoreEnd
-			}
 		} catch (InfoException $e) {
 			// @codeCoverageIgnoreStart
 			$data[] = DiagnosticData::error('An error occurred while checking the PHP settings.', self::class, ['ini_get() is not available.']);
+			// @codeCoverageIgnoreEnd
+		}
+
+		$path = sys_get_temp_dir();
+		if (!is_writable($path)) {
+			// @codeCoverageIgnoreStart
+			$data[] = DiagnosticData::error('sys_get_temp_dir() is not writable, this will prevent you from uploading pictures.', self::class);
+			// @codeCoverageIgnoreEnd
+		}
+		if (!is_readable($path)) {
+			// @codeCoverageIgnoreStart
+			$data[] = DiagnosticData::error('sys_get_temp_dir() is not readable, this will prevent you from uploading pictures.', self::class);
 			// @codeCoverageIgnoreEnd
 		}
 

--- a/app/Actions/Diagnostics/Pipes/Checks/IniSettingsCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/IniSettingsCheck.php
@@ -13,6 +13,7 @@ use App\DTO\DiagnosticData;
 use App\Facades\Helpers;
 use App\Models\Configs;
 use LycheeVerify\Verify;
+use Safe\Exceptions\InfoException;
 use function Safe\ini_get;
 use function Safe\preg_match;
 
@@ -39,98 +40,104 @@ class IniSettingsCheck implements DiagnosticPipe
 			$data[] = DiagnosticData::warn('Your installation has been tampered. Please verify the integrity of your files.', self::class);
 		}
 
-		if (Helpers::convertSize(ini_get('upload_max_filesize')) < Helpers::convertSize(('30M'))) {
-			$data[] = DiagnosticData::warn('You may experience problems when uploading a photo of large size. Take a look in the FAQ for details.', self::class);
-		}
-		if (Helpers::convertSize(ini_get('post_max_size')) < Helpers::convertSize(('100M'))) {
-			$data[] = DiagnosticData::warn('You may experience problems when uploading a photo of large size. Take a look in the FAQ for details.', self::class);
-		}
-		$max_execution_time = intval(ini_get('max_execution_time'));
-		if (0 < $max_execution_time && $max_execution_time < 200) {
-			// @codeCoverageIgnoreStart
-			$data[] = DiagnosticData::warn('You may experience problems when uploading a photo of large size or handling many/large albums. Take a look in the FAQ for details.', self::class);
-			// @codeCoverageIgnoreEnd
-		}
-		if (filter_var(ini_get('allow_url_fopen'), FILTER_VALIDATE_BOOLEAN) !== true) {
-			// @codeCoverageIgnoreStart
-			$data[] = DiagnosticData::warn('You may experience problems with the Dropbox- and URL-Import. Edit your php.ini and set allow_url_fopen to 1.', self::class);
-			// @codeCoverageIgnoreEnd
-		}
-
-		// Check imagick
-		if (!extension_loaded('imagick')) {
-			// @codeCoverageIgnoreStart
-			$data[] = DiagnosticData::warn('Pictures that are rotated lose their metadata! Please install Imagick to avoid that.', self::class);
-		// @codeCoverageIgnoreEnd
-		} else {
-			if (!isset($settings['imagick'])) {
+		try {
+			if (Helpers::convertSize(ini_get('upload_max_filesize')) < Helpers::convertSize(('30M'))) {
+				$data[] = DiagnosticData::warn('You may experience problems when uploading a photo of large size. Take a look in the FAQ for details.', self::class);
+			}
+			if (Helpers::convertSize(ini_get('post_max_size')) < Helpers::convertSize(('100M'))) {
+				$data[] = DiagnosticData::warn('You may experience problems when uploading a photo of large size. Take a look in the FAQ for details.', self::class);
+			}
+			$max_execution_time = intval(ini_get('max_execution_time'));
+			if (0 < $max_execution_time && $max_execution_time < 200) {
 				// @codeCoverageIgnoreStart
-				$data[] = DiagnosticData::warn('Pictures that are rotated lose their metadata! Please enable Imagick in settings to avoid that.', self::class);
+				$data[] = DiagnosticData::warn('You may experience problems when uploading a photo of large size or handling many/large albums. Take a look in the FAQ for details.', self::class);
 				// @codeCoverageIgnoreEnd
 			}
-		}
+			if (filter_var(ini_get('allow_url_fopen'), FILTER_VALIDATE_BOOLEAN) !== true) {
+				// @codeCoverageIgnoreStart
+				$data[] = DiagnosticData::warn('You may experience problems with the Dropbox- and URL-Import. Edit your php.ini and set allow_url_fopen to 1.', self::class);
+				// @codeCoverageIgnoreEnd
+			}
 
-		if (!Helpers::isExecAvailable()) {
-			// @codeCoverageIgnoreStart
-			$data[] = DiagnosticData::warn('exec function has been disabled. You may experience some error 500, please report them to us.', self::class);
+			// Check imagick
+			if (!extension_loaded('imagick')) {
+				// @codeCoverageIgnoreStart
+				$data[] = DiagnosticData::warn('Pictures that are rotated lose their metadata! Please install Imagick to avoid that.', self::class);
 			// @codeCoverageIgnoreEnd
-		}
+			} else {
+				if (!isset($settings['imagick'])) {
+					// @codeCoverageIgnoreStart
+					$data[] = DiagnosticData::warn('Pictures that are rotated lose their metadata! Please enable Imagick in settings to avoid that.', self::class);
+					// @codeCoverageIgnoreEnd
+				}
+			}
 
-		if (preg_match('!^[-_a-zA-Z]+/\d+(\.\d+)*[a-z]? \(.*\)!', ini_get('user_agent')) === 0) {
-			// @codeCoverageIgnoreStart
-			$data[] = DiagnosticData::warn('user_agent for PHP is not properly set. You may experience problems when importing images via URL.', self::class);
-			// @codeCoverageIgnoreEnd
-		}
+			if (!Helpers::isExecAvailable()) {
+				// @codeCoverageIgnoreStart
+				$data[] = DiagnosticData::warn('exec function has been disabled. You may experience some error 500, please report them to us.', self::class);
+				// @codeCoverageIgnoreEnd
+			}
 
-		if (extension_loaded('xdebug')) {
-			// @codeCoverageIgnoreStart
-			$msg = config('app.debug') !== true
-			? DiagnosticData::error('xdebug is enabled although Lychee is not in debug mode. Outside of debugging, xdebug will generate significant slowdown on your application.', self::class)
-			: DiagnosticData::warn('xdebug is enabled. This will generate significant slowdown on your application.', self::class);
-			$data[] = $msg;
-			// @codeCoverageIgnoreEnd
-		}
+			if (preg_match('!^[-_a-zA-Z]+/\d+(\.\d+)*[a-z]? \(.*\)!', ini_get('user_agent')) === 0) {
+				// @codeCoverageIgnoreStart
+				$data[] = DiagnosticData::warn('user_agent for PHP is not properly set. You may experience problems when importing images via URL.', self::class);
+				// @codeCoverageIgnoreEnd
+			}
 
-		if (extension_loaded('xdebug')) {
-			// @codeCoverageIgnoreStart
-			$data[] = DiagnosticData::info('xdebug mode:' . ini_get('xdebug.mode'), self::class);
-			$data[] = DiagnosticData::info('xdebug start_with_request:' . ini_get('xdebug.start_with_request'), self::class);
-			// @codeCoverageIgnoreEnd
-		}
+			if (extension_loaded('xdebug')) {
+				// @codeCoverageIgnoreStart
+				$msg = config('app.debug') !== true
+				? DiagnosticData::error('xdebug is enabled although Lychee is not in debug mode. Outside of debugging, xdebug will generate significant slowdown on your application.', self::class)
+				: DiagnosticData::warn('xdebug is enabled. This will generate significant slowdown on your application.', self::class);
+				$data[] = $msg;
+				// @codeCoverageIgnoreEnd
+			}
 
-		if (ini_get('assert.exception') !== '1') {
-			// @codeCoverageIgnoreStart
-			$data[] = DiagnosticData::warn('assert.exception is set to false. Lychee assumes that failing assertions throw proper exceptions.', self::class);
-			// @codeCoverageIgnoreEnd
-		}
+			if (extension_loaded('xdebug')) {
+				// @codeCoverageIgnoreStart
+				$data[] = DiagnosticData::info('xdebug mode:' . ini_get('xdebug.mode'), self::class);
+				$data[] = DiagnosticData::info('xdebug start_with_request:' . ini_get('xdebug.start_with_request'), self::class);
+				// @codeCoverageIgnoreEnd
+			}
 
-		if (ini_get('zend.assertions') !== '-1' && config('app.debug') !== true) {
-			// @codeCoverageIgnoreStart
-			$data[] = DiagnosticData::warn('zend.assertions is enabled although Lychee is not in debug mode. Outside of debugging, code generation for assertions is recommended to be disabled for efficiency reasons', self::class);
-			// @codeCoverageIgnoreEnd
-		}
+			if (ini_get('assert.exception') !== '1') {
+				// @codeCoverageIgnoreStart
+				$data[] = DiagnosticData::warn('assert.exception is set to false. Lychee assumes that failing assertions throw proper exceptions.', self::class);
+				// @codeCoverageIgnoreEnd
+			}
 
-		if (ini_get('zend.assertions') !== '1' && config('app.debug') === true) {
-			$data[] = DiagnosticData::warn('zend.assertions is disabled although Lychee is in debug mode. For easier debugging code generation for assertions should be enabled.', self::class);
-		}
+			if (ini_get('zend.assertions') !== '-1' && config('app.debug') !== true) {
+				// @codeCoverageIgnoreStart
+				$data[] = DiagnosticData::warn('zend.assertions is enabled although Lychee is not in debug mode. Outside of debugging, code generation for assertions is recommended to be disabled for efficiency reasons', self::class);
+				// @codeCoverageIgnoreEnd
+			}
 
-		$disabled_functions = explode(',', ini_get('disable_functions'));
-		$tmpfile_exists = function_exists('tmpfile') && !in_array('tmpfile', $disabled_functions, true);
-		if ($tmpfile_exists !== true) {
-			// @codeCoverageIgnoreStart
-			$data[] = DiagnosticData::error('tmpfile() is disabled, this will prevent you from uploading pictures.', self::class);
-			// @codeCoverageIgnoreEnd
-		}
+			if (ini_get('zend.assertions') !== '1' && config('app.debug') === true) {
+				$data[] = DiagnosticData::warn('zend.assertions is disabled although Lychee is in debug mode. For easier debugging code generation for assertions should be enabled.', self::class);
+			}
 
-		$path = sys_get_temp_dir();
-		if (!is_writable($path)) {
+			$disabled_functions = explode(',', ini_get('disable_functions'));
+			$tmpfile_exists = function_exists('tmpfile') && !in_array('tmpfile', $disabled_functions, true);
+			if ($tmpfile_exists !== true) {
+				// @codeCoverageIgnoreStart
+				$data[] = DiagnosticData::error('tmpfile() is disabled, this will prevent you from uploading pictures.', self::class);
+				// @codeCoverageIgnoreEnd
+			}
+
+			$path = sys_get_temp_dir();
+			if (!is_writable($path)) {
+				// @codeCoverageIgnoreStart
+				$data[] = DiagnosticData::error('sys_get_temp_dir() is not writable, this will prevent you from uploading pictures.', self::class);
+				// @codeCoverageIgnoreEnd
+			}
+			if (!is_readable($path)) {
+				// @codeCoverageIgnoreStart
+				$data[] = DiagnosticData::error('sys_get_temp_dir() is not readable, this will prevent you from uploading pictures.', self::class);
+				// @codeCoverageIgnoreEnd
+			}
+		} catch (InfoException $e) {
 			// @codeCoverageIgnoreStart
-			$data[] = DiagnosticData::error('sys_get_temp_dir() is not writable, this will prevent you from uploading pictures.', self::class);
-			// @codeCoverageIgnoreEnd
-		}
-		if (!is_readable($path)) {
-			// @codeCoverageIgnoreStart
-			$data[] = DiagnosticData::error('sys_get_temp_dir() is not readable, this will prevent you from uploading pictures.', self::class);
+			$data[] = DiagnosticData::error('An error occurred while checking the PHP settings.', self::class, ['ini_get() is not available.']);
 			// @codeCoverageIgnoreEnd
 		}
 

--- a/app/Actions/Diagnostics/Pipes/Checks/OpCacheCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/OpCacheCheck.php
@@ -10,6 +10,8 @@ namespace App\Actions\Diagnostics\Pipes\Checks;
 
 use App\Contracts\DiagnosticPipe;
 use App\DTO\DiagnosticData;
+use Safe\Exceptions\InfoException;
+use function Safe\ini_get;
 
 /**
  * We want to make sure that our users are using OPcache for faster php code execution.
@@ -45,8 +47,12 @@ class OpCacheCheck implements DiagnosticPipe
 	 */
 	private function isOpcacheGetConfigurationAvailable(): bool
 	{
-		$disabled_functions = explode(',', ini_get('disable_functions'));
+		try {
+			$disabled_functions = explode(',', ini_get('disable_functions'));
 
-		return function_exists('opcache_get_configuration') && !in_array('opcache_get_configuration', $disabled_functions, true);
+			return function_exists('opcache_get_configuration') && !in_array('opcache_get_configuration', $disabled_functions, true);
+		} catch (InfoException $e) {
+			return false;
+		}
 	}
 }

--- a/app/Actions/Diagnostics/Pipes/Checks/OpCacheCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/OpCacheCheck.php
@@ -21,6 +21,12 @@ class OpCacheCheck implements DiagnosticPipe
 	 */
 	public function handle(array &$data, \Closure $next): array
 	{
+		if (!$this->isOpcacheGetConfigurationAvailable()) {
+			$data[] = DiagnosticData::warn('opcache_get_configuration() is not available.', self::class, ['We are unable to check for performance optimizations.']);
+
+			return $next($data);
+		}
+
 		$opcache_conf = opcache_get_configuration();
 
 		if (
@@ -32,5 +38,15 @@ class OpCacheCheck implements DiagnosticPipe
 		}
 
 		return $next($data);
+	}
+
+	/**
+	 * Check if the `opcache_get_configuration` function is available.
+	 */
+	private function isOpcacheGetConfigurationAvailable(): bool
+	{
+		$disabled_functions = explode(',', ini_get('disable_functions'));
+
+		return function_exists('opcache_get_configuration') && !in_array('opcache_get_configuration', $disabled_functions, true);
 	}
 }

--- a/app/Assets/Helpers.php
+++ b/app/Assets/Helpers.php
@@ -12,6 +12,7 @@ use App\Exceptions\Internal\ZeroModuloException;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\File;
+use Safe\Exceptions\InfoException;
 use function Safe\ini_get;
 
 class Helpers
@@ -127,9 +128,13 @@ class Helpers
 	 */
 	public function isExecAvailable(): bool
 	{
-		$disabled_functions = explode(',', ini_get('disable_functions'));
+		try {
+			$disabled_functions = explode(',', ini_get('disable_functions'));
 
-		return function_exists('exec') && !in_array('exec', $disabled_functions, true);
+			return function_exists('exec') && !in_array('exec', $disabled_functions, true);
+		} catch (InfoException $e) {
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
This kills the "smart" diagnostics in e.g. LinuxServer installs...