### PR TITLE
Reorganise pipes when syncing to find and reject duplicates quicker

### DIFF
--- a/app/Actions/Photo/Create.php
+++ b/app/Actions/Photo/Create.php
@@ -84,7 +84,7 @@ class Create
 		];
 
 		if (!$this->strategy_parameters->import_mode->shall_resync_metadata) {
-			unset($pipes[array_search(Init\LoadFileMetadata::class, $pipes)]);
+			unset($pipes[array_search(Init\LoadFileMetadata::class, $pipes, true)]);
 		}
 
 		$init_dto = app(Pipeline::class)
@@ -103,7 +103,7 @@ class Create
 		];
 
 		if ($this->strategy_parameters->import_mode->shall_resync_metadata) {
-			unset($pipes[array_search(Init\LoadFileMetadata::class, $pipes)]);
+			unset($pipes[array_search(Init\LoadFileMetadata::class, $pipes, true)]);
 		}
 
 		$init_dto = app(Pipeline::class)

--- a/app/Actions/Photo/Create.php
+++ b/app/Actions/Photo/Create.php
@@ -79,21 +79,9 @@ class Create
 		$pre_pipes = [
 			Init\AssertSupportedMedia::class,
 			Init\FetchLastModifiedTime::class,
-			Init\LoadFileMetadata::class,
+			Init\MayLoadFileMetadata::class,
 			Init\FindDuplicate::class,
 		];
-
-		$post_pipes = [
-			Init\InitParentAlbum::class,
-			Init\LoadFileMetadata::class,
-			Init\FindLivePartner::class,
-		];
-
-		if ($this->strategy_parameters->import_mode->shall_resync_metadata) {
-			unset($post_pipes[array_search(Init\LoadFileMetadata::class, $post_pipes, true)]);
-		} else {
-			unset($pre_pipes[array_search(Init\LoadFileMetadata::class, $pre_pipes, true)]);
-		}
 
 		$init_dto = app(Pipeline::class)
 			->send($init_dto)
@@ -103,6 +91,12 @@ class Create
 		if ($init_dto->duplicate !== null) {
 			return $this->handleDuplicate($init_dto);
 		}
+
+		$post_pipes = [
+			Init\InitParentAlbum::class,
+			Init\LoadFileMetadata::class,
+			Init\FindLivePartner::class,
+		];
 
 		$init_dto = app(Pipeline::class)
 			->send($init_dto)

--- a/app/Actions/Photo/Pipes/Init/MayLoadFileMetadata.php
+++ b/app/Actions/Photo/Pipes/Init/MayLoadFileMetadata.php
@@ -11,12 +11,11 @@ namespace App\Actions\Photo\Pipes\Init;
 use App\Contracts\PhotoCreate\InitPipe;
 use App\DTO\PhotoCreate\InitDTO;
 use App\Exceptions\InvalidPropertyException;
-use App\Metadata\Extractor;
 
 /**
  * Load metadata from the file.
  */
-class LoadFileMetadata implements InitPipe
+class MayLoadFileMetadata extends LoadFileMetadata implements InitPipe
 {
 	/**
 	 * {@inheritDoc}
@@ -25,19 +24,9 @@ class LoadFileMetadata implements InitPipe
 	 */
 	public function handle(InitDTO $state, \Closure $next): InitDTO
 	{
-		if ($state->exif_info !== null) {
-			// Metadata already loaded
-			return $next($state);
-		}
-
-		$state->exif_info = Extractor::createFromFile($state->source_file, $state->file_last_modified_time);
-
-		// Use basename of file if IPTC title missing
-		if (
-			$state->exif_info->title === null ||
-			$state->exif_info->title === ''
-		) {
-			$state->exif_info->title = substr($state->source_file->getOriginalBasename(), 0, 98);
+		if ($state->import_mode->shall_resync_metadata) {
+			// Load the metadata from the file
+			return parent::handle($state, $next);
 		}
 
 		return $next($state);

--- a/app/DTO/PhotoCreate/DuplicateDTO.php
+++ b/app/DTO/PhotoCreate/DuplicateDTO.php
@@ -31,7 +31,7 @@ class DuplicateDTO implements PhotoDTO
 		public readonly bool $is_starred,
 
 		// The extracted EXIF information (populated during init phase).
-		public readonly Extractor $exif_info,
+		public readonly ?Extractor $exif_info,
 
 		// The intended parent album
 		public readonly ?AbstractAlbum $album,


### PR DESCRIPTION
Rebased changes from the latest master.

This MR rearranges the DTO Pipes slightly to perform the minimal amount of processing required before detecting and handling duplicates, it does not aim to alter or optimise any of the existing processing. 

Locally tested with 710 of my own photos after an initial import;

```
~/Herd/Lychee » git status
On branch sync-detect-duplicate-early
Your branch is up-to-date with 'origin/sync-detect-duplicate-early'.

nothing to commit, working tree clean


~/Herd/Lychee » time php artisan lychee:sync --album_id=JgvCwUL3ELKnmXw75-muNCaX ~/Downloads/flickr-import-testfolder --skip_duplicates=1
Start syncing.

Done syncing.
php artisan lychee:sync --album_id=JgvCwUL3ELKnmXw75-muNCaX    64.46s user 3.10s system 93% cpu 1:12.25 total
```
Compared to the current master branch

```
~/Herd/Lychee » git status
On branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working tree clean


~/Herd/Lychee » time php artisan lychee:sync --album_id=JgvCwUL3ELKnmXw75-muNCaX ~/Downloads/flickr-import-testfolder --skip_duplicates=1
Start syncing.

Done syncing.
php artisan lychee:sync --album_id=JgvCwUL3ELKnmXw75-muNCaX    417.59s user 38.91s system 96% cpu 7:54.83 total
```
