### PR TITLE
Fix 500 on direct photo access without small variants

### DIFF
--- a/app/View/Components/Meta.php
+++ b/app/View/Components/Meta.php
@@ -91,7 +91,7 @@ class Meta extends Component
 		if ($this->photo !== null) {
 			$this->page_title = $this->photo->title;
 			$this->page_description = $this->photo->description ?? Configs::getValueAsString('site_title');
-			$this->image_url = $this->photo->size_variants->getSmall()->url;
+			$this->image_url = $this->photo->size_variants->getSmall()?->url ?? $this->image_url;
 		}
 	}
 


### PR DESCRIPTION
Fix 500 thrown when there are no small thumbs existing and trying to access directly
