### PR TITLE
Add triggers for statistics.

### DIFF
--- a/app/Actions/Album/Create.php
+++ b/app/Actions/Album/Create.php
@@ -40,6 +40,7 @@ class Create
 		$this->set_parent($album, $parent_album);
 		$album->save();
 		$this->set_permissions($album, $parent_album);
+		$this->setStatistics($album);
 
 		return $album;
 	}
@@ -133,5 +134,17 @@ class Create
 		$access_perm = AccessPermission::withGrantFullPermissionsToUser($this->intended_owner_id);
 
 		$album->access_permissions()->save($access_perm);
+	}
+
+	private function setStatistics(Album $album): void
+	{
+		$album->statistics()->create([
+			'album_id' => $album->id,
+			'photo_id' => null,
+			'visit_count' => 0,
+			'download_count' => 0,
+			'favourite_count' => 0,
+			'shared_count' => 0,
+		]);
 	}
 }

--- a/app/Actions/Album/Create.php
+++ b/app/Actions/Album/Create.php
@@ -140,7 +140,6 @@ class Create
 	{
 		$album->statistics()->create([
 			'album_id' => $album->id,
-			'photo_id' => null,
 			'visit_count' => 0,
 			'download_count' => 0,
 			'favourite_count' => 0,

--- a/app/Actions/Album/CreateTagAlbum.php
+++ b/app/Actions/Album/CreateTagAlbum.php
@@ -36,7 +36,20 @@ class CreateTagAlbum
 		$album->show_tags = $show_tags;
 		$album->owner_id = $user_id;
 		$album->save();
+		$this->setStatistics($album);
 
 		return $album;
+	}
+
+	private function setStatistics(TagAlbum $album): void
+	{
+		$album->statistics()->create([
+			'album_id' => $album->id,
+			'photo_id' => null,
+			'visit_count' => 0,
+			'download_count' => 0,
+			'favourite_count' => 0,
+			'shared_count' => 0,
+		]);
 	}
 }

--- a/app/Actions/Album/Delete.php
+++ b/app/Actions/Album/Delete.php
@@ -21,6 +21,7 @@ use App\Image\FileDeleter;
 use App\Models\AccessPermission;
 use App\Models\Album;
 use App\Models\BaseAlbumImpl;
+use App\Models\Statistics;
 use App\Models\TagAlbum;
 use App\SmartAlbums\UnsortedAlbum;
 use Illuminate\Database\Eloquent\Collection;
@@ -131,6 +132,14 @@ class Delete
 			})->whereNotExists(function (BaseBuilder $base_builder): void {
 				$base_builder->from('tag_albums')->whereColumn('tag_albums.id', '=', 'base_albums.id');
 			})->delete();
+
+			// We remove the statistics for the albums.
+			Statistics::query()
+				->whereNotNull('album_id') // Only target the statistics for albums
+				->whereNotExists(fn (BaseBuilder $base_builder) => $base_builder
+						->from('base_albums')
+						->whereColumn('base_albums.id', '=', 'statistics.album_id')
+				)->delete();
 
 			// We also delete the permissions & sharing.
 			// Note that we explicitly avoid the smart albums.

--- a/app/Actions/Photo/Delete.php
+++ b/app/Actions/Photo/Delete.php
@@ -16,6 +16,7 @@ use App\Image\FileDeleter;
 use App\Models\Album;
 use App\Models\Photo;
 use App\Models\SizeVariant;
+use App\Models\Statistics;
 use App\Models\SymLink;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\JoinClause;
@@ -386,6 +387,21 @@ readonly class Delete
 						$query
 							->from('photos', 'p')
 							->whereColumn('p.id', '=', 'size_variants.photo_id')
+							->whereIn('p.album_id', $album_ids);
+					})
+					->delete();
+			}
+			if (count($photo_ids) !== 0) {
+				Statistics::query()
+					->whereIn('photo_id', $photo_ids)
+					->delete();
+			}
+			if (count($album_ids) !== 0) {
+				Statistics::query()
+					->whereExists(function (BaseBuilder $query) use ($album_ids): void {
+						$query
+							->from('photos', 'p')
+							->whereColumn('p.id', '=', 'statistics.photo_id')
 							->whereIn('p.album_id', $album_ids);
 					})
 					->delete();

--- a/app/Actions/Photo/Pipes/Shared/SetParentAndOwnership.php
+++ b/app/Actions/Photo/Pipes/Shared/SetParentAndOwnership.php
@@ -12,6 +12,7 @@ use App\Contracts\PhotoCreate\SharedPipe;
 use App\DTO\PhotoCreate\DuplicateDTO;
 use App\DTO\PhotoCreate\StandaloneDTO;
 use App\Models\Album;
+use App\Models\Statistics;
 
 class SetParentAndOwnership implements SharedPipe
 {
@@ -30,6 +31,16 @@ class SetParentAndOwnership implements SharedPipe
 			$state->photo->setRelation('album', null);
 			$state->photo->owner_id = $state->intended_owner_id;
 		}
+
+		$stats = Statistics::create([
+			'photo_id' => $state->photo->id,
+			'visit_count' => 0,
+			'download_count' => 0,
+			'favourite_count' => 0,
+			'shared_count' => 0,
+		]);
+
+		$state->photo->setRelation('statistics', $stats);
 
 		return $next($state);
 	}

--- a/app/Contracts/Http/Requests/HasVisitorId.php
+++ b/app/Contracts/Http/Requests/HasVisitorId.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Contracts\Http\Requests;
+
+interface HasVisitorId
+{
+	/**
+	 * @return string
+	 */
+	public function visitorId(): string;
+}

--- a/app/Enum/MetricsAccess.php
+++ b/app/Enum/MetricsAccess.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Enum;
+
+enum MetricsAccess: string
+{
+	case PUBLIC = 'public';
+	case LOGGEDIN = 'logged-in users';
+	case OWNER = 'owner';
+	case ADMIN = 'admin';
+}

--- a/app/Enum/MetricsAccess.php
+++ b/app/Enum/MetricsAccess.php
@@ -11,7 +11,7 @@ namespace App\Enum;
 enum MetricsAccess: string
 {
 	case PUBLIC = 'public';
-	case LOGGEDIN = 'logged-in users';
+	case LOGGED_IN = 'logged-in users';
 	case OWNER = 'owner';
 	case ADMIN = 'admin';
 }

--- a/app/Enum/MetricsAction.php
+++ b/app/Enum/MetricsAction.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Enum;
+
+enum MetricsAction: string
+{
+	case VISIT = 'visit';
+	case FAVOURITE = 'favourite';
+	case DOWNLOAD = 'download';
+	case SHARED = 'shared';
+
+	/**
+	 * Given a MetricsAction return the associated column name.
+	 *
+	 * @return string
+	 */
+	public function column(): string
+	{
+		return match ($this) {
+			self::VISIT => 'visit_count',
+			self::FAVOURITE => 'favourite_count',
+			self::DOWNLOAD => 'download_count',
+			self::SHARED => 'shared_count',
+		};
+	}
+}

--- a/app/Events/Metrics/AlbumDownload.php
+++ b/app/Events/Metrics/AlbumDownload.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Events\Metrics;
+
+use App\Enum\MetricsAction;
+
+/**
+ * This event is fired when an album is downloaded.
+ */
+final class AlbumDownload extends BaseMetricsEvent
+{
+	public function key(): string
+	{
+		return 'album_id';
+	}
+
+	public function metricAction(): MetricsAction
+	{
+		return MetricsAction::DOWNLOAD;
+	}
+}

--- a/app/Events/Metrics/AlbumShared.php
+++ b/app/Events/Metrics/AlbumShared.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Events\Metrics;
+
+use App\Enum\MetricsAction;
+
+/**
+ * This event is fired when a direct link to an album is used.
+ */
+final class AlbumShared extends BaseMetricsEvent
+{
+	public function key(): string
+	{
+		return 'album_id';
+	}
+
+	public function metricAction(): MetricsAction
+	{
+		return MetricsAction::SHARED;
+	}
+}

--- a/app/Events/Metrics/AlbumVisit.php
+++ b/app/Events/Metrics/AlbumVisit.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Events\Metrics;
+
+use App\Enum\MetricsAction;
+
+/**
+ * This event is fired when an album is open.
+ */
+final class AlbumVisit extends BaseMetricsEvent
+{
+	public function key(): string
+	{
+		return 'album_id';
+	}
+
+	public function metricAction(): MetricsAction
+	{
+		return MetricsAction::VISIT;
+	}
+}

--- a/app/Events/Metrics/BaseMetricsEvent.php
+++ b/app/Events/Metrics/BaseMetricsEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Events\Metrics;
+
+use App\Enum\MetricsAction;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+
+abstract class BaseMetricsEvent
+{
+	use Dispatchable;
+	use InteractsWithSockets;
+
+	public function __construct(
+		public readonly string $visitor_id,
+		public readonly string $id,
+	) {
+	}
+
+	/**
+	 * Return the type of key : photo_id or album_id.
+	 *
+	 * @return string
+	 *
+	 * @codeCoverageIgnore, abstract method can't be covered
+	 */
+	abstract public function key(): string;
+
+	/**
+	 * Return the column name in the database to update.
+	 *
+	 * @return MetricsAction
+	 *
+	 * @codeCoverageIgnore, abstract method can't be covered
+	 */
+	abstract public function metricAction(): MetricsAction;
+}

--- a/app/Events/Metrics/PhotoDownload.php
+++ b/app/Events/Metrics/PhotoDownload.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Events\Metrics;
+
+use App\Enum\MetricsAction;
+
+/**
+ * This event is fired when one or multiple photos are downloaded.
+ */
+final class PhotoDownload extends BaseMetricsEvent
+{
+	public function key(): string
+	{
+		return 'photo_id';
+	}
+
+	public function metricAction(): MetricsAction
+	{
+		return MetricsAction::DOWNLOAD;
+	}
+}

--- a/app/Events/Metrics/PhotoFavourite.php
+++ b/app/Events/Metrics/PhotoFavourite.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Events\Metrics;
+
+use App\Enum\MetricsAction;
+
+/**
+ * This event is fired when a photo is visited.
+ */
+class PhotoFavourite extends BaseMetricsEvent
+{
+	public function key(): string
+	{
+		return 'photo_id';
+	}
+
+	public function metricAction(): MetricsAction
+	{
+		return MetricsAction::FAVOURITE;
+	}
+}

--- a/app/Events/Metrics/PhotoShared.php
+++ b/app/Events/Metrics/PhotoShared.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Events\Metrics;
+
+use App\Enum\MetricsAction;
+
+/**
+ * This event is fired when a direct link to a photo is used.
+ */
+class PhotoShared extends BaseMetricsEvent
+{
+	public function key(): string
+	{
+		return 'photo_id';
+	}
+
+	public function metricAction(): MetricsAction
+	{
+		return MetricsAction::SHARED;
+	}
+}

--- a/app/Events/Metrics/PhotoVisit.php
+++ b/app/Events/Metrics/PhotoVisit.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Events\Metrics;
+
+use App\Enum\MetricsAction;
+
+/**
+ * This event is fired when a photo is visited.
+ */
+final class PhotoVisit extends BaseMetricsEvent
+{
+	public function key(): string
+	{
+		return 'photo_id';
+	}
+
+	public function metricAction(): MetricsAction
+	{
+		return MetricsAction::VISIT;
+	}
+}

--- a/app/Factories/AlbumFactory.php
+++ b/app/Factories/AlbumFactory.php
@@ -96,7 +96,7 @@ class AlbumFactory
 		$tag_album_query = TagAlbum::query();
 
 		if ($with_relations) {
-			$album_query->with(['access_permissions', 'photos', 'children', 'children.owner', 'photos.size_variants']);
+			$album_query->with(['access_permissions', 'photos', 'children', 'children.owner', 'photos.size_variants', 'photos.statistics']);
 			$tag_album_query->with(['photos']);
 		}
 

--- a/app/Http/Controllers/MetricsController.php
+++ b/app/Http/Controllers/MetricsController.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Controllers;
+
+use App\Events\Metrics\PhotoFavourite;
+use App\Events\Metrics\PhotoVisit;
+use App\Http\Requests\Metrics\PhotoMetricsRequest;
+use App\Models\Configs;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * This is a Metrics Controller.
+ * Most of the call here do not return anything.
+ */
+class MetricsController extends Controller
+{
+	/**
+	 * This method is called when a photo is visited.
+	 */
+	public function photo(PhotoMetricsRequest $request): void
+	{
+		PhotoVisit::dispatchIf(self::shouldMeasure(), $request->visitorId(), $request->photoIds()[0]);
+
+		return;
+	}
+
+	/**
+	 * This method is called when a photo is marked as favourited.
+	 *
+	 * Note that it is impossible to know if a photo has been removed from favourites.
+	 * This is because the data is stored client-side, as a result, we do not know if
+	 * the user is e.g. in incognito mode...
+	 */
+	public function favourite(PhotoMetricsRequest $request): void
+	{
+		PhotoFavourite::dispatchIf(self::shouldMeasure(), $request->visitorId(), $request->photoIds()[0]);
+
+		return;
+	}
+
+	/**
+	 * Determine whether we should apply measurements or not.
+	 */
+	public static function shouldMeasure(): bool
+	{
+		if (Configs::getValueAsBool('metrics_enabled') === false && Configs::getValueAsBool('live_metrics_enabled') === false) {
+			return false;
+		}
+
+		if (Auth::guest()) {
+			return true;
+		}
+
+		if (Auth::user()->may_administrate) {
+			return false;
+		}
+
+		return Configs::getValueAsBool('metrics_logged_in_users_enabed');
+	}
+}

--- a/app/Http/Controllers/VueController.php
+++ b/app/Http/Controllers/VueController.php
@@ -9,9 +9,12 @@
 namespace App\Http\Controllers;
 
 use App\Contracts\Models\AbstractAlbum;
+use App\Events\Metrics\AlbumShared;
+use App\Events\Metrics\PhotoShared;
 use App\Exceptions\Internal\InvalidSmartIdException;
 use App\Exceptions\UnauthorizedException;
 use App\Factories\AlbumFactory;
+use App\Http\Requests\Traits\HasVisitorIdTrait;
 use App\Models\Extensions\BaseAlbum;
 use App\Models\Photo;
 use App\Policies\AlbumPolicy;
@@ -29,6 +32,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class VueController extends Controller
 {
+	use HasVisitorIdTrait;
+
 	public const ACCESS = 'access';
 	public const PASSWORD = 'password';
 
@@ -41,6 +46,9 @@ class VueController extends Controller
 	public function view(?string $album_id = null, ?string $photo_id = null): View
 	{
 		$album_factory = resolve(AlbumFactory::class);
+		$album = null;
+		$photo = null;
+
 		try {
 			if ($album_id !== null && $album_id !== 'all') {
 				$album = $album_factory->findAbstractAlbumOrFail($album_id, false);
@@ -56,6 +64,12 @@ class VueController extends Controller
 			}
 		} catch (ModelNotFoundException) {
 			throw new NotFoundHttpException();
+		}
+
+		if ($photo !== null) {
+			PhotoShared::dispatchIf(MetricsController::shouldMeasure(), $this->visitorId(), $photo->id);
+		} elseif ($album !== null) {
+			AlbumShared::dispatchIf(MetricsController::shouldMeasure(), $this->visitorId(), $album->get_id());
 		}
 
 		return view('vueapp');

--- a/app/Http/Middleware/ConfigIntegrity.php
+++ b/app/Http/Middleware/ConfigIntegrity.php
@@ -18,6 +18,7 @@ class ConfigIntegrity
 {
 	public const SE_FIELDS = [
 		'default_user_quota',
+		'metrics_enabled',
 		'disable_small_download',
 		'disable_small2x_download',
 		'disable_medium_download',
@@ -40,6 +41,12 @@ class ConfigIntegrity
 		'low_number_of_shoots_per_day',
 		'medium_number_of_shoots_per_day',
 		'high_number_of_shoots_per_day',
+		'metrics_enabled',
+		'metrics_logged_in_users_enabed',
+		'metrics_access',
+		'live_metrics_enabled',
+		'live_metrics_access',
+		'live_metrics_max_time',
 	];
 
 	/**

--- a/app/Http/Requests/Metrics/PhotoMetricsRequest.php
+++ b/app/Http/Requests/Metrics/PhotoMetricsRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Metrics;
+
+use App\Contracts\Http\Requests\HasPhotoIds;
+use App\Contracts\Http\Requests\HasVisitorId;
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Http\Requests\BaseApiRequest;
+use App\Http\Requests\Traits\HasPhotoIdsTrait;
+use App\Http\Requests\Traits\HasVisitorIdTrait;
+use App\Rules\RandomIDRule;
+
+class PhotoMetricsRequest extends BaseApiRequest implements HasPhotoIds, HasVisitorId
+{
+	use HasPhotoIdsTrait;
+	use HasVisitorIdTrait;
+
+	// No need to authorize this request as it is only used for metrics purposes
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		$this->photo_ids = $values[RequestAttribute::PHOTO_IDS_ATTRIBUTE];
+	}
+}

--- a/app/Http/Requests/Traits/HasVisitorIdTrait.php
+++ b/app/Http/Requests/Traits/HasVisitorIdTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Traits;
+
+use Illuminate\Http\Request;
+
+trait HasVisitorIdTrait
+{
+	protected ?string $visitor_id = null;
+
+	/**
+	 * @return string
+	 */
+	public function visitorId(): string
+	{
+		if ($this->visitor_id === null) {
+			// Hash the ip of the the request with the user agent to create a unique visitor id
+			// This is not a secure way to create a unique id, but it is good enough for our purpose.
+			// For privacy reasons we don't want to store the ip or user agent in the database.
+
+			/** @var Request $request */
+			$request = request();
+
+			// xxh64 is a fast hash function that is not cryptographically secure.
+			// The cryptographic properties of xxh64 is actually not important to us.
+			// We do not need to have a strong non-collision guarantee. (Yes, that is counter intuitive, lol)
+			// Collisions are actually a "good thing" as it gives plausible deniability.
+			$this->visitor_id = hash('xxh64', $request->ip() . $request->userAgent());
+		}
+
+		return $this->visitor_id;
+	}
+}

--- a/app/Http/Resources/Models/AlbumResource.php
+++ b/app/Http/Resources/Models/AlbumResource.php
@@ -19,8 +19,10 @@ use App\Http\Resources\Traits\HasPrepPhotoCollection;
 use App\Http\Resources\Traits\HasTimelineData;
 use App\Models\Album;
 use App\Models\Configs;
+use App\Policies\AlbumPolicy;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
@@ -62,6 +64,8 @@ class AlbumResource extends Data
 	public AlbumRightsResource $rights;
 	public PreFormattedAlbumData $preFormattedData;
 	public ?EditableBaseAlbumResource $editable;
+
+	public ?AlbumStatisticsResource $statistics = null;
 
 	public function __construct(Album $album)
 	{
@@ -110,6 +114,10 @@ class AlbumResource extends Data
 
 		if ($this->rights->can_edit) {
 			$this->editable = EditableBaseAlbumResource::fromModel($album);
+		}
+
+		if (Configs::getValueAsBool('metrics_enabled') && Gate::check(AlbumPolicy::CAN_READ_METRICS, [Album::class, $album])) {
+			$this->statistics = AlbumStatisticsResource::fromModel($album->statistics);
 		}
 	}
 

--- a/app/Http/Resources/Models/AlbumStatisticsResource.php
+++ b/app/Http/Resources/Models/AlbumStatisticsResource.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Models;
+
+use App\Models\Statistics;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class AlbumStatisticsResource extends Data
+{
+	public function __construct(
+		public int $visit_count = 0,
+		public int $download_count = 0,
+		public int $shared_count = 0,
+	) {
+	}
+
+	public static function fromModel(Statistics $stats): AlbumStatisticsResource
+	{
+		return new self(
+			$stats->visit_count,
+			$stats->download_count,
+			$stats->shared_count,
+		);
+	}
+}

--- a/app/Http/Resources/Models/PhotoStatisticsResource.php
+++ b/app/Http/Resources/Models/PhotoStatisticsResource.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Models;
+
+use App\Models\Statistics;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class PhotoStatisticsResource extends Data
+{
+	public function __construct(
+		public int $visit_count = 0,
+		public int $download_count = 0,
+		public int $favourite_count = 0,
+		public int $shared_count = 0,
+	) {
+	}
+
+	public static function fromModel(Statistics $stats): PhotoStatisticsResource
+	{
+		return new self(
+			$stats->visit_count,
+			$stats->download_count,
+			$stats->favourite_count,
+			$stats->shared_count,
+		);
+	}
+}

--- a/app/Http/Resources/Models/SmartAlbumResource.php
+++ b/app/Http/Resources/Models/SmartAlbumResource.php
@@ -37,6 +37,7 @@ class SmartAlbumResource extends Data
 	public AlbumProtectionPolicy $policy;
 	public AlbumRightsResource $rights;
 	public PreFormattedAlbumData $preFormattedData;
+	public null $statistics = null; // Needed to unify the API response with the AlbumResource and TagAlbumResource.
 
 	public function __construct(BaseSmartAlbum $smart_album)
 	{

--- a/app/Http/Resources/Models/TagAlbumResource.php
+++ b/app/Http/Resources/Models/TagAlbumResource.php
@@ -16,9 +16,12 @@ use App\Http\Resources\Rights\AlbumRightsResource;
 use App\Http\Resources\Traits\HasHeaderUrl;
 use App\Http\Resources\Traits\HasPrepPhotoCollection;
 use App\Http\Resources\Traits\HasTimelineData;
+use App\Models\Configs;
 use App\Models\TagAlbum;
+use App\Policies\AlbumPolicy;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
@@ -52,6 +55,8 @@ class TagAlbumResource extends Data
 	public PreFormattedAlbumData $preFormattedData;
 	public ?EditableBaseAlbumResource $editable;
 
+	public ?AlbumStatisticsResource $statistics = null;
+
 	public function __construct(TagAlbum $tag_album)
 	{
 		// basic
@@ -84,6 +89,10 @@ class TagAlbumResource extends Data
 
 		if ($this->rights->can_edit) {
 			$this->editable = EditableBaseAlbumResource::fromModel($tag_album);
+		}
+
+		if (Configs::getValueAsBool('metrics_enabled') && Gate::check(AlbumPolicy::CAN_READ_METRICS, [TagAlbum::class, $tag_album])) {
+			$this->statistics = AlbumStatisticsResource::fromModel($tag_album->statistics);
 		}
 	}
 

--- a/app/Listeners/MetricsListener.php
+++ b/app/Listeners/MetricsListener.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Listeners;
+
+use App\Events\Metrics\BaseMetricsEvent;
+use App\Models\Configs;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Just logging of Cache events.
+ */
+class MetricsListener
+{
+	/**
+	 * Handle the event.
+	 */
+	public function handle(BaseMetricsEvent $event): void
+	{
+		if (Configs::getValueAsBool('metrics_enabled') === true) {
+			// Increment the respective metric in the database
+			DB::table('statistics')
+				->where($event->key(), '=', $event->id)
+				->increment($event->metricAction()->column(), 1);
+		}
+	}
+}

--- a/app/Models/BaseAlbumImpl.php
+++ b/app/Models/BaseAlbumImpl.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Facades\Auth;
 
 /**
@@ -187,6 +188,7 @@ class BaseAlbumImpl extends Model implements HasRandomID
 		// Special visibility attributes
 		'is_nsfw' => false,
 		'photo_layout' => null,
+		// 'statistics' => null,
 	];
 
 	/**
@@ -205,7 +207,7 @@ class BaseAlbumImpl extends Model implements HasRandomID
 	/**
 	 * The relationships that should always be eagerly loaded by default.
 	 */
-	protected $with = ['owner', 'access_permissions'];
+	protected $with = ['owner', 'access_permissions', 'statistics'];
 
 	public function newEloquentBuilder($query): BaseAlbumImplBuilder
 	{
@@ -262,6 +264,16 @@ class BaseAlbumImpl extends Model implements HasRandomID
 	public function public_permissions(): AccessPermission|null
 	{
 		return $this->access_permissions->first(fn (AccessPermission $p) => $p->user_id === null);
+	}
+
+	/**
+	 * Returns the relationship between an album and its associated statistics.
+	 *
+	 * @return HasOne<Statistics,$this>
+	 */
+	public function statistics(): HasOne
+	{
+		return $this->hasOne(Statistics::class, 'album_id', 'id');
 	}
 
 	protected function getPhotoSortingAttribute(): ?PhotoSortingCriterion

--- a/app/Models/Builders/StatisticsBuilder.php
+++ b/app/Models/Builders/StatisticsBuilder.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Models\Builders;
+
+use App\Eloquent\FixedQueryBuilder;
+use App\Models\Statistics;
+
+/**
+ * Specialized query builder for {@link \App\Models\Statistics}.
+ *
+ * @template TModelClass of Statistics
+ *
+ * @extends FixedQueryBuilder<TModelClass>
+ */
+class StatisticsBuilder extends FixedQueryBuilder
+{
+}

--- a/app/Models/Extensions/BaseAlbum.php
+++ b/app/Models/Extensions/BaseAlbum.php
@@ -16,12 +16,14 @@ use App\Enum\PhotoLayoutType;
 use App\Enum\TimelinePhotoGranularity;
 use App\Models\AccessPermission;
 use App\Models\BaseAlbumImpl;
+use App\Models\Statistics;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Carbon;
 
@@ -122,6 +124,16 @@ abstract class BaseAlbum extends Model implements AbstractAlbum, HasRandomID
 	public function public_permissions(): AccessPermission|null
 	{
 		return $this->base_class->public_permissions();
+	}
+
+	/**
+	 * Returns the relationship between an album and its associated statistics.
+	 *
+	 * @return HasOne<Statistics,BaseAlbumImpl>
+	 */
+	public function statistics(): HasOne
+	{
+		return $this->base_class->statistics();
 	}
 
 	/**

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -34,6 +34,7 @@ use App\Relations\HasManySizeVariants;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 use function Safe\preg_match;
@@ -178,6 +179,10 @@ class Photo extends Model implements HasUTCBasedTimes
 		'live_photo_short_path', // serialize live_photo_url instead
 	];
 
+	// protected $with = [
+	// 	'statistics',
+	// ];
+
 	public function newEloquentBuilder($query): PhotoBuilder
 	{
 		return new PhotoBuilder($query);
@@ -206,6 +211,16 @@ class Photo extends Model implements HasUTCBasedTimes
 	public function size_variants(): HasManySizeVariants
 	{
 		return new HasManySizeVariants($this);
+	}
+
+	/**
+	 * Returns the relationship between a photo and its associated statistics.
+	 *
+	 * @return HasOne<Statistics,$this>
+	 */
+	public function statistics(): HasOne
+	{
+		return $this->hasOne(Statistics::class, 'photo_id', 'id');
 	}
 
 	/**

--- a/app/Models/Statistics.php
+++ b/app/Models/Statistics.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Models;
+
+use App\Models\Builders\StatisticsBuilder;
+use App\Models\Extensions\ThrowsConsistentExceptions;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * App\Models\Statistics.
+ *
+ * @property int         $id
+ * @property string|null $album_id
+ * @property string|null $photo_id
+ * @property int         $visit_count
+ * @property int         $download_count
+ * @property int         $favourite_count
+ * @property int         $shared_count
+ *
+ * @method static StatisticsBuilder|Statistics addSelect($column)
+ * @method static StatisticsBuilder|Statistics join(string $table, string $first, string $operator = null, string $second = null, string $type = 'inner', string $where = false)
+ * @method static StatisticsBuilder|Statistics joinSub($query, $as, $first, $operator = null, $second = null, $type = 'inner', $where = false)
+ * @method static StatisticsBuilder|Statistics leftJoin(string $table, string $first, string $operator = null, string $second = null)
+ * @method static StatisticsBuilder|Statistics newModelQuery()
+ * @method static StatisticsBuilder|Statistics newQuery()
+ * @method static StatisticsBuilder|Statistics orderBy($column, $direction = 'asc')
+ * @method static StatisticsBuilder|Statistics query()
+ * @method static StatisticsBuilder|Statistics select($columns = [])
+ * @method static StatisticsBuilder|Statistics whereCreatedAt($value)
+ * @method static StatisticsBuilder|Statistics whereId($value)
+ * @method static StatisticsBuilder|Statistics whereIn(string $column, string $values, string $boolean = 'and', string $not = false)
+ * @method static StatisticsBuilder|Statistics whereNotIn(string $column, string $values, string $boolean = 'and')
+ *
+ * @mixin \Eloquent
+ */
+class Statistics extends Model
+{
+	use ThrowsConsistentExceptions;
+	/** @phpstan-use HasFactory<\Database\Factories\StatisticsFactory> */
+	use HasFactory;
+
+	public $timestamps = false;
+
+	/**
+	 * @param $query
+	 *
+	 * @return StatisticsBuilder
+	 */
+	public function newEloquentBuilder($query): StatisticsBuilder
+	{
+		return new StatisticsBuilder($query);
+	}
+
+	protected $fillable = [
+		'album_id',
+		'photo_id',
+		'visit_count',
+		'download_count',
+		'favourite_count',
+		'shared_count',
+	];
+}

--- a/app/Policies/AlbumPolicy.php
+++ b/app/Policies/AlbumPolicy.php
@@ -592,7 +592,7 @@ class AlbumPolicy extends BasePolicy
 
 		return match ($access_level) {
 			MetricsAccess::PUBLIC => true,
-			MetricsAccess::LOGGEDIN => $user !== null,
+			MetricsAccess::LOGGED_IN => $user !== null,
 			MetricsAccess::OWNER => $user !== null && $album->owner_id === $user->id,
 			MetricsAccess::ADMIN => $user?->may_administrate === true,
 			default => false,

--- a/app/Policies/PhotoPolicy.php
+++ b/app/Policies/PhotoPolicy.php
@@ -246,7 +246,7 @@ class PhotoPolicy extends BasePolicy
 
 		return match ($access_level) {
 			MetricsAccess::PUBLIC => true,
-			MetricsAccess::LOGGEDIN => $user !== null,
+			MetricsAccess::LOGGED_IN => $user !== null,
 			MetricsAccess::OWNER => $user !== null && $photo->owner_id === $user->id,
 			MetricsAccess::ADMIN => $user?->may_administrate === true,
 			default => false,

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,14 +14,9 @@ use App\Assets\Helpers;
 use App\Assets\SizeVariantGroupedWithRandomSuffixNamingStrategy;
 use App\Contracts\Models\AbstractSizeVariantNamingStrategy;
 use App\Contracts\Models\SizeVariantFactory;
-use App\Events\AlbumRouteCacheUpdated;
-use App\Events\TaggedRouteCacheUpdated;
 use App\Factories\AlbumFactory;
 use App\Image\SizeVariantDefaultFactory;
 use App\Image\StreamStatFilter;
-use App\Listeners\AlbumCacheCleaner;
-use App\Listeners\CacheListener;
-use App\Listeners\TaggedRouteCacheCleaner;
 use App\Metadata\Json\CommitsRequest;
 use App\Metadata\Json\UpdateRequest;
 use App\Metadata\Versions\FileVersion;
@@ -34,16 +29,11 @@ use App\Models\Configs;
 use App\Policies\AlbumQueryPolicy;
 use App\Policies\PhotoQueryPolicy;
 use App\Policies\SettingsPolicy;
-use Illuminate\Cache\Events\CacheHit;
-use Illuminate\Cache\Events\CacheMissed;
-use Illuminate\Cache\Events\KeyForgotten;
-use Illuminate\Cache\Events\KeyWritten;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
@@ -106,14 +96,6 @@ class AppServiceProvider extends ServiceProvider
 	 */
 	public function boot()
 	{
-		Event::listen(CacheHit::class, CacheListener::class . '@handle');
-		Event::listen(CacheMissed::class, CacheListener::class . '@handle');
-		Event::listen(KeyForgotten::class, CacheListener::class . '@handle');
-		Event::listen(KeyWritten::class, CacheListener::class . '@handle');
-
-		Event::listen(AlbumRouteCacheUpdated::class, AlbumCacheCleaner::class . '@handle');
-		Event::listen(TaggedRouteCacheUpdated::class, TaggedRouteCacheCleaner::class . '@handle');
-
 		// Prohibits: db:wipe, migrate:fresh, migrate:refresh, and migrate:reset
 		DB::prohibitDestructiveCommands(config('app.env', 'production') !== 'dev');
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -8,8 +8,26 @@
 
 namespace App\Providers;
 
+use App\Events\AlbumRouteCacheUpdated;
+use App\Events\Metrics\AlbumDownload;
+use App\Events\Metrics\AlbumShared;
+use App\Events\Metrics\AlbumVisit;
+use App\Events\Metrics\PhotoDownload;
+use App\Events\Metrics\PhotoFavourite;
+use App\Events\Metrics\PhotoShared;
+use App\Events\Metrics\PhotoVisit;
+use App\Events\TaggedRouteCacheUpdated;
+use App\Listeners\AlbumCacheCleaner;
+use App\Listeners\CacheListener;
+use App\Listeners\MetricsListener;
+use App\Listeners\TaggedRouteCacheCleaner;
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Cache\Events\CacheHit;
+use Illuminate\Cache\Events\CacheMissed;
+use Illuminate\Cache\Events\KeyForgotten;
+use Illuminate\Cache\Events\KeyWritten;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Event;
 use SocialiteProviders\Amazon\AmazonExtendSocialite;
 use SocialiteProviders\Apple\AppleExtendSocialite;
 use SocialiteProviders\Authelia\AutheliaExtendSocialite;
@@ -55,5 +73,20 @@ class EventServiceProvider extends ServiceProvider
 	 */
 	public function boot(): void
 	{
+		Event::listen(CacheHit::class, CacheListener::class . '@handle');
+		Event::listen(CacheMissed::class, CacheListener::class . '@handle');
+		Event::listen(KeyForgotten::class, CacheListener::class . '@handle');
+		Event::listen(KeyWritten::class, CacheListener::class . '@handle');
+
+		Event::listen(AlbumRouteCacheUpdated::class, AlbumCacheCleaner::class . '@handle');
+		Event::listen(TaggedRouteCacheUpdated::class, TaggedRouteCacheCleaner::class . '@handle');
+
+		Event::listen(AlbumDownload::class, MetricsListener::class . '@handle');
+		Event::listen(AlbumShared::class, MetricsListener::class . '@handle');
+		Event::listen(AlbumVisit::class, MetricsListener::class . '@handle');
+		Event::listen(PhotoDownload::class, MetricsListener::class . '@handle');
+		Event::listen(PhotoFavourite::class, MetricsListener::class . '@handle');
+		Event::listen(PhotoShared::class, MetricsListener::class . '@handle');
+		Event::listen(PhotoVisit::class, MetricsListener::class . '@handle');
 	}
 }

--- a/database/factories/AlbumFactory.php
+++ b/database/factories/AlbumFactory.php
@@ -9,6 +9,7 @@
 namespace Database\Factories;
 
 use App\Models\Album;
+use App\Models\Statistics;
 use Database\Factories\Traits\OwnedBy;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -66,6 +67,19 @@ class AlbumFactory extends Factory
 	{
 		return $this->afterMaking(function (Album $album) {
 			$album->makeRoot();
+		});
+	}
+
+	/**
+	 * Configure the model factory.
+	 * We also create the associated statistics model.
+	 */
+	public function configure(): static
+	{
+		return $this->afterCreating(function (Album $album) {
+			Statistics::factory()->with_album($album->id)->create();
+			$album->fresh();
+			$album->load('statistics');
 		});
 	}
 }

--- a/database/factories/PhotoFactory.php
+++ b/database/factories/PhotoFactory.php
@@ -11,6 +11,7 @@ namespace Database\Factories;
 use App\Models\Album;
 use App\Models\Photo;
 use App\Models\SizeVariant;
+use App\Models\Statistics;
 use Database\Factories\Traits\OwnedBy;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -165,17 +166,22 @@ class PhotoFactory extends Factory
 
 	/**
 	 * Configure the model factory.
-	 * We create 7 random Size Variants.
+	 * We create 7 random Size Variants and the associated statistics model.
 	 */
 	public function configure(): static
 	{
 		return $this->afterCreating(function (Photo $photo) {
+			Statistics::factory()->with_photo($photo->id)->create();
+			$photo->fresh();
+
 			// Creates the size variants
 			if ($this->with_size_variants) {
 				SizeVariant::factory()->count(7)->allSizeVariants()->create(['photo_id' => $photo->id]);
 				$photo->fresh();
 				$photo->load('size_variants');
 			}
+
+			$photo->load('statistics');
 
 			// Reset the value if it was disabled.
 			$this->with_size_variants = true;

--- a/database/factories/StatisticsFactory.php
+++ b/database/factories/StatisticsFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace Database\Factories;
+
+use App\Models\Statistics;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Statistics>
+ */
+class StatisticsFactory extends Factory
+{
+	/**
+	 * The name of the factory's corresponding model.
+	 *
+	 * @var string
+	 */
+	protected $model = Statistics::class;
+
+	/**
+	 * Define the model's default state.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function definition(): array
+	{
+		return [
+			'album_id' => null,
+			'photo_id' => null,
+			'visit_count' => 0,
+			'download_count' => 0,
+			'favourite_count' => 0,
+			'shared_count' => 0,
+		];
+	}
+
+	public function with_album(string $album_id): self
+	{
+		return $this->state(function (array $attributes) use ($album_id) {
+			return [
+				'album_id' => $album_id,
+			];
+		});
+	}
+
+	public function with_photo(string $photo_id): self
+	{
+		return $this->state(function (array $attributes) use ($photo_id) {
+			return [
+				'photo_id' => $photo_id,
+			];
+		});
+	}
+}

--- a/database/factories/TagAlbumFactory.php
+++ b/database/factories/TagAlbumFactory.php
@@ -8,6 +8,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Statistics;
 use App\Models\TagAlbum;
 use Database\Factories\Traits\OwnedBy;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -45,6 +46,19 @@ class TagAlbumFactory extends Factory
 			return [
 				'show_tags' => $tags,
 			];
+		});
+	}
+
+	/**
+	 * Configure the model factory.
+	 * We also create the associated statistics model.
+	 */
+	public function configure(): static
+	{
+		return $this->afterCreating(function (TagAlbum $album) {
+			Statistics::factory()->with_album($album->id)->create();
+			$album->fresh();
+			$album->load('statistics');
 		});
 	}
 }

--- a/database/migrations/2025_04_07_211144_add_stats_columns.php
+++ b/database/migrations/2025_04_07_211144_add_stats_columns.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+	private const COL_VISIT = 'visit_count';
+	private const COL_DOWNLOAD = 'download_count';
+	private const COL_FAVOURITE = 'favourite_count';
+	private const COL_SHARED = 'shared_count';
+	public const RANDOM_ID_LENGTH = 24;
+
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		Schema::create('statistics', function (Blueprint $table) {
+			$table->id();
+			$table->char('album_id', self::RANDOM_ID_LENGTH)->index()->unique()->nullable(true);
+			$table->char('photo_id', self::RANDOM_ID_LENGTH)->index()->unique()->nullable(true);
+			$table->unsignedBigInteger(self::COL_VISIT)->default(0)->comment('Number of times this photo/album has been viewed');
+			$table->unsignedBigInteger(self::COL_DOWNLOAD)->default(0)->comment('Number of times this photo/album has been downloaded (excluding albums)');
+			$table->unsignedBigInteger(self::COL_FAVOURITE)->default(0)->comment('Number of times this photo has been favourite');
+			$table->unsignedBigInteger(self::COL_SHARED)->default(0)->comment('Number of times this photo/album has been shared');
+		});
+
+		DB::statement('INSERT INTO statistics (photo_id) SELECT id FROM photos');
+		DB::statement('INSERT INTO statistics (album_id) SELECT id FROM base_albums');
+
+		DB::table('configs')->where('key', 'client_side_favourite_enabled')->update(['order' => 1]);
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		Schema::dropIfExists('statistics');
+
+		DB::table('configs')->where('key', 'client_side_favourite_enabled')->update(['order' => 32767]);
+	}
+};

--- a/database/migrations/2025_04_07_211147_metrics_config.php
+++ b/database/migrations/2025_04_07_211147_metrics_config.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const CAT = 'Mod Pro';
+
+	public function getConfigs(): array
+	{
+		// landing_background
+		return [
+			[
+				'key' => 'metrics_enabled',
+				'value' => '0',
+				'cat' => self::CAT,
+				'type_range' => self::BOOL,
+				'description' => 'Enable statistics on photos & albums',
+				'details' => 'If enabled, anonymours users will be measured.',
+				'is_expert' => false,
+				'is_secret' => true,
+				'level' => 1,
+				'order' => 2,
+			],
+			[
+				'key' => 'metrics_logged_in_users_enabed',
+				'value' => '0',
+				'cat' => self::CAT,
+				'type_range' => self::BOOL,
+				'description' => 'Enable statistics for logged-in users',
+				'details' => 'If enabled, logged-in users will be measured as well (admin users are not measured).',
+				'is_expert' => false,
+				'is_secret' => true,
+				'level' => 1,
+				'order' => 3,
+			],
+			[
+				'key' => 'metrics_access',
+				'value' => 'admin',
+				'cat' => self::CAT,
+				'type_range' => 'admin|owner|logged-in users|public',
+				'description' => 'Access level for statistics of the album/photo',
+				'details' => '',
+				'is_expert' => true,
+				'is_secret' => true,
+				'level' => 1,
+				'order' => 4,
+			],
+			[
+				'key' => 'live_metrics_enabled',
+				'value' => '0',
+				'cat' => self::CAT,
+				'type_range' => self::BOOL,
+				'description' => 'Enable live statistics',
+				'details' => 'Live metrics provides you an activity history of your gallery.',
+				'is_expert' => false,
+				'is_secret' => true,
+				'level' => 1,
+				'order' => 5,
+			],
+			[
+				'key' => 'live_metrics_access',
+				'value' => 'admin',
+				'cat' => self::CAT,
+				'type_range' => 'admin|logged-in users',
+				'description' => 'Access level for live metrics',
+				'details' => 'If set to "admin", only admins can see the live metrics.',
+				'is_expert' => false,
+				'is_secret' => true,
+				'level' => 1,
+				'order' => 6,
+			],
+			[
+				'key' => 'live_metrics_max_time',
+				'value' => '30',
+				'cat' => self::CAT,
+				'type_range' => self::POSITIVE,
+				'description' => 'Max age for live metrics in days',
+				'details' => 'After this time, the live metrics will be deleted.',
+				'is_expert' => false,
+				'is_secret' => true,
+				'level' => 1,
+				'order' => 7,
+			],
+		];
+	}
+};

--- a/resources/js/components/drawers/PhotoDetails.vue
+++ b/resources/js/components/drawers/PhotoDetails.vue
@@ -144,6 +144,30 @@
 						</h2>
 						<span class="py-0.5 pl-0 text-sm text-muted-color">{{ props.photo.preformatted.license }}</span>
 					</template>
+
+					<template v-if="props.photo.statistics">
+						<h2 class="text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+							{{ $t("gallery.photo.details.stats.header") }}
+						</h2>
+						<div class="flex flex-wrap text-muted-color text-sm gap-y-0.5">
+							<div class="w-1/2">
+								<i class="pi pi-eye mr-2" v-tooltip.right="$t('gallery.photo.details.stats.number_of_visits')" />
+								{{ props.photo.statistics.visit_count }}
+							</div>
+							<div class="w-1/2">
+								<i class="pi pi-cloud-download mr-2" v-tooltip.right="$t('gallery.photo.details.stats.number_of_downloads')" />
+								{{ props.photo.statistics.download_count }}
+							</div>
+							<div class="w-1/2">
+								<i class="pi pi-share-alt mr-2" v-tooltip.right="$t('gallery.photo.details.stats.number_of_shares')" />
+								{{ props.photo.statistics.shared_count }}
+							</div>
+							<div class="w-1/2">
+								<i class="pi pi-heart mr-2" v-tooltip.right="$t('gallery.photo.details.stats.number_of_favourites')" />
+								{{ props.photo.statistics.favourite_count }}
+							</div>
+						</div>
+					</template>
 				</div>
 			</template>
 		</Card>
@@ -151,6 +175,7 @@
 </template>
 <script setup lang="ts">
 import { Ref } from "vue";
+import Tag from "primevue/tag";
 import Card from "primevue/card";
 import MapInclude from "../gallery/photoModule/MapInclude.vue";
 import MiniIcon from "../icons/MiniIcon.vue";

--- a/resources/js/components/gallery/albumModule/AlbumHero.vue
+++ b/resources/js/components/gallery/albumModule/AlbumHero.vue
@@ -29,78 +29,93 @@
 						</span>
 					</span>
 				</div>
-				<a
-					v-if="props.album.rights.can_download"
-					class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-					:title="$t('gallery.album.hero.download')"
-					@click="download"
-				>
-					<i class="pi pi-cloud-download" />
-				</a>
-				<a
-					v-if="props.album.rights.can_share"
-					class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-					:title="$t('gallery.album.hero.share')"
-					v-on:click="openSharingModal"
-				>
-					<i class="pi pi-share-alt" />
-				</a>
-				<a
-					v-if="is_se_enabled && user?.id !== null"
-					class="shrink-0 px-3 cursor-pointer inline-block transform duration-300 hover:scale-150 hover:text-color"
-					v-on:click="openStatistics"
-				>
-					<i class="pi pi-chart-scatter text-primary-emphasis" />
-				</a>
-				<a
-					v-if="is_se_preview_enabled && user?.id !== null"
-					class="shrink-0 px-3 cursor-not-allowed text-primary-emphasis"
-					v-tooltip.bottom="$t('gallery.album.hero.stats_only_se')"
-				>
-					<i class="pi pi-chart-scatter" />
-				</a>
-				<router-link
-					:to="{ name: 'frame-with-album', params: { albumid: props.album.id } }"
-					v-if="props.config.is_mod_frame_enabled"
-					class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-					v-tooltip.bottom="'Frame'"
-				>
-					<i class="pi pi-desktop" />
-				</router-link>
-				<router-link
-					:to="{ name: 'map-with-album', params: { albumid: props.album.id } }"
-					v-if="props.config.is_map_accessible && hasCoordinates"
-					class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-				>
-					<i class="pi pi-map" />
-				</router-link>
-				<a
-					v-tooltip.bottom="'Start slideshow'"
-					@click="emits('toggleSlideShow')"
-					v-if="props.album.photos.length > 0"
-					class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-				>
-					<i class="pi pi-play" />
-				</a>
+				<div class="flex flex-col w-full gap-2">
+					<div class="flex flex-row-reverse items-center">
+						<a
+							v-if="props.album.rights.can_download"
+							class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+							:title="$t('gallery.album.hero.download')"
+							@click="download"
+						>
+							<i class="pi pi-cloud-download" />
+						</a>
+						<a
+							v-if="props.album.rights.can_share"
+							class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+							:title="$t('gallery.album.hero.share')"
+							v-on:click="openSharingModal"
+						>
+							<i class="pi pi-share-alt" />
+						</a>
+						<a
+							v-if="is_se_enabled && user?.id !== null"
+							class="shrink-0 px-3 cursor-pointer inline-block transform duration-300 hover:scale-150 hover:text-color"
+							v-on:click="openStatistics"
+						>
+							<i class="pi pi-chart-scatter text-primary-emphasis" />
+						</a>
+						<a
+							v-if="is_se_preview_enabled && user?.id !== null"
+							class="shrink-0 px-3 cursor-not-allowed text-primary-emphasis"
+							v-tooltip.left="$t('gallery.album.hero.stats_only_se')"
+						>
+							<i class="pi pi-chart-scatter" />
+						</a>
+						<router-link
+							:to="{ name: 'frame-with-album', params: { albumid: props.album.id } }"
+							v-if="props.config.is_mod_frame_enabled"
+							class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+							v-tooltip.bottom="'Frame'"
+						>
+							<i class="pi pi-desktop" />
+						</router-link>
+						<router-link
+							:to="{ name: 'map-with-album', params: { albumid: props.album.id } }"
+							v-if="props.config.is_map_accessible && hasCoordinates"
+							class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+						>
+							<i class="pi pi-map" />
+						</router-link>
+						<a
+							v-tooltip.bottom="'Start slideshow'"
+							@click="emits('toggleSlideShow')"
+							v-if="props.album.photos.length > 0"
+							class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+						>
+							<i class="pi pi-play" />
+						</a>
 
-				<template v-if="isTouchDevice() && user?.id !== null">
-					<a
-						v-if="props.hasHidden && are_nsfw_visible"
-						class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-						:title="'hide hidden'"
-						@click="are_nsfw_visible = false"
-					>
-						<i class="pi pi pi-eye-slash" />
-					</a>
-					<a
-						v-if="props.hasHidden && !are_nsfw_visible"
-						class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-						:title="'show hidden'"
-						@click="are_nsfw_visible = true"
-					>
-						<i class="pi pi-eye" />
-					</a>
-				</template>
+						<template v-if="isTouchDevice() && user?.id !== null">
+							<a
+								v-if="props.hasHidden && are_nsfw_visible"
+								class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+								:title="'hide hidden'"
+								@click="are_nsfw_visible = false"
+							>
+								<i class="pi pi pi-eye-slash" />
+							</a>
+							<a
+								v-if="props.hasHidden && !are_nsfw_visible"
+								class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+								:title="'show hidden'"
+								@click="are_nsfw_visible = true"
+							>
+								<i class="pi pi-eye" />
+							</a>
+						</template>
+					</div>
+					<div v-if="props.album.statistics" class="flex gap-4 text-base justify-end text-muted-color">
+						<span v-tooltip.bottom="{ value: $t('gallery.album.stats.number_of_visits') }"
+							>{{ props.album.statistics.visit_count }} <i class="pi pi-eye text-xs ml-1"></i
+						></span>
+						<span v-tooltip.bottom="{ value: $t('gallery.album.stats.number_of_downloads') }"
+							>{{ props.album.statistics.download_count }} <i class="pi pi-cloud-download text-xs ml-1"></i
+						></span>
+						<span v-tooltip.bottom="{ value: $t('gallery.album.stats.number_of_shares') }"
+							>{{ props.album.statistics.shared_count }} <i class="pi pi-share-alt text-xs ml-1"></i
+						></span>
+					</div>
+				</div>
 			</div>
 			<div
 				v-if="props.album.preFormattedData.description"

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -75,6 +75,8 @@ declare namespace App.Enum {
 		| "CC-BY-NC-SA-4.0";
 	export type MapProviders = "Wikimedia" | "OpenStreetMap.org" | "OpenStreetMap.de" | "OpenStreetMap.fr" | "RRZE";
 	export type MessageType = "info" | "warning" | "error";
+	export type MetricsAccess = "public" | "logged-in users" | "owner" | "admin";
+	export type MetricsAction = "visit" | "favourite" | "download" | "shared";
 	export type OauthProvidersType =
 		| "amazon"
 		| "apple"
@@ -343,6 +345,12 @@ declare namespace App.Http.Resources.Models {
 		rights: App.Http.Resources.Rights.AlbumRightsResource;
 		preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
 		editable: App.Http.Resources.Editable.EditableBaseAlbumResource | null;
+		statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
+	};
+	export type AlbumStatisticsResource = {
+		visit_count: number;
+		download_count: number;
+		shared_count: number;
 	};
 	export type ConfigCategoryResource = {
 		cat: string;
@@ -408,6 +416,13 @@ declare namespace App.Http.Resources.Models {
 		preformatted: App.Http.Resources.Models.Utils.PreformattedPhotoData;
 		precomputed: App.Http.Resources.Models.Utils.PreComputedPhotoData;
 		timeline: App.Http.Resources.Models.Utils.TimelineData | null;
+		statistics: App.Http.Resources.Models.PhotoStatisticsResource | null;
+	};
+	export type PhotoStatisticsResource = {
+		visit_count: number;
+		download_count: number;
+		favourite_count: number;
+		shared_count: number;
 	};
 	export type SizeVariantResource = {
 		type: App.Enum.SizeVariantType;
@@ -435,6 +450,7 @@ declare namespace App.Http.Resources.Models {
 		policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
 		rights: App.Http.Resources.Rights.AlbumRightsResource;
 		preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
+		statistics: null | null;
 	};
 	export type TagAlbumResource = {
 		id: string;
@@ -449,6 +465,7 @@ declare namespace App.Http.Resources.Models {
 		rights: App.Http.Resources.Rights.AlbumRightsResource;
 		preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
 		editable: App.Http.Resources.Editable.EditableBaseAlbumResource | null;
+		statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
 	};
 	export type TargetAlbumResource = {
 		id: string | null;

--- a/resources/js/services/metrics-service.ts
+++ b/resources/js/services/metrics-service.ts
@@ -1,0 +1,14 @@
+import axios, { type AxiosResponse } from "axios";
+import Constants from "./constants";
+
+const MetricsService = {
+	photo(photo_id: string): Promise<AxiosResponse<null>> {
+		return axios.post(`${Constants.getApiUrl()}Metrics::photo`, { photo_ids: [photo_id] });
+	},
+
+	favourite(photo_id: string): Promise<AxiosResponse<null>> {
+		return axios.post(`${Constants.getApiUrl()}Metrics::favourite`, { photo_ids: [photo_id] });
+	},
+};
+
+export default MetricsService;

--- a/resources/js/stores/FavouriteState.ts
+++ b/resources/js/stores/FavouriteState.ts
@@ -1,3 +1,4 @@
+import MetricsService from "@/services/metrics-service";
 import { defineStore } from "pinia";
 
 export type FavouriteStore = ReturnType<typeof useFavouriteStore>;
@@ -43,6 +44,7 @@ export const useFavouriteStore = defineStore("favourite-store", {
 				this.removePhoto(photo.id);
 			} else {
 				this.addPhoto(photo);
+				MetricsService.favourite(photo.id);
 			}
 		},
 	},

--- a/resources/js/views/gallery-panels/Search.vue
+++ b/resources/js/views/gallery-panels/Search.vue
@@ -145,7 +145,7 @@ import { useGalleryModals } from "@/composables/modalsTriggers/galleryModals";
 import { useSelection } from "@/composables/selections/selections";
 import { useAuthStore } from "@/stores/Auth";
 import { useLycheeStateStore } from "@/stores/LycheeState";
-import { onKeyStroke } from "@vueuse/core";
+import { onKeyStroke, useDebounceFn } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
@@ -178,6 +178,7 @@ import SearchHeader from "@/components/headers/SearchHeader.vue";
 import LoadingProgress from "@/components/loading/LoadingProgress.vue";
 import { shouldIgnoreKeystroke } from "@/utils/keybindings-utils";
 import { useHasNextPreviousPhoto } from "@/composables/photo/hasNextPreviousPhoto";
+import MetricsService from "@/services/metrics-service";
 
 const route = useRoute();
 const router = useRouter();
@@ -433,12 +434,20 @@ onMounted(() => {
 	loadLayoutConfig();
 });
 
+const debouncedPhotoMetrics = useDebounceFn(() => {
+	if (photoId.value !== undefined) {
+		MetricsService.photo(photoId.value);
+		return;
+	}
+}, 100);
+
 watch(
 	() => route.params.photoid,
 	(newPhotoId, _) => {
 		unselect();
 
 		photoId.value = newPhotoId as string;
+		debouncedPhotoMetrics();
 		if (photoId.value !== undefined) {
 			togglableStore.rememberScrollThumb(photoId.value);
 			refreshPhoto();

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -232,6 +232,12 @@ Route::get('/Statistics::totalAlbumSpace', [StatisticsController::class, 'getTot
 Route::get('/Statistics::getCountsOverTime', [StatisticsController::class, 'getPhotoCountOverTime'])->middleware(['support:se']);
 
 /**
+ * Metrics.
+ */
+Route::post('/Metrics::photo', [MetricsController::class, 'photo'])->withoutMiddleware(['content_type:json']);
+Route::post('/Metrics::favourite', [MetricsController::class, 'favourite'])->withoutMiddleware(['content_type:json']);
+
+/**
  * UPDATE.
  */
 // Route::post('/Update::apply', [AdministrationUpdateController::class, 'apply']);

--- a/tests/Feature_v2/Album/AlbumCreateTagTest.php
+++ b/tests/Feature_v2/Album/AlbumCreateTagTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\Album;
+
+use App\Models\Statistics;
+use Tests\Feature_v2\Base\BaseApiV2Test;
+
+class AlbumCreateTagTest extends BaseApiV2Test
+{
+	public function testCreateTagAlbumUnauthorizedForbidden(): void
+	{
+		$response = $this->postJson('TagAlbum', []);
+		$this->assertUnprocessable($response);
+
+		$response = $this->postJson('TagAlbum', [
+			'title' => 'test_tag',
+			'tags' => ['tag1', 'tag2'],
+		]);
+		$this->assertUnauthorized($response);
+
+		$response = $this->actingAs($this->userLocked)->postJson('TagAlbum', [
+			'title' => 'test_tag',
+			'tags' => ['tag1', 'tag2'],
+		]);
+		$this->assertForbidden($response);
+	}
+
+	public function testCreateTagAlbumAuthorizedOwner(): void
+	{
+		$response = $this->actingAs($this->userMayUpload1)->postJson('TagAlbum', [
+			'title' => 'test_tag',
+			'tags' => ['tag1', 'tag2'],
+		]);
+		self::assertEquals(200, $response->getStatusCode());
+		$new_album_id = $response->getOriginalContent();
+		$this->assertEquals(1, Statistics::where('album_id', $new_album_id)->count());
+
+		$response = $this->getJsonWithData('Albums');
+		$this->assertOk($response);
+		$response->assertSee($new_album_id);
+	}
+}

--- a/tests/Feature_v2/Album/AlbumCreateTest.php
+++ b/tests/Feature_v2/Album/AlbumCreateTest.php
@@ -18,7 +18,7 @@
 
 namespace Tests\Feature_v2\Album;
 
-// use App\Models\AccessPermission;
+use App\Models\Statistics;
 use Tests\Feature_v2\Base\BaseApiV2Test;
 
 class AlbumCreateTest extends BaseApiV2Test
@@ -49,6 +49,7 @@ class AlbumCreateTest extends BaseApiV2Test
 		]);
 		self::assertEquals(200, $response->getStatusCode());
 		$new_album_id = $response->getOriginalContent();
+		$this->assertEquals(1, Statistics::where('album_id', $new_album_id)->count());
 
 		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
@@ -67,5 +68,6 @@ class AlbumCreateTest extends BaseApiV2Test
 		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertSee($new_album_id);
+		$this->assertEquals(1, Statistics::where('album_id', $new_album_id)->count());
 	}
 }

--- a/tests/Feature_v2/Album/AlbumDeleteTest.php
+++ b/tests/Feature_v2/Album/AlbumDeleteTest.php
@@ -18,6 +18,7 @@
 
 namespace Tests\Feature_v2\Album;
 
+use App\Models\Statistics;
 use Tests\Feature_v2\Base\BaseApiV2Test;
 
 class AlbumDeleteTest extends BaseApiV2Test
@@ -59,5 +60,6 @@ class AlbumDeleteTest extends BaseApiV2Test
 		$response = $this->getJson('Albums');
 		$this->assertOk($response);
 		$response->assertDontSee($this->album1->id);
+		$this->assertEquals(0, Statistics::where('album_id', $this->album1->id)->count());
 	}
 }

--- a/tests/Feature_v2/Album/AlbumMergeTest.php
+++ b/tests/Feature_v2/Album/AlbumMergeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\Album;
+
+use Tests\Feature_v2\Base\BaseApiV2Test;
+
+class AlbumMergeTest extends BaseApiV2Test
+{
+	public function testMergeAlbumUnauthorizedForbidden(): void
+	{
+		$response = $this->postJson('Album::merge', []);
+		$this->assertUnprocessable($response);
+
+		$response = $this->postJson('Album::merge', [
+			'album_id' => $this->album1->id,
+			'album_ids' => [$this->album2->id],
+		]);
+		$this->assertUnauthorized($response);
+
+		$response = $this->actingAs($this->userNoUpload)->postJson('Album::merge', [
+			'album_id' => $this->album1->id,
+			'album_ids' => [$this->album2->id],
+		]);
+		$this->assertForbidden($response);
+	}
+
+	public function testMergeAlbumAuthorizedUser(): void
+	{
+		$response = $this->actingAs($this->userMayUpload2)->postJson('Album::merge', [
+			'album_id' => $this->album1->id, // has edit rights
+			'album_ids' => [$this->album2->id], // own
+		]);
+		$this->assertNoContent($response);
+		$response = $this->getJson('Albums');
+		$this->assertOk($response);
+		$response->assertSee($this->album1->id);
+		$response->assertDontSee($this->album2->id);
+
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$this->assertOk($response);
+		$response->assertSee($this->subAlbum1->id);
+		$response->assertSee($this->subAlbum2->id);
+	}
+}

--- a/tests/Feature_v2/Base/BaseApiV2Test.php
+++ b/tests/Feature_v2/Base/BaseApiV2Test.php
@@ -26,36 +26,6 @@ abstract class BaseApiV2Test extends BaseV2Test
 	public const API_PREFIX = '/api/v2/';
 
 	/**
-	 * Visit the given URI with a GET request.
-	 *
-	 * @param Uri|string $uri
-	 * @param array      $headers
-	 *
-	 * @return TestResponse<\Illuminate\Http\JsonResponse>
-	 */
-	public function get($uri, array $headers = [])
-	{
-		return parent::get(self::API_PREFIX . ltrim($uri, '/'), $headers);
-	}
-
-	/**
-	 * Visit the given URI with a POST request.
-	 *
-	 * @param Uri|string $uri
-	 * @param array      $data
-	 * @param array      $headers
-	 *
-	 * @return TestResponse<\Illuminate\Http\JsonResponse>
-	 */
-	public function post($uri, array $data = [], array $headers = [])
-	{
-		$server = $this->transformHeadersToServerVars($headers);
-		$cookies = $this->prepareCookiesForRequest();
-
-		return $this->call('POST', self::API_PREFIX . ltrim($uri, '/'), $data, $cookies, [], $server);
-	}
-
-	/**
 	 * Visit the given URI with a GET request, expecting a JSON response.
 	 *
 	 * @param string $uri

--- a/tests/Feature_v2/Metrics/EventsFiredTest.php
+++ b/tests/Feature_v2/Metrics/EventsFiredTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\Metrics;
+
+use App\Models\Configs;
+use App\Models\Statistics;
+use Tests\Feature_v2\Base\BaseApiV2Test;
+
+class EventsFiredTest extends BaseApiV2Test
+{
+	public function setUp(): void
+	{
+		parent::setUp();
+		Configs::set('metrics_enabled', true);
+		Configs::invalidateCache();
+	}
+
+	public function tearDown(): void
+	{
+		Configs::set('metrics_enabled', false);
+		Configs::invalidateCache();
+		parent::tearDown();
+	}
+
+	public function testVisitSharedAlbum(): void
+	{
+		$response = $this->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$this->assertOk($response);
+		$this->assertEquals(1, Statistics::where('album_id', $this->album4->id)->firstOrFail()->visit_count);
+
+		$response = $this->get('gallery/' . $this->album4->id);
+		$this->assertOk($response);
+		$this->assertEquals(1, Statistics::where('album_id', $this->album4->id)->firstOrFail()->shared_count);
+	}
+
+	public function testVisitSharedPhoto(): void
+	{
+		$response = $this->postJson('Metrics::photo', ['photo_ids' => [$this->photo4->id]]);
+		$this->assertNoContent($response);
+		$this->assertEquals(1, Statistics::where('photo_id', $this->photo4->id)->firstOrFail()->visit_count);
+
+		$response = $this->postJson('Metrics::favourite', ['photo_ids' => [$this->photo4->id]]);
+		$this->assertNoContent($response);
+		$this->assertEquals(1, Statistics::where('photo_id', $this->photo4->id)->firstOrFail()->favourite_count);
+
+		$response = $this->get('gallery/' . $this->album4->id . '/' . $this->photo4->id);
+		$this->assertOk($response);
+		$this->assertEquals(1, Statistics::where('photo_id', $this->photo4->id)->firstOrFail()->shared_count);
+		$this->assertEquals(0, Statistics::where('album_id', $this->album4->id)->firstOrFail()->shared_count);
+	}
+}

--- a/tests/Traits/RequiresEmptyAlbums.php
+++ b/tests/Traits/RequiresEmptyAlbums.php
@@ -56,6 +56,7 @@ trait RequiresEmptyAlbums
 				->whereNotIn('base_album_id', SmartAlbumType::values())
 				->count()
 		);
+		static::assertEquals(0, DB::table('statistics')->whereNotNull('album_id')->count());
 	}
 
 	protected function tearDownRequiresEmptyAlbums(): void
@@ -68,5 +69,6 @@ trait RequiresEmptyAlbums
 		DB::table('albums')->orderBy('_lft', 'desc')->delete();
 		DB::table('base_albums')->delete();
 		DB::table('access_permissions')->whereNotIn('base_album_id', SmartAlbumType::values())->delete();
+		DB::table('statistics')->whereNotNull('album_id')->delete();
 	}
 }

--- a/tests/Traits/RequiresEmptyPhotos.php
+++ b/tests/Traits/RequiresEmptyPhotos.php
@@ -27,6 +27,8 @@ trait RequiresEmptyPhotos
 {
 	use InteractsWithFilesystemPermissions;
 
+	abstract protected function assertDatabaseCount($table, int $count, $connection = null);
+
 	protected function setUpRequiresEmptyPhotos(): void
 	{
 		$this->setUpInteractsWithFilesystemPermissions();
@@ -35,6 +37,11 @@ trait RequiresEmptyPhotos
 		$this->assertDatabaseCount('size_variants', 0);
 		$this->assertDatabaseCount('photos', 0);
 		$this->assertDatabaseCount('jobs_history', 0);
+		static::assertEquals(
+			0,
+			DB::table('statistics')->whereNotNull('photo_id')
+				->count()
+		);
 	}
 
 	protected function tearDownRequiresEmptyPhotos(): void
@@ -44,6 +51,7 @@ trait RequiresEmptyPhotos
 		DB::table('size_variants')->delete();
 		DB::table('photos')->delete();
 		DB::table('jobs_history')->delete();
+		DB::table('statistics')->whereNotNull('photo_id')->delete();
 		self::cleanPublicFolders();
 	}
 
@@ -94,6 +102,4 @@ trait RequiresEmptyPhotos
 			}
 		}
 	}
-
-	abstract protected function assertDatabaseCount($table, int $count, $connection = null);
 }


### PR DESCRIPTION
This pull request introduces a metrics tracking system for albums and photos, enabling the collection of statistics such as visits, downloads, favorites, and shares. It includes changes to the creation, deletion, and event handling processes for albums and photos, as well as the addition of new enums, events, and a dedicated `MetricsController`. Below is a summary of the most important changes grouped by theme.

### Metrics Tracking for Albums and Photos

* Added a `setStatistics` method in `app/Actions/Album/Create.php` and `app/Actions/Album/CreateTagAlbum.php` to initialize statistics (e.g., visit count, download count) for new albums. (`[[1]](diffhunk://#diff-60e777dd88f8cc6f332a00b3409171ed28ad0d0f630403db0fe48f9bc972512eR43)`, `[[2]](diffhunk://#diff-d09e8bec941857e0270ab8132f142944120ae3c238c09bd88213d5a9573ef0d3R39-R54)`)
* Updated `app/Actions/Photo/Pipes/Shared/SetParentAndOwnership.php` to create and associate a `Statistics` record for new photos. (`[app/Actions/Photo/Pipes/Shared/SetParentAndOwnership.phpR35-R44](diffhunk://#diff-c3a3a6182e6a03129c935cdde3ceda72316b0272b0a899f518438d4b585e1314R35-R44)`)

### Deletion of Statistics

* Modified `app/Actions/Album/Delete.php` and `app/Actions/Photo/Delete.php` to delete associated statistics when albums or photos are removed. (`[[1]](diffhunk://#diff-7f930fae35b7991a670c42b5fd0ba57c4d1d594f52124d468eb9980dd4518146R136-R143)`, `[[2]](diffhunk://#diff-e0c4b6ea7da25e3d3dc2950d2d409081dc505d4eac7dbee1904486c1f580909dR394-R408)`)

### New Enums and Events

* Introduced `MetricsAction` and `MetricsAccess` enums to define metric types and access levels. (`[[1]](diffhunk://#diff-5bedd80d127ba7658724861c36fb017f84e653b4c5c1ed267f868acf4b5c39bfR1-R17)`, `[[2]](diffhunk://#diff-26324c1b05eb29b40113531a2303b6edbb6c84cbbbf1c973c522e8ae157f1c09R1-R32)`)
* Added new events (e.g., `AlbumVisit`, `PhotoDownload`) to track specific actions on albums and photos. (`[[1]](diffhunk://#diff-cb5fe5e9a00b43266eedb510cda96d0ff57ea32666395f724a89050381240ca3R1-R27)`, `[[2]](diffhunk://#diff-1f8cf4aa8b9020a37566820e7844d4d7d5c641c90887fd3247d5dcfc9d7ca5d2R1-R27)`)

### Metrics Controller

* Created `MetricsController` to handle metrics-related requests, such as tracking photo visits and favorites. (`[app/Http/Controllers/MetricsController.phpR1-R67](diffhunk://#diff-bcceea8e72d4763f5b7fb06d4390ea6ca737a9cf829b07db40a1093345bf1a06R1-R67)`)

### Integration with Existing Controllers

* Updated `AlbumController` and `VueController` to dispatch metrics events (e.g., `AlbumVisit`, `PhotoShared`) during relevant actions like album access or sharing. (`[[1]](diffhunk://#diff-f394122b1fa83e350f325feb732e5db83b9667adc38132dfd49293072ccadf76R89-R96)`, `[[2]](diffhunk://#diff-14114934584327716ef1afd7084b8b2138c895d7acfce95d2bc0483dd6c2cae6R12-R17)`)