### PR TITLE
Display statistics

### DIFF
--- a/app/Http/Resources/Models/AlbumResource.php
+++ b/app/Http/Resources/Models/AlbumResource.php
@@ -19,8 +19,10 @@ use App\Http\Resources\Traits\HasPrepPhotoCollection;
 use App\Http\Resources\Traits\HasTimelineData;
 use App\Models\Album;
 use App\Models\Configs;
+use App\Policies\AlbumPolicy;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
@@ -62,6 +64,8 @@ class AlbumResource extends Data
 	public AlbumRightsResource $rights;
 	public PreFormattedAlbumData $preFormattedData;
 	public ?EditableBaseAlbumResource $editable;
+
+	public ?AlbumStatisticsResource $statistics = null;
 
 	public function __construct(Album $album)
 	{
@@ -110,6 +114,10 @@ class AlbumResource extends Data
 
 		if ($this->rights->can_edit) {
 			$this->editable = EditableBaseAlbumResource::fromModel($album);
+		}
+
+		if (Configs::getValueAsBool('metrics_enabled') && Gate::check(AlbumPolicy::CAN_READ_METRICS, [Album::class, $album])) {
+			$this->statistics = AlbumStatisticsResource::fromModel($album->statistics);
 		}
 	}
 

--- a/app/Http/Resources/Models/AlbumStatisticsResource.php
+++ b/app/Http/Resources/Models/AlbumStatisticsResource.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Models;
+
+use App\Models\Statistics;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class AlbumStatisticsResource extends Data
+{
+	public function __construct(
+		public int $visit_count = 0,
+		public int $download_count = 0,
+		public int $shared_count = 0,
+	) {
+	}
+
+	public static function fromModel(Statistics $stats): AlbumStatisticsResource
+	{
+		return new self(
+			$stats->visit_count,
+			$stats->download_count,
+			$stats->shared_count,
+		);
+	}
+}

--- a/app/Http/Resources/Models/PhotoStatisticsResource.php
+++ b/app/Http/Resources/Models/PhotoStatisticsResource.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Models;
+
+use App\Models\Statistics;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class PhotoStatisticsResource extends Data
+{
+	public function __construct(
+		public int $visit_count = 0,
+		public int $download_count = 0,
+		public int $favourite_count = 0,
+		public int $shared_count = 0,
+	) {
+	}
+
+	public static function fromModel(Statistics $stats): PhotoStatisticsResource
+	{
+		return new self(
+			$stats->visit_count,
+			$stats->download_count,
+			$stats->favourite_count,
+			$stats->shared_count,
+		);
+	}
+}

--- a/app/Http/Resources/Models/SmartAlbumResource.php
+++ b/app/Http/Resources/Models/SmartAlbumResource.php
@@ -37,6 +37,7 @@ class SmartAlbumResource extends Data
 	public AlbumProtectionPolicy $policy;
 	public AlbumRightsResource $rights;
 	public PreFormattedAlbumData $preFormattedData;
+	public null $statistics = null; // Needed to unify the API response with the AlbumResource and TagAlbumResource.
 
 	public function __construct(BaseSmartAlbum $smart_album)
 	{

--- a/app/Http/Resources/Models/TagAlbumResource.php
+++ b/app/Http/Resources/Models/TagAlbumResource.php
@@ -16,9 +16,12 @@ use App\Http\Resources\Rights\AlbumRightsResource;
 use App\Http\Resources\Traits\HasHeaderUrl;
 use App\Http\Resources\Traits\HasPrepPhotoCollection;
 use App\Http\Resources\Traits\HasTimelineData;
+use App\Models\Configs;
 use App\Models\TagAlbum;
+use App\Policies\AlbumPolicy;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
@@ -52,6 +55,8 @@ class TagAlbumResource extends Data
 	public PreFormattedAlbumData $preFormattedData;
 	public ?EditableBaseAlbumResource $editable;
 
+	public ?AlbumStatisticsResource $statistics = null;
+
 	public function __construct(TagAlbum $tag_album)
 	{
 		// basic
@@ -84,6 +89,10 @@ class TagAlbumResource extends Data
 
 		if ($this->rights->can_edit) {
 			$this->editable = EditableBaseAlbumResource::fromModel($tag_album);
+		}
+
+		if (Configs::getValueAsBool('metrics_enabled') && Gate::check(AlbumPolicy::CAN_READ_METRICS, [TagAlbum::class, $tag_album])) {
+			$this->statistics = AlbumStatisticsResource::fromModel($tag_album->statistics);
 		}
 	}
 

--- a/resources/js/components/drawers/PhotoDetails.vue
+++ b/resources/js/components/drawers/PhotoDetails.vue
@@ -144,6 +144,30 @@
 						</h2>
 						<span class="py-0.5 pl-0 text-sm text-muted-color">{{ props.photo.preformatted.license }}</span>
 					</template>
+
+					<template v-if="props.photo.statistics">
+						<h2 class="text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+							{{ $t("gallery.photo.details.stats.header") }}
+						</h2>
+						<div class="flex flex-wrap text-muted-color text-sm gap-y-0.5">
+							<div class="w-1/2">
+								<i class="pi pi-eye mr-2" v-tooltip.right="$t('gallery.photo.details.stats.number_of_visits')" />
+								{{ props.photo.statistics.visit_count }}
+							</div>
+							<div class="w-1/2">
+								<i class="pi pi-cloud-download mr-2" v-tooltip.right="$t('gallery.photo.details.stats.number_of_downloads')" />
+								{{ props.photo.statistics.download_count }}
+							</div>
+							<div class="w-1/2">
+								<i class="pi pi-share-alt mr-2" v-tooltip.right="$t('gallery.photo.details.stats.number_of_shares')" />
+								{{ props.photo.statistics.shared_count }}
+							</div>
+							<div class="w-1/2">
+								<i class="pi pi-heart mr-2" v-tooltip.right="$t('gallery.photo.details.stats.number_of_favourites')" />
+								{{ props.photo.statistics.favourite_count }}
+							</div>
+						</div>
+					</template>
 				</div>
 			</template>
 		</Card>
@@ -151,6 +175,7 @@
 </template>
 <script setup lang="ts">
 import { Ref } from "vue";
+import Tag from "primevue/tag";
 import Card from "primevue/card";
 import MapInclude from "../gallery/photoModule/MapInclude.vue";
 import MiniIcon from "../icons/MiniIcon.vue";

--- a/resources/js/components/gallery/albumModule/AlbumHero.vue
+++ b/resources/js/components/gallery/albumModule/AlbumHero.vue
@@ -29,78 +29,93 @@
 						</span>
 					</span>
 				</div>
-				<a
-					v-if="props.album.rights.can_download"
-					class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-					:title="$t('gallery.album.hero.download')"
-					@click="download"
-				>
-					<i class="pi pi-cloud-download" />
-				</a>
-				<a
-					v-if="props.album.rights.can_share"
-					class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-					:title="$t('gallery.album.hero.share')"
-					v-on:click="openSharingModal"
-				>
-					<i class="pi pi-share-alt" />
-				</a>
-				<a
-					v-if="is_se_enabled && user?.id !== null"
-					class="shrink-0 px-3 cursor-pointer inline-block transform duration-300 hover:scale-150 hover:text-color"
-					v-on:click="openStatistics"
-				>
-					<i class="pi pi-chart-scatter text-primary-emphasis" />
-				</a>
-				<a
-					v-if="is_se_preview_enabled && user?.id !== null"
-					class="shrink-0 px-3 cursor-not-allowed text-primary-emphasis"
-					v-tooltip.bottom="$t('gallery.album.hero.stats_only_se')"
-				>
-					<i class="pi pi-chart-scatter" />
-				</a>
-				<router-link
-					:to="{ name: 'frame-with-album', params: { albumid: props.album.id } }"
-					v-if="props.config.is_mod_frame_enabled"
-					class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-					v-tooltip.bottom="'Frame'"
-				>
-					<i class="pi pi-desktop" />
-				</router-link>
-				<router-link
-					:to="{ name: 'map-with-album', params: { albumid: props.album.id } }"
-					v-if="props.config.is_map_accessible && hasCoordinates"
-					class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-				>
-					<i class="pi pi-map" />
-				</router-link>
-				<a
-					v-tooltip.bottom="'Start slideshow'"
-					@click="emits('toggleSlideShow')"
-					v-if="props.album.photos.length > 0"
-					class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-				>
-					<i class="pi pi-play" />
-				</a>
+				<div class="flex flex-col w-full gap-2">
+					<div class="flex flex-row-reverse items-center">
+						<a
+							v-if="props.album.rights.can_download"
+							class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+							:title="$t('gallery.album.hero.download')"
+							@click="download"
+						>
+							<i class="pi pi-cloud-download" />
+						</a>
+						<a
+							v-if="props.album.rights.can_share"
+							class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+							:title="$t('gallery.album.hero.share')"
+							v-on:click="openSharingModal"
+						>
+							<i class="pi pi-share-alt" />
+						</a>
+						<a
+							v-if="is_se_enabled && user?.id !== null"
+							class="shrink-0 px-3 cursor-pointer inline-block transform duration-300 hover:scale-150 hover:text-color"
+							v-on:click="openStatistics"
+						>
+							<i class="pi pi-chart-scatter text-primary-emphasis" />
+						</a>
+						<a
+							v-if="is_se_preview_enabled && user?.id !== null"
+							class="shrink-0 px-3 cursor-not-allowed text-primary-emphasis"
+							v-tooltip.left="$t('gallery.album.hero.stats_only_se')"
+						>
+							<i class="pi pi-chart-scatter" />
+						</a>
+						<router-link
+							:to="{ name: 'frame-with-album', params: { albumid: props.album.id } }"
+							v-if="props.config.is_mod_frame_enabled"
+							class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+							v-tooltip.bottom="'Frame'"
+						>
+							<i class="pi pi-desktop" />
+						</router-link>
+						<router-link
+							:to="{ name: 'map-with-album', params: { albumid: props.album.id } }"
+							v-if="props.config.is_map_accessible && hasCoordinates"
+							class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+						>
+							<i class="pi pi-map" />
+						</router-link>
+						<a
+							v-tooltip.bottom="'Start slideshow'"
+							@click="emits('toggleSlideShow')"
+							v-if="props.album.photos.length > 0"
+							class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+						>
+							<i class="pi pi-play" />
+						</a>
 
-				<template v-if="isTouchDevice() && user?.id !== null">
-					<a
-						v-if="props.hasHidden && are_nsfw_visible"
-						class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-						:title="'hide hidden'"
-						@click="are_nsfw_visible = false"
-					>
-						<i class="pi pi pi-eye-slash" />
-					</a>
-					<a
-						v-if="props.hasHidden && !are_nsfw_visible"
-						class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
-						:title="'show hidden'"
-						@click="are_nsfw_visible = true"
-					>
-						<i class="pi pi-eye" />
-					</a>
-				</template>
+						<template v-if="isTouchDevice() && user?.id !== null">
+							<a
+								v-if="props.hasHidden && are_nsfw_visible"
+								class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+								:title="'hide hidden'"
+								@click="are_nsfw_visible = false"
+							>
+								<i class="pi pi pi-eye-slash" />
+							</a>
+							<a
+								v-if="props.hasHidden && !are_nsfw_visible"
+								class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
+								:title="'show hidden'"
+								@click="are_nsfw_visible = true"
+							>
+								<i class="pi pi-eye" />
+							</a>
+						</template>
+					</div>
+					<div v-if="props.album.statistics" class="flex gap-4 text-base justify-end text-muted-color">
+						<span v-tooltip.bottom="{ value: $t('gallery.album.stats.number_of_visits') }"
+							>{{ props.album.statistics.visit_count }} <i class="pi pi-eye text-xs ml-1"></i
+						></span>
+						<span v-tooltip.bottom="{ value: $t('gallery.album.stats.number_of_downloads') }"
+							>{{ props.album.statistics.download_count }} <i class="pi pi-cloud-download text-xs ml-1"></i
+						></span>
+						<span v-tooltip.bottom="{ value: $t('gallery.album.stats.number_of_shares') }"
+							>{{ props.album.statistics.shared_count }} <i class="pi pi-share-alt text-xs ml-1"></i
+						></span>
+					</div>
+				</div>
 			</div>
 			<div
 				v-if="props.album.preFormattedData.description"

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -75,6 +75,8 @@ declare namespace App.Enum {
 		| "CC-BY-NC-SA-4.0";
 	export type MapProviders = "Wikimedia" | "OpenStreetMap.org" | "OpenStreetMap.de" | "OpenStreetMap.fr" | "RRZE";
 	export type MessageType = "info" | "warning" | "error";
+	export type MetricsAccess = "public" | "logged-in users" | "owner" | "admin";
+	export type MetricsAction = "visit" | "favourite" | "download" | "shared";
 	export type OauthProvidersType =
 		| "amazon"
 		| "apple"
@@ -343,6 +345,12 @@ declare namespace App.Http.Resources.Models {
 		rights: App.Http.Resources.Rights.AlbumRightsResource;
 		preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
 		editable: App.Http.Resources.Editable.EditableBaseAlbumResource | null;
+		statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
+	};
+	export type AlbumStatisticsResource = {
+		visit_count: number;
+		download_count: number;
+		shared_count: number;
 	};
 	export type ConfigCategoryResource = {
 		cat: string;
@@ -408,6 +416,13 @@ declare namespace App.Http.Resources.Models {
 		preformatted: App.Http.Resources.Models.Utils.PreformattedPhotoData;
 		precomputed: App.Http.Resources.Models.Utils.PreComputedPhotoData;
 		timeline: App.Http.Resources.Models.Utils.TimelineData | null;
+		statistics: App.Http.Resources.Models.PhotoStatisticsResource | null;
+	};
+	export type PhotoStatisticsResource = {
+		visit_count: number;
+		download_count: number;
+		favourite_count: number;
+		shared_count: number;
 	};
 	export type SizeVariantResource = {
 		type: App.Enum.SizeVariantType;
@@ -435,6 +450,7 @@ declare namespace App.Http.Resources.Models {
 		policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
 		rights: App.Http.Resources.Rights.AlbumRightsResource;
 		preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
+		statistics: null | null;
 	};
 	export type TagAlbumResource = {
 		id: string;
@@ -449,6 +465,7 @@ declare namespace App.Http.Resources.Models {
 		rights: App.Http.Resources.Rights.AlbumRightsResource;
 		preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
 		editable: App.Http.Resources.Editable.EditableBaseAlbumResource | null;
+		statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
 	};
 	export type TargetAlbumResource = {
 		id: string | null;

--- a/resources/js/services/metrics-service.ts
+++ b/resources/js/services/metrics-service.ts
@@ -1,0 +1,14 @@
+import axios, { type AxiosResponse } from "axios";
+import Constants from "./constants";
+
+const MetricsService = {
+	photo(photo_id: string): Promise<AxiosResponse<null>> {
+		return axios.post(`${Constants.getApiUrl()}Metrics::photo`, { photo_ids: [photo_id] });
+	},
+
+	favourite(photo_id: string): Promise<AxiosResponse<null>> {
+		return axios.post(`${Constants.getApiUrl()}Metrics::favourite`, { photo_ids: [photo_id] });
+	},
+};
+
+export default MetricsService;

--- a/resources/js/stores/FavouriteState.ts
+++ b/resources/js/stores/FavouriteState.ts
@@ -1,3 +1,4 @@
+import MetricsService from "@/services/metrics-service";
 import { defineStore } from "pinia";
 
 export type FavouriteStore = ReturnType<typeof useFavouriteStore>;
@@ -43,6 +44,7 @@ export const useFavouriteStore = defineStore("favourite-store", {
 				this.removePhoto(photo.id);
 			} else {
 				this.addPhoto(photo);
+				MetricsService.favourite(photo.id);
 			}
 		},
 	},

--- a/resources/js/views/gallery-panels/Search.vue
+++ b/resources/js/views/gallery-panels/Search.vue
@@ -145,7 +145,7 @@ import { useGalleryModals } from "@/composables/modalsTriggers/galleryModals";
 import { useSelection } from "@/composables/selections/selections";
 import { useAuthStore } from "@/stores/Auth";
 import { useLycheeStateStore } from "@/stores/LycheeState";
-import { onKeyStroke } from "@vueuse/core";
+import { onKeyStroke, useDebounceFn } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
@@ -178,6 +178,7 @@ import SearchHeader from "@/components/headers/SearchHeader.vue";
 import LoadingProgress from "@/components/loading/LoadingProgress.vue";
 import { shouldIgnoreKeystroke } from "@/utils/keybindings-utils";
 import { useHasNextPreviousPhoto } from "@/composables/photo/hasNextPreviousPhoto";
+import MetricsService from "@/services/metrics-service";
 
 const route = useRoute();
 const router = useRouter();
@@ -433,12 +434,20 @@ onMounted(() => {
 	loadLayoutConfig();
 });
 
+const debouncedPhotoMetrics = useDebounceFn(() => {
+	if (photoId.value !== undefined) {
+		MetricsService.photo(photoId.value);
+		return;
+	}
+}, 100);
+
 watch(
 	() => route.params.photoid,
 	(newPhotoId, _) => {
 		unselect();
 
 		photoId.value = newPhotoId as string;
+		debouncedPhotoMetrics();
 		if (photoId.value !== undefined) {
 			togglableStore.rememberScrollThumb(photoId.value);
 			refreshPhoto();


### PR DESCRIPTION
Add statistics info on the sidebar and album view.

![image](https://github.com/user-attachments/assets/3a37f73c-7231-4c48-97a6-100c793f10cf)
![image](https://github.com/user-attachments/assets/78f52840-fb89-4ac8-b1ec-a0ca7d10390e)

This pull request introduces functionality to track and display metrics for albums and photos, such as visit counts, download counts, and shares. It includes updates to resource classes, policies, Vue components, and the addition of a new metrics service. Below is a summary of the most important changes:

### Backend Changes: Metrics Tracking and Policies

* **Album and Photo Resource Updates**: Added `statistics` properties to `AlbumResource`, `PhotoResource`, and `TagAlbumResource` to include metrics data when `metrics_enabled` is true and the user has appropriate permissions. (`app/Http/Resources/Models/AlbumResource.php` [[1]](diffhunk://#diff-ae0ee69e73fa8ec97c0208a816a7b7801fc80b1f01e85ddd428e6e0afcf12043R68-R69) [[2]](diffhunk://#diff-ae0ee69e73fa8ec97c0208a816a7b7801fc80b1f01e85ddd428e6e0afcf12043R118-R121); `app/Http/Resources/Models/PhotoResource.php` [[3]](diffhunk://#diff-799502cd5e91f491e54316f1b4eeb8c485a8e60c7d42028520ed4ebc4a4c9a86R67-R68) [[4]](diffhunk://#diff-799502cd5e91f491e54316f1b4eeb8c485a8e60c7d42028520ed4ebc4a4c9a86R107-R110); `app/Http/Resources/Models/TagAlbumResource.php` [[5]](diffhunk://#diff-f7b2f52e345f2d2ca100e84e604978acaacdad76fe7ccda1cf6ce5c8bf2e3679R58-R59) [[6]](diffhunk://#diff-f7b2f52e345f2d2ca100e84e604978acaacdad76fe7ccda1cf6ce5c8bf2e3679R93-R96)
* **New Resource Classes**: Created `AlbumStatisticsResource` and `PhotoStatisticsResource` to encapsulate metrics data such as visit counts, download counts, and shares. (`app/Http/Resources/Models/AlbumStatisticsResource.php` [[1]](diffhunk://#diff-1125a885fd8e5fa7102804266f96d3e03529f8b0ebbba37ca60f9643100818a2R1-R33); `app/Http/Resources/Models/PhotoStatisticsResource.php` [[2]](diffhunk://#diff-daf28ac536900401b7e773588332b2915893321ad8e3e462a0c9a8168e8de336R1-R35)
* **Policy Enhancements**: Added `canReadMetrics` methods to `AlbumPolicy` and `PhotoPolicy` to enforce access control for viewing metrics based on configuration and user roles. (`app/Policies/AlbumPolicy.php` [[1]](diffhunk://#diff-f3709d8072b3229a928c52fe03d7c3698489978b206a2a84cd4cc64941712684R46) [[2]](diffhunk://#diff-f3709d8072b3229a928c52fe03d7c3698489978b206a2a84cd4cc64941712684R576-R600); `app/Policies/PhotoPolicy.php` [[3]](diffhunk://#diff-ec3b288476162d6cd3bc59445e3bcec599234d2dc1c27e63b0b94416d54ea4a2R31) [[4]](diffhunk://#diff-ec3b288476162d6cd3bc59445e3bcec599234d2dc1c27e63b0b94416d54ea4a2R234-R254)

### Frontend Changes: Metrics Display

* **Photo Details View**: Updated `PhotoDetails.vue` to display metrics such as visits, downloads, shares, and favorites if available. (`resources/js/components/drawers/PhotoDetails.vue` [resources/js/components/drawers/PhotoDetails.vueR147-R178](diffhunk://#diff-4dbf72dfdeb259d1bf26e1a458dc16ee9c688581644178ee03be7c4c4b3acf9fR147-R178))
* **Album Hero View**: Updated `AlbumHero.vue` to display album metrics (visit and download counts, shares) in the album header. (`resources/js/components/gallery/albumModule/AlbumHero.vue` [resources/js/components/gallery/albumModule/AlbumHero.vueR107-R119](diffhunk://#diff-9be5751687fc3866426c0508141eee931c75e7fd469339b643867f68634eb47fR107-R119))

### New Services and State Management

* **Metrics Service**: Added a new `metrics-service.ts` to handle API requests for tracking photo and favorite metrics. (`resources/js/services/metrics-service.ts` [resources/js/services/metrics-service.tsR1-R14](diffhunk://#diff-e081103bbf5b4a618c2510746556b2a0d3f16d3eb95f48d1066d9f8847590b9eR1-R14))
* **Favorite State**: Integrated the metrics service into the favorite toggle functionality to track favorite actions. (`resources/js/stores/FavouriteState.ts` [resources/js/stores/FavouriteState.tsR47](diffhunk://#diff-8f4f0963b4ddc72ceec1cd5abc78244e127e90f32cca271f22548659e823508aR47))

### Miscellaneous Updates

* **Debounced Metrics Tracking**: Added debounced API calls to track photo views when navigating between photos in the album and search views. (`resources/js/views/gallery-panels/Album.vue` [[1]](diffhunk://#diff-88a848123a6b43d2f9695bb217b0d435421b52774f19ea9cc79388f46de23c3cR415-R430); `resources/js/views/gallery-panels/Search.vue` [[2]](diffhunk://#diff-e5023252e2c9afc91608da26a88b70b3e5dc53aba16bd66087a86d3e52e409a9L148-R148)

These changes collectively enhance the application by introducing metrics tracking and display, improving user insights while maintaining proper access control.
