### PR TITLE
Add LiveMetrics activity drawer

### DIFF
--- a/resources/js/components/drawers/LiveMetrics.vue
+++ b/resources/js/components/drawers/LiveMetrics.vue
@@ -1,0 +1,196 @@
+<template>
+	<Drawer :closeOnEsc="false" v-model:visible="is_metrics_open" position="right" :pt:root:class="' w-sm'">
+		<template #header>
+			<span class="text-xl font-bold">
+				{{ $t("statistics.metrics.header") }}
+			</span>
+		</template>
+		<div class="flex flex-col">
+			<div v-for="item in prettifiedData" :key="item.action + item.ago" class="flex pt-2 pb-1">
+				<div class="flex flex-col w-full text-sm text-muted-color">
+					<router-link :to="item.link" v-if="item.count === 1" v-html="printSingular(item)"></router-link>
+					<router-link :to="item.link" v-if="item.count > 1" v-html="printPlural(item)"></router-link>
+					<span class="text-xs -mt-1">{{ item.ago }}</span>
+				</div>
+				<div class="w-12 h-12 relative shrink-0">
+					<div
+						class="absolute top-0 right-0 translate-x-2.5 -translate-y-2 w-6 h-6 rounded-full bg-primary-emphasis flex justify-center items-center border-3 border-solid border-surface-0 text-surface-0 dark:border-surface-900 dark:text-surface-900"
+					>
+						<span
+							class="pi text-2xs"
+							:class="{
+								'pi-bookmark': item.action === 'favourite',
+								'pi-download': item.action === 'download',
+								'pi-share-alt': item.action === 'shared',
+								'pi-eye': item.action === 'visit',
+							}"
+						></span>
+					</div>
+					<img :src="item.src" v-if="item.src" class="rounded w-full h-full object-cover" />
+				</div>
+			</div>
+		</div>
+	</Drawer>
+</template>
+<script setup lang="ts">
+import MetricsService from "@/services/metrics-service";
+import { useTogglablesStateStore } from "@/stores/ModalsState";
+import { trans } from "laravel-vue-i18n";
+import { storeToRefs } from "pinia";
+import Drawer from "primevue/drawer";
+import { sprintf } from "sprintf-js";
+import { ref } from "vue";
+import { onMounted } from "vue";
+import { watch } from "vue";
+
+const togglableStore = useTogglablesStateStore();
+const { is_metrics_open } = storeToRefs(togglableStore);
+
+type LiveMetrics = {
+	ago: string;
+	date: Date;
+	id: string;
+	link: { name: string; params: {} };
+	action: App.Enum.MetricsAction;
+	title: string;
+	count: number;
+	src: string | null;
+};
+const data = ref<App.Http.Resources.Models.LiveMetricsResource[] | undefined>(undefined);
+const prettifiedData = ref<LiveMetrics[] | undefined>(undefined);
+
+function load() {
+	MetricsService.get()
+		.then((response) => {
+			data.value = response.data;
+			prettifyData();
+		})
+		.catch((error) => {
+			console.error(error);
+		});
+}
+
+function printSingular(data: LiveMetrics) {
+	const visitor = `<span class="font-bold text-muted-color-emphasis">${trans("statistics.metrics.a_visitor")}</span>`;
+	switch (data.action) {
+		case "visit":
+			return sprintf(trans("statistics.metrics.visit_singular"), visitor, titlize(data.title));
+		case "favourite":
+			return sprintf(trans("statistics.metrics.favourite_singular"), visitor, titlize(data.title));
+		case "download":
+			return sprintf(trans("statistics.metrics.download_singular"), visitor, titlize(data.title));
+		case "shared":
+			return sprintf(trans("statistics.metrics.shared_singular"), visitor, titlize(data.title));
+	}
+}
+
+function printPlural(data: LiveMetrics) {
+	const visitors = sprintf(`<span class="font-bold text-muted-color-emphasis">${trans("statistics.metrics.visitors")}</span>`, data.count);
+	switch (data.action) {
+		case "visit":
+			return sprintf(trans("statistics.metrics.visit_plural"), visitors, titlize(data.title));
+		case "favourite":
+			return sprintf(trans("statistics.metrics.favourite_plural"), visitors, titlize(data.title));
+		case "download":
+			return sprintf(trans("statistics.metrics.download_plural"), visitors, titlize(data.title));
+		case "shared":
+			return sprintf(trans("statistics.metrics.shared_plural"), visitors, titlize(data.title));
+	}
+}
+
+function titlize(title: string) {
+	const t = title.length > 20 ? title.substring(0, 20) + "..." : title;
+	return `<span class="font-bold text-primary-emphasis">${t}</span>`;
+}
+
+function prettifyData() {
+	if (data.value === undefined || data.value.length === 0) {
+		return;
+	}
+
+	const dateMetrics: Record<string, LiveMetrics> = {};
+
+	data.value.forEach((item) => {
+		const k = genKey(item);
+
+		if (k in dateMetrics) {
+			dateMetrics[k].count++;
+		} else {
+			dateMetrics[k] = LiveMetricsToPretty(item, 1);
+		}
+	});
+
+	prettifiedData.value = Object.values(dateMetrics).sort((a, b) => {
+		return b.date.getTime() - a.date.getTime();
+	});
+}
+
+function genKey(item: App.Http.Resources.Models.LiveMetricsResource) {
+	return item.action + dateToAgo(item.created_at) + (item.photo_id ?? item.album_id ?? "undefined");
+}
+
+function dateToAgo(date: string) {
+	const dateObj = new Date(date);
+	const now = new Date();
+	const diff = Math.abs(now.getTime() - dateObj.getTime());
+	const seconds = Math.floor(diff / 1000);
+	const minutes = Math.floor(seconds / 60);
+	const hours = Math.floor(minutes / 60);
+	const days = Math.floor(hours / 24);
+
+	if (days > 1) {
+		return sprintf(trans("statistics.metrics.ago.days"), days);
+	} else if (days > 0) {
+		return trans("statistics.metrics.ago.day");
+	} else if (hours > 1) {
+		return sprintf(trans("statistics.metrics.ago.hours"), hours);
+	} else if (hours > 0) {
+		return trans("statistics.metrics.ago.hour");
+	} else if (minutes > 30) {
+		return sprintf(trans("statistics.metrics.ago.minutes"), 30);
+	} else if (minutes > 15) {
+		return sprintf(trans("statistics.metrics.ago.minutes"), 15);
+	} else if (minutes > 5) {
+		return sprintf(trans("statistics.metrics.ago.minutes"), minutes);
+	} else if (minutes > 0) {
+		return trans("statistics.metrics.ago.few_minutes");
+	} else {
+		return trans("statistics.metrics.ago.seconds");
+	}
+}
+
+function LiveMetricsToPretty(data: App.Http.Resources.Models.LiveMetricsResource, count: number): LiveMetrics {
+	const ago = dateToAgo(data.created_at);
+	return {
+		ago: ago,
+		date: new Date(data.created_at),
+		action: data.action,
+		title: data.title ?? "undefined",
+		id: data.photo_id ?? data.album_id ?? "undefined",
+		count: count,
+		src: data.url,
+		link: {
+			name: data.photo_id ? "photo" : "album",
+			params: {
+				albumid: data.album_id,
+				photoid: data.photo_id,
+			},
+		},
+	};
+}
+
+onMounted(() => {
+	if (is_metrics_open.value) {
+		load();
+	}
+});
+
+watch(
+	() => is_metrics_open.value,
+	(newValue) => {
+		if (newValue) {
+			load();
+		}
+	},
+);
+</script>

--- a/resources/js/components/headers/AlbumsHeader.vue
+++ b/resources/js/components/headers/AlbumsHeader.vue
@@ -25,7 +25,9 @@
 			<span class="sm:hidden font-bold">
 				{{ $t("gallery.albums") }}
 			</span>
-			<span class="hidden sm:block font-bold text-sm lg:text-base text-center w-full">{{ props.title }}</span>
+			<span class="hidden sm:block font-bold text-sm lg:text-base text-center w-full" @click="is_metrics_open = !is_metrics_open">{{
+				props.title
+			}}</span>
 		</template>
 
 		<template #end>
@@ -125,7 +127,7 @@ const togglableStore = useTogglablesStateStore();
 const favourites = useFavouriteStore();
 
 const { dropbox_api_key, is_favourite_enabled } = storeToRefs(lycheeStore);
-const { is_login_open, is_upload_visible, is_create_album_visible, is_create_tag_album_visible } = storeToRefs(togglableStore);
+const { is_login_open, is_upload_visible, is_create_album_visible, is_create_tag_album_visible, is_metrics_open } = storeToRefs(togglableStore);
 
 const router = useRouter();
 
@@ -229,6 +231,12 @@ const menu = computed(() =>
 			type: "fn",
 			callback: openSearch,
 			if: props.config.is_search_accessible,
+		},
+		{
+			icon: "pi pi-bell",
+			type: "fn",
+			callback: () => (is_metrics_open.value = true),
+			if: props.rights.can_see_live_metrics,
 		},
 		{
 			icon: "pi pi-sign-in",

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -73,6 +73,7 @@ declare namespace App.Enum {
 		| "CC-BY-NC-SA-2.5"
 		| "CC-BY-NC-SA-3.0"
 		| "CC-BY-NC-SA-4.0";
+	export type LiveMetricsAccess = "logged-in users" | "admin";
 	export type MapProviders = "Wikimedia" | "OpenStreetMap.org" | "OpenStreetMap.de" | "OpenStreetMap.fr" | "RRZE";
 	export type MessageType = "info" | "warning" | "error";
 	export type MetricsAccess = "public" | "logged-in users" | "owner" | "admin";
@@ -382,6 +383,15 @@ declare namespace App.Http.Resources.Models {
 		id: number;
 		username: string;
 	};
+	export type LiveMetricsResource = {
+		created_at: string;
+		visitor_id: string;
+		action: App.Enum.MetricsAction;
+		photo_id: string | null;
+		album_id: string | null;
+		title: string | null;
+		url: string | null;
+	};
 	export type PhotoResource = {
 		id: string;
 		album_id: string | null;
@@ -637,6 +647,7 @@ declare namespace App.Http.Resources.Rights {
 	export type RootAlbumRightsResource = {
 		can_edit: boolean;
 		can_upload: boolean;
+		can_see_live_metrics: boolean;
 	};
 	export type SettingsRightsResource = {
 		can_edit: boolean;

--- a/resources/js/services/metrics-service.ts
+++ b/resources/js/services/metrics-service.ts
@@ -2,6 +2,10 @@ import axios, { type AxiosResponse } from "axios";
 import Constants from "./constants";
 
 const MetricsService = {
+	get(): Promise<AxiosResponse<App.Http.Resources.Models.LiveMetricsResource[]>> {
+		return axios.get(`${Constants.getApiUrl()}Metrics`, { data: {} });
+	},
+
 	photo(photo_id: string): Promise<AxiosResponse<null>> {
 		return axios.post(`${Constants.getApiUrl()}Metrics::photo`, { photo_ids: [photo_id] });
 	},

--- a/resources/js/stores/ModalsState.ts
+++ b/resources/js/stores/ModalsState.ts
@@ -9,6 +9,7 @@ export const useTogglablesStateStore = defineStore("togglables-store", {
 		is_full_screen: false,
 		is_login_open: false,
 		is_webauthn_open: false,
+		is_metrics_open: false,
 
 		// upload
 		is_upload_visible: false,

--- a/resources/js/views/gallery-panels/Albums.vue
+++ b/resources/js/views/gallery-panels/Albums.vue
@@ -6,6 +6,7 @@
 	<AlbumCreateTagDialog v-if="rootRights?.can_upload" key="create_tag_album_modal" />
 	<LoginModal v-if="user?.id === null" @logged-in="refresh" />
 	<WebauthnModal v-if="user?.id === null" @logged-in="refresh" />
+	<LiveMetrics v-if="user?.id" />
 
 	<div v-if="rootConfig && rootRights" @click="unselect" class="h-svh overflow-y-auto" id="galleryView" v-on:scroll="onScroll">
 		<Collapse :when="!is_full_screen">
@@ -163,6 +164,7 @@ import { EmptyPhotoCallbacks } from "@/utils/Helpers";
 import WebauthnModal from "@/components/modals/WebauthnModal.vue";
 import LoginModal from "@/components/modals/LoginModal.vue";
 import LoadingProgress from "@/components/loading/LoadingProgress.vue";
+import LiveMetrics from "@/components/drawers/LiveMetrics.vue";
 import { useLeftMenuStateStore } from "@/stores/LeftMenuState";
 
 const auth = useAuthStore();


### PR DESCRIPTION
This pull request introduces a new "Live Metrics" feature, allowing users to view real-time statistics about specific actions (e.g., visits, downloads) in a sidebar drawer. It includes the implementation of the `LiveMetrics` component, integration with the existing UI, and updates to the state management system.

### New Feature: Live Metrics

#### Component Implementation:
* Added a new `LiveMetrics` component in `resources/js/components/drawers/LiveMetrics.vue`. This component fetches and displays real-time metrics data, including actions like visits, favorites, downloads, and shares, in a visually structured drawer interface.

#### State Management Updates:
* Extended the `togglables-store` in `resources/js/stores/ModalsState.ts` to include a new state variable, `is_metrics_open`, for controlling the visibility of the Live Metrics drawer.

### UI Integration

#### Albums Header:
* Updated the `AlbumsHeader.vue` to toggle the Live Metrics drawer when the header title is clicked and added a new notification icon to open the drawer if the user has the appropriate permissions. [[1]](diffhunk://#diff-36954f066edc20366a3e9bc63ddafb3162b3d35ddbb989292e3e1009a69aea1cL28-R30) [[2]](diffhunk://#diff-36954f066edc20366a3e9bc63ddafb3162b3d35ddbb989292e3e1009a69aea1cR235-R240)
* Updated the `togglables-store` references in `AlbumsHeader.vue` to include `is_metrics_open`.

#### Albums View:
* Integrated the `LiveMetrics` component into the `Albums.vue` view, ensuring it is conditionally rendered for authenticated users. [[1]](diffhunk://#diff-2ddfe21738ea4ed7b8d4370902edd893a5921143729843c759f675773289daf6R9) [[2]](diffhunk://#diff-2ddfe21738ea4ed7b8d4370902edd893a5921143729843c759f675773289daf6R167)

### Backend Service Integration
* Added a new `get()` method to the `MetricsService` in `resources/js/services/metrics-service.ts` to fetch metrics data from the backend API.

![image](https://github.com/user-attachments/assets/0b839fdd-49b5-4dd2-88f7-9fe0b69ed7e5)
