### PR TITLE
Fixes sharing access rights.

### DIFF
--- a/app/Actions/Album/ListAlbums.php
+++ b/app/Actions/Album/ListAlbums.php
@@ -27,13 +27,15 @@ class ListAlbums
 	/**
 	 * @return TAlbumSaved[]
 	 */
-	public function do(Collection $albums_filtering, ?string $parent_id): array
+	public function do(Collection $albums_filtering, ?string $parent_id, ?int $owner_id = null): array
 	{
 		$album_query_policy = resolve(AlbumQueryPolicy::class);
 		$unfiltered = $album_query_policy->applyReachabilityFilter(
 			// We remove all sub albums
 			// Otherwise it would create cyclic dependency
 			Album::query()
+				->when($owner_id !== null,
+					fn ($q) => $q->where('owner_id', '=', $owner_id))
 				->when($albums_filtering->count() > 0,
 					function ($q) use ($albums_filtering) {
 						$albums_filtering->each(

--- a/app/Http/Controllers/Gallery/AlbumController.php
+++ b/app/Http/Controllers/Gallery/AlbumController.php
@@ -241,12 +241,12 @@ class AlbumController extends Controller
 	 *
 	 * @return array<string|int,TargetAlbumResource>
 	 */
-	public function getTargetListAlbums(TargetListAlbumRequest $request, ListAlbums $list_albums)
+	public function getTargetListAlbums(TargetListAlbumRequest $request, ListAlbums $list_albums): array
 	{
 		$albums = $request->albums();
 		$parent_id = $albums->count() > 0 ? $albums->first()->parent_id : null;
 
-		return TargetAlbumResource::collect($list_albums->do($albums, $parent_id));
+		return TargetAlbumResource::collect($list_albums->do($albums, $parent_id, null));
 	}
 
 	/**

--- a/app/Http/Controllers/Gallery/SharingController.php
+++ b/app/Http/Controllers/Gallery/SharingController.php
@@ -25,6 +25,7 @@ use App\Http\Resources\Models\TargetAlbumResource;
 use App\Models\AccessPermission;
 use App\Models\Album;
 use App\Models\BaseAlbumImpl;
+use App\Models\User;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;

--- a/app/Metadata/Cache/RouteCacheManager.php
+++ b/app/Metadata/Cache/RouteCacheManager.php
@@ -91,6 +91,7 @@ final readonly class RouteCacheManager
 			'api/v2/Settings::getLanguages' => new RouteCacheConfig(tag: CacheTag::SETTINGS),
 			'api/v2/Sharing' => new RouteCacheConfig(tag: CacheTag::GALLERY, user_dependant: true, extra: [RequestAttribute::ALBUM_ID_ATTRIBUTE]),
 			'api/v2/Sharing::all' => new RouteCacheConfig(tag: CacheTag::GALLERY, user_dependant: true),
+			'api/v2/Sharing::albums' => new RouteCacheConfig(tag: CacheTag::GALLERY, user_dependant: true),
 			'api/v2/Statistics::albumSpace' => new RouteCacheConfig(tag: CacheTag::STATISTICS, user_dependant: true),
 			'api/v2/Statistics::sizeVariantSpace' => new RouteCacheConfig(tag: CacheTag::STATISTICS, user_dependant: true),
 			'api/v2/Statistics::totalAlbumSpace' => new RouteCacheConfig(tag: CacheTag::STATISTICS, user_dependant: true),

--- a/app/Policies/AlbumPolicy.php
+++ b/app/Policies/AlbumPolicy.php
@@ -466,7 +466,8 @@ class AlbumPolicy extends BasePolicy
 
 		// If this is null, this means that we are looking at the list.
 		if ($abstract_album === null) {
-			return true;
+			// We need to be at least owner of an album to be able to share anything.
+			return BaseAlbumImpl::query()->where('owner_id', '=', $user->id)->toBase()->count() > 0;
 		}
 
 		if (!$abstract_album instanceof BaseAlbum && !$abstract_album instanceof BaseAlbumImpl) {

--- a/lang/cz/sharing.php
+++ b/lang/cz/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/de/sharing.php
+++ b/lang/de/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/el/sharing.php
+++ b/lang/el/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/en/sharing.php
+++ b/lang/en/sharing.php
@@ -34,6 +34,10 @@ return [
 
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/es/sharing.php
+++ b/lang/es/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/fr/sharing.php
+++ b/lang/fr/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation réussie ! Autorisations mises à jour !',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Autorise la lecture',

--- a/lang/hu/sharing.php
+++ b/lang/hu/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/it/sharing.php
+++ b/lang/it/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/ja/sharing.php
+++ b/lang/ja/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/nl/sharing.php
+++ b/lang/nl/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/no/sharing.php
+++ b/lang/no/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/pl/sharing.php
+++ b/lang/pl/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagacja zakończona sukcesem! Pozwolenie zaktualizowane!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Przyznaje dostęp do odczytu',

--- a/lang/pt/sharing.php
+++ b/lang/pt/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/ru/sharing.php
+++ b/lang/ru/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Распространение успешно! Разрешение обновлено!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Предоставляет доступ для чтения',

--- a/lang/sk/sharing.php
+++ b/lang/sk/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/sv/sharing.php
+++ b/lang/sv/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/vi/sharing.php
+++ b/lang/vi/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/lang/zh_CN/sharing.php
+++ b/lang/zh_CN/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => '传播成功！权限已更新！',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => '授予读取权限',

--- a/lang/zh_TW/sharing.php
+++ b/lang/zh_TW/sharing.php
@@ -33,6 +33,10 @@ return [
 	'permission_updated' => 'Propagation successful! Permission updated!',
 	'bluk_share' => 'Bulk share',
 	'bulk_share_instr' => 'Select multiple albums and users to share with.',
+	'albums' => 'Albums',
+	'users' => 'Users',
+	'no_users' => 'No selectable users.',
+	'no_albums' => 'No selectable albums.',
 
 	'grants' => [
 		'read' => 'Grants read access',

--- a/resources/js/components/forms/sharing/BulkSharingModal.vue
+++ b/resources/js/components/forms/sharing/BulkSharingModal.vue
@@ -21,6 +21,12 @@
 						class="w-full"
 						:virtualScrollerOptions="{ itemSize: 28 }"
 					>
+						<template #header
+							><span class="text-muted-color-emphasis font-bold">{{ $t("sharing.albums") }}</span></template
+						>
+						<template #empty
+							><span class="text-muted-color">{{ $t("sharing.no_albums") }}</span></template
+						>
 						<template #option="slotProps">
 							<div class="flex items-center">
 								<div
@@ -45,7 +51,14 @@
 						:highlightOnSelect="false"
 						class="w-full"
 						:virtualScrollerOptions="{ itemSize: 28 }"
-					/>
+					>
+						<template #header
+							><span class="text-muted-color-emphasis font-bold">{{ $t("sharing.users") }}</span></template
+						>
+						<template #empty
+							><span class="text-muted-color">{{ $t("sharing.no_users") }}</span></template
+						>
+					</Listbox>
 				</div>
 
 				<div class="w-1/2 flex justify-around items-center">
@@ -85,7 +98,6 @@
 <script setup lang="ts">
 import Dialog from "primevue/dialog";
 import { ref } from "vue";
-import AlbumService from "@/services/album-service";
 import UsersService from "@/services/users-service";
 import { onMounted } from "vue";
 import Checkbox from "primevue/checkbox";
@@ -146,7 +158,7 @@ function closeCallback() {
 }
 
 function loadAlbums() {
-	AlbumService.getTargetListAlbums(null).then((response) => {
+	SharingService.listAlbums().then((response) => {
 		targetAlbums.value = response.data;
 	});
 }

--- a/resources/js/services/album-service.ts
+++ b/resources/js/services/album-service.ts
@@ -57,7 +57,7 @@ const AlbumService = {
 	clearCache(album_id: string | null = null): void {
 		const axiosWithCache = axios as unknown as AxiosCacheInstance;
 		if (!album_id) {
-			// @ts-expect-error
+			// @ts-expect-error  we now what we are doing here.
 			axiosWithCache.storage.clear();
 		} else {
 			axiosWithCache.storage.remove("album_" + album_id);

--- a/resources/js/services/sharing-service.ts
+++ b/resources/js/services/sharing-service.ts
@@ -49,6 +49,10 @@ const SharingService = {
 	list(): Promise<AxiosResponse<App.Http.Resources.Models.AccessPermissionResource[]>> {
 		return axios.get(`${Constants.getApiUrl()}Sharing::all`, { data: {} });
 	},
+
+	listAlbums(): Promise<AxiosResponse<App.Http.Resources.Models.TargetAlbumResource[]>> {
+		return axios.get(`${Constants.getApiUrl()}Sharing::albums`, { data: {} });
+	},
 };
 
 export default SharingService;

--- a/resources/js/views/Sharing.vue
+++ b/resources/js/views/Sharing.vue
@@ -36,7 +36,7 @@
 				<div class="w-1/6"></div>
 			</div>
 			<template v-if="perms?.length > 0">
-				<ShareLine v-for="perm in perms" :perm="perm" @delete="deletePermission" :with-album="true" />
+				<ShareLine v-for="(perm, idx) in perms" :perm="perm" @delete="deletePermission" :with-album="true" :key="'p' + (perm.id ?? idx)" />
 			</template>
 			<p v-else class="text-center">{{ $t("sharing.no_data") }}</p>
 		</div>

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -78,6 +78,7 @@ Route::put('/Sharing', [Gallery\SharingController::class, 'propagate']);
 Route::patch('/Sharing', [Gallery\SharingController::class, 'edit']);
 Route::delete('/Sharing', [Gallery\SharingController::class, 'delete']);
 Route::get('/Sharing::all', [Gallery\SharingController::class, 'listAll']);
+Route::get('/Sharing::albums', [Gallery\SharingController::class, 'listAlbums']);
 
 /**
  * IMPORT.

--- a/tests/Feature_v2/Album/SharingTest.php
+++ b/tests/Feature_v2/Album/SharingTest.php
@@ -31,6 +31,21 @@ class SharingTest extends BaseApiWithDataTest
 
 		$response = $this->getJsonWithData('Sharing', ['album_id' => $this->album1->id]);
 		$this->assertUnauthorized($response);
+
+		$response = $this->getJsonWithData('Sharing::albums');
+		$this->assertUnauthorized($response);
+	}
+
+	public function testUserForbidden(): void
+	{
+		$response = $this->actingAs($this->userNoUpload)->getJsonWithData('Sharing');
+		$this->assertUnprocessable($response);
+
+		$response = $this->actingAs($this->userNoUpload)->getJsonWithData('Sharing::all');
+		$this->assertForbidden($response);
+
+		$response = $this->actingAs($this->userNoUpload)->getJsonWithData('Sharing::albums');
+		$this->assertForbidden($response);
 	}
 
 	public function testUserGet(): void
@@ -43,6 +58,23 @@ class SharingTest extends BaseApiWithDataTest
 
 		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Sharing::all');
 		$this->assertOk($response);
+
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Sharing::albums');
+		$this->assertOk($response);
+		$response->assertJson([
+			[
+				'id' => $this->album1->id,
+				'title' => $this->album1->title,
+				'original' => $this->album1->title,
+				'short_title' => $this->album1->title,
+			],
+			[
+				'id' => $this->subAlbum1->id,
+				'title' => $this->album1->title . '/' . $this->subAlbum1->title,
+				'original' => $this->subAlbum1->title,
+				'short_title' => $this->album1->title . '/' . $this->subAlbum1->title,
+			],
+		]);
 
 		$response = $this->actingAs($this->userMayUpload1)->patchJson('Sharing', [
 			'perm_id' => $this->perm1->id,


### PR DESCRIPTION
fixes #3280

This pull request introduces several changes to enhance album sharing functionality, improve user-specific album filtering, and update language files for better localization. The most significant updates include extending the `ListAlbums` action to support owner-based filtering, adding a new `listAlbums` method in the `SharingController`, and updating language files across multiple locales.

### Enhancements to Album Sharing and Filtering:

* **`ListAlbums` Action Update**: The `do` method of the `ListAlbums` class now supports an optional `owner_id` parameter to filter albums by their owner. This change ensures that album queries can be restricted based on ownership when needed. (`app/Actions/Album/ListAlbums.php`, [app/Actions/Album/ListAlbums.phpL30-R38](diffhunk://#diff-5705950a80bd46ec9267a63f391afdee07f764abfdc11e9dc062240d21538da3L30-R38))

* **New `listAlbums` Method in `SharingController`**: A `listAlbums` endpoint has been added to the `SharingController` to retrieve albums based on the authenticated user's permissions. Admin users can fetch all albums, while regular users are limited to their own albums. (`app/Http/Controllers/Gallery/SharingController.php`, [app/Http/Controllers/Gallery/SharingController.phpR121-R142](diffhunk://#diff-600f9aa425dff07d96b096d9f9dc193ebd32ebfd8b6cacd23dd944f2c53a83dfR121-R142))

* **Album Sharing Policy Update**: The `canShareWithUsers` method in `AlbumPolicy` was modified to ensure that users must own at least one album to share it. (`app/Policies/AlbumPolicy.php`, [app/Policies/AlbumPolicy.phpL469-R470](diffhunk://#diff-f3709d8072b3229a928c52fe03d7c3698489978b206a2a84cd4cc64941712684L469-R470))

### Localization Improvements:

* **Language File Updates**: Added new keys (`albums`, `users`, `no_users`, `no_albums`) to the `sharing.php` language files across multiple locales (e.g., English, French, German, etc.) to support better user interface messages for album sharing. (`lang/*/sharing.php`, [[1]](diffhunk://#diff-fe88cdca99f89e16da673949d59d302c74cfeba557faa61fa7000a2b6b80fcceR36-R39) [[2]](diffhunk://#diff-d825ba813d4f8965f0d035f6702c5e5a16df48833cac06f99ee7907eea404b3cR37-R40) [[3]](diffhunk://#diff-37c8563577237c6225218aa5aa317516af4f87984eea4b2d69613c17badcc7f0R36-R39) [[4]](diffhunk://#diff-243881d9a6cf4ad8a6ae604232a6f538de8af2ed64169be92e18228745dbc935R36-R39) [[5]](diffhunk://#diff-a12820d26c0adf3eb72867f5efe05f4fc19ac2538a2d90177e1d3b411cce410eR36-R39)

### Miscellaneous:

* **Route Caching**: Added a cache configuration for the new `listAlbums` endpoint in the `RouteCacheManager`. (`app/Metadata/Cache/RouteCacheManager.php`, [app/Metadata/Cache/RouteCacheManager.phpR94](diffhunk://#diff-2e648fa2732dd85407cfa455547d789e2688a12e94be13a51e22f2e3f238ff35R94))

These changes collectively improve the album sharing workflow, enhance user experience with localized messages, and ensure efficient handling of user-specific album queries.