### PR TITLE
Fix Settings crash on docker + pgsql setup

### DIFF
--- a/app/Factories/AlbumFactory.php
+++ b/app/Factories/AlbumFactory.php
@@ -96,7 +96,7 @@ class AlbumFactory
 		$tag_album_query = TagAlbum::query();
 
 		if ($with_relations) {
-			$album_query->with(['access_permissions', 'photos', 'children', 'photos.size_variants']);
+			$album_query->with(['access_permissions', 'photos', 'children', 'children.owner', 'photos.size_variants']);
 			$tag_album_query->with(['photos']);
 		}
 

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -44,7 +44,7 @@ class SettingsController extends Controller
 	{
 		$editable_configs = ConfigCategory::with([
 			'configs' => fn ($query) => $query->when(config('features.hide-lychee-SE', false) === true, fn ($q) => $q->where('cat', '!=', 'lychee SE'))
-				->when($docker_info->isDocker(), fn ($q) => $q->where('not_on_docker', '!==', true))
+				->when($docker_info->isDocker(), fn ($q) => $q->where('not_on_docker', '!=', true))
 				->when(!$request->is_se() && !Configs::getValueAsBool('enable_se_preview'), fn ($q) => $q->where('level', '=', 0)),
 		])->orderBy('order', 'asc')->get();
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -49,6 +49,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use LycheeVerify\Verify;
 use Opcodes\LogViewer\Facades\LogViewer;
 use Safe\Exceptions\StreamException;
 use function Safe\stream_filter_register;
@@ -94,6 +95,8 @@ class AppServiceProvider extends ServiceProvider
 			// JsonParsers
 			GitCommits::class => GitCommits::class,
 			GitTags::class => GitTags::class,
+
+			Verify::class => Verify::class,
 		];
 
 	/**


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and maintainability of the codebase. The most important changes include modifications to the `AlbumFactory` and `SettingsController` to fix relation loading and conditional queries, and updates to the `AppServiceProvider` to include a new service.

Improvements and fixes:

* [`app/Factories/AlbumFactory.php`](diffhunk://#diff-3a764911217fa81fec6c8ef209628001d4dff178b33daed7ed544be6afd0f7e1L99-R99): Added `children.owner` to the relations loaded by the `album_query` when `$with_relations` is true.
* [`app/Http/Controllers/Admin/SettingsController.php`](diffhunk://#diff-7422c36bc42add38de6a297e3b3fcaddc93e4de75d0de1c733d04d27267183b4L47-R47): Corrected the conditional operator in the `getAll` method to properly handle the `not_on_docker` field.

Service provider updates:

* [`app/Providers/AppServiceProvider.php`](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR52): Imported `LycheeVerify\Verify` and registered `Verify::class` in the `bindings` array. [[1]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR52) [[2]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR98-R99)