### PR TITLE
Improve left menu

### DIFF
--- a/app/Http/Resources/Rights/GlobalRightsResource.php
+++ b/app/Http/Resources/Rights/GlobalRightsResource.php
@@ -18,9 +18,11 @@ class GlobalRightsResource extends Data
 	public SettingsRightsResource $settings;
 	public UserManagementRightsResource $user_management;
 	public UserRightsResource $user;
+	public ModulesRightsResource $modules;
 
 	public function __construct()
 	{
+		$this->modules = new ModulesRightsResource();
 		$this->root_album = new RootAlbumRightsResource();
 		$this->settings = new SettingsRightsResource();
 		$this->user_management = new UserManagementRightsResource();

--- a/app/Http/Resources/Rights/ModulesRightsResource.php
+++ b/app/Http/Resources/Rights/ModulesRightsResource.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Rights;
+
+use App\Contracts\Models\AbstractAlbum;
+use App\Factories\AlbumFactory;
+use App\Models\Configs;
+use App\Models\Photo;
+use App\Policies\AlbumPolicy;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class ModulesRightsResource extends Data
+{
+	public bool $is_map_enabled = false;
+	public bool $is_mod_frame_enabled = false;
+	public bool $is_photo_timeline_enabled = false;
+
+	public function __construct()
+	{
+		$is_logged_in = Auth::check();
+		$count_locations = Photo::whereNotNull('latitude')->whereNotNull('longitude')->count() > 0;
+		$map_display = Configs::getValueAsBool('map_display');
+		$public_display = $is_logged_in || Configs::getValueAsBool('map_display_public');
+
+		$this->is_map_enabled = $count_locations && $map_display && $public_display;
+		$this->is_mod_frame_enabled = $this->checkModFrameEnabled();
+
+		$timeline_photos_enabled = Configs::getValueAsBool('timeline_photos_enabled');
+		$timeline_photos_public = Configs::getValueAsBool('timeline_photos_public');
+		$this->is_photo_timeline_enabled = $timeline_photos_enabled && ($is_logged_in || $timeline_photos_public);
+	}
+
+	private function checkModFrameEnabled(): bool
+	{
+		if (!Configs::getValueAsBool('mod_frame_enabled')) {
+			return false;
+		}
+
+		$factory = resolve(AlbumFactory::class);
+		try {
+			$random_album_id = Configs::getValueAsString('random_album_id');
+			$random_album_id = ($random_album_id !== '') ? $random_album_id : null;
+			$album = $factory->findNullalbleAbstractAlbumOrFail($random_album_id);
+
+			return Gate::check(AlbumPolicy::CAN_ACCESS, [AbstractAlbum::class, $album]);
+		} catch (\Throwable) {
+			Log::critical('Could not find random album for frame with ID:' . Configs::getValueAsString('random_album_id'));
+
+			return false;
+		}
+	}
+}

--- a/lang/cz/gallery.php
+++ b/lang/cz/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/cz/left-menu.php
+++ b/lang/cz/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/de/gallery.php
+++ b/lang/de/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/de/left-menu.php
+++ b/lang/de/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/el/gallery.php
+++ b/lang/el/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/el/left-menu.php
+++ b/lang/el/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/en/gallery.php
+++ b/lang/en/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/en/left-menu.php
+++ b/lang/en/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/es/gallery.php
+++ b/lang/es/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/es/left-menu.php
+++ b/lang/es/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/fr/gallery.php
+++ b/lang/fr/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Albums intelligents',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Moyen',

--- a/lang/fr/left-menu.php
+++ b/lang/fr/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Retour à la galerie',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Administration',
 	'clockwork' => 'Application Clockwork',
 	'logs' => 'Afficher les journaux',

--- a/lang/hu/gallery.php
+++ b/lang/hu/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/hu/left-menu.php
+++ b/lang/hu/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/it/gallery.php
+++ b/lang/it/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/it/left-menu.php
+++ b/lang/it/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/ja/gallery.php
+++ b/lang/ja/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/ja/left-menu.php
+++ b/lang/ja/left-menu.php
@@ -14,6 +14,11 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/ja/left-menu.php
+++ b/lang/ja/left-menu.php
@@ -17,8 +17,6 @@ return [
 	'login' => 'Login',
 	'frame' => 'Frame',
 	'map' => 'Map',
-	'frame' => 'Frame',
-	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/nl/gallery.php
+++ b/lang/nl/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/nl/left-menu.php
+++ b/lang/nl/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/no/gallery.php
+++ b/lang/no/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/no/left-menu.php
+++ b/lang/no/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/pl/gallery.php
+++ b/lang/pl/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Inteligentne albumy',
 	'albums' => 'Albumy',
 	'root' => 'Albumy',
+	'favourites' => 'Favourites',
 
 	'original' => 'Oryginał',
 	'medium' => 'Średni',

--- a/lang/pl/left-menu.php
+++ b/lang/pl/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Powrót do galerii',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Administrator',
 	'clockwork' => 'clockwork',
 	'logs' => 'Pokaż dzienniki',

--- a/lang/pt/gallery.php
+++ b/lang/pt/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/pt/left-menu.php
+++ b/lang/pt/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/ru/gallery.php
+++ b/lang/ru/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Умные альбомы',
 	'albums' => 'Альбомы',
 	'root' => 'Альбомы',
+	'favourites' => 'Favourites',
 
 	'original' => 'Оригинал',
 	'medium' => 'Средний',

--- a/lang/ru/left-menu.php
+++ b/lang/ru/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Вернуться в галерею',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Админ',
 	'clockwork' => 'Приложение Clockwork',
 	'logs' => 'Показать логи',

--- a/lang/sk/gallery.php
+++ b/lang/sk/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/sk/left-menu.php
+++ b/lang/sk/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/sv/gallery.php
+++ b/lang/sv/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/sv/left-menu.php
+++ b/lang/sv/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/vi/gallery.php
+++ b/lang/vi/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/vi/left-menu.php
+++ b/lang/vi/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/lang/zh_CN/gallery.php
+++ b/lang/zh_CN/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => '智能相册',
 	'albums' => '相册',
 	'root' => '相册',
+	'favourites' => 'Favourites',
 
 	'original' => '原图',
 	'medium' => '中等',

--- a/lang/zh_CN/left-menu.php
+++ b/lang/zh_CN/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => '返回相册',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => '管理',
 	'clockwork' => 'Clockwork 应用',
 	'logs' => '查看日志',

--- a/lang/zh_TW/gallery.php
+++ b/lang/zh_TW/gallery.php
@@ -17,6 +17,7 @@ return [
 	'smart_albums' => 'Smart albums',
 	'albums' => 'Albums',
 	'root' => 'Albums',
+	'favourites' => 'Favourites',
 
 	'original' => 'Original',
 	'medium' => 'Medium',

--- a/lang/zh_TW/left-menu.php
+++ b/lang/zh_TW/left-menu.php
@@ -14,6 +14,9 @@ return [
 	*/
 	'back_to_gallery' => 'Back to Gallery',
 
+	'login' => 'Login',
+	'frame' => 'Frame',
+	'map' => 'Map',
 	'admin' => 'Admin',
 	'clockwork' => 'Clockwork App',
 	'logs' => 'Show Logs',

--- a/resources/js/components/gallery/albumModule/AlbumHero.vue
+++ b/resources/js/components/gallery/albumModule/AlbumHero.vue
@@ -55,10 +55,34 @@
 				<a
 					v-if="is_se_preview_enabled && user?.id !== null"
 					class="shrink-0 px-3 cursor-not-allowed text-primary-emphasis"
-					v-tooltip.left="$t('gallery.album.hero.stats_only_se')"
+					v-tooltip.bottom="$t('gallery.album.hero.stats_only_se')"
 				>
 					<i class="pi pi-chart-scatter" />
 				</a>
+				<router-link
+					:to="{ name: 'frame-with-album', params: { albumid: props.album.id } }"
+					v-if="props.config.is_mod_frame_enabled"
+					class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+					v-tooltip.bottom="'Frame'"
+				>
+					<i class="pi pi-desktop" />
+				</router-link>
+				<router-link
+					:to="{ name: 'map-with-album', params: { albumid: props.album.id } }"
+					v-if="props.config.is_map_accessible && hasCoordinates"
+					class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+				>
+					<i class="pi pi-map" />
+				</router-link>
+				<a
+					v-tooltip.bottom="'Start slideshow'"
+					@click="emits('toggleSlideShow')"
+					v-if="props.album.photos.length > 0"
+					class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+				>
+					<i class="pi pi-play" />
+				</a>
+
 				<template v-if="isTouchDevice() && user?.id !== null">
 					<a
 						v-if="props.hasHidden && are_nsfw_visible"
@@ -93,6 +117,7 @@ import { useLycheeStateStore } from "@/stores/LycheeState";
 import { isTouchDevice } from "@/utils/keybindings-utils";
 import { storeToRefs } from "pinia";
 import Card from "primevue/card";
+import { computed } from "vue";
 
 const auth = useAuthStore();
 const lycheeStore = useLycheeStateStore();
@@ -102,19 +127,26 @@ const { user } = storeToRefs(auth);
 const props = defineProps<{
 	album: App.Http.Resources.Models.AlbumResource | App.Http.Resources.Models.TagAlbumResource | App.Http.Resources.Models.SmartAlbumResource;
 	hasHidden: boolean;
+	config: {
+		is_map_accessible: boolean;
+		is_mod_frame_enabled: boolean;
+	};
 }>();
 
+const hasCoordinates = computed(() => props.album.photos.some((photo) => photo.latitude !== null && photo.longitude !== null));
+
 const emits = defineEmits<{
-	"open-sharing-modal": [];
-	"open-statistics": [];
+	openSharingModal: [];
+	openStatistics: [];
+	toggleSlideShow: [];
 }>();
 
 function openSharingModal() {
-	emits("open-sharing-modal");
+	emits("openSharingModal");
 }
 
 function openStatistics() {
-	emits("open-statistics");
+	emits("openStatistics");
 }
 
 function download() {

--- a/resources/js/components/gallery/albumModule/AlbumPanel.vue
+++ b/resources/js/components/gallery/albumModule/AlbumPanel.vue
@@ -8,7 +8,6 @@
 				:config="config"
 				:user="user"
 				@refresh="emits('refresh')"
-				@toggle-slide-show="emits('toggleSlideShow')"
 				@toggle-edit="emits('toggleEdit')"
 				@open-search="emits('openSearch')"
 				@go-back="emits('goBack')"
@@ -37,9 +36,11 @@
 				<AlbumHero
 					v-if="!noData"
 					:album="album"
+					:config="config"
 					:has-hidden="hasHidden"
 					@open-sharing-modal="toggleShareAlbum"
 					@open-statistics="toggleStatistics"
+					@toggle-slide-show="emits('toggleSlideShow')"
 				/>
 				<template v-if="is_se_enabled && user?.id !== null">
 					<AlbumStatistics

--- a/resources/js/components/headers/AlbumHeader.vue
+++ b/resources/js/components/headers/AlbumHeader.vue
@@ -20,31 +20,6 @@
 				<Button icon="pi pi-heart" class="border-none" severity="secondary" text />
 			</router-link>
 			<Button
-				v-tooltip.bottom="'Start slideshow'"
-				icon="pi pi-play"
-				class="border-none"
-				severity="secondary"
-				text
-				@click="emits('toggleSlideShow')"
-				v-if="props.album.photos.length > 0"
-				label=""
-			/>
-			<router-link
-				:to="{ name: 'frame-with-album', params: { albumid: props.album.id } }"
-				v-if="props.config.is_mod_frame_enabled"
-				class="hidden sm:block"
-				v-tooltip="'Frame'"
-			>
-				<Button icon="pi pi-desktop" class="border-none" severity="secondary" text />
-			</router-link>
-			<router-link
-				:to="{ name: 'map-with-album', params: { albumid: props.album.id } }"
-				v-if="props.config.is_map_accessible && hasCoordinates"
-				class="hidden sm:block"
-			>
-				<Button icon="pi pi-map" class="border-none" severity="secondary" text />
-			</router-link>
-			<Button
 				icon="pi pi-search"
 				class="border-none hidden sm:block"
 				severity="secondary"
@@ -108,14 +83,11 @@ const favourites = useFavouriteStore();
 const { dropbox_api_key } = storeToRefs(lycheeStore);
 const { is_album_edit_open } = storeToRefs(togglableStore);
 
-const hasCoordinates = computed(() => props.album.photos.find((photo) => photo.latitude !== null && photo.longitude !== null) !== undefined);
-
 const { toggleCreateAlbum, is_import_from_link_open, toggleImportFromLink, is_import_from_dropbox_open, toggleImportFromDropbox, toggleUpload } =
 	useGalleryModals(togglableStore);
 
 const emits = defineEmits<{
 	refresh: [];
-	toggleSlideShow: [];
 	toggleEdit: [];
 	goBack: [];
 	openSearch: [];

--- a/resources/js/components/headers/AlbumsHeader.vue
+++ b/resources/js/components/headers/AlbumsHeader.vue
@@ -8,7 +8,7 @@
 	>
 		<template #start>
 			<!-- Not logged in. -->
-			<BackLinkButton v-if="props.user.id === null && !isLoginLeft" :config="props.config" />
+			<!-- <BackLinkButton v-if="props.user.id === null && !isLoginLeft" :config="props.config" />
 			<Button
 				v-if="props.user.id === null && isLoginLeft"
 				icon="pi pi-sign-in"
@@ -16,9 +16,9 @@
 				severity="secondary"
 				text
 				@click="togglableStore.toggleLogin()"
-			/>
+			/> -->
 			<!-- Logged in. -->
-			<OpenLeftMenu v-if="user.id" />
+			<OpenLeftMenu />
 		</template>
 
 		<template #center>
@@ -97,14 +97,13 @@ import DropBox from "../modals/DropBox.vue";
 import BackLinkButton from "./BackLinkButton.vue";
 import OpenLeftMenu from "./OpenLeftMenu.vue";
 import { useFavouriteStore } from "@/stores/FavouriteState";
+import { useLeftMenuStateStore } from "@/stores/LeftMenuState";
 
 const props = defineProps<{
 	user: App.Http.Resources.Models.UserResource;
 	title: string;
 	rights: App.Http.Resources.Rights.RootAlbumRightsResource;
 	config: {
-		is_map_accessible: boolean;
-		is_mod_frame_enabled: boolean;
 		is_search_accessible: boolean;
 		show_keybinding_help_button: boolean;
 		back_button_enabled: boolean;
@@ -120,6 +119,7 @@ const emits = defineEmits<{
 	help: [];
 }>();
 
+const leftMenuStore = useLeftMenuStateStore();
 const lycheeStore = useLycheeStateStore();
 const togglableStore = useTogglablesStateStore();
 const favourites = useFavouriteStore();
@@ -199,7 +199,7 @@ onKeyStroke("escape", () => {
 		return;
 	}
 
-	togglableStore.left_menu_open = false;
+	leftMenuStore.left_menu_open = false;
 });
 
 type Link = {
@@ -223,18 +223,6 @@ const menu = computed(() =>
 			type: "link",
 			icon: "pi pi-heart",
 			if: (favourites.photos?.length ?? 0) > 0,
-		},
-		{
-			to: { name: "frame" },
-			type: "link",
-			icon: "pi pi-desktop",
-			if: props.config.is_mod_frame_enabled,
-		},
-		{
-			to: { name: "map" },
-			type: "link",
-			icon: "pi pi-map",
-			if: props.config.is_map_accessible,
 		},
 		{
 			icon: "pi pi-search",

--- a/resources/js/components/headers/OpenLeftMenu.vue
+++ b/resources/js/components/headers/OpenLeftMenu.vue
@@ -2,11 +2,11 @@
 	<Button @click="openLeftMenu" icon="pi pi-bars" class="mr-2 border-none" severity="secondary" text />
 </template>
 <script setup lang="ts">
-import { useTogglablesStateStore } from "@/stores/ModalsState";
+import { useLeftMenuStateStore } from "@/stores/LeftMenuState";
 import { storeToRefs } from "pinia";
 import Button from "primevue/button";
 
-const togglableStore = useTogglablesStateStore();
-const { left_menu_open } = storeToRefs(togglableStore);
+const leftMenuStore = useLeftMenuStateStore();
+const { left_menu_open } = storeToRefs(leftMenuStore);
 const openLeftMenu = () => (left_menu_open.value = !left_menu_open.value);
 </script>

--- a/resources/js/components/icons/MiniIcon.vue
+++ b/resources/js/components/icons/MiniIcon.vue
@@ -1,5 +1,5 @@
 <template>
-	<svg :class="'inline-block ' + props.fill + ' ' + props.class">
+	<svg :class="'inline-block ' + (props.fill ?? 'fill-neutral-400') + ' ' + (props.class ?? '')">
 		<use :xlink:href="'#' + props.icon" />
 	</svg>
 </template>
@@ -11,8 +11,5 @@ type IconProps = {
 	icon: string;
 };
 
-const props = withDefaults(defineProps<IconProps>(), {
-	class: "",
-	fill: "fill-neutral-400",
-});
+const props = defineProps<IconProps>();
 </script>

--- a/resources/js/components/icons/PiMiniIcon.vue
+++ b/resources/js/components/icons/PiMiniIcon.vue
@@ -1,0 +1,14 @@
+<template>
+	<template v-if="props.icon">
+		<MiniIcon :icon="props.icon" :class="props.class ?? 'w-3 h-3'" v-if="!props.icon.startsWith('pi')" />
+		<i v-else :class="props.icon + ' ' + props.class" />
+	</template>
+</template>
+<script lang="ts" setup>
+import MiniIcon from "./MiniIcon.vue";
+
+const props = defineProps<{
+	icon: string | undefined;
+	class?: string;
+}>();
+</script>

--- a/resources/js/composables/contextMenus/leftMenu.ts
+++ b/resources/js/composables/contextMenus/leftMenu.ts
@@ -1,0 +1,211 @@
+import Constants from "@/services/constants";
+import InitService from "@/services/init-service";
+import { AuthStore } from "@/stores/Auth";
+import { LeftMenuStateStore } from "@/stores/LeftMenuState";
+import { LycheeStateStore } from "@/stores/LycheeState";
+import { storeToRefs } from "pinia";
+import { computed, ref } from "vue";
+
+export type MenyType =
+	| {
+			label: string;
+			icon: string;
+			route?: string;
+			url?: string;
+			target?: string;
+			access: boolean;
+			seTag?: boolean;
+			command?: () => void;
+	  }
+	| {
+			label: string;
+			items: MenyType[];
+	  };
+
+export function useLeftMenu(lycheeStore: LycheeStateStore, LeftMenuStateStore: LeftMenuStateStore, authStore: AuthStore) {
+	const { user } = storeToRefs(authStore);
+
+	const { initData, left_menu_open } = storeToRefs(LeftMenuStateStore);
+	const { clockwork_url, is_se_enabled, is_se_preview_enabled, is_se_info_hidden } = storeToRefs(lycheeStore);
+	const openLycheeAbout = ref(false);
+	const logsEnabled = ref(true);
+
+	const canSeeAdmin = computed(() => {
+		return (
+			initData.value?.settings.can_edit ||
+			initData.value?.user_management.can_edit ||
+			initData.value?.settings.can_see_diagnostics ||
+			initData.value?.settings.can_see_logs ||
+			false
+		);
+	});
+
+	function load() {
+		InitService.fetchGlobalRights().then((data) => {
+			initData.value = data.data;
+		});
+	}
+
+	const items = computed<MenyType[]>(() => {
+		if (!initData.value) {
+			return [];
+		}
+
+		const baseMenu = [
+			{
+				label: "Frame",
+				icon: "pi pi-desktop",
+				access: initData.value.modules.is_mod_frame_enabled ?? false,
+				route: "/frame",
+			},
+			{
+				label: "Map",
+				icon: "pi pi-map",
+				access: initData.value.modules.is_map_enabled ?? false,
+				route: "/map",
+			},
+			{
+				label: "left-menu.admin",
+				access: canSeeAdmin.value,
+				items: [
+					{
+						label: "settings.title",
+						icon: "cog",
+						route: "/settings",
+						access: initData.value.settings.can_edit ?? false,
+					},
+					{
+						label: "users.title",
+						icon: "people",
+						route: "/users",
+						access: initData.value.user_management.can_edit ?? false,
+					},
+					{
+						label: "diagnostics.title",
+						icon: "wrench",
+						route: "/diagnostics",
+						access: initData.value.settings.can_see_diagnostics ?? false,
+					},
+					{
+						label: "maintenance.title",
+						icon: "timer",
+						route: "/maintenance",
+						access: initData.value.settings.can_edit ?? false,
+					},
+					{
+						label: "left-menu.logs",
+						icon: "excerpt",
+						url: Constants.BASE_URL + "/Logs",
+						access: (initData.value.settings.can_see_logs ?? false) && logsEnabled.value,
+					},
+					{
+						label: "left-menu.logs",
+						icon: "excerpt",
+						access: (initData.value.settings.can_see_logs ?? false) && !logsEnabled.value,
+					},
+					{
+						label: "left-menu.jobs",
+						icon: "project",
+						route: "/jobs",
+						access: initData.value.settings.can_see_logs ?? false,
+					},
+					{
+						label: "left-menu.clockwork",
+						icon: "telescope",
+						url: clockwork_url.value ?? "",
+						access: clockwork_url.value !== null && (initData.value.settings.can_access_dev_tools ?? false),
+					},
+				],
+			},
+			{
+				label: "Lychee",
+				items: [
+					{
+						label: "left-menu.about",
+						icon: "info",
+						access: true,
+						command: () => (openLycheeAbout.value = true),
+					},
+					{
+						label: "left-menu.changelog",
+						icon: "copywriting",
+						access: true,
+						route: "/changelogs",
+					},
+					{
+						label: "left-menu.api",
+						icon: "book",
+						access: initData.value.settings.can_edit ?? false,
+						url: "/docs/api",
+					},
+					{
+						label: "left-menu.source_code",
+						icon: "code",
+						access: user.value?.id === null || is_se_info_hidden.value === false,
+						url: "https://github.com/LycheeOrg/Lychee",
+					},
+					{
+						label: "left-menu.support",
+						icon: "heart",
+						access: is_se_info_hidden.value === false,
+						url: "https://lycheeorg.dev/get-supporter-edition/",
+					},
+				],
+			},
+		];
+
+		return baseMenu.filter((item) => {
+			if (item.items) {
+				item.items = item.items.filter((subItem) => subItem.access !== false);
+				return item.items.length > 0;
+			}
+			return item.access !== false;
+		});
+	});
+
+	const profileItems = computed<MenyType[]>(() => {
+		if (!initData.value) {
+			return [];
+		}
+		const userMenu = [
+			{
+				label: "left-menu.user",
+				icon: "person",
+				route: "/profile",
+				access: initData.value.user.can_edit ?? false,
+			},
+			{
+				label: "sharing.title",
+				icon: "cloud",
+				route: "/sharing",
+				access: initData.value.root_album.can_upload ?? false,
+			},
+			{
+				label: "statistics.title",
+				icon: "bar-chart",
+				route: "/statistics",
+				access: is_se_enabled.value === true,
+			},
+			{
+				label: "statistics.title",
+				icon: "bar-chart",
+				route: "/statistics",
+				access: is_se_enabled.value === false && is_se_preview_enabled.value === true,
+				seTag: true,
+			},
+		];
+
+		return userMenu.filter((item) => item.access !== false);
+	});
+
+	return {
+		user,
+		left_menu_open,
+		initData,
+		openLycheeAbout,
+		canSeeAdmin,
+		load,
+		items,
+		profileItems,
+	};
+}

--- a/resources/js/composables/contextMenus/leftMenu.ts
+++ b/resources/js/composables/contextMenus/leftMenu.ts
@@ -1,6 +1,7 @@
 import Constants from "@/services/constants";
 import InitService from "@/services/init-service";
 import { AuthStore } from "@/stores/Auth";
+import { FavouriteStore } from "@/stores/FavouriteState";
 import { LeftMenuStateStore } from "@/stores/LeftMenuState";
 import { LycheeStateStore } from "@/stores/LycheeState";
 import { storeToRefs } from "pinia";
@@ -22,11 +23,11 @@ export type MenyType =
 			items: MenyType[];
 	  };
 
-export function useLeftMenu(lycheeStore: LycheeStateStore, LeftMenuStateStore: LeftMenuStateStore, authStore: AuthStore) {
+export function useLeftMenu(lycheeStore: LycheeStateStore, LeftMenuStateStore: LeftMenuStateStore, authStore: AuthStore, favourites: FavouriteStore) {
 	const { user } = storeToRefs(authStore);
 
 	const { initData, left_menu_open } = storeToRefs(LeftMenuStateStore);
-	const { clockwork_url, is_se_enabled, is_se_preview_enabled, is_se_info_hidden } = storeToRefs(lycheeStore);
+	const { clockwork_url, is_se_enabled, is_se_preview_enabled, is_se_info_hidden, is_favourite_enabled } = storeToRefs(lycheeStore);
 	const openLycheeAbout = ref(false);
 	const logsEnabled = ref(true);
 
@@ -53,16 +54,22 @@ export function useLeftMenu(lycheeStore: LycheeStateStore, LeftMenuStateStore: L
 
 		const baseMenu = [
 			{
-				label: "Frame",
+				label: "left-menu.frame",
 				icon: "pi pi-desktop",
 				access: initData.value.modules.is_mod_frame_enabled ?? false,
 				route: "/frame",
 			},
 			{
-				label: "Map",
+				label: "left-menu.map",
 				icon: "pi pi-map",
 				access: initData.value.modules.is_map_enabled ?? false,
 				route: "/map",
+			},
+			{
+				label: "gallery.favourites",
+				icon: "pi pi-heart",
+				access: (favourites.photos?.length ?? 0) > 0,
+				route: "/gallery/favourites",
 			},
 			{
 				label: "left-menu.admin",

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -282,9 +282,6 @@ declare namespace App.Http.Resources.GalleryConfigs {
 		success: boolean;
 	};
 	export type RootConfig = {
-		is_map_accessible: boolean;
-		is_mod_frame_enabled: boolean;
-		is_photo_timeline_enabled: boolean;
 		is_album_timeline_enabled: boolean;
 		is_search_accessible: boolean;
 		show_keybinding_help_button: boolean;
@@ -605,6 +602,12 @@ declare namespace App.Http.Resources.Rights {
 		settings: App.Http.Resources.Rights.SettingsRightsResource;
 		user_management: App.Http.Resources.Rights.UserManagementRightsResource;
 		user: App.Http.Resources.Rights.UserRightsResource;
+		modules: App.Http.Resources.Rights.ModulesRightsResource;
+	};
+	export type ModulesRightsResource = {
+		is_map_enabled: boolean;
+		is_mod_frame_enabled: boolean;
+		is_photo_timeline_enabled: boolean;
 	};
 	export type PhotoRightsResource = {
 		can_edit: boolean;

--- a/resources/js/menus/LeftMenu.vue
+++ b/resources/js/menus/LeftMenu.vue
@@ -1,7 +1,12 @@
 <template>
 	<Drawer v-model:visible="left_menu_open" :pt:content:class="'flex flex-col justify-start gap-10'">
 		<template #header>
-			<div class="flex items-center gap-2 text-muted-color hover:text-primary-400">
+			<div v-if="user?.id === null" class="flex items-center gap-2 text-muted-color hover:text-primary-400 w-full">
+				<Button icon="pi pi-sign-in" class="border-none w-full text-left" severity="secondary" text @click="togglableStore.toggleLogin()">
+					{{ $t("left-menu.login") }}
+				</Button>
+			</div>
+			<div v-else class="flex items-center gap-2 text-muted-color hover:text-primary-400">
 				<router-link v-if="!isGallery" v-slot="{ href, navigate }" :to="{ name: 'gallery' }" custom>
 					<a v-ripple :href="href" @click="navigate">
 						<span class="text-lg font-bold pl-3">{{ $t("left-menu.back_to_gallery") }}</span>
@@ -18,6 +23,39 @@
 			</template>
 			<template #item="{ item, props }">
 				<template v-if="item.access">
+					<router-link v-if="item.route" v-slot="{ href, navigate }" :to="item.route" custom>
+						<a v-ripple :href="href" v-bind="props.action" @click="navigate">
+							<PiMiniIcon :icon="item.icon" :key="item.icon" />
+							<span class="ml-2">
+								<!-- @vue-ignore -->
+								{{ $t(item.label) }}
+							</span>
+							<SETag v-if="item.seTag" />
+						</a>
+					</router-link>
+					<a v-if="item.url" v-ripple :href="item.url" :target="item.target" v-bind="props.action">
+						<PiMiniIcon :icon="item.icon" :key="item.icon" />
+						<span class="ml-2">
+							<!-- @vue-ignore -->
+							{{ $t(item.label) }}
+						</span>
+						<SETag v-if="item.seTag" />
+					</a>
+					<a v-if="!item.route && !item.url" v-ripple v-bind="props.action">
+						<PiMiniIcon :icon="item.icon" :key="item.icon" />
+						<span class="ml-2">
+							<!-- @vue-ignore -->
+							{{ $t(item.label) }}
+						</span>
+						<SETag v-if="item.seTag" />
+					</a>
+				</template>
+			</template>
+		</Menu>
+		<AboutLychee v-model:visible="openLycheeAbout" />
+		<div class="mt-auto" v-if="user?.id !== null">
+			<Menu :model="profileItems" v-if="initData" class="!border-none">
+				<template #item="{ item, props }">
 					<router-link v-if="item.route" v-slot="{ href, navigate }" :to="item.route" custom>
 						<a v-ripple :href="href" v-bind="props.action" @click="navigate">
 							<MiniIcon :icon="item.icon ?? ''" :class="'w-3 h-3'" />
@@ -45,41 +83,6 @@
 						<SETag v-if="item.seTag" />
 					</a>
 				</template>
-			</template>
-		</Menu>
-		<AboutLychee v-model:visible="openLycheeAbout" />
-		<div class="mt-auto">
-			<Menu :model="profileItems" v-if="initData" class="!border-none">
-				<template #item="{ item, props }">
-					<template v-if="item.access">
-						<router-link v-if="item.route" v-slot="{ href, navigate }" :to="item.route" custom>
-							<a v-ripple :href="href" v-bind="props.action" @click="navigate">
-								<MiniIcon :icon="item.icon ?? ''" :class="'w-3 h-3'" />
-								<span class="ml-2">
-									<!-- @vue-ignore -->
-									{{ $t(item.label) }}
-								</span>
-								<SETag v-if="item.seTag" />
-							</a>
-						</router-link>
-						<a v-if="item.url" v-ripple :href="item.url" :target="item.target" v-bind="props.action">
-							<MiniIcon :icon="item.icon ?? ''" :class="'w-3 h-3'" />
-							<span class="ml-2">
-								<!-- @vue-ignore -->
-								{{ $t(item.label) }}
-							</span>
-							<SETag v-if="item.seTag" />
-						</a>
-						<a v-if="!item.route && !item.url" v-ripple v-bind="props.action">
-							<MiniIcon :icon="item.icon ?? ''" :class="'w-3 h-3'" />
-							<span class="ml-2">
-								<!-- @vue-ignore -->
-								{{ $t(item.label) }}
-							</span>
-							<SETag v-if="item.seTag" />
-						</a>
-					</template>
-				</template>
 			</Menu>
 			<div class="border-t border-surface-700 pt-2 p-(--p-navigation-item-padding) flex justify-between pr-0">
 				<div class="flex items-center gap-2">
@@ -97,14 +100,13 @@
 	</Drawer>
 </template>
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, watch } from "vue";
 import { storeToRefs } from "pinia";
 import Drawer from "primevue/drawer";
 import Menu from "primevue/menu";
 import MiniIcon from "@/components/icons/MiniIcon.vue";
 import AboutLychee from "@/components/modals/AboutLychee.vue";
 import AuthService from "@/services/auth-service";
-import InitService from "@/services/init-service";
 import { useAuthStore } from "@/stores/Auth";
 import { useLycheeStateStore } from "@/stores/LycheeState";
 import AlbumService from "@/services/album-service";
@@ -113,56 +115,22 @@ import Constants from "@/services/constants";
 import { useRoute } from "vue-router";
 import { useTogglablesStateStore } from "@/stores/ModalsState";
 import Button from "primevue/button";
+import PiMiniIcon from "@/components/icons/PiMiniIcon.vue";
+import { useLeftMenuStateStore } from "@/stores/LeftMenuState";
+import { useLeftMenu } from "@/composables/contextMenus/leftMenu";
+import { onMounted } from "vue";
 
-type MenyType =
-	| {
-			label: string;
-			icon: string;
-			route?: string;
-			url?: string;
-			target?: string;
-			access: boolean;
-			seTag?: boolean;
-			command?: () => void;
-	  }
-	| {
-			label: string;
-			items: MenyType[];
-	  };
-
-const initData = ref<App.Http.Resources.Rights.GlobalRightsResource | undefined>(undefined);
-const openLycheeAbout = ref(false);
-const logsEnabled = ref(true);
-
+const leftMenuState = useLeftMenuStateStore();
 const route = useRoute();
 const authStore = useAuthStore();
 const lycheeStore = useLycheeStateStore();
 const togglableStore = useTogglablesStateStore();
-lycheeStore.init();
 
-const { left_menu_open } = storeToRefs(togglableStore);
-const { clockwork_url, is_se_enabled, is_se_preview_enabled, is_se_info_hidden } = storeToRefs(lycheeStore);
-const { user } = storeToRefs(authStore);
-authStore.getUser();
-
-watch(
-	() => user.value,
-	(newValue, oldValue) => {
-		if (newValue === null) {
-			initData.value = undefined;
-		} else if (newValue.id !== oldValue?.id) {
-			load();
-		}
-	},
+const { user, left_menu_open, initData, openLycheeAbout, canSeeAdmin, load, items, profileItems } = useLeftMenu(
+	lycheeStore,
+	leftMenuState,
+	authStore,
 );
-
-load();
-
-function load() {
-	InitService.fetchGlobalRights().then((data) => {
-		initData.value = data.data;
-	});
-}
 
 function logout() {
 	AuthService.logout().then(() => {
@@ -174,147 +142,24 @@ function logout() {
 	});
 }
 
-const canSeeAdmin = computed(() => {
-	return (
-		initData.value?.settings.can_edit ||
-		initData.value?.user_management.can_edit ||
-		initData.value?.settings.can_see_diagnostics ||
-		initData.value?.settings.can_see_logs ||
-		false
-	);
-});
-
 const isGallery = computed(() => {
 	return route.name === "gallery";
 });
 
-const items = computed<MenyType[]>(() => {
-	if (!initData.value) {
-		return [];
-	}
-
-	return [
-		{
-			label: "left-menu.admin",
-			access: canSeeAdmin.value,
-			items: [
-				{
-					label: "settings.title",
-					icon: "cog",
-					route: "/settings",
-					access: initData.value.settings.can_edit ?? false,
-				},
-				{
-					label: "users.title",
-					icon: "people",
-					route: "/users",
-					access: initData.value.user_management.can_edit ?? false,
-				},
-				{
-					label: "diagnostics.title",
-					icon: "wrench",
-					route: "/diagnostics",
-					access: initData.value.settings.can_see_diagnostics ?? false,
-				},
-				{
-					label: "maintenance.title",
-					icon: "timer",
-					route: "/maintenance",
-					access: initData.value.settings.can_edit ?? false,
-				},
-				{
-					label: "left-menu.logs",
-					icon: "excerpt",
-					url: Constants.BASE_URL + "/Logs",
-					access: (initData.value.settings.can_see_logs ?? false) && logsEnabled.value,
-				},
-				{
-					label: "left-menu.logs",
-					icon: "excerpt",
-					access: (initData.value.settings.can_see_logs ?? false) && !logsEnabled.value,
-				},
-				{
-					label: "left-menu.jobs",
-					icon: "project",
-					route: "/jobs",
-					access: initData.value.settings.can_see_logs ?? false,
-				},
-				{
-					label: "left-menu.clockwork",
-					icon: "telescope",
-					url: clockwork_url.value ?? "",
-					access: clockwork_url.value !== null && (initData.value.settings.can_access_dev_tools ?? false),
-				},
-			],
-		},
-		{
-			label: "Lychee",
-			items: [
-				{
-					label: "left-menu.about",
-					icon: "info",
-					access: true,
-					command: () => (openLycheeAbout.value = true),
-				},
-				{
-					label: "left-menu.changelog",
-					icon: "copywriting",
-					access: true,
-					route: "/changelogs",
-				},
-				{
-					label: "left-menu.api",
-					icon: "book",
-					access: initData.value.settings.can_edit ?? false,
-					url: "/docs/api",
-				},
-				{
-					label: "left-menu.source_code",
-					icon: "code",
-					access: is_se_info_hidden.value === false,
-					url: "https://github.com/LycheeOrg/Lychee",
-				},
-				{
-					label: "left-menu.support",
-					icon: "heart",
-					access: is_se_info_hidden.value === false,
-					url: "https://lycheeorg.dev/get-supporter-edition/",
-				},
-			],
-		},
-	];
+onMounted(() => {
+	lycheeStore.init();
+	authStore.getUser();
+	load();
 });
 
-const profileItems = computed<MenyType[]>(() => {
-	if (!initData.value) {
-		return [];
-	}
-	return [
-		{
-			label: "left-menu.user",
-			icon: "person",
-			route: "/profile",
-			access: initData.value.user.can_edit ?? false,
-		},
-		{
-			label: "sharing.title",
-			icon: "cloud",
-			route: "/sharing",
-			access: initData.value.root_album.can_upload ?? false,
-		},
-		{
-			label: "statistics.title",
-			icon: "bar-chart",
-			route: "/statistics",
-			access: is_se_enabled.value === true,
-		},
-		{
-			label: "statistics.title",
-			icon: "bar-chart",
-			route: "/statistics",
-			access: is_se_preview_enabled.value === true,
-			seTag: true,
-		},
-	];
-});
+watch(
+	() => user.value,
+	(newValue, oldValue) => {
+		if (newValue === null) {
+			initData.value = undefined;
+		} else if (newValue.id !== oldValue?.id) {
+			load();
+		}
+	},
+);
 </script>

--- a/resources/js/menus/LeftMenu.vue
+++ b/resources/js/menus/LeftMenu.vue
@@ -2,7 +2,8 @@
 	<Drawer v-model:visible="left_menu_open" :pt:content:class="'flex flex-col justify-start gap-10'">
 		<template #header>
 			<div v-if="user?.id === null" class="flex items-center gap-2 text-muted-color hover:text-primary-400 w-full">
-				<Button icon="pi pi-sign-in" class="border-none w-full text-left" severity="secondary" text @click="togglableStore.toggleLogin()">
+				<Button class="border-none w-full text-left justify-start" severity="secondary" text @click="togglableStore.toggleLogin()">
+					<i class="pi pi-sign-in text-lg mr-2" />
 					{{ $t("left-menu.login") }}
 				</Button>
 			</div>
@@ -101,7 +102,6 @@
 </template>
 <script setup lang="ts">
 import { computed, watch } from "vue";
-import { storeToRefs } from "pinia";
 import Drawer from "primevue/drawer";
 import Menu from "primevue/menu";
 import MiniIcon from "@/components/icons/MiniIcon.vue";
@@ -119,17 +119,20 @@ import PiMiniIcon from "@/components/icons/PiMiniIcon.vue";
 import { useLeftMenuStateStore } from "@/stores/LeftMenuState";
 import { useLeftMenu } from "@/composables/contextMenus/leftMenu";
 import { onMounted } from "vue";
+import { useFavouriteStore } from "@/stores/FavouriteState";
 
 const leftMenuState = useLeftMenuStateStore();
 const route = useRoute();
 const authStore = useAuthStore();
 const lycheeStore = useLycheeStateStore();
 const togglableStore = useTogglablesStateStore();
+const favouritesStore = useFavouriteStore();
 
 const { user, left_menu_open, initData, openLycheeAbout, canSeeAdmin, load, items, profileItems } = useLeftMenu(
 	lycheeStore,
 	leftMenuState,
 	authStore,
+	favouritesStore,
 );
 
 function logout() {

--- a/resources/js/stores/FavouriteState.ts
+++ b/resources/js/stores/FavouriteState.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 
-export type favouriteStore = ReturnType<typeof useFavouriteStore>;
+export type FavouriteStore = ReturnType<typeof useFavouriteStore>;
 
 export type PhotoFavourite = {
 	albumId?: string;

--- a/resources/js/stores/LeftMenuState.ts
+++ b/resources/js/stores/LeftMenuState.ts
@@ -1,0 +1,18 @@
+import { defineStore } from "pinia";
+
+export type LeftMenuStateStore = ReturnType<typeof useLeftMenuStateStore>;
+
+export const useLeftMenuStateStore = defineStore("leftmenu-store", {
+	state: () => ({
+		// Togglable
+		left_menu_open: false,
+
+		// Info needed for the menu to be displayed
+		initData: undefined as App.Http.Resources.Rights.GlobalRightsResource | undefined,
+	}),
+	actions: {
+		toggleLeftMenu() {
+			this.left_menu_open = !this.left_menu_open;
+		},
+	},
+});

--- a/resources/js/stores/ModalsState.ts
+++ b/resources/js/stores/ModalsState.ts
@@ -6,7 +6,6 @@ export type TogglablesStateStore = ReturnType<typeof useTogglablesStateStore>;
 export const useTogglablesStateStore = defineStore("togglables-store", {
 	state: () => ({
 		// togglables
-		left_menu_open: false,
 		is_full_screen: false,
 		is_login_open: false,
 		is_webauthn_open: false,
@@ -52,10 +51,6 @@ export const useTogglablesStateStore = defineStore("togglables-store", {
 
 		toggleLogin() {
 			this.is_login_open = !this.is_login_open;
-		},
-
-		toggleLeftMenu() {
-			this.left_menu_open = !this.left_menu_open;
 		},
 
 		rememberScrollPage(elem: HTMLElement, path: string) {

--- a/resources/js/views/ChangeLogs.vue
+++ b/resources/js/views/ChangeLogs.vue
@@ -1,7 +1,7 @@
 <template>
 	<Toolbar class="w-full border-0 h-14">
 		<template #start>
-			<Button @click="togglableStore.toggleLeftMenu" icon="pi pi-bars" class="mr-2 border-none" severity="secondary" text />
+			<OpenLeftMenu />
 		</template>
 
 		<template #center>
@@ -23,14 +23,12 @@
 	</Panel>
 </template>
 <script setup lang="ts">
+import OpenLeftMenu from "@/components/headers/OpenLeftMenu.vue";
 import InitService from "@/services/init-service";
-import { useTogglablesStateStore } from "@/stores/ModalsState";
-import Button from "primevue/button";
 import Panel from "primevue/panel";
 import Toolbar from "primevue/toolbar";
 import { ref } from "vue";
 
-const togglableStore = useTogglablesStateStore();
 const changeLogs = ref<App.Http.Resources.Diagnostics.ChangeLogInfo[] | undefined>(undefined);
 
 InitService.fetchChangeLog()

--- a/resources/js/views/Diagnostics.vue
+++ b/resources/js/views/Diagnostics.vue
@@ -27,7 +27,6 @@ import ErrorsDiagnotics from "@/components/diagnostics/ErrorsDiagnostics.vue";
 import SpaceDiagnostics from "@/components/diagnostics/SpaceDiagnostics.vue";
 import { useAuthStore } from "@/stores/Auth";
 import { storeToRefs } from "pinia";
-import { useTogglablesStateStore } from "@/stores/ModalsState";
 import { useToast } from "primevue/usetoast";
 import { trans } from "laravel-vue-i18n";
 import OpenLeftMenu from "@/components/headers/OpenLeftMenu.vue";
@@ -35,7 +34,6 @@ import OpenLeftMenu from "@/components/headers/OpenLeftMenu.vue";
 const authStore = useAuthStore();
 const { user } = storeToRefs(authStore);
 authStore.getUser();
-const togglableStore = useTogglablesStateStore();
 
 const toast = useToast();
 

--- a/resources/js/views/Diagnostics.vue
+++ b/resources/js/views/Diagnostics.vue
@@ -1,7 +1,7 @@
 <template>
 	<Toolbar class="w-full border-0 h-14">
 		<template #start>
-			<Button @click="togglableStore.toggleLeftMenu" icon="pi pi-bars" class="mr-2 border-none" severity="secondary" text />
+			<OpenLeftMenu />
 		</template>
 
 		<template #center>
@@ -30,6 +30,7 @@ import { storeToRefs } from "pinia";
 import { useTogglablesStateStore } from "@/stores/ModalsState";
 import { useToast } from "primevue/usetoast";
 import { trans } from "laravel-vue-i18n";
+import OpenLeftMenu from "@/components/headers/OpenLeftMenu.vue";
 
 const authStore = useAuthStore();
 const { user } = storeToRefs(authStore);

--- a/resources/js/views/gallery-panels/Albums.vue
+++ b/resources/js/views/gallery-panels/Albums.vue
@@ -163,10 +163,12 @@ import { EmptyPhotoCallbacks } from "@/utils/Helpers";
 import WebauthnModal from "@/components/modals/WebauthnModal.vue";
 import LoginModal from "@/components/modals/LoginModal.vue";
 import LoadingProgress from "@/components/loading/LoadingProgress.vue";
+import { useLeftMenuStateStore } from "@/stores/LeftMenuState";
 
 const auth = useAuthStore();
 const lycheeStore = useLycheeStateStore();
 const togglableStore = useTogglablesStateStore();
+const leftMenuStore = useLeftMenuStateStore();
 
 lycheeStore.init();
 const albumid = ref("gallery");
@@ -235,7 +237,7 @@ onMounted(() => {
 	window.addEventListener("paste", onPaste);
 	window.addEventListener("dragover", dragEnd);
 	window.addEventListener("drop", dropUpload);
-	togglableStore.left_menu_open = false;
+	leftMenuStore.left_menu_open = false;
 });
 
 onMounted(async () => {

--- a/resources/js/views/gallery-panels/Favourites.vue
+++ b/resources/js/views/gallery-panels/Favourites.vue
@@ -8,7 +8,7 @@
 				</template>
 
 				<template #center>
-					{{ $t("favourites") }}
+					{{ $t("gallery.favourites") }}
 				</template>
 
 				<template #end> </template>

--- a/resources/js/views/gallery-panels/Frame.vue
+++ b/resources/js/views/gallery-panels/Frame.vue
@@ -19,6 +19,7 @@
 <script setup lang="ts">
 import { useSlideshowFunction } from "@/composables/photo/slideshow";
 import AlbumService from "@/services/album-service";
+import { useLeftMenuStateStore } from "@/stores/LeftMenuState";
 import { onKeyStroke } from "@vueuse/core";
 import Button from "primevue/button";
 import { ref, onMounted, onUnmounted } from "vue";
@@ -32,6 +33,7 @@ const router = useRouter();
 const imgSrc = ref("");
 const imgSrcset = ref("");
 const refreshTimeout = ref(5);
+const leftMenuStore = useLeftMenuStateStore();
 
 const is_slideshow_active = ref(false);
 
@@ -53,6 +55,7 @@ function start() {
 }
 
 onMounted(() => {
+	leftMenuStore.left_menu_open = false;
 	let elem = document.getElementsByTagName("body")[0];
 
 	elem.requestFullscreen()

--- a/resources/js/views/gallery-panels/Map.vue
+++ b/resources/js/views/gallery-panels/Map.vue
@@ -39,6 +39,8 @@ import Toolbar from "primevue/toolbar";
 import { onKeyStroke } from "@vueuse/core";
 import Constants from "@/services/constants";
 import { useTogglablesStateStore } from "@/stores/ModalsState";
+import { onMounted } from "vue";
+import { useLeftMenuStateStore } from "@/stores/LeftMenuState";
 
 type MapPhotoEntry = {
 	lat?: number | null;
@@ -59,6 +61,7 @@ const props = defineProps<{
 
 const toast = useToast();
 const router = useRouter();
+const leftMenuStore = useLeftMenuStateStore();
 const togglableStore = useTogglablesStateStore();
 const lycheeStore = useLycheeStateStore();
 lycheeStore.init();
@@ -273,9 +276,12 @@ function updateZoom() {
 	}
 }
 
-loadMapProvider();
-
 onKeyStroke("Escape", () => {
 	goBack();
+});
+
+onMounted(() => {
+	leftMenuStore.left_menu_open = false;
+	loadMapProvider();
 });
 </script>

--- a/tests/Feature_v2/Album/AlbumsTest.php
+++ b/tests/Feature_v2/Album/AlbumsTest.php
@@ -47,8 +47,6 @@ class AlbumsTest extends BaseApiV2Test
 			],
 			'shared_albums' => [],
 			'config' => [
-				'is_map_accessible' => false,
-				'is_mod_frame_enabled' => false,
 				'is_search_accessible' => false,
 				'album_thumb_css_aspect_ratio' => 'aspect-square',
 			],
@@ -102,8 +100,6 @@ class AlbumsTest extends BaseApiV2Test
 				],
 			],
 			'config' => [
-				'is_map_accessible' => false,
-				'is_mod_frame_enabled' => true,
 				'is_search_accessible' => true,
 				'album_thumb_css_aspect_ratio' => 'aspect-square',
 			],
@@ -161,8 +157,6 @@ class AlbumsTest extends BaseApiV2Test
 				],
 			],
 			'config' => [
-				'is_map_accessible' => false,
-				'is_mod_frame_enabled' => true,
 				'is_search_accessible' => true,
 				'album_thumb_css_aspect_ratio' => 'aspect-square',
 			],


### PR DESCRIPTION
If we want to add more functionalities to Lychee we need to make more use of the Left menu, we cannot add more and more buttons to the header as it does not makes it explicit what functionalities does what. As a result, this PR creates the following changes on front-end:

1. make left menu always available.
2. move the login action to the left menu (I will admit that this one sucks, fortunately there is the `L` shortcut).
3. move the map button on Albums page to the left menu.
4. move the frame button on Albums page to the left menu.
5. move the map button on Album page near the download etc. buttons.
6. move the frame button on Album page near the download etc. buttons.

on backend: this PR creates a new ModulesRightsResource which is embeded in the GlobalRightsResources. That way we are able to extend with more configuration options. This makes it easier to track what is enabled or not. 

<table>
<tr><td>Logged in</td><td>Logged out</td></tr>
<tr>
<td>
	<img src="https://github.com/user-attachments/assets/3f988327-74f8-412b-8a00-460f30cd1caa" width="200px">
</td>
<td>
	<img src="https://github.com/user-attachments/assets/79040fdf-2e4d-4ec0-b95e-a00f7362dccf" width="200px">
</td>
</tr>
</table>
