### PR TITLE
Add activity drawer & live-metrics

### DIFF
--- a/app/Actions/Metrics/CleanupMetrics.php
+++ b/app/Actions/Metrics/CleanupMetrics.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Metrics;
+
+use App\Models\Configs;
+use App\Models\LiveMetrics;
+
+class CleanupMetrics
+{
+	public function do(): void
+	{
+		$num_days = Configs::getValueAsInt('live_metrics_max_time');
+
+		LiveMetrics::query()->where('created_at', '<=', now()->subDays($num_days))->delete();
+	}
+}

--- a/app/Actions/Metrics/GetMetrics.php
+++ b/app/Actions/Metrics/GetMetrics.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Metrics;
+
+use App\Exceptions\UnauthorizedException;
+use App\Models\LiveMetrics;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
+
+class GetMetrics
+{
+	public function get(): Collection
+	{
+		/** @var User $user */
+		$user = Auth::user() ?? throw new UnauthorizedException();
+
+		return LiveMetrics::query()->with(['photo', 'photo.size_variants', 'album', 'album_impl', 'album.thumb'])
+			->join('photos', 'photos.id', '=', 'live_metrics.photo_id', 'left')
+			->join('base_albums', 'base_albums.id', '=', 'live_metrics.album_id', 'left')
+			->join('albums', 'albums.id', '=', 'live_metrics.album_id', 'left')
+
+			// Owner check (if not admin)
+			->when(!$user->may_administrate, fn ($q_owner) => $q_owner
+				->where(fn ($q) => $q
+					->where('base_albums.owner_id', $user->id)
+					->orWhere('photos.owner_id', $user->id))
+			)
+
+			// Do not fetch the visit for photos (too noisy)
+			->where(fn ($q) => $q->where('live_metrics.action', '!=', 'visit')
+				->orWhere(fn ($q1) => $q1->where('live_metrics.action', 'visit')
+					->whereNotNull('live_metrics.album_id')))
+
+			// Do not fetch the tag albums too.
+			// Maybe refactor if we decide to unify tag albums and normal albums...
+			->where(fn ($q) => $q->whereNull('live_metrics.album_id')
+				->orWhereNotNull('albums.id'))
+
+			->select([
+				'live_metrics.*',
+				// // 	// 'photos.title as photo_title',
+				// // 	// 'base_albums.title as album_title',
+			])
+			->orderBy('live_metrics.created_at', 'desc')
+			->get();
+	}
+}

--- a/app/Enum/LiveMetricsAccess.php
+++ b/app/Enum/LiveMetricsAccess.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Enum;
+
+enum LiveMetricsAccess: string
+{
+	case LOGGEDIN = 'logged-in users';
+	case ADMIN = 'admin';
+}

--- a/app/Http/Requests/Metrics/MetricsRequest.php
+++ b/app/Http/Requests/Metrics/MetricsRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Metrics;
+
+use App\Http\Requests\AbstractEmptyRequest;
+use App\Models\LiveMetrics;
+use App\Policies\MetricsPolicy;
+use Illuminate\Support\Facades\Gate;
+
+class MetricsRequest extends AbstractEmptyRequest
+{
+	public function authorize(): bool
+	{
+		return Gate::check(MetricsPolicy::CAN_SEE_LIVE, LiveMetrics::class);
+	}
+}

--- a/app/Http/Resources/Models/LiveMetricsResource.php
+++ b/app/Http/Resources/Models/LiveMetricsResource.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Models;
+
+use App\Enum\MetricsAction;
+use App\Models\LiveMetrics;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class LiveMetricsResource extends Data
+{
+	public function __construct(
+		public string $created_at,
+		public string $visitor_id,
+		public MetricsAction $action,
+		public ?string $photo_id,
+		public ?string $album_id,
+		public ?string $title,
+		public ?string $url = null,
+	) {
+	}
+
+	/**
+	 * @return LiveMetricsResource
+	 */
+	public static function fromModel(LiveMetrics $a): LiveMetricsResource
+	{
+		$title = $a->photo_id !== null ? $a->photo->title : $a->album_impl->title;
+		$url = $a->photo_id !== null ? $a->photo->size_variants?->getSmall()?->url ?? $a->photo->size_variants?->getThumb()?->url : $a->album?->thumb?->thumbUrl;
+
+		return new self(
+			created_at: $a->created_at->toIso8601String(), // toIso8601String() is used to ensure the date has the correct timezone
+			visitor_id: $a->visitor_id,
+			action: $a->action,
+			photo_id: $a->photo_id,
+			album_id: $a->album_id ?? $a->photo->album_id,
+			title: $title,
+			url: $url,
+		);
+	}
+}

--- a/app/Http/Resources/Rights/RootAlbumRightsResource.php
+++ b/app/Http/Resources/Rights/RootAlbumRightsResource.php
@@ -9,7 +9,9 @@
 namespace App\Http\Resources\Rights;
 
 use App\Contracts\Models\AbstractAlbum;
+use App\Models\LiveMetrics;
 use App\Policies\AlbumPolicy;
+use App\Policies\MetricsPolicy;
 use Illuminate\Support\Facades\Gate;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
@@ -19,10 +21,12 @@ class RootAlbumRightsResource extends Data
 {
 	public bool $can_edit;
 	public bool $can_upload;
+	public bool $can_see_live_metrics;
 
 	public function __construct()
 	{
 		$this->can_edit = Gate::check(AlbumPolicy::CAN_EDIT, [AbstractAlbum::class, null]);
 		$this->can_upload = Gate::check(AlbumPolicy::CAN_UPLOAD, [AbstractAlbum::class, null]);
+		$this->can_see_live_metrics = Gate::check(MetricsPolicy::CAN_SEE_LIVE, LiveMetrics::class);
 	}
 }

--- a/app/Listeners/MetricsListener.php
+++ b/app/Listeners/MetricsListener.php
@@ -28,5 +28,18 @@ class MetricsListener
 				->where($event->key(), '=', $event->id)
 				->increment($event->metricAction()->column(), 1);
 		}
+
+		if (Configs::getValueAsBool('live_metrics_enabled') === true) {
+			// Add event to the live metrics table
+			DB::table('live_metrics')
+				->insert([
+					[
+						'visitor_id' => $event->visitor_id,
+						'action' => $event->metricAction(),
+						$event->key() => $event->id,
+						'created_at' => now(),
+					],
+				]);
+		}
 	}
 }

--- a/app/Metadata/Cache/RouteCacheManager.php
+++ b/app/Metadata/Cache/RouteCacheManager.php
@@ -104,6 +104,9 @@ final readonly class RouteCacheManager
 
 			// This is returning a stream, we do not cache it.
 			'api/v2/Zip' => false,
+
+			// No point in caching this.
+			'api/v2/Metrics' => false,
 		];
 	}
 

--- a/app/Models/Builders/LiveMetricsBuilder.php
+++ b/app/Models/Builders/LiveMetricsBuilder.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Models\Builders;
+
+use App\Eloquent\FixedQueryBuilder;
+use App\Models\LiveMetrics;
+
+/**
+ * Specialized query builder for {@link \App\Models\LiveMetrics}.
+ *
+ * @template TModelClass of LiveMetrics
+ *
+ * @extends FixedQueryBuilder<TModelClass>
+ */
+class LiveMetricsBuilder extends FixedQueryBuilder
+{
+}

--- a/app/Models/LiveMetrics.php
+++ b/app/Models/LiveMetrics.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Models;
+
+use App\Enum\MetricsAction;
+use App\Models\Builders\LiveMetricsBuilder;
+use App\Models\Extensions\ThrowsConsistentExceptions;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * App\Models\LiveMetrics.
+ *
+ * @property int           $id
+ * @property Carbon        $created_at
+ * @property string        $visitor_id
+ * @property MetricsAction $action
+ * @property string        $album_id
+ * @property string        $photo_id
+ * @property Photo         $photo
+ * @property Album         $album
+ * @property BaseAlbumImpl $album_impl
+ *
+ * @method static LiveMetricsBuilder|LiveMetrics addSelect($column)
+ * @method static LiveMetricsBuilder|LiveMetrics join(string $table, string $first, string $operator = null, string $second = null, string $type = 'inner', string $where = false)
+ * @method static LiveMetricsBuilder|LiveMetrics joinSub($query, $as, $first, $operator = null, $second = null, $type = 'inner', $where = false)
+ * @method static LiveMetricsBuilder|LiveMetrics leftJoin(string $table, string $first, string $operator = null, string $second = null)
+ * @method static LiveMetricsBuilder|LiveMetrics newModelQuery()
+ * @method static LiveMetricsBuilder|LiveMetrics newQuery()
+ * @method static LiveMetricsBuilder|LiveMetrics orderBy($column, $direction = 'asc')
+ * @method static LiveMetricsBuilder|LiveMetrics query()
+ * @method static LiveMetricsBuilder|LiveMetrics select($columns = [])
+ * @method static LiveMetricsBuilder|LiveMetrics whereCreatedAt($value)
+ * @method static LiveMetricsBuilder|LiveMetrics whereId($value)
+ * @method static LiveMetricsBuilder|LiveMetrics whereIn(string $column, string $values, string $boolean = 'and', string $not = false)
+ * @method static LiveMetricsBuilder|LiveMetrics whereNotIn(string $column, string $values, string $boolean = 'and')
+ *
+ * @mixin \Eloquent
+ */
+class LiveMetrics extends Model
+{
+	use ThrowsConsistentExceptions;
+
+	/**
+	 * @param $query
+	 *
+	 * @return LiveMetricsBuilder
+	 */
+	public function newEloquentBuilder($query): LiveMetricsBuilder
+	{
+		return new LiveMetricsBuilder($query);
+	}
+
+	/**
+	 * @var array<string, string>
+	 */
+	protected $casts = [
+		'action' => MetricsAction::class,
+		'created_at' => 'datetime',
+	];
+
+	protected $fillable = [
+		'created_at',
+		'visitor_id',
+		'action',
+		'album_id',
+		'photo_id',
+	];
+
+	/**
+	 * Return the albums owned by the user.
+	 *
+	 * @return BelongsTo<Album,$this>
+	 */
+	public function album(): BelongsTo
+	{
+		return $this->belongsTo(Album::class, 'album_id', 'id');
+	}
+
+	/**
+	 * Return the albums owned by the user.
+	 *
+	 * @return BelongsTo<BaseAlbumImpl,$this>
+	 */
+	public function album_impl(): BelongsTo
+	{
+		return $this->belongsTo(BaseAlbumImpl::class, 'album_id', 'id');
+	}
+
+	/**
+	 * Return the photos owned by the user.
+	 *
+	 * @return BelongsTo<Photo,$this>
+	 */
+	public function photo(): BelongsTo
+	{
+		return $this->belongsTo(Photo::class, 'photo_id', 'id');
+	}
+}

--- a/app/Policies/MetricsPolicy.php
+++ b/app/Policies/MetricsPolicy.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Policies;
+
+use App\Enum\LiveMetricsAccess;
+use App\Models\Configs;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class MetricsPolicy
+{
+	use HandlesAuthorization;
+
+	public const CAN_SEE_LIVE = 'canSeeLive';
+
+	/**
+	 * Check if the user can access the activlty activity metrics.
+	 */
+	public function canSeeLive(?User $user): bool
+	{
+		$access_level = Configs::getValueAsEnum('live_metrics_access', LiveMetricsAccess::class);
+
+		return match ($access_level) {
+			LiveMetricsAccess::LOGGEDIN => true,
+			LiveMetricsAccess::ADMIN => $user?->may_administrate === true,
+			default => false,
+		};
+	}
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -12,9 +12,11 @@ use App\Contracts\Models\AbstractAlbum;
 use App\Models\Album;
 use App\Models\Configs;
 use App\Models\Extensions\BaseAlbum;
+use App\Models\LiveMetrics;
 use App\Models\Photo;
 use App\Models\User;
 use App\Policies\AlbumPolicy;
+use App\Policies\MetricsPolicy;
 use App\Policies\PhotoPolicy;
 use App\Policies\SettingsPolicy;
 use App\Policies\UserPolicy;
@@ -43,6 +45,8 @@ class AuthServiceProvider extends ServiceProvider
 		AbstractAlbum::class => AlbumPolicy::class,
 
 		Configs::class => SettingsPolicy::class,
+
+		LiveMetrics::class => MetricsPolicy::class,
 	];
 
 	/**

--- a/app/SmartAlbums/BaseSmartAlbum.php
+++ b/app/SmartAlbums/BaseSmartAlbum.php
@@ -115,7 +115,7 @@ abstract class BaseSmartAlbum implements AbstractAlbum
 	{
 		$query = $this->photo_query_policy
 			->applySearchabilityFilter(
-				query: Photo::query()->with(['album', 'size_variants', 'size_variants.sym_links']),
+				query: Photo::query()->with(['album', 'size_variants', 'size_variants.sym_links', 'statistics']),
 				origin: null,
 				include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums')
 			)->where($this->smart_photo_condition);

--- a/app/SmartAlbums/UnsortedAlbum.php
+++ b/app/SmartAlbums/UnsortedAlbum.php
@@ -45,7 +45,7 @@ class UnsortedAlbum extends BaseSmartAlbum
 	public function photos(): Builder
 	{
 		if ($this->public_permissions !== null) {
-			return Photo::query()->with(['album', 'size_variants', 'size_variants.sym_links'])
+			return Photo::query()->with(['album', 'size_variants', 'size_variants.sym_links', 'statistics'])
 			->where($this->smart_photo_condition);
 		}
 

--- a/database/migrations/2025_04_07_211142_create_live_metrics_table.php
+++ b/database/migrations/2025_04_07_211142_create_live_metrics_table.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+	private const CREATED_AT_COL_NAME = 'created_at';
+	private const DATETIME_PRECISION = 0;
+	public const RANDOM_ID_LENGTH = 24;
+
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		Schema::create('live_metrics', function (Blueprint $table) {
+			$table->id();
+			$table->dateTime(
+				self::CREATED_AT_COL_NAME,
+				self::DATETIME_PRECISION
+			)->nullable();
+			$table->string('visitor_id')->index();
+			$table->string('action', 100)->index();
+			$table->char('album_id', self::RANDOM_ID_LENGTH)->nullable(true);
+			$table->char('photo_id', self::RANDOM_ID_LENGTH)->nullable(true);
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		Schema::dropIfExists('live_metrics');
+	}
+};

--- a/resources/js/components/drawers/LiveMetrics.vue
+++ b/resources/js/components/drawers/LiveMetrics.vue
@@ -1,0 +1,200 @@
+<template>
+	<Drawer :closeOnEsc="false" v-model:visible="is_metrics_open" position="right" :pt:root:class="' w-sm'">
+		<template #header>
+			<span class="text-xl font-bold">
+				{{ $t("statistics.metrics.header") }}
+			</span>
+		</template>
+		<div class="flex flex-col">
+			<div v-for="item in prettifiedData" :key="item.action + item.ago" class="flex pt-2 pb-1">
+				<div class="flex flex-col w-full text-sm text-muted-color">
+					<router-link :to="item.link" v-if="item.count === 1" v-html="printSingular(item)"></router-link>
+					<router-link :to="item.link" v-if="item.count > 1" v-html="printPlural(item)"></router-link>
+					<span class="text-xs -mt-1">{{ item.ago }}</span>
+				</div>
+				<div class="w-12 h-12 relative shrink-0">
+					<div
+						class="absolute top-0 right-0 translate-x-2.5 -translate-y-2 w-6 h-6 rounded-full bg-primary-emphasis flex justify-center items-center border-3 border-solid border-surface-0 text-surface-0 dark:border-surface-900 dark:text-surface-900"
+					>
+						<span
+							class="pi text-2xs"
+							:class="{
+								'pi-bookmark': item.action === 'favourite',
+								'pi-download': item.action === 'download',
+								'pi-share-alt': item.action === 'shared',
+								'pi-eye': item.action === 'visit',
+							}"
+						></span>
+					</div>
+					<img :src="item.src" v-if="item.src" class="rounded w-full h-full object-cover" />
+				</div>
+			</div>
+		</div>
+	</Drawer>
+</template>
+<script setup lang="ts">
+import MetricsService from "@/services/metrics-service";
+import { useTogglablesStateStore } from "@/stores/ModalsState";
+import { trans } from "laravel-vue-i18n";
+import { storeToRefs } from "pinia";
+import Drawer from "primevue/drawer";
+import { sprintf } from "sprintf-js";
+import { ref } from "vue";
+import { onMounted } from "vue";
+import { watch } from "vue";
+
+const togglableStore = useTogglablesStateStore();
+const { is_metrics_open } = storeToRefs(togglableStore);
+
+type LiveMetrics = {
+	ago: string;
+	date: Date;
+	id: string;
+	link: { name: string; params: {} };
+	action: App.Enum.MetricsAction;
+	title: string;
+	count: number;
+	src: string | null;
+};
+const data = ref<App.Http.Resources.Models.LiveMetricsResource[] | undefined>(undefined);
+const prettifiedData = ref<LiveMetrics[] | undefined>(undefined);
+
+function load() {
+	MetricsService.get()
+		.then((response) => {
+			data.value = response.data;
+			console.log(response.data);
+			prettifyData();
+		})
+		.catch((error) => {
+			console.error(error);
+		});
+}
+
+function printSingular(data: LiveMetrics) {
+	const visitor = `<span class="font-bold text-muted-color-emphasis">${trans("statistics.metrics.a_visitor")}</span>`;
+	switch (data.action) {
+		case "visit":
+			return sprintf(trans("statistics.metrics.visit_singular"), visitor, titlize(data.title));
+		case "favourite":
+			return sprintf(trans("statistics.metrics.favourite_singular"), visitor, titlize(data.title));
+		case "download":
+			return sprintf(trans("statistics.metrics.download_singular"), visitor, titlize(data.title));
+		case "shared":
+			return sprintf(trans("statistics.metrics.shared_singular"), visitor, titlize(data.title));
+	}
+}
+
+function printPlural(data: LiveMetrics) {
+	const visitors = sprintf(`<span class="font-bold text-muted-color-emphasis">${trans("statistics.metrics.visitors")}</span>`, data.count);
+	switch (data.action) {
+		case "visit":
+			return sprintf(trans("statistics.metrics.visit_plural"), visitors, titlize(data.title));
+		case "favourite":
+			return sprintf(trans("statistics.metrics.favourite_plural"), visitors, titlize(data.title));
+		case "download":
+			return sprintf(trans("statistics.metrics.download_plural"), visitors, titlize(data.title));
+		case "shared":
+			return sprintf(trans("statistics.metrics.shared_plural"), visitors, titlize(data.title));
+	}
+}
+
+function titlize(title: string) {
+	const t = title.length > 20 ? title.substring(0, 20) + "..." : title;
+	return `<span class="font-bold text-primary-emphasis">${t}</span>`;
+}
+
+function prettifyData() {
+	if (data.value === undefined || data.value.length === 0) {
+		return;
+	}
+
+	const dateMetrics: Record<string, LiveMetrics> = {};
+
+	data.value.forEach((item) => {
+		const k = genKey(item);
+
+		if (k in dateMetrics) {
+			dateMetrics[k].count++;
+		} else {
+			dateMetrics[k] = LiveMetricsToPretty(item, 1);
+		}
+	});
+
+	prettifiedData.value = Object.values(dateMetrics).sort((a, b) => {
+		return b.date.getTime() - a.date.getTime();
+	});
+}
+
+function genKey(item: App.Http.Resources.Models.LiveMetricsResource) {
+	return item.action + dateToAgo(item.created_at) + (item.photo_id ?? item.album_id ?? "undefined");
+}
+
+function dateToAgo(date: string) {
+	const dateObj = new Date(date);
+	const now = new Date();
+	console.log(dateObj);
+	console.log(now);
+	const diff = Math.abs(now.getTime() - dateObj.getTime());
+	const seconds = Math.floor(diff / 1000);
+	const minutes = Math.floor(seconds / 60);
+	const hours = Math.floor(minutes / 60);
+	const days = Math.floor(hours / 24);
+	console.log(diff, seconds, minutes, hours, days);
+
+	if (days > 1) {
+		return sprintf(trans("statistics.metrics.ago.days"), days);
+	} else if (days > 0) {
+		return trans("statistics.metrics.ago.day");
+	} else if (hours > 1) {
+		return sprintf(trans("statistics.metrics.ago.hours"), hours);
+	} else if (hours > 0) {
+		return trans("statistics.metrics.ago.hour");
+	} else if (minutes > 30) {
+		return sprintf(trans("statistics.metrics.ago.minutes"), 30);
+	} else if (minutes > 15) {
+		return sprintf(trans("statistics.metrics.ago.minutes"), 15);
+	} else if (minutes > 5) {
+		return sprintf(trans("statistics.metrics.ago.minutes"), minutes);
+	} else if (minutes > 0) {
+		return trans("statistics.metrics.ago.few_minutes");
+	} else {
+		return trans("statistics.metrics.ago.seconds");
+	}
+}
+
+function LiveMetricsToPretty(data: App.Http.Resources.Models.LiveMetricsResource, count: number): LiveMetrics {
+	const ago = dateToAgo(data.created_at);
+	return {
+		ago: ago,
+		date: new Date(data.created_at),
+		action: data.action,
+		title: data.title ?? "undefined",
+		id: data.photo_id ?? data.album_id ?? "undefined",
+		count: count,
+		src: data.url,
+		link: {
+			name: data.photo_id ? "photo" : "album",
+			params: {
+				albumid: data.album_id,
+				photoid: data.photo_id,
+			},
+		},
+	};
+}
+
+onMounted(() => {
+	if (is_metrics_open.value) {
+		load();
+	}
+});
+
+watch(
+	() => is_metrics_open.value,
+	(newValue) => {
+		if (newValue) {
+			load();
+		}
+	},
+);
+</script>

--- a/resources/js/components/drawers/LiveMetrics.vue
+++ b/resources/js/components/drawers/LiveMetrics.vue
@@ -63,7 +63,6 @@ function load() {
 	MetricsService.get()
 		.then((response) => {
 			data.value = response.data;
-			console.log(response.data);
 			prettifyData();
 		})
 		.catch((error) => {
@@ -133,14 +132,11 @@ function genKey(item: App.Http.Resources.Models.LiveMetricsResource) {
 function dateToAgo(date: string) {
 	const dateObj = new Date(date);
 	const now = new Date();
-	console.log(dateObj);
-	console.log(now);
 	const diff = Math.abs(now.getTime() - dateObj.getTime());
 	const seconds = Math.floor(diff / 1000);
 	const minutes = Math.floor(seconds / 60);
 	const hours = Math.floor(minutes / 60);
 	const days = Math.floor(hours / 24);
-	console.log(diff, seconds, minutes, hours, days);
 
 	if (days > 1) {
 		return sprintf(trans("statistics.metrics.ago.days"), days);

--- a/resources/js/components/drawers/PhotoDetails.vue
+++ b/resources/js/components/drawers/PhotoDetails.vue
@@ -175,6 +175,7 @@
 </template>
 <script setup lang="ts">
 import { Ref } from "vue";
+import Tag from "primevue/tag";
 import Card from "primevue/card";
 import MapInclude from "../gallery/photoModule/MapInclude.vue";
 import MiniIcon from "../icons/MiniIcon.vue";

--- a/resources/js/components/drawers/PhotoDetails.vue
+++ b/resources/js/components/drawers/PhotoDetails.vue
@@ -175,7 +175,6 @@
 </template>
 <script setup lang="ts">
 import { Ref } from "vue";
-import Tag from "primevue/tag";
 import Card from "primevue/card";
 import MapInclude from "../gallery/photoModule/MapInclude.vue";
 import MiniIcon from "../icons/MiniIcon.vue";

--- a/resources/js/components/headers/AlbumsHeader.vue
+++ b/resources/js/components/headers/AlbumsHeader.vue
@@ -25,7 +25,9 @@
 			<span class="sm:hidden font-bold">
 				{{ $t("gallery.albums") }}
 			</span>
-			<span class="hidden sm:block font-bold text-sm lg:text-base text-center w-full">{{ props.title }}</span>
+			<span class="hidden sm:block font-bold text-sm lg:text-base text-center w-full" @click="is_metrics_open = !is_metrics_open">{{
+				props.title
+			}}</span>
 		</template>
 
 		<template #end>
@@ -125,7 +127,7 @@ const togglableStore = useTogglablesStateStore();
 const favourites = useFavouriteStore();
 
 const { dropbox_api_key } = storeToRefs(lycheeStore);
-const { is_login_open, is_upload_visible, is_create_album_visible, is_create_tag_album_visible } = storeToRefs(togglableStore);
+const { is_login_open, is_upload_visible, is_create_album_visible, is_create_tag_album_visible, is_metrics_open } = storeToRefs(togglableStore);
 
 const router = useRouter();
 
@@ -229,6 +231,12 @@ const menu = computed(() =>
 			type: "fn",
 			callback: openSearch,
 			if: props.config.is_search_accessible,
+		},
+		{
+			icon: "pi pi-bell",
+			type: "fn",
+			callback: () => (is_metrics_open.value = true),
+			if: props.rights.can_see_live_metrics,
 		},
 		{
 			icon: "pi pi-sign-in",

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -73,6 +73,7 @@ declare namespace App.Enum {
 		| "CC-BY-NC-SA-2.5"
 		| "CC-BY-NC-SA-3.0"
 		| "CC-BY-NC-SA-4.0";
+	export type LiveMetricsAccess = "logged-in users" | "admin";
 	export type MapProviders = "Wikimedia" | "OpenStreetMap.org" | "OpenStreetMap.de" | "OpenStreetMap.fr" | "RRZE";
 	export type MessageType = "info" | "warning" | "error";
 	export type MetricsAccess = "public" | "logged-in users" | "owner" | "admin";
@@ -380,6 +381,15 @@ declare namespace App.Http.Resources.Models {
 		id: number;
 		username: string;
 	};
+	export type LiveMetricsResource = {
+		created_at: string;
+		visitor_id: string;
+		action: App.Enum.MetricsAction;
+		photo_id: string | null;
+		album_id: string | null;
+		title: string | null;
+		url: string | null;
+	};
 	export type PhotoResource = {
 		id: string;
 		album_id: string | null;
@@ -635,6 +645,7 @@ declare namespace App.Http.Resources.Rights {
 	export type RootAlbumRightsResource = {
 		can_edit: boolean;
 		can_upload: boolean;
+		can_see_live_metrics: boolean;
 	};
 	export type SettingsRightsResource = {
 		can_edit: boolean;

--- a/resources/js/services/metrics-service.ts
+++ b/resources/js/services/metrics-service.ts
@@ -2,6 +2,10 @@ import axios, { type AxiosResponse } from "axios";
 import Constants from "./constants";
 
 const MetricsService = {
+	get(): Promise<AxiosResponse<App.Http.Resources.Models.LiveMetricsResource[]>> {
+		return axios.get(`${Constants.getApiUrl()}Metrics`, { data: {} });
+	},
+
 	photo(photo_id: string): Promise<AxiosResponse<null>> {
 		return axios.post(`${Constants.getApiUrl()}Metrics::photo`, { photo_ids: [photo_id] });
 	},

--- a/resources/js/stores/ModalsState.ts
+++ b/resources/js/stores/ModalsState.ts
@@ -9,6 +9,7 @@ export const useTogglablesStateStore = defineStore("togglables-store", {
 		is_full_screen: false,
 		is_login_open: false,
 		is_webauthn_open: false,
+		is_metrics_open: false,
 
 		// upload
 		is_upload_visible: false,

--- a/resources/js/views/gallery-panels/Albums.vue
+++ b/resources/js/views/gallery-panels/Albums.vue
@@ -6,6 +6,7 @@
 	<AlbumCreateTagDialog v-if="rootRights?.can_upload" key="create_tag_album_modal" />
 	<LoginModal v-if="user?.id === null" @logged-in="refresh" />
 	<WebauthnModal v-if="user?.id === null" @logged-in="refresh" />
+	<LiveMetrics v-if="user?.id" />
 
 	<div v-if="rootConfig && rootRights" @click="unselect" class="h-svh overflow-y-auto" id="galleryView" v-on:scroll="onScroll">
 		<Collapse :when="!is_full_screen">
@@ -163,6 +164,7 @@ import { EmptyPhotoCallbacks } from "@/utils/Helpers";
 import WebauthnModal from "@/components/modals/WebauthnModal.vue";
 import LoginModal from "@/components/modals/LoginModal.vue";
 import LoadingProgress from "@/components/loading/LoadingProgress.vue";
+import LiveMetrics from "@/components/drawers/LiveMetrics.vue";
 import { useLeftMenuStateStore } from "@/stores/LeftMenuState";
 
 const auth = useAuthStore();

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -234,6 +234,7 @@ Route::get('/Statistics::getCountsOverTime', [StatisticsController::class, 'getP
 /**
  * Metrics.
  */
+Route::get('/Metrics', [MetricsController::class, 'get'])->middleware(['support:se']);
 Route::post('/Metrics::photo', [MetricsController::class, 'photo'])->withoutMiddleware(['content_type:json']);
 Route::post('/Metrics::favourite', [MetricsController::class, 'favourite'])->withoutMiddleware(['content_type:json']);
 

--- a/tests/Feature_v2/Base/BaseV2Test.php
+++ b/tests/Feature_v2/Base/BaseV2Test.php
@@ -28,6 +28,7 @@ use Tests\AbstractTestCase;
 use Tests\Traits\InteractWithSmartAlbums;
 use Tests\Traits\RequireSE;
 use Tests\Traits\RequiresEmptyAlbums;
+use Tests\Traits\RequiresEmptyLiveMetrics;
 use Tests\Traits\RequiresEmptyPhotos;
 use Tests\Traits\RequiresEmptyUsers;
 use Tests\Traits\RequiresEmptyWebAuthnCredentials;
@@ -37,6 +38,7 @@ abstract class BaseV2Test extends AbstractTestCase
 	use RequiresEmptyUsers;
 	use RequiresEmptyAlbums;
 	use RequiresEmptyPhotos;
+	use RequiresEmptyLiveMetrics;
 	use RequiresEmptyWebAuthnCredentials;
 	use DatabaseTransactions;
 	use InteractWithSmartAlbums;
@@ -84,6 +86,7 @@ abstract class BaseV2Test extends AbstractTestCase
 		$this->setUpRequiresEmptyUsers();
 		$this->setUpRequiresEmptyAlbums();
 		$this->setUpRequiresEmptyPhotos();
+		$this->setUpRequiresEmptyLiveMetrics();
 
 		$this->admin = User::factory()->may_administrate()->create();
 		$this->userMayUpload1 = User::factory()->may_upload()->create();
@@ -133,6 +136,7 @@ abstract class BaseV2Test extends AbstractTestCase
 
 	public function tearDown(): void
 	{
+		$this->tearDownRequiresEmptyLiveMetrics();
 		$this->tearDownRequiresEmptyPhotos();
 		$this->tearDownRequiresEmptyAlbums();
 		$this->tearDownRequiresEmptyUsers();

--- a/tests/Feature_v2/Metrics/MetricsGetTest.php
+++ b/tests/Feature_v2/Metrics/MetricsGetTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\Metrics;
+
+use App\Enum\LiveMetricsAccess;
+use App\Models\Configs;
+use App\Models\LiveMetrics;
+use Tests\Feature_v2\Base\BaseApiV2Test;
+
+class MetricsGetTest extends BaseApiV2Test
+{
+	public function tearDown(): void
+	{
+		Configs::set('live_metrics_enabled', false);
+		parent::tearDown();
+	}
+
+	public function testGetMetricsDenied(): void
+	{
+		$response = $this->getJson('Metrics');
+		$this->assertSupporterRequired($response);
+
+		$this->requireSe();
+
+		$response = $this->getJson('Metrics');
+		$this->assertUnauthorized($response);
+
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Metrics');
+		$this->assertForbidden($response);
+
+		$response = $this->actingAs($this->admin)->getJson('Metrics');
+		$this->assertForbidden($response); // Not active
+	}
+
+	public function testGetMetricsOk(): void
+	{
+		$this->requireSe();
+		Configs::set('live_metrics_enabled', true);
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Metrics');
+		$this->assertForbidden($response);
+
+		$response = $this->actingAs($this->admin)->getJson('Metrics');
+		$this->assertOk($response);
+
+		Configs::set('live_metrics_access', LiveMetricsAccess::LOGGEDIN);
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Metrics');
+		$this->assertOk($response);
+	}
+
+	public function testWithData(): void
+	{
+		$this->requireSe();
+		Configs::set('live_metrics_enabled', true);
+		Configs::set('live_metrics_access', LiveMetricsAccess::LOGGEDIN);
+
+		$response = $this->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$this->assertOk($response); // 1: - viewed album4
+		$response = $this->get('gallery/' . $this->album4->id);
+		$this->assertOk($response); // 2: - shared album4
+		$response = $this->postJson('Metrics::photo', ['photo_ids' => [$this->photo4->id]]);
+		$this->assertNoContent($response); // 3: viewed photo4
+		$response = $this->postJson('Metrics::favourite', ['photo_ids' => [$this->photo4->id]]);
+		$this->assertNoContent($response); // 4: favourite photo4
+		$response = $this->get('gallery/' . $this->album4->id . '/' . $this->photo4->id);
+		$this->assertOk($response); // 5: shared photo4
+
+		$this->assertEquals(5, LiveMetrics::count());
+		$response = $this->actingAs($this->userLocked)->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$this->assertEquals(5, LiveMetrics::count()); // Still 5: We do not count the logged in users yet.
+		Configs::set('metrics_logged_in_users_enabed', true);
+		$response = $this->actingAs($this->userLocked)->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$this->assertEquals(6, LiveMetrics::count()); // 6: We do count the logged in users now.
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$this->assertEquals(6, LiveMetrics::count()); // Still 6: We do not count the admin user though.
+
+		// Now we check/fetch the metrics data.
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Metrics');
+		$this->assertOk($response);
+		$this->assertCount(0, $response->json()); // Album 4 (which we visited above) belongs to userLocked, not userMayUpload1
+
+		$response = $this->actingAs($this->userLocked)->getJson('Metrics');
+		$this->assertOk($response);
+		$this->assertCount(5, $response->json()); // while we have 6 events in the table, we do not show the view of the photo, those are too noisy.
+
+		$response = $this->actingAs($this->admin)->getJson('Metrics');
+		$this->assertOk($response);
+		$this->assertCount(5, $response->json());
+	}
+}

--- a/tests/Traits/RequiresEmptyLiveMetrics.php
+++ b/tests/Traits/RequiresEmptyLiveMetrics.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Traits;
+
+use Illuminate\Support\Facades\DB;
+
+trait RequiresEmptyLiveMetrics
+{
+	abstract protected function assertDatabaseCount($table, int $count, $connection = null);
+
+	protected function setUpRequiresEmptyLiveMetrics(): void
+	{
+		$this->assertDatabaseCount('live_metrics', 0);
+	}
+
+	protected function tearDownRequiresEmptyLiveMetrics(): void
+	{
+		DB::table('live_metrics')->delete();
+	}
+}


### PR DESCRIPTION
This pull request introduces a new feature for managing live metrics in the application. It includes the creation of a `LiveMetrics` model, associated policies, resources, and a database migration, along with the implementation of logic to fetch, clean up, and manage live metrics data. Below is a summary of the most significant changes:

### Core Feature: Live Metrics Management

* **New `LiveMetrics` Model and Builder**: Added `LiveMetrics` model (`app/Models/LiveMetrics.php`) and a specialized query builder (`app/Models/Builders/LiveMetricsBuilder.php`) to handle live metrics data. The model includes relationships to `Photo` and `Album` for accessing related data. [[1]](diffhunk://#diff-05297b1b6c425974d424f0736be049f43b7ca3ee9b3cbdf5da25998329d51744R1-R106) [[2]](diffhunk://#diff-158d7ec13200b1db1e2ca545aa415b92517107b7808e379dc1fb7744c2568277R1-R23)
* **Database Migration**: Created a migration to define the `live_metrics` table, which includes fields for visitor ID, action, album ID, photo ID, and timestamps.

### Data Access and Cleanup

* **`GetMetrics` and `CleanupMetrics` Actions**: Implemented the `GetMetrics` action to retrieve live metrics with filtering and the `CleanupMetrics` action to remove outdated metrics based on a configurable retention period. [[1]](diffhunk://#diff-cdd42d3c465aac4fd89b368cf2ddacf0102095aff3b427e18ef9d6fcee3d1115R1-R54) [[2]](diffhunk://#diff-fca806170e6b1379794f323b9551add8a755c2a47dc9f5fb5598b3153f035f1bR1-R22)
* **Controller Integration**: Updated `MetricsController` to include a new `get` method that uses the `GetMetrics` and `CleanupMetrics` actions. This method validates whether live metrics are enabled before proceeding.

### Authorization and Policy

* **`MetricsPolicy` and Authorization**: Added a new `MetricsPolicy` to control access to live metrics based on user roles and configuration settings. Integrated the policy into the `AuthServiceProvider`. [[1]](diffhunk://#diff-302716b674f7bf188b50ec5b5fb0f1216677b5684de3d79074bb53f61eb793c0R1-R35) [[2]](diffhunk://#diff-9d0a077acda375ef8f06f27e2f823037207bcbaa21c2c87cf4c113a13a3eb0c4R48-R49)
* **`MetricsRequest`**: Introduced a new request class to enforce authorization checks for live metrics access.

### Resource and Presentation

* **`LiveMetricsResource`**: Created a data resource for transforming live metrics data into a consistent format for API responses, including related photo and album details.
* **Frontend Rights Resource**: Updated `RootAlbumRightsResource` to include a new `can_see_live_metrics` property, reflecting the user's ability to view live metrics.

### Miscellaneous

* **Event Listener Update**: Modified `MetricsListener` to log live metrics events into the `live_metrics` table when the feature is enabled.
* **Route Cache Exclusion**: Excluded the new live metrics API endpoint from route caching to ensure dynamic responses.

![image](https://github.com/user-attachments/assets/0b839fdd-49b5-4dd2-88f7-9fe0b69ed7e5)
