### PR TITLE
Fix create tag album modal: close after create, border rounding

### DIFF
--- a/resources/js/components/forms/album/AlbumCreateTagDialog.vue
+++ b/resources/js/components/forms/album/AlbumCreateTagDialog.vue
@@ -28,7 +28,7 @@
 					<div class="text-muted-color-emphasis" v-html="$t('dialogs.new_tag_album.warn')" />
 				</div>
 				<div class="flex items-center mt-9">
-					<Button @click="closeCallback" severity="secondary" class="w-full font-bold border-none rounded-bl-xl">
+					<Button @click="closeCallback" severity="secondary" class="w-full font-bold border-none rounded-none rounded-bl-xl">
 						{{ $t("dialogs.button.cancel") }}
 					</Button>
 					<Button @click="create" severity="contrast" class="font-bold w-full border-none rounded-none rounded-br-xl" :disabled="!isValid">
@@ -74,6 +74,7 @@ function create() {
 		tags: tags.value,
 	})
 		.then((response) => {
+			is_create_tag_album_visible.value = false;
 			AlbumService.clearAlbums();
 			router.push(`/gallery/${response.data}`);
 		})


### PR DESCRIPTION
- Fix border rounding of the cancel button.
- Close modal after creation.

Fixes #3206