### PR TITLE
Remove electerious from copyright

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -47,7 +47,7 @@ $rules = [
 		'only_booleans' => true,
 		'position' => 'end',
 	],
-	// 'header_comment' => ['header' => "SPDX-License-Identifier: MIT\nCopyright (c) 2017-2018 Tobias Reich\nCopyright (c) 2018-2025 LycheeOrg", 'comment_type' => 'PHPDoc', 'location' => 'after_open', 'separate' => 'bottom'],
+	// 'header_comment' => ['header' => "SPDX-License-Identifier: MIT\nCopyright (c) 2018-2025 LycheeOrg", 'comment_type' => 'PHPDoc', 'location' => 'after_open', 'separate' => 'bottom'],
 ];
 $config = new PhpCsFixer\Config();
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,5 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2018 Tobias Reich
 Copyright (c) 2018-2024 LycheeOrg
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/app/Actions/Album/Archive32.php
+++ b/app/Actions/Album/Archive32.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/Archive64.php
+++ b/app/Actions/Album/Archive64.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/BaseArchive.php
+++ b/app/Actions/Album/BaseArchive.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/Create.php
+++ b/app/Actions/Album/Create.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/CreateTagAlbum.php
+++ b/app/Actions/Album/CreateTagAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/Delete.php
+++ b/app/Actions/Album/Delete.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/ListAlbums.php
+++ b/app/Actions/Album/ListAlbums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/Merge.php
+++ b/app/Actions/Album/Merge.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/Move.php
+++ b/app/Actions/Album/Move.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/PositionData.php
+++ b/app/Actions/Album/PositionData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/SetHeader.php
+++ b/app/Actions/Album/SetHeader.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/SetProtectionPolicy.php
+++ b/app/Actions/Album/SetProtectionPolicy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/SetSmartProtectionPolicy.php
+++ b/app/Actions/Album/SetSmartProtectionPolicy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/Transfer.php
+++ b/app/Actions/Album/Transfer.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Album/Unlock.php
+++ b/app/Actions/Album/Unlock.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Albums/PositionData.php
+++ b/app/Actions/Albums/PositionData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Albums/Top.php
+++ b/app/Actions/Albums/Top.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Db/BaseOptimizer.php
+++ b/app/Actions/Db/BaseOptimizer.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Db/OptimizeDb.php
+++ b/app/Actions/Db/OptimizeDb.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Db/OptimizeTables.php
+++ b/app/Actions/Db/OptimizeTables.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Configuration.php
+++ b/app/Actions/Diagnostics/Configuration.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Diagnostics.php
+++ b/app/Actions/Diagnostics/Diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Errors.php
+++ b/app/Actions/Diagnostics/Errors.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Info.php
+++ b/app/Actions/Diagnostics/Info.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/AdminUserExistsCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/AdminUserExistsCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/AppUrlMatchCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/AppUrlMatchCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/BasicPermissionCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/BasicPermissionCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/CachePasswordCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/CachePasswordCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/ConfigSanityCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/ConfigSanityCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/CountSizeVariantsCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/CountSizeVariantsCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/DBIntegrityCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/DBIntegrityCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/DBSupportCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/DBSupportCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/ForeignKeyListInfo.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/ForeignKeyListInfo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/GDSupportCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/GDSupportCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/ImageOptCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/ImageOptCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/IniSettingsCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/IniSettingsCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/MigrationCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/MigrationCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/OpCacheCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/OpCacheCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/PHPVersionCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/PHPVersionCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/PlaceholderExistsCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/PlaceholderExistsCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/SmallMediumExistsCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/SmallMediumExistsCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/SupporterCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/SupporterCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/TimezoneCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/TimezoneCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Checks/UpdatableCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/UpdatableCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Infos/CountForeignKeyInfo.php
+++ b/app/Actions/Diagnostics/Pipes/Infos/CountForeignKeyInfo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Infos/DockerVersionInfo.php
+++ b/app/Actions/Diagnostics/Pipes/Infos/DockerVersionInfo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Infos/ExtensionsInfo.php
+++ b/app/Actions/Diagnostics/Pipes/Infos/ExtensionsInfo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Infos/InstallTypeInfo.php
+++ b/app/Actions/Diagnostics/Pipes/Infos/InstallTypeInfo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Infos/SystemInfo.php
+++ b/app/Actions/Diagnostics/Pipes/Infos/SystemInfo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Pipes/Infos/VersionInfo.php
+++ b/app/Actions/Diagnostics/Pipes/Infos/VersionInfo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Diagnostics/Space.php
+++ b/app/Actions/Diagnostics/Space.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/HoneyPot/BasePipe.php
+++ b/app/Actions/HoneyPot/BasePipe.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/HoneyPot/DefaultNotFound.php
+++ b/app/Actions/HoneyPot/DefaultNotFound.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/HoneyPot/EnvAccessTentative.php
+++ b/app/Actions/HoneyPot/EnvAccessTentative.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/HoneyPot/FlaggedPathsAccessTentative.php
+++ b/app/Actions/HoneyPot/FlaggedPathsAccessTentative.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/HoneyPot/HoneyIsActive.php
+++ b/app/Actions/HoneyPot/HoneyIsActive.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Import/Exec.php
+++ b/app/Actions/Import/Exec.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Import/FromUrl.php
+++ b/app/Actions/Import/FromUrl.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/ApplyUpdate.php
+++ b/app/Actions/InstallUpdate/ApplyUpdate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/CheckUpdate.php
+++ b/app/Actions/InstallUpdate/CheckUpdate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/DefaultConfig.php
+++ b/app/Actions/InstallUpdate/DefaultConfig.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/PermissionsChecker.php
+++ b/app/Actions/InstallUpdate/PermissionsChecker.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/Pipes/AbstractUpdateInstallerPipe.php
+++ b/app/Actions/InstallUpdate/Pipes/AbstractUpdateInstallerPipe.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/Pipes/AllowMigrationCheck.php
+++ b/app/Actions/InstallUpdate/Pipes/AllowMigrationCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/Pipes/ArtisanKeyGenerate.php
+++ b/app/Actions/InstallUpdate/Pipes/ArtisanKeyGenerate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/Pipes/ArtisanMigrate.php
+++ b/app/Actions/InstallUpdate/Pipes/ArtisanMigrate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/Pipes/ArtisanViewClear.php
+++ b/app/Actions/InstallUpdate/Pipes/ArtisanViewClear.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/Pipes/BranchCheck.php
+++ b/app/Actions/InstallUpdate/Pipes/BranchCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/Pipes/ComposerCall.php
+++ b/app/Actions/InstallUpdate/Pipes/ComposerCall.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/Pipes/GitPull.php
+++ b/app/Actions/InstallUpdate/Pipes/GitPull.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/Pipes/QueryExceptionChecker.php
+++ b/app/Actions/InstallUpdate/Pipes/QueryExceptionChecker.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/Pipes/Spacer.php
+++ b/app/Actions/InstallUpdate/Pipes/Spacer.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/InstallUpdate/RequirementsChecker.php
+++ b/app/Actions/InstallUpdate/RequirementsChecker.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Oauth/Oauth.php
+++ b/app/Actions/Oauth/Oauth.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Archive32.php
+++ b/app/Actions/Photo/Archive32.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Archive64.php
+++ b/app/Actions/Photo/Archive64.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/BaseArchive.php
+++ b/app/Actions/Photo/BaseArchive.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Create.php
+++ b/app/Actions/Photo/Create.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Delete.php
+++ b/app/Actions/Photo/Delete.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Duplicate.php
+++ b/app/Actions/Photo/Duplicate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/DuplicateFinder.php
+++ b/app/Actions/Photo/DuplicateFinder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Extensions/ArchiveFileInfo.php
+++ b/app/Actions/Photo/Extensions/ArchiveFileInfo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Move.php
+++ b/app/Actions/Photo/Move.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Duplicate/ReplicateAsPhoto.php
+++ b/app/Actions/Photo/Pipes/Duplicate/ReplicateAsPhoto.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Duplicate/SaveIfDirty.php
+++ b/app/Actions/Photo/Pipes/Duplicate/SaveIfDirty.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Duplicate/ThrowSkipDuplicate.php
+++ b/app/Actions/Photo/Pipes/Duplicate/ThrowSkipDuplicate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Init/AssertSupportedMedia.php
+++ b/app/Actions/Photo/Pipes/Init/AssertSupportedMedia.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Init/FetchLastModifiedTime.php
+++ b/app/Actions/Photo/Pipes/Init/FetchLastModifiedTime.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Init/FindDuplicate.php
+++ b/app/Actions/Photo/Pipes/Init/FindDuplicate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Init/FindLivePartner.php
+++ b/app/Actions/Photo/Pipes/Init/FindLivePartner.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Init/InitParentAlbum.php
+++ b/app/Actions/Photo/Pipes/Init/InitParentAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Init/LoadFileMetadata.php
+++ b/app/Actions/Photo/Pipes/Init/LoadFileMetadata.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Init/MayLoadFileMetadata.php
+++ b/app/Actions/Photo/Pipes/Init/MayLoadFileMetadata.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/PhotoPartner/DeleteOldVideoPartner.php
+++ b/app/Actions/Photo/Pipes/PhotoPartner/DeleteOldVideoPartner.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/PhotoPartner/SetOldChecksum.php
+++ b/app/Actions/Photo/Pipes/PhotoPartner/SetOldChecksum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Shared/HydrateMetadata.php
+++ b/app/Actions/Photo/Pipes/Shared/HydrateMetadata.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Shared/NotifyAlbums.php
+++ b/app/Actions/Photo/Pipes/Shared/NotifyAlbums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Shared/Save.php
+++ b/app/Actions/Photo/Pipes/Shared/Save.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Shared/SetParentAndOwnership.php
+++ b/app/Actions/Photo/Pipes/Shared/SetParentAndOwnership.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Shared/SetStarred.php
+++ b/app/Actions/Photo/Pipes/Shared/SetStarred.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Shared/UploadSizeVariantsToS3.php
+++ b/app/Actions/Photo/Pipes/Shared/UploadSizeVariantsToS3.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Standalone/CreateOriginalSizeVariant.php
+++ b/app/Actions/Photo/Pipes/Standalone/CreateOriginalSizeVariant.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Standalone/CreateSizeVariants.php
+++ b/app/Actions/Photo/Pipes/Standalone/CreateSizeVariants.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
+++ b/app/Actions/Photo/Pipes/Standalone/EncodePlaceholder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Standalone/ExtractGoogleMotionPictures.php
+++ b/app/Actions/Photo/Pipes/Standalone/ExtractGoogleMotionPictures.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Standalone/FetchSourceImage.php
+++ b/app/Actions/Photo/Pipes/Standalone/FetchSourceImage.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Standalone/FixTimeStamps.php
+++ b/app/Actions/Photo/Pipes/Standalone/FixTimeStamps.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Standalone/InitNamingStrategy.php
+++ b/app/Actions/Photo/Pipes/Standalone/InitNamingStrategy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Standalone/PlaceGoogleMotionVideo.php
+++ b/app/Actions/Photo/Pipes/Standalone/PlaceGoogleMotionVideo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Standalone/PlacePhoto.php
+++ b/app/Actions/Photo/Pipes/Standalone/PlacePhoto.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Standalone/ReplaceOriginalWithBackup.php
+++ b/app/Actions/Photo/Pipes/Standalone/ReplaceOriginalWithBackup.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Standalone/SetChecksum.php
+++ b/app/Actions/Photo/Pipes/Standalone/SetChecksum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/Standalone/SetOriginalChecksum.php
+++ b/app/Actions/Photo/Pipes/Standalone/SetOriginalChecksum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/VideoPartner/GetVideoPath.php
+++ b/app/Actions/Photo/Pipes/VideoPartner/GetVideoPath.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/VideoPartner/PlaceVideo.php
+++ b/app/Actions/Photo/Pipes/VideoPartner/PlaceVideo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Pipes/VideoPartner/UpdateLivePartner.php
+++ b/app/Actions/Photo/Pipes/VideoPartner/UpdateLivePartner.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Photo/Rotate.php
+++ b/app/Actions/Photo/Rotate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Profile/UpdateLogin.php
+++ b/app/Actions/Profile/UpdateLogin.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/RSS/Generate.php
+++ b/app/Actions/RSS/Generate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Search/AlbumSearch.php
+++ b/app/Actions/Search/AlbumSearch.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Search/PhotoSearch.php
+++ b/app/Actions/Search/PhotoSearch.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Sharing/Propagate.php
+++ b/app/Actions/Sharing/Propagate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Sharing/Share.php
+++ b/app/Actions/Sharing/Share.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/SizeVariant/Delete.php
+++ b/app/Actions/SizeVariant/Delete.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Statistics/Counts.php
+++ b/app/Actions/Statistics/Counts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/Statistics/Spaces.php
+++ b/app/Actions/Statistics/Spaces.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/User/Create.php
+++ b/app/Actions/User/Create.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/User/Notify.php
+++ b/app/Actions/User/Notify.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/User/Save.php
+++ b/app/Actions/User/Save.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/User/TokenDisable.php
+++ b/app/Actions/User/TokenDisable.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Actions/User/TokenReset.php
+++ b/app/Actions/User/TokenReset.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Assets/ArrayToTextTable.php
+++ b/app/Assets/ArrayToTextTable.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Assets/BaseSizeVariantNamingStrategy.php
+++ b/app/Assets/BaseSizeVariantNamingStrategy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Assets/Features.php
+++ b/app/Assets/Features.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Assets/Helpers.php
+++ b/app/Assets/Helpers.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Assets/SizeVariantGroupedWithRandomSuffixNamingStrategy.php
+++ b/app/Assets/SizeVariantGroupedWithRandomSuffixNamingStrategy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Casts/ArrayCast.php
+++ b/app/Casts/ArrayCast.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Casts/DateTimeWithTimezoneCast.php
+++ b/app/Casts/DateTimeWithTimezoneCast.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Casts/MustNotSetCast.php
+++ b/app/Casts/MustNotSetCast.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/Diagnostics.php
+++ b/app/Console/Commands/Diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/FixPermissions.php
+++ b/app/Console/Commands/FixPermissions.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/FixTree.php
+++ b/app/Console/Commands/FixTree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/Ghostbuster.php
+++ b/app/Console/Commands/Ghostbuster.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/ImageProcessing/DecodeGpsLocations.php
+++ b/app/Console/Commands/ImageProcessing/DecodeGpsLocations.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/ImageProcessing/EncodePlaceholders.php
+++ b/app/Console/Commands/ImageProcessing/EncodePlaceholders.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/ImageProcessing/ExifLens.php
+++ b/app/Console/Commands/ImageProcessing/ExifLens.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/ImageProcessing/GenerateThumbs.php
+++ b/app/Console/Commands/ImageProcessing/GenerateThumbs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/ImageProcessing/Takedate.php
+++ b/app/Console/Commands/ImageProcessing/Takedate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/ImageProcessing/VariantFilesize.php
+++ b/app/Console/Commands/ImageProcessing/VariantFilesize.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/ImageProcessing/VideoData.php
+++ b/app/Console/Commands/ImageProcessing/VideoData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/Laravel/KeyGenerateCommand.php
+++ b/app/Console/Commands/Laravel/KeyGenerateCommand.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/Laravel/LangFilesToJson.php
+++ b/app/Console/Commands/Laravel/LangFilesToJson.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/Laravel/Migrate.php
+++ b/app/Console/Commands/Laravel/Migrate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/Laravel/Optimize.php
+++ b/app/Console/Commands/Laravel/Optimize.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/Legacy/ResetAdmin.php
+++ b/app/Console/Commands/Legacy/ResetAdmin.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/PhotosAddedNotification.php
+++ b/app/Console/Commands/PhotosAddedNotification.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/Sync.php
+++ b/app/Console/Commands/Sync.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/UserManagment/CreateUser.php
+++ b/app/Console/Commands/UserManagment/CreateUser.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/UserManagment/UpdateUser.php
+++ b/app/Console/Commands/UserManagment/UpdateUser.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Commands/Utilities/Colorize.php
+++ b/app/Console/Commands/Utilities/Colorize.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Constants/AccessPermissionConstants.php
+++ b/app/Constants/AccessPermissionConstants.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Constants/FileSystem.php
+++ b/app/Constants/FileSystem.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Constants/RandomID.php
+++ b/app/Constants/RandomID.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/DTO.php
+++ b/app/Contracts/DTO.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/DiagnosticPipe.php
+++ b/app/Contracts/DiagnosticPipe.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/DiagnosticStringPipe.php
+++ b/app/Contracts/DiagnosticStringPipe.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Exceptions/ExternalLycheeException.php
+++ b/app/Contracts/Exceptions/ExternalLycheeException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Exceptions/Handlers/HttpExceptionHandler.php
+++ b/app/Contracts/Exceptions/Handlers/HttpExceptionHandler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Exceptions/InternalLycheeException.php
+++ b/app/Contracts/Exceptions/InternalLycheeException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Exceptions/LycheeException.php
+++ b/app/Contracts/Exceptions/LycheeException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/ExternalRequest.php
+++ b/app/Contracts/ExternalRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/MiddlewareCheck.php
+++ b/app/Contracts/Http/MiddlewareCheck.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Redirection.php
+++ b/app/Contracts/Http/Redirection.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasAbstractAlbum.php
+++ b/app/Contracts/Http/Requests/HasAbstractAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasAccessPermission.php
+++ b/app/Contracts/Http/Requests/HasAccessPermission.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasAccessPermissionResource.php
+++ b/app/Contracts/Http/Requests/HasAccessPermissionResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasAlbum.php
+++ b/app/Contracts/Http/Requests/HasAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasAlbumIds.php
+++ b/app/Contracts/Http/Requests/HasAlbumIds.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasAlbumSortingCriterion.php
+++ b/app/Contracts/Http/Requests/HasAlbumSortingCriterion.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasAlbums.php
+++ b/app/Contracts/Http/Requests/HasAlbums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasBaseAlbum.php
+++ b/app/Contracts/Http/Requests/HasBaseAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasCompactBoolean.php
+++ b/app/Contracts/Http/Requests/HasCompactBoolean.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasConfigs.php
+++ b/app/Contracts/Http/Requests/HasConfigs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasCopyright.php
+++ b/app/Contracts/Http/Requests/HasCopyright.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasDescription.php
+++ b/app/Contracts/Http/Requests/HasDescription.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasLicense.php
+++ b/app/Contracts/Http/Requests/HasLicense.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasNote.php
+++ b/app/Contracts/Http/Requests/HasNote.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasOwnerId.php
+++ b/app/Contracts/Http/Requests/HasOwnerId.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasParentAlbum.php
+++ b/app/Contracts/Http/Requests/HasParentAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasPassword.php
+++ b/app/Contracts/Http/Requests/HasPassword.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasPhoto.php
+++ b/app/Contracts/Http/Requests/HasPhoto.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasPhotoIds.php
+++ b/app/Contracts/Http/Requests/HasPhotoIds.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasPhotoLayout.php
+++ b/app/Contracts/Http/Requests/HasPhotoLayout.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasPhotoSortingCriterion.php
+++ b/app/Contracts/Http/Requests/HasPhotoSortingCriterion.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasPhotos.php
+++ b/app/Contracts/Http/Requests/HasPhotos.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasQuotaKB.php
+++ b/app/Contracts/Http/Requests/HasQuotaKB.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasSeStatusBoolean.php
+++ b/app/Contracts/Http/Requests/HasSeStatusBoolean.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasSizeVariant.php
+++ b/app/Contracts/Http/Requests/HasSizeVariant.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasTagAlbum.php
+++ b/app/Contracts/Http/Requests/HasTagAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasTags.php
+++ b/app/Contracts/Http/Requests/HasTags.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasTakenAt.php
+++ b/app/Contracts/Http/Requests/HasTakenAt.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasTerms.php
+++ b/app/Contracts/Http/Requests/HasTerms.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasTimelineAlbum.php
+++ b/app/Contracts/Http/Requests/HasTimelineAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasTimelinePhoto.php
+++ b/app/Contracts/Http/Requests/HasTimelinePhoto.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasTitle.php
+++ b/app/Contracts/Http/Requests/HasTitle.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasUploadDate.php
+++ b/app/Contracts/Http/Requests/HasUploadDate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasUser.php
+++ b/app/Contracts/Http/Requests/HasUser.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasUserIds.php
+++ b/app/Contracts/Http/Requests/HasUserIds.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasUsername.php
+++ b/app/Contracts/Http/Requests/HasUsername.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/HasVisitorId.php
+++ b/app/Contracts/Http/Requests/HasVisitorId.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Http/Requests/RequestAttribute.php
+++ b/app/Contracts/Http/Requests/RequestAttribute.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Image/BinaryBlob.php
+++ b/app/Contracts/Image/BinaryBlob.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Image/ImageHandlerInterface.php
+++ b/app/Contracts/Image/ImageHandlerInterface.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Image/MediaFile.php
+++ b/app/Contracts/Image/MediaFile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Image/StreamStats.php
+++ b/app/Contracts/Image/StreamStats.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/JsonRequest.php
+++ b/app/Contracts/JsonRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Models/AbstractAlbum.php
+++ b/app/Contracts/Models/AbstractAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Models/AbstractSizeVariantNamingStrategy.php
+++ b/app/Contracts/Models/AbstractSizeVariantNamingStrategy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Models/HasRandomID.php
+++ b/app/Contracts/Models/HasRandomID.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Models/HasUTCBasedTimes.php
+++ b/app/Contracts/Models/HasUTCBasedTimes.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Models/SizeVariantFactory.php
+++ b/app/Contracts/Models/SizeVariantFactory.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/PhotoCreate/DuplicatePipe.php
+++ b/app/Contracts/PhotoCreate/DuplicatePipe.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/PhotoCreate/InitPipe.php
+++ b/app/Contracts/PhotoCreate/InitPipe.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/PhotoCreate/PhotoDTO.php
+++ b/app/Contracts/PhotoCreate/PhotoDTO.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/PhotoCreate/PhotoPartnerPipe.php
+++ b/app/Contracts/PhotoCreate/PhotoPartnerPipe.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/PhotoCreate/PhotoPipe.php
+++ b/app/Contracts/PhotoCreate/PhotoPipe.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/PhotoCreate/SharedPipe.php
+++ b/app/Contracts/PhotoCreate/SharedPipe.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/PhotoCreate/StandalonePipe.php
+++ b/app/Contracts/PhotoCreate/StandalonePipe.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/PhotoCreate/VideoPartnerPipe.php
+++ b/app/Contracts/PhotoCreate/VideoPartnerPipe.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Relations/BidirectionalRelation.php
+++ b/app/Contracts/Relations/BidirectionalRelation.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Versions/HasIsRelease.php
+++ b/app/Contracts/Versions/HasIsRelease.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Versions/HasVersion.php
+++ b/app/Contracts/Versions/HasVersion.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Versions/Remote/GitRemote.php
+++ b/app/Contracts/Versions/Remote/GitRemote.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Contracts/Versions/VersionControl.php
+++ b/app/Contracts/Versions/VersionControl.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/AbstractDTO.php
+++ b/app/DTO/AbstractDTO.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/AlbumSortingCriterion.php
+++ b/app/DTO/AlbumSortingCriterion.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/ArrayableDTO.php
+++ b/app/DTO/ArrayableDTO.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/BacktraceRecord.php
+++ b/app/DTO/BacktraceRecord.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/BaseImportReport.php
+++ b/app/DTO/BaseImportReport.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/DiagnosticData.php
+++ b/app/DTO/DiagnosticData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/ImageDimension.php
+++ b/app/DTO/ImageDimension.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/ImportEventReport.php
+++ b/app/DTO/ImportEventReport.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/ImportMode.php
+++ b/app/DTO/ImportMode.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/ImportParam.php
+++ b/app/DTO/ImportParam.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/ImportProgressReport.php
+++ b/app/DTO/ImportProgressReport.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/LycheeGitInfo.php
+++ b/app/DTO/LycheeGitInfo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/PhotoCreate/DuplicateDTO.php
+++ b/app/DTO/PhotoCreate/DuplicateDTO.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/PhotoCreate/InitDTO.php
+++ b/app/DTO/PhotoCreate/InitDTO.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/PhotoCreate/PhotoPartnerDTO.php
+++ b/app/DTO/PhotoCreate/PhotoPartnerDTO.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/PhotoCreate/StandaloneDTO.php
+++ b/app/DTO/PhotoCreate/StandaloneDTO.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/PhotoCreate/VideoPartnerDTO.php
+++ b/app/DTO/PhotoCreate/VideoPartnerDTO.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/PhotoSortingCriterion.php
+++ b/app/DTO/PhotoSortingCriterion.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/SortingCriterion.php
+++ b/app/DTO/SortingCriterion.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/TopAlbumDTO.php
+++ b/app/DTO/TopAlbumDTO.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/DTO/Version.php
+++ b/app/DTO/Version.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Eloquent/FixedQueryBuilder.php
+++ b/app/Eloquent/FixedQueryBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Eloquent/FixedQueryBuilderTrait.php
+++ b/app/Eloquent/FixedQueryBuilderTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/AlbumDecorationOrientation.php
+++ b/app/Enum/AlbumDecorationOrientation.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/AlbumDecorationType.php
+++ b/app/Enum/AlbumDecorationType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/AspectRatioCSSType.php
+++ b/app/Enum/AspectRatioCSSType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/AspectRatioType.php
+++ b/app/Enum/AspectRatioType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/CacheTag.php
+++ b/app/Enum/CacheTag.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/ColumnSortingAlbumType.php
+++ b/app/Enum/ColumnSortingAlbumType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/ColumnSortingPhotoType.php
+++ b/app/Enum/ColumnSortingPhotoType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/ColumnSortingType.php
+++ b/app/Enum/ColumnSortingType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/ConfigType.php
+++ b/app/Enum/ConfigType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/CountType.php
+++ b/app/Enum/CountType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/DateOrderingType.php
+++ b/app/Enum/DateOrderingType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/DbDriverType.php
+++ b/app/Enum/DbDriverType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/DefaultAlbumProtectionType.php
+++ b/app/Enum/DefaultAlbumProtectionType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/DownloadVariantType.php
+++ b/app/Enum/DownloadVariantType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/FileStatus.php
+++ b/app/Enum/FileStatus.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/ImageOverlayType.php
+++ b/app/Enum/ImageOverlayType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/JobStatus.php
+++ b/app/Enum/JobStatus.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/LicenseType.php
+++ b/app/Enum/LicenseType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/MapProviders.php
+++ b/app/Enum/MapProviders.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/MessageType.php
+++ b/app/Enum/MessageType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/MetricsAccess.php
+++ b/app/Enum/MetricsAccess.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/MetricsAction.php
+++ b/app/Enum/MetricsAction.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/OauthProvidersType.php
+++ b/app/Enum/OauthProvidersType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/OrderSortingType.php
+++ b/app/Enum/OrderSortingType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/PhotoLayoutType.php
+++ b/app/Enum/PhotoLayoutType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/PhotoThumbInfoType.php
+++ b/app/Enum/PhotoThumbInfoType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/SeverityType.php
+++ b/app/Enum/SeverityType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/SizeVariantType.php
+++ b/app/Enum/SizeVariantType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/SmartAlbumType.php
+++ b/app/Enum/SmartAlbumType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/StorageDiskType.php
+++ b/app/Enum/StorageDiskType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/ThumbAlbumSubtitleType.php
+++ b/app/Enum/ThumbAlbumSubtitleType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/ThumbOverlayVisibilityType.php
+++ b/app/Enum/ThumbOverlayVisibilityType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/TimelineAlbumGranularity.php
+++ b/app/Enum/TimelineAlbumGranularity.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/TimelinePhotoGranularity.php
+++ b/app/Enum/TimelinePhotoGranularity.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/UpdateStatus.php
+++ b/app/Enum/UpdateStatus.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Enum/VersionChannelType.php
+++ b/app/Enum/VersionChannelType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Events/AlbumRouteCacheUpdated.php
+++ b/app/Events/AlbumRouteCacheUpdated.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Events/Metrics/AlbumDownload.php
+++ b/app/Events/Metrics/AlbumDownload.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Events/Metrics/AlbumShared.php
+++ b/app/Events/Metrics/AlbumShared.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Events/Metrics/AlbumVisit.php
+++ b/app/Events/Metrics/AlbumVisit.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Events/Metrics/BaseMetricsEvent.php
+++ b/app/Events/Metrics/BaseMetricsEvent.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Events/Metrics/PhotoDownload.php
+++ b/app/Events/Metrics/PhotoDownload.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Events/Metrics/PhotoFavourite.php
+++ b/app/Events/Metrics/PhotoFavourite.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Events/Metrics/PhotoShared.php
+++ b/app/Events/Metrics/PhotoShared.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Events/Metrics/PhotoVisit.php
+++ b/app/Events/Metrics/PhotoVisit.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Events/TaggedRouteCacheUpdated.php
+++ b/app/Events/TaggedRouteCacheUpdated.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/AdminUserAlreadySetException.php
+++ b/app/Exceptions/AdminUserAlreadySetException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/AdminUserRequiredException.php
+++ b/app/Exceptions/AdminUserRequiredException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/BadRequestHeaderException.php
+++ b/app/Exceptions/BadRequestHeaderException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/BaseLycheeException.php
+++ b/app/Exceptions/BaseLycheeException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/ConfigurationException.php
+++ b/app/Exceptions/ConfigurationException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/ConfigurationKeyMissingException.php
+++ b/app/Exceptions/ConfigurationKeyMissingException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/ConflictingPropertyException.php
+++ b/app/Exceptions/ConflictingPropertyException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/ExternalComponentFailedException.php
+++ b/app/Exceptions/ExternalComponentFailedException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/ExternalComponentMissingException.php
+++ b/app/Exceptions/ExternalComponentMissingException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/FileOperationException.php
+++ b/app/Exceptions/FileOperationException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/FlySystemLycheeException.php
+++ b/app/Exceptions/FlySystemLycheeException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Handlers/AccessDBDenied.php
+++ b/app/Exceptions/Handlers/AccessDBDenied.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Handlers/AdminSetterHandler.php
+++ b/app/Exceptions/Handlers/AdminSetterHandler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Handlers/InstallationHandler.php
+++ b/app/Exceptions/Handlers/InstallationHandler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Handlers/LegacyIdExceptionHandler.php
+++ b/app/Exceptions/Handlers/LegacyIdExceptionHandler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Handlers/MigrationHandler.php
+++ b/app/Exceptions/Handlers/MigrationHandler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Handlers/NoEncryptionKey.php
+++ b/app/Exceptions/Handlers/NoEncryptionKey.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Handlers/ViteManifestNotFoundHandler.php
+++ b/app/Exceptions/Handlers/ViteManifestNotFoundHandler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/HttpHoneyPotException.php
+++ b/app/Exceptions/HttpHoneyPotException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/ImageProcessingException.php
+++ b/app/Exceptions/ImageProcessingException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/ImportCancelledException.php
+++ b/app/Exceptions/ImportCancelledException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/InstallationAlreadyCompletedException.php
+++ b/app/Exceptions/InstallationAlreadyCompletedException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/InstallationFailedException.php
+++ b/app/Exceptions/InstallationFailedException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/InstallationRequiredException.php
+++ b/app/Exceptions/InstallationRequiredException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/InsufficientEntropyException.php
+++ b/app/Exceptions/InsufficientEntropyException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/InsufficientFilesystemPermissions.php
+++ b/app/Exceptions/InsufficientFilesystemPermissions.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/FailedModelAssumptionException.php
+++ b/app/Exceptions/Internal/FailedModelAssumptionException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/FeaturesDoesNotExistsException.php
+++ b/app/Exceptions/Internal/FeaturesDoesNotExistsException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/FileDeletionException.php
+++ b/app/Exceptions/Internal/FileDeletionException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/FrameworkException.php
+++ b/app/Exceptions/Internal/FrameworkException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/IllegalOrderOfOperationException.php
+++ b/app/Exceptions/Internal/IllegalOrderOfOperationException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/InvalidConfigOption.php
+++ b/app/Exceptions/Internal/InvalidConfigOption.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/InvalidOrderDirectionException.php
+++ b/app/Exceptions/Internal/InvalidOrderDirectionException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/InvalidQueryModelException.php
+++ b/app/Exceptions/Internal/InvalidQueryModelException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/InvalidRotationDirectionException.php
+++ b/app/Exceptions/Internal/InvalidRotationDirectionException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/InvalidSizeVariantException.php
+++ b/app/Exceptions/Internal/InvalidSizeVariantException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/InvalidSmartIdException.php
+++ b/app/Exceptions/Internal/InvalidSmartIdException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/LycheeAssertionError.php
+++ b/app/Exceptions/Internal/LycheeAssertionError.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/LycheeDomainException.php
+++ b/app/Exceptions/Internal/LycheeDomainException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/LycheeInvalidArgumentException.php
+++ b/app/Exceptions/Internal/LycheeInvalidArgumentException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/LycheeLogicException.php
+++ b/app/Exceptions/Internal/LycheeLogicException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/MissingModelAttributeException.php
+++ b/app/Exceptions/Internal/MissingModelAttributeException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/MissingValueException.php
+++ b/app/Exceptions/Internal/MissingValueException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/NotImplementedException.php
+++ b/app/Exceptions/Internal/NotImplementedException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/QueryBuilderException.php
+++ b/app/Exceptions/Internal/QueryBuilderException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/RequestFailedException.php
+++ b/app/Exceptions/Internal/RequestFailedException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/TimeBasedIdException.php
+++ b/app/Exceptions/Internal/TimeBasedIdException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/Internal/ZeroModuloException.php
+++ b/app/Exceptions/Internal/ZeroModuloException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/InvalidDirectoryException.php
+++ b/app/Exceptions/InvalidDirectoryException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/InvalidPropertyException.php
+++ b/app/Exceptions/InvalidPropertyException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/LocationDecodingFailed.php
+++ b/app/Exceptions/LocationDecodingFailed.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/MassImportException.php
+++ b/app/Exceptions/MassImportException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/MediaFileOperationException.php
+++ b/app/Exceptions/MediaFileOperationException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/MediaFileUnsupportedException.php
+++ b/app/Exceptions/MediaFileUnsupportedException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/MigrationAlreadyCompletedException.php
+++ b/app/Exceptions/MigrationAlreadyCompletedException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/MigrationRequiredException.php
+++ b/app/Exceptions/MigrationRequiredException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/ModelDBException.php
+++ b/app/Exceptions/ModelDBException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/NoWriteAccessOnLogsExceptions.php
+++ b/app/Exceptions/NoWriteAccessOnLogsExceptions.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/OwnerRequiredException.php
+++ b/app/Exceptions/OwnerRequiredException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/PasswordRequiredException.php
+++ b/app/Exceptions/PasswordRequiredException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/PhotoCollectionEmptyException.php
+++ b/app/Exceptions/PhotoCollectionEmptyException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/PhotoResyncedException.php
+++ b/app/Exceptions/PhotoResyncedException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/PhotoSkippedException.php
+++ b/app/Exceptions/PhotoSkippedException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/QuotaExceededException.php
+++ b/app/Exceptions/QuotaExceededException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/ReservedDirectoryException.php
+++ b/app/Exceptions/ReservedDirectoryException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/SessionExpiredException.php
+++ b/app/Exceptions/SessionExpiredException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/UnauthenticatedException.php
+++ b/app/Exceptions/UnauthenticatedException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/UnauthorizedException.php
+++ b/app/Exceptions/UnauthorizedException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/UnexpectedContentType.php
+++ b/app/Exceptions/UnexpectedContentType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/UnexpectedException.php
+++ b/app/Exceptions/UnexpectedException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Exceptions/VersionControlException.php
+++ b/app/Exceptions/VersionControlException.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Facades/Helpers.php
+++ b/app/Facades/Helpers.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Factories/AlbumFactory.php
+++ b/app/Factories/AlbumFactory.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/DiagnosticsController.php
+++ b/app/Http/Controllers/Admin/DiagnosticsController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/JobsController.php
+++ b/app/Http/Controllers/Admin/JobsController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/Maintenance/Cleaning.php
+++ b/app/Http/Controllers/Admin/Maintenance/Cleaning.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/Maintenance/DuplicateFinder.php
+++ b/app/Http/Controllers/Admin/Maintenance/DuplicateFinder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/Maintenance/FixJobs.php
+++ b/app/Http/Controllers/Admin/Maintenance/FixJobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/Maintenance/FixTree.php
+++ b/app/Http/Controllers/Admin/Maintenance/FixTree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/Maintenance/FlushCache.php
+++ b/app/Http/Controllers/Admin/Maintenance/FlushCache.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/Maintenance/FullTree.php
+++ b/app/Http/Controllers/Admin/Maintenance/FullTree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/Maintenance/GenSizeVariants.php
+++ b/app/Http/Controllers/Admin/Maintenance/GenSizeVariants.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/Maintenance/MissingFileSizes.php
+++ b/app/Http/Controllers/Admin/Maintenance/MissingFileSizes.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/Maintenance/Model/Album.php
+++ b/app/Http/Controllers/Admin/Maintenance/Model/Album.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/Maintenance/Optimize.php
+++ b/app/Http/Controllers/Admin/Maintenance/Optimize.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/Maintenance/RegisterController.php
+++ b/app/Http/Controllers/Admin/Maintenance/RegisterController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/UpdateController.php
+++ b/app/Http/Controllers/Admin/UpdateController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Admin/UserManagementController.php
+++ b/app/Http/Controllers/Admin/UserManagementController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Gallery/AlbumController.php
+++ b/app/Http/Controllers/Gallery/AlbumController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Gallery/AlbumsController.php
+++ b/app/Http/Controllers/Gallery/AlbumsController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Gallery/ConfigController.php
+++ b/app/Http/Controllers/Gallery/ConfigController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Gallery/FrameController.php
+++ b/app/Http/Controllers/Gallery/FrameController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Gallery/MapController.php
+++ b/app/Http/Controllers/Gallery/MapController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Gallery/PhotoController.php
+++ b/app/Http/Controllers/Gallery/PhotoController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Gallery/SearchController.php
+++ b/app/Http/Controllers/Gallery/SearchController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Gallery/SharingController.php
+++ b/app/Http/Controllers/Gallery/SharingController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/HoneyPotController.php
+++ b/app/Http/Controllers/HoneyPotController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Install/EnvController.php
+++ b/app/Http/Controllers/Install/EnvController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Install/MigrationController.php
+++ b/app/Http/Controllers/Install/MigrationController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Install/PermissionsController.php
+++ b/app/Http/Controllers/Install/PermissionsController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Install/RequirementsController.php
+++ b/app/Http/Controllers/Install/RequirementsController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Install/SetUpAdminController.php
+++ b/app/Http/Controllers/Install/SetUpAdminController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/Install/WelcomeController.php
+++ b/app/Http/Controllers/Install/WelcomeController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/MetricsController.php
+++ b/app/Http/Controllers/MetricsController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/RSSController.php
+++ b/app/Http/Controllers/RSSController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/StatisticsController.php
+++ b/app/Http/Controllers/StatisticsController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/VersionController.php
+++ b/app/Http/Controllers/VersionController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/VueController.php
+++ b/app/Http/Controllers/VueController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/WebAuthn/WebAuthnLoginController.php
+++ b/app/Http/Controllers/WebAuthn/WebAuthnLoginController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/WebAuthn/WebAuthnManageController.php
+++ b/app/Http/Controllers/WebAuthn/WebAuthnManageController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Controllers/WebAuthn/WebAuthnRegisterController.php
+++ b/app/Http/Controllers/WebAuthn/WebAuthnRegisterController.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/AcceptContentType.php
+++ b/app/Http/Middleware/AcceptContentType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/AdminUserStatus.php
+++ b/app/Http/Middleware/AdminUserStatus.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/Caching/AlbumRouteCacheRefresher.php
+++ b/app/Http/Middleware/Caching/AlbumRouteCacheRefresher.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/Caching/CacheControl.php
+++ b/app/Http/Middleware/Caching/CacheControl.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/Caching/ResponseCache.php
+++ b/app/Http/Middleware/Caching/ResponseCache.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/Checks/HasAdminUser.php
+++ b/app/Http/Middleware/Checks/HasAdminUser.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/Checks/IsInstalled.php
+++ b/app/Http/Middleware/Checks/IsInstalled.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/Checks/IsMigrated.php
+++ b/app/Http/Middleware/Checks/IsMigrated.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/ConfigIntegrity.php
+++ b/app/Http/Middleware/ConfigIntegrity.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/ContentType.php
+++ b/app/Http/Middleware/ContentType.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/DisableCSP.php
+++ b/app/Http/Middleware/DisableCSP.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/FixStatusCode.php
+++ b/app/Http/Middleware/FixStatusCode.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/InstallationStatus.php
+++ b/app/Http/Middleware/InstallationStatus.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/Latency.php
+++ b/app/Http/Middleware/Latency.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/LoginRequired.php
+++ b/app/Http/Middleware/LoginRequired.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/MigrationStatus.php
+++ b/app/Http/Middleware/MigrationStatus.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/TrimStrings.php
+++ b/app/Http/Middleware/TrimStrings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/UnlockWithPassword.php
+++ b/app/Http/Middleware/UnlockWithPassword.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Redirections/ToAdminSetter.php
+++ b/app/Http/Redirections/ToAdminSetter.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Redirections/ToHome.php
+++ b/app/Http/Redirections/ToHome.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Redirections/ToInstall.php
+++ b/app/Http/Redirections/ToInstall.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Redirections/ToMigration.php
+++ b/app/Http/Redirections/ToMigration.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/AbstractEmptyRequest.php
+++ b/app/Http/Requests/AbstractEmptyRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/AddAlbumRequest.php
+++ b/app/Http/Requests/Album/AddAlbumRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/AddTagAlbumRequest.php
+++ b/app/Http/Requests/Album/AddTagAlbumRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/DeleteAlbumsRequest.php
+++ b/app/Http/Requests/Album/DeleteAlbumsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/DeleteTrackRequest.php
+++ b/app/Http/Requests/Album/DeleteTrackRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/GetAlbumRequest.php
+++ b/app/Http/Requests/Album/GetAlbumRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/MergeAlbumsRequest.php
+++ b/app/Http/Requests/Album/MergeAlbumsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/MoveAlbumsRequest.php
+++ b/app/Http/Requests/Album/MoveAlbumsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/RenameAlbumRequest.php
+++ b/app/Http/Requests/Album/RenameAlbumRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/SetAlbumProtectionPolicyRequest.php
+++ b/app/Http/Requests/Album/SetAlbumProtectionPolicyRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/SetAlbumTrackRequest.php
+++ b/app/Http/Requests/Album/SetAlbumTrackRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/SetAsCoverRequest.php
+++ b/app/Http/Requests/Album/SetAsCoverRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/SetAsHeaderRequest.php
+++ b/app/Http/Requests/Album/SetAsHeaderRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/TargetListAlbumRequest.php
+++ b/app/Http/Requests/Album/TargetListAlbumRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/TransferAlbumRequest.php
+++ b/app/Http/Requests/Album/TransferAlbumRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/UnlockAlbumRequest.php
+++ b/app/Http/Requests/Album/UnlockAlbumRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/UpdateAlbumRequest.php
+++ b/app/Http/Requests/Album/UpdateAlbumRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/UpdateTagAlbumRequest.php
+++ b/app/Http/Requests/Album/UpdateTagAlbumRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Album/ZipRequest.php
+++ b/app/Http/Requests/Album/ZipRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/BaseApiRequest.php
+++ b/app/Http/Requests/BaseApiRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Diagnostics/DiagnosticsRequest.php
+++ b/app/Http/Requests/Diagnostics/DiagnosticsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Frame/FrameRequest.php
+++ b/app/Http/Requests/Frame/FrameRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Install/SetUpAdminRequest.php
+++ b/app/Http/Requests/Install/SetUpAdminRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Jobs/ShowJobsRequest.php
+++ b/app/Http/Requests/Jobs/ShowJobsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Maintenance/CleaningRequest.php
+++ b/app/Http/Requests/Maintenance/CleaningRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Maintenance/CreateThumbsRequest.php
+++ b/app/Http/Requests/Maintenance/CreateThumbsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Maintenance/FullTreeUpdateRequest.php
+++ b/app/Http/Requests/Maintenance/FullTreeUpdateRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Maintenance/MaintenanceRequest.php
+++ b/app/Http/Requests/Maintenance/MaintenanceRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Maintenance/MigrateRequest.php
+++ b/app/Http/Requests/Maintenance/MigrateRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Maintenance/RegisterRequest.php
+++ b/app/Http/Requests/Maintenance/RegisterRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Maintenance/SearchDuplicateRequest.php
+++ b/app/Http/Requests/Maintenance/SearchDuplicateRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Maintenance/UpdateRequest.php
+++ b/app/Http/Requests/Maintenance/UpdateRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Map/MapDataRequest.php
+++ b/app/Http/Requests/Map/MapDataRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Metrics/PhotoMetricsRequest.php
+++ b/app/Http/Requests/Metrics/PhotoMetricsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Photo/CopyPhotosRequest.php
+++ b/app/Http/Requests/Photo/CopyPhotosRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Photo/DeletePhotosRequest.php
+++ b/app/Http/Requests/Photo/DeletePhotosRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Photo/EditPhotoRequest.php
+++ b/app/Http/Requests/Photo/EditPhotoRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Photo/FromUrlRequest.php
+++ b/app/Http/Requests/Photo/FromUrlRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Photo/MovePhotosRequest.php
+++ b/app/Http/Requests/Photo/MovePhotosRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Photo/RenamePhotoRequest.php
+++ b/app/Http/Requests/Photo/RenamePhotoRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Photo/RotatePhotoRequest.php
+++ b/app/Http/Requests/Photo/RotatePhotoRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Photo/SetPhotosStarredRequest.php
+++ b/app/Http/Requests/Photo/SetPhotosStarredRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Photo/SetPhotosTagsRequest.php
+++ b/app/Http/Requests/Photo/SetPhotosTagsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Photo/UploadPhotoRequest.php
+++ b/app/Http/Requests/Photo/UploadPhotoRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Profile/ChangeTokenRequest.php
+++ b/app/Http/Requests/Profile/ChangeTokenRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Profile/ClearOauthRequest.php
+++ b/app/Http/Requests/Profile/ClearOauthRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Profile/OauthListRequest.php
+++ b/app/Http/Requests/Profile/OauthListRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Profile/UpdateProfileRequest.php
+++ b/app/Http/Requests/Profile/UpdateProfileRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Search/GetSearchRequest.php
+++ b/app/Http/Requests/Search/GetSearchRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Search/InitSearchRequest.php
+++ b/app/Http/Requests/Search/InitSearchRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Session/LoginRequest.php
+++ b/app/Http/Requests/Session/LoginRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Settings/GetAllConfigsRequest.php
+++ b/app/Http/Requests/Settings/GetAllConfigsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Settings/SetCSSSettingRequest.php
+++ b/app/Http/Requests/Settings/SetCSSSettingRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Settings/SetConfigsRequest.php
+++ b/app/Http/Requests/Settings/SetConfigsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Settings/SetJSSettingRequest.php
+++ b/app/Http/Requests/Settings/SetJSSettingRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Sharing/AddSharingRequest.php
+++ b/app/Http/Requests/Sharing/AddSharingRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Sharing/DeleteSharingRequest.php
+++ b/app/Http/Requests/Sharing/DeleteSharingRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Sharing/EditSharingRequest.php
+++ b/app/Http/Requests/Sharing/EditSharingRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Sharing/ListAllSharingRequest.php
+++ b/app/Http/Requests/Sharing/ListAllSharingRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Sharing/ListSharingRequest.php
+++ b/app/Http/Requests/Sharing/ListSharingRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Sharing/PropagateSharingRequest.php
+++ b/app/Http/Requests/Sharing/PropagateSharingRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Statistics/CountsRequest.php
+++ b/app/Http/Requests/Statistics/CountsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Statistics/SpacePerAlbumRequest.php
+++ b/app/Http/Requests/Statistics/SpacePerAlbumRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Statistics/SpacePerUserRequest.php
+++ b/app/Http/Requests/Statistics/SpacePerUserRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Statistics/SpaceSizeVariantRequest.php
+++ b/app/Http/Requests/Statistics/SpaceSizeVariantRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/Authorize/AuthorizeCanEditAlbumAlbumsTrait.php
+++ b/app/Http/Requests/Traits/Authorize/AuthorizeCanEditAlbumAlbumsTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/Authorize/AuthorizeCanEditAlbumTrait.php
+++ b/app/Http/Requests/Traits/Authorize/AuthorizeCanEditAlbumTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/Authorize/AuthorizeCanEditPhotoTrait.php
+++ b/app/Http/Requests/Traits/Authorize/AuthorizeCanEditPhotoTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/Authorize/AuthorizeCanEditPhotosAlbumTrait.php
+++ b/app/Http/Requests/Traits/Authorize/AuthorizeCanEditPhotosAlbumTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/Authorize/AuthorizeCanEditPhotosTrait.php
+++ b/app/Http/Requests/Traits/Authorize/AuthorizeCanEditPhotosTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasAbstractAlbumTrait.php
+++ b/app/Http/Requests/Traits/HasAbstractAlbumTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasAccessPermissionResourceTrait.php
+++ b/app/Http/Requests/Traits/HasAccessPermissionResourceTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasAccessPermissionTrait.php
+++ b/app/Http/Requests/Traits/HasAccessPermissionTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasAlbumIdsTrait.php
+++ b/app/Http/Requests/Traits/HasAlbumIdsTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasAlbumSortingCriterionTrait.php
+++ b/app/Http/Requests/Traits/HasAlbumSortingCriterionTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasAlbumTrait.php
+++ b/app/Http/Requests/Traits/HasAlbumTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasAlbumsTrait.php
+++ b/app/Http/Requests/Traits/HasAlbumsTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasAspectRatioTrait.php
+++ b/app/Http/Requests/Traits/HasAspectRatioTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasBaseAlbumTrait.php
+++ b/app/Http/Requests/Traits/HasBaseAlbumTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasCompactBooleanTrait.php
+++ b/app/Http/Requests/Traits/HasCompactBooleanTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasConfigsTrait.php
+++ b/app/Http/Requests/Traits/HasConfigsTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasCopyrightTrait.php
+++ b/app/Http/Requests/Traits/HasCopyrightTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasDescriptionTrait.php
+++ b/app/Http/Requests/Traits/HasDescriptionTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasLicenseTrait.php
+++ b/app/Http/Requests/Traits/HasLicenseTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasNoteTrait.php
+++ b/app/Http/Requests/Traits/HasNoteTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasOwnerIdTrait.php
+++ b/app/Http/Requests/Traits/HasOwnerIdTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasParentAlbumTrait.php
+++ b/app/Http/Requests/Traits/HasParentAlbumTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasPasswordTrait.php
+++ b/app/Http/Requests/Traits/HasPasswordTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasPhotoIdsTrait.php
+++ b/app/Http/Requests/Traits/HasPhotoIdsTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasPhotoLayoutTrait.php
+++ b/app/Http/Requests/Traits/HasPhotoLayoutTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasPhotoSortingCriterionTrait.php
+++ b/app/Http/Requests/Traits/HasPhotoSortingCriterionTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasPhotoTrait.php
+++ b/app/Http/Requests/Traits/HasPhotoTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasPhotosTrait.php
+++ b/app/Http/Requests/Traits/HasPhotosTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasQuotaKBTrait.php
+++ b/app/Http/Requests/Traits/HasQuotaKBTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasSeStatusBooleanTrait.php
+++ b/app/Http/Requests/Traits/HasSeStatusBooleanTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasSizeVariantTrait.php
+++ b/app/Http/Requests/Traits/HasSizeVariantTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasTagAlbumTrait.php
+++ b/app/Http/Requests/Traits/HasTagAlbumTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasTagsTrait.php
+++ b/app/Http/Requests/Traits/HasTagsTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasTakenAtDateTrait.php
+++ b/app/Http/Requests/Traits/HasTakenAtDateTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasTermsTrait.php
+++ b/app/Http/Requests/Traits/HasTermsTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasTimelineAlbumTrait.php
+++ b/app/Http/Requests/Traits/HasTimelineAlbumTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasTimelinePhotoTrait.php
+++ b/app/Http/Requests/Traits/HasTimelinePhotoTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasTitleTrait.php
+++ b/app/Http/Requests/Traits/HasTitleTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasUploadDateTrait.php
+++ b/app/Http/Requests/Traits/HasUploadDateTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasUserIdsTrait.php
+++ b/app/Http/Requests/Traits/HasUserIdsTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasUserTrait.php
+++ b/app/Http/Requests/Traits/HasUserTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasUsernameTrait.php
+++ b/app/Http/Requests/Traits/HasUsernameTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Traits/HasVisitorIdTrait.php
+++ b/app/Http/Requests/Traits/HasVisitorIdTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/UserManagement/AddUserRequest.php
+++ b/app/Http/Requests/UserManagement/AddUserRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/UserManagement/DeleteUserRequest.php
+++ b/app/Http/Requests/UserManagement/DeleteUserRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/UserManagement/ManagmentListUsersRequest.php
+++ b/app/Http/Requests/UserManagement/ManagmentListUsersRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/UserManagement/SetUserSettingsRequest.php
+++ b/app/Http/Requests/UserManagement/SetUserSettingsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Users/ListUsersRequest.php
+++ b/app/Http/Requests/Users/ListUsersRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/Users/UsersRequest.php
+++ b/app/Http/Requests/Users/UsersRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/WebAuthn/DeleteCredentialRequest.php
+++ b/app/Http/Requests/WebAuthn/DeleteCredentialRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/WebAuthn/EditCredentialRequest.php
+++ b/app/Http/Requests/WebAuthn/EditCredentialRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Requests/WebAuthn/ListCredentialsRequest.php
+++ b/app/Http/Requests/WebAuthn/ListCredentialsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Collections/PositionDataResource.php
+++ b/app/Http/Resources/Collections/PositionDataResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Collections/RootAlbumResource.php
+++ b/app/Http/Resources/Collections/RootAlbumResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Diagnostics/AlbumTree.php
+++ b/app/Http/Resources/Diagnostics/AlbumTree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Diagnostics/ChangeLogInfo.php
+++ b/app/Http/Resources/Diagnostics/ChangeLogInfo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Diagnostics/CleaningState.php
+++ b/app/Http/Resources/Diagnostics/CleaningState.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Diagnostics/ErrorLine.php
+++ b/app/Http/Resources/Diagnostics/ErrorLine.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Diagnostics/Permissions.php
+++ b/app/Http/Resources/Diagnostics/Permissions.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Diagnostics/TreeState.php
+++ b/app/Http/Resources/Diagnostics/TreeState.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Diagnostics/UpdateCheckInfo.php
+++ b/app/Http/Resources/Diagnostics/UpdateCheckInfo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Diagnostics/UpdateInfo.php
+++ b/app/Http/Resources/Diagnostics/UpdateInfo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Editable/EditableBaseAlbumResource.php
+++ b/app/Http/Resources/Editable/EditableBaseAlbumResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Editable/EditableConfigResource.php
+++ b/app/Http/Resources/Editable/EditableConfigResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Editable/UploadMetaResource.php
+++ b/app/Http/Resources/Editable/UploadMetaResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Frame/FrameData.php
+++ b/app/Http/Resources/Frame/FrameData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/GalleryConfigs/AlbumConfig.php
+++ b/app/Http/Resources/GalleryConfigs/AlbumConfig.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/GalleryConfigs/FooterConfig.php
+++ b/app/Http/Resources/GalleryConfigs/FooterConfig.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/GalleryConfigs/InitConfig.php
+++ b/app/Http/Resources/GalleryConfigs/InitConfig.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/GalleryConfigs/LandingPageResource.php
+++ b/app/Http/Resources/GalleryConfigs/LandingPageResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/GalleryConfigs/MapProviderData.php
+++ b/app/Http/Resources/GalleryConfigs/MapProviderData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/GalleryConfigs/PhotoLayoutConfig.php
+++ b/app/Http/Resources/GalleryConfigs/PhotoLayoutConfig.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/GalleryConfigs/RegisterData.php
+++ b/app/Http/Resources/GalleryConfigs/RegisterData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/GalleryConfigs/RootConfig.php
+++ b/app/Http/Resources/GalleryConfigs/RootConfig.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/GalleryConfigs/SettingsConfig.php
+++ b/app/Http/Resources/GalleryConfigs/SettingsConfig.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/GalleryConfigs/UploadConfig.php
+++ b/app/Http/Resources/GalleryConfigs/UploadConfig.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/AbstractAlbumResource.php
+++ b/app/Http/Resources/Models/AbstractAlbumResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/AccessPermissionResource.php
+++ b/app/Http/Resources/Models/AccessPermissionResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/AlbumResource.php
+++ b/app/Http/Resources/Models/AlbumResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/AlbumStatisticsResource.php
+++ b/app/Http/Resources/Models/AlbumStatisticsResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/ConfigCategoryResource.php
+++ b/app/Http/Resources/Models/ConfigCategoryResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/ConfigResource.php
+++ b/app/Http/Resources/Models/ConfigResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/Duplicates/Duplicate.php
+++ b/app/Http/Resources/Models/Duplicates/Duplicate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/Duplicates/DuplicateCount.php
+++ b/app/Http/Resources/Models/Duplicates/DuplicateCount.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/JobHistoryResource.php
+++ b/app/Http/Resources/Models/JobHistoryResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/LightUserResource.php
+++ b/app/Http/Resources/Models/LightUserResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/PhotoResource.php
+++ b/app/Http/Resources/Models/PhotoResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/PhotoStatisticsResource.php
+++ b/app/Http/Resources/Models/PhotoStatisticsResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/SizeVariantResource.php
+++ b/app/Http/Resources/Models/SizeVariantResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/SizeVariantsResouce.php
+++ b/app/Http/Resources/Models/SizeVariantsResouce.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/SmartAlbumResource.php
+++ b/app/Http/Resources/Models/SmartAlbumResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/TagAlbumResource.php
+++ b/app/Http/Resources/Models/TagAlbumResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/TargetAlbumResource.php
+++ b/app/Http/Resources/Models/TargetAlbumResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/ThumbAlbumResource.php
+++ b/app/Http/Resources/Models/ThumbAlbumResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/ThumbResource.php
+++ b/app/Http/Resources/Models/ThumbResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/UserManagementResource.php
+++ b/app/Http/Resources/Models/UserManagementResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/UserResource.php
+++ b/app/Http/Resources/Models/UserResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/Utils/AlbumProtectionPolicy.php
+++ b/app/Http/Resources/Models/Utils/AlbumProtectionPolicy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/Utils/PreComputedPhotoData.php
+++ b/app/Http/Resources/Models/Utils/PreComputedPhotoData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/Utils/PreFormattedAlbumData.php
+++ b/app/Http/Resources/Models/Utils/PreFormattedAlbumData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/Utils/PreformattedPhotoData.php
+++ b/app/Http/Resources/Models/Utils/PreformattedPhotoData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/Utils/TimelineData.php
+++ b/app/Http/Resources/Models/Utils/TimelineData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/Utils/UserToken.php
+++ b/app/Http/Resources/Models/Utils/UserToken.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Models/WebAuthnResource.php
+++ b/app/Http/Resources/Models/WebAuthnResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Oauth/OauthRegistrationData.php
+++ b/app/Http/Resources/Oauth/OauthRegistrationData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/OpenApi/DataToResponse.php
+++ b/app/Http/Resources/OpenApi/DataToResponse.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Rights/AlbumRightsResource.php
+++ b/app/Http/Resources/Rights/AlbumRightsResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Rights/GlobalRightsResource.php
+++ b/app/Http/Resources/Rights/GlobalRightsResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Rights/ModulesRightsResource.php
+++ b/app/Http/Resources/Rights/ModulesRightsResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Rights/PhotoRightsResource.php
+++ b/app/Http/Resources/Rights/PhotoRightsResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Rights/RootAlbumRightsResource.php
+++ b/app/Http/Resources/Rights/RootAlbumRightsResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Rights/SettingsRightsResource.php
+++ b/app/Http/Resources/Rights/SettingsRightsResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Rights/UserManagementRightsResource.php
+++ b/app/Http/Resources/Rights/UserManagementRightsResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Rights/UserRightsResource.php
+++ b/app/Http/Resources/Rights/UserRightsResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Root/AuthConfig.php
+++ b/app/Http/Resources/Root/AuthConfig.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Root/VersionResource.php
+++ b/app/Http/Resources/Root/VersionResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Search/InitResource.php
+++ b/app/Http/Resources/Search/InitResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Search/ResultsResource.php
+++ b/app/Http/Resources/Search/ResultsResource.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Statistics/Album.php
+++ b/app/Http/Resources/Statistics/Album.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Statistics/CountsData.php
+++ b/app/Http/Resources/Statistics/CountsData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Statistics/DayCount.php
+++ b/app/Http/Resources/Statistics/DayCount.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Statistics/Sizes.php
+++ b/app/Http/Resources/Statistics/Sizes.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Statistics/UserSpace.php
+++ b/app/Http/Resources/Statistics/UserSpace.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Traits/HasHeaderUrl.php
+++ b/app/Http/Resources/Traits/HasHeaderUrl.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Traits/HasPrepPhotoCollection.php
+++ b/app/Http/Resources/Traits/HasPrepPhotoCollection.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Http/Resources/Traits/HasTimelineData.php
+++ b/app/Http/Resources/Traits/HasTimelineData.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/FileDeleter.php
+++ b/app/Image/FileDeleter.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Files/AbstractBinaryBlob.php
+++ b/app/Image/Files/AbstractBinaryBlob.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Files/BaseMediaFile.php
+++ b/app/Image/Files/BaseMediaFile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Files/DownloadedFile.php
+++ b/app/Image/Files/DownloadedFile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Files/FlysystemFile.php
+++ b/app/Image/Files/FlysystemFile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Files/InMemoryBuffer.php
+++ b/app/Image/Files/InMemoryBuffer.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Files/LoadTemporaryFileTrait.php
+++ b/app/Image/Files/LoadTemporaryFileTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Files/NativeLocalFile.php
+++ b/app/Image/Files/NativeLocalFile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Files/ProcessableJobFile.php
+++ b/app/Image/Files/ProcessableJobFile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Files/TemporaryJobFile.php
+++ b/app/Image/Files/TemporaryJobFile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Files/TemporaryLocalFile.php
+++ b/app/Image/Files/TemporaryLocalFile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Files/UploadedFile.php
+++ b/app/Image/Files/UploadedFile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Handlers/BaseImageHandler.php
+++ b/app/Image/Handlers/BaseImageHandler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Handlers/GdHandler.php
+++ b/app/Image/Handlers/GdHandler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Handlers/GoogleMotionPictureHandler.php
+++ b/app/Image/Handlers/GoogleMotionPictureHandler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Handlers/ImageHandler.php
+++ b/app/Image/Handlers/ImageHandler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Handlers/ImagickHandler.php
+++ b/app/Image/Handlers/ImagickHandler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/Handlers/VideoHandler.php
+++ b/app/Image/Handlers/VideoHandler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/PlaceholderEncoder.php
+++ b/app/Image/PlaceholderEncoder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/SizeVariantDefaultFactory.php
+++ b/app/Image/SizeVariantDefaultFactory.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/SizeVariantDimensionHelpers.php
+++ b/app/Image/SizeVariantDimensionHelpers.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/StreamStat.php
+++ b/app/Image/StreamStat.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Image/StreamStatFilter.php
+++ b/app/Image/StreamStatFilter.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Jobs/ProcessImageJob.php
+++ b/app/Jobs/ProcessImageJob.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Jobs/UploadSizeVariantToS3Job.php
+++ b/app/Jobs/UploadSizeVariantToS3Job.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Legacy/BaseConfigMigration.php
+++ b/app/Legacy/BaseConfigMigration.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Listeners/AlbumCacheCleaner.php
+++ b/app/Listeners/AlbumCacheCleaner.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Listeners/CacheListener.php
+++ b/app/Listeners/CacheListener.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Listeners/MetricsListener.php
+++ b/app/Listeners/MetricsListener.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Listeners/TaggedRouteCacheCleaner.php
+++ b/app/Listeners/TaggedRouteCacheCleaner.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Mail/PhotosAdded.php
+++ b/app/Mail/PhotosAdded.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Cache/RouteCacheConfig.php
+++ b/app/Metadata/Cache/RouteCacheConfig.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Cache/RouteCacheManager.php
+++ b/app/Metadata/Cache/RouteCacheManager.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Cache/RouteCacher.php
+++ b/app/Metadata/Cache/RouteCacher.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/DiskUsage.php
+++ b/app/Metadata/DiskUsage.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Geodecoder.php
+++ b/app/Metadata/Geodecoder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Json/ChangeLogsRequest.php
+++ b/app/Metadata/Json/ChangeLogsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Json/CommitsRequest.php
+++ b/app/Metadata/Json/CommitsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Json/ExternalRequestFunctions.php
+++ b/app/Metadata/Json/ExternalRequestFunctions.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Json/JsonRequestFunctions.php
+++ b/app/Metadata/Json/JsonRequestFunctions.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Json/TagsRequest.php
+++ b/app/Metadata/Json/TagsRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Json/UpdateRequest.php
+++ b/app/Metadata/Json/UpdateRequest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Versions/FileVersion.php
+++ b/app/Metadata/Versions/FileVersion.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Versions/GitHubVersion.php
+++ b/app/Metadata/Versions/GitHubVersion.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Versions/InstalledVersion.php
+++ b/app/Metadata/Versions/InstalledVersion.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Versions/Remote/AbstractGitRemote.php
+++ b/app/Metadata/Versions/Remote/AbstractGitRemote.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Versions/Remote/GitCommits.php
+++ b/app/Metadata/Versions/Remote/GitCommits.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Versions/Remote/GitTags.php
+++ b/app/Metadata/Versions/Remote/GitTags.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Metadata/Versions/Trimable.php
+++ b/app/Metadata/Versions/Trimable.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/ModelFunctions/HasAbstractAlbumProperties.php
+++ b/app/ModelFunctions/HasAbstractAlbumProperties.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/ModelFunctions/MOVFormat.php
+++ b/app/ModelFunctions/MOVFormat.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/ModelFunctions/SymLinkFunctions.php
+++ b/app/ModelFunctions/SymLinkFunctions.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/AccessPermission.php
+++ b/app/Models/AccessPermission.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/BaseAlbumImpl.php
+++ b/app/Models/BaseAlbumImpl.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Builders/AccessPermissionBuilder.php
+++ b/app/Models/Builders/AccessPermissionBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Builders/AlbumBuilder.php
+++ b/app/Models/Builders/AlbumBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Builders/BaseAlbumImplBuilder.php
+++ b/app/Models/Builders/BaseAlbumImplBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Builders/ConfigCategoryBuilder.php
+++ b/app/Models/Builders/ConfigCategoryBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Builders/ConfigsBuilder.php
+++ b/app/Models/Builders/ConfigsBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Builders/JobHistoryBuilder.php
+++ b/app/Models/Builders/JobHistoryBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Builders/OauthCredentialBuilder.php
+++ b/app/Models/Builders/OauthCredentialBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Builders/PhotoBuilder.php
+++ b/app/Models/Builders/PhotoBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Builders/SizeVariantBuilder.php
+++ b/app/Models/Builders/SizeVariantBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Builders/StatisticsBuilder.php
+++ b/app/Models/Builders/StatisticsBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Builders/SymLinkBuilder.php
+++ b/app/Models/Builders/SymLinkBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Builders/TagAlbumBuilder.php
+++ b/app/Models/Builders/TagAlbumBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Builders/UserBuilder.php
+++ b/app/Models/Builders/UserBuilder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/ConfigCategory.php
+++ b/app/Models/ConfigCategory.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Configs.php
+++ b/app/Models/Configs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/AbstractBaseConfigMigration.php
+++ b/app/Models/Extensions/AbstractBaseConfigMigration.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/BaseAlbum.php
+++ b/app/Models/Extensions/BaseAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/BaseConfigMigration.php
+++ b/app/Models/Extensions/BaseConfigMigration.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/BaseConfigMigrationReversed.php
+++ b/app/Models/Extensions/BaseConfigMigrationReversed.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/ConfigsHas.php
+++ b/app/Models/Extensions/ConfigsHas.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/ForwardsToParentImplementation.php
+++ b/app/Models/Extensions/ForwardsToParentImplementation.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/HasBidirectionalRelationships.php
+++ b/app/Models/Extensions/HasBidirectionalRelationships.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/HasRandomIDAndLegacyTimeBasedID.php
+++ b/app/Models/Extensions/HasRandomIDAndLegacyTimeBasedID.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/HasUrlGenerator.php
+++ b/app/Models/Extensions/HasUrlGenerator.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/SizeVariants.php
+++ b/app/Models/Extensions/SizeVariants.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/SortingDecorator.php
+++ b/app/Models/Extensions/SortingDecorator.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/ThrowsConsistentExceptions.php
+++ b/app/Models/Extensions/ThrowsConsistentExceptions.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/Thumb.php
+++ b/app/Models/Extensions/Thumb.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/ToArrayThrowsNotImplemented.php
+++ b/app/Models/Extensions/ToArrayThrowsNotImplemented.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Extensions/UTCBasedTimes.php
+++ b/app/Models/Extensions/UTCBasedTimes.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/JobHistory.php
+++ b/app/Models/JobHistory.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/OauthCredential.php
+++ b/app/Models/OauthCredential.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/SizeVariant.php
+++ b/app/Models/SizeVariant.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/Statistics.php
+++ b/app/Models/Statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/SymLink.php
+++ b/app/Models/SymLink.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/TagAlbum.php
+++ b/app/Models/TagAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Notifications/PhotoAdded.php
+++ b/app/Notifications/PhotoAdded.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Policies/AlbumPolicy.php
+++ b/app/Policies/AlbumPolicy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Policies/AlbumQueryPolicy.php
+++ b/app/Policies/AlbumQueryPolicy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Policies/BasePolicy.php
+++ b/app/Policies/BasePolicy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Policies/PhotoPolicy.php
+++ b/app/Policies/PhotoPolicy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Policies/PhotoQueryPolicy.php
+++ b/app/Policies/PhotoQueryPolicy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Policies/SettingsPolicy.php
+++ b/app/Policies/SettingsPolicy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Relations/BaseHasManyPhotos.php
+++ b/app/Relations/BaseHasManyPhotos.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Relations/BidirectionalRelationTrait.php
+++ b/app/Relations/BidirectionalRelationTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Relations/HasAlbumThumb.php
+++ b/app/Relations/HasAlbumThumb.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Relations/HasManyBidirectionally.php
+++ b/app/Relations/HasManyBidirectionally.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Relations/HasManyChildAlbums.php
+++ b/app/Relations/HasManyChildAlbums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Relations/HasManyChildPhotos.php
+++ b/app/Relations/HasManyChildPhotos.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Relations/HasManyPhotosByTag.php
+++ b/app/Relations/HasManyPhotosByTag.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Relations/HasManyPhotosRecursively.php
+++ b/app/Relations/HasManyPhotosRecursively.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Relations/HasManySizeVariants.php
+++ b/app/Relations/HasManySizeVariants.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/AlbumIDListRule.php
+++ b/app/Rules/AlbumIDListRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/AlbumIDRule.php
+++ b/app/Rules/AlbumIDRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/BooleanRequireSupportRule.php
+++ b/app/Rules/BooleanRequireSupportRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/ConfigKeyRequireSupportRule.php
+++ b/app/Rules/ConfigKeyRequireSupportRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/ConfigKeyRule.php
+++ b/app/Rules/ConfigKeyRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/ConfigValueRule.php
+++ b/app/Rules/ConfigValueRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/CopyrightRule.php
+++ b/app/Rules/CopyrightRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/CurrentPasswordRule.php
+++ b/app/Rules/CurrentPasswordRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/DescriptionRule.php
+++ b/app/Rules/DescriptionRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/EnumRequireSupportRule.php
+++ b/app/Rules/EnumRequireSupportRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/ExtensionRule.php
+++ b/app/Rules/ExtensionRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/FileUuidRule.php
+++ b/app/Rules/FileUuidRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/IntegerIDRule.php
+++ b/app/Rules/IntegerIDRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/IntegerRequireSupportRule.php
+++ b/app/Rules/IntegerRequireSupportRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/PasswordRule.php
+++ b/app/Rules/PasswordRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/RandomIDListRule.php
+++ b/app/Rules/RandomIDListRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/RandomIDRule.php
+++ b/app/Rules/RandomIDRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/StringRequireSupportRule.php
+++ b/app/Rules/StringRequireSupportRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/StringRule.php
+++ b/app/Rules/StringRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/TitleRule.php
+++ b/app/Rules/TitleRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/UsernameRule.php
+++ b/app/Rules/UsernameRule.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Rules/ValidateTrait.php
+++ b/app/Rules/ValidateTrait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Services/Archives/Zip21Trait.php
+++ b/app/Services/Archives/Zip21Trait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Services/Archives/Zip31Trait.php
+++ b/app/Services/Archives/Zip31Trait.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/Services/Auth/SessionOrTokenGuard.php
+++ b/app/Services/Auth/SessionOrTokenGuard.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/SmartAlbums/BaseSmartAlbum.php
+++ b/app/SmartAlbums/BaseSmartAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/SmartAlbums/OnThisDayAlbum.php
+++ b/app/SmartAlbums/OnThisDayAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/SmartAlbums/RecentAlbum.php
+++ b/app/SmartAlbums/RecentAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/SmartAlbums/StarredAlbum.php
+++ b/app/SmartAlbums/StarredAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/SmartAlbums/UnsortedAlbum.php
+++ b/app/SmartAlbums/UnsortedAlbum.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/SmartAlbums/Utils/MimicModel.php
+++ b/app/SmartAlbums/Utils/MimicModel.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/app/View/Components/Meta.php
+++ b/app/View/Components/Meta.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/bootstrap/PanicAttack.php
+++ b/bootstrap/PanicAttack.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/bootstrap/initialize.php
+++ b/bootstrap/initialize.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/config/features.php
+++ b/config/features.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/config/honeypot.php
+++ b/config/honeypot.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/factories/AccessPermissionFactory.php
+++ b/database/factories/AccessPermissionFactory.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/factories/AlbumFactory.php
+++ b/database/factories/AlbumFactory.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/factories/PhotoFactory.php
+++ b/database/factories/PhotoFactory.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/factories/SizeVariantFactory.php
+++ b/database/factories/SizeVariantFactory.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/factories/StatisticsFactory.php
+++ b/database/factories/StatisticsFactory.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/factories/TagAlbumFactory.php
+++ b/database/factories/TagAlbumFactory.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/factories/Traits/OwnedBy.php
+++ b/database/factories/Traits/OwnedBy.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2018_08_03_110935_create_albums_table.php
+++ b/database/migrations/2018_08_03_110935_create_albums_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2018_08_03_110936_create_photos_table.php
+++ b/database/migrations/2018_08_03_110936_create_photos_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2018_08_03_110942_create_configs_table.php
+++ b/database/migrations/2018_08_03_110942_create_configs_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2018_08_03_111324_create_logs_table.php
+++ b/database/migrations/2018_08_03_111324_create_logs_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2018_08_10_134924_move_settings.php
+++ b/database/migrations/2018_08_10_134924_move_settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2018_08_15_102039_move_albums.php
+++ b/database/migrations/2018_08_15_102039_move_albums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2018_08_15_103716_move_photos.php
+++ b/database/migrations/2018_08_15_103716_move_photos.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2018_10_30_135411_sharing.php
+++ b/database/migrations/2018_10_30_135411_sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_02_21_114356_create_pages_table.php
+++ b/database/migrations/2019_02_21_114356_create_pages_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_02_21_114408_create_page_contents_table.php
+++ b/database/migrations/2019_02_21_114408_create_page_contents_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_06_21_180451_create_sym_links_table.php
+++ b/database/migrations/2019_06_21_180451_create_sym_links_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_09_28_171753_config_fix.php
+++ b/database/migrations/2019_09_28_171753_config_fix.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_09_28_190822_photos_fix.php
+++ b/database/migrations/2019_09_28_190822_photos_fix.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_10_01_add_livephoto_cols.php
+++ b/database/migrations/2019_10_01_add_livephoto_cols.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_10_02_1400_config_map_display_public.php
+++ b/database/migrations/2019_10_02_1400_config_map_display_public.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_10_03_214750_frame_refresh_in_sec.php
+++ b/database/migrations/2019_10_03_214750_frame_refresh_in_sec.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_10_06_1400_config_map_providers.php
+++ b/database/migrations/2019_10_06_1400_config_map_providers.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_10_06_152017_add_force_32bit_ids.php
+++ b/database/migrations/2019_10_06_152017_add_force_32bit_ids.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_10_07_0900_config_map_include_sub_albums.php
+++ b/database/migrations/2019_10_07_0900_config_map_include_sub_albums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_10_09_233402_config_map_mod.php
+++ b/database/migrations/2019_10_09_233402_config_map_mod.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_10_11_093442_config_check_update_every.php
+++ b/database/migrations/2019_10_11_093442_config_check_update_every.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_12_02_2100_config_exiftool.php
+++ b/database/migrations/2019_12_02_2100_config_exiftool.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_12_15_0700_add_share_button_visible_option.php
+++ b/database/migrations/2019_12_15_0700_add_share_button_visible_option.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_12_15_1000_config_check_update_every_cat_fix.php
+++ b/database/migrations/2019_12_15_1000_config_check_update_every_cat_fix.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2019_12_25_0600_config_exiftool_ternary.php
+++ b/database/migrations/2019_12_25_0600_config_exiftool_ternary.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_01_018_2300_config_import_via_symlink.php
+++ b/database/migrations/2020_01_018_2300_config_import_via_symlink.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_01_04_1200_config_has_ffmpeg.php
+++ b/database/migrations/2020_01_04_1200_config_has_ffmpeg.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_01_26_1200_config_public_sorting.php
+++ b/database/migrations/2020_01_26_1200_config_public_sorting.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_01_28_133201_composer_update.php
+++ b/database/migrations/2020_01_28_133201_composer_update.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_02_14_0600_location_decoding.php
+++ b/database/migrations/2020_02_14_0600_location_decoding.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_03_11_124417_increase_length_photo_type.php
+++ b/database/migrations/2020_03_11_124417_increase_length_photo_type.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_03_17_200000_unhide_configs.php
+++ b/database/migrations/2020_03_17_200000_unhide_configs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_04_19_122905_bump_version.php
+++ b/database/migrations/2020_04_19_122905_bump_version.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_04_22_155712_bump_version040002.php
+++ b/database/migrations/2020_04_22_155712_bump_version040002.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_04_29_000250_bump_version040003.php
+++ b/database/migrations/2020_04_29_000250_bump_version040003.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_05_12_114228_rss.php
+++ b/database/migrations/2020_05_12_114228_rss.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_05_12_161427_bump_version040005.php
+++ b/database/migrations/2020_05_12_161427_bump_version040005.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_05_19_174233_config_prefer_available_xmp_metadata.php
+++ b/database/migrations/2020_05_19_174233_config_prefer_available_xmp_metadata.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_05_26_135052_bump_version040006.php
+++ b/database/migrations/2020_05_26_135052_bump_version040006.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_06_04_104605_config_editor_enabled.php
+++ b/database/migrations/2020_06_04_104605_config_editor_enabled.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_07_11_104605_config_lossless_optimization.php
+++ b/database/migrations/2020_07_11_104605_config_lossless_optimization.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_07_11_184605_update_licences.php
+++ b/database/migrations/2020_07_11_184605_update_licences.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_07_26_085322_config_swipe_tolerance.php
+++ b/database/migrations/2020_07_26_085322_config_swipe_tolerance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_07_29_132731_config_local_takestamp.php
+++ b/database/migrations/2020_07_29_132731_config_local_takestamp.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_08_21_123622_add_smart_tag_album_cols.php
+++ b/database/migrations/2020_08_21_123622_add_smart_tag_album_cols.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_10_09_130043_bump_version040007.php
+++ b/database/migrations/2020_10_09_130043_bump_version040007.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_10_15_104504_add_log_max_num_line.php
+++ b/database/migrations/2020_10_15_104504_add_log_max_num_line.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_10_15_161346_sort_image_per_album.php
+++ b/database/migrations/2020_10_15_161346_sort_image_per_album.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_11_12_183345_config_password_url_param_for_smart_album.php
+++ b/database/migrations/2020_11_12_183345_config_password_url_param_for_smart_album.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_11_19_231553_bump_version040008.php
+++ b/database/migrations/2020_11_19_231553_bump_version040008.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_12_12_203153_migrate_admin_user.php
+++ b/database/migrations/2020_12_12_203153_migrate_admin_user.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_12_12_203831_create_web_authn_tables.php
+++ b/database/migrations/2020_12_12_203831_create_web_authn_tables.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_12_18_162100_bump_version040009.php
+++ b/database/migrations/2020_12_18_162100_bump_version040009.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_12_18_162155_add_nsfw_album.php
+++ b/database/migrations/2020_12_18_162155_add_nsfw_album.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_12_18_163800_bump_version040010.php
+++ b/database/migrations/2020_12_18_163800_bump_version040010.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_12_24_022307_bump_version040100.php
+++ b/database/migrations/2020_12_24_022307_bump_version040100.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2020_12_26_153220_nested_set_for_albums.php
+++ b/database/migrations/2020_12_26_153220_nested_set_for_albums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_01_09_163715_remove_max_min_takestamps.php
+++ b/database/migrations/2021_01_09_163715_remove_max_min_takestamps.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_01_12_122546_bump_version040200.php
+++ b/database/migrations/2021_01_12_122546_bump_version040200.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_01_18_103729_add_album_cover.php
+++ b/database/migrations/2021_01_18_103729_add_album_cover.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_01_20_113912_bump_version040201.php
+++ b/database/migrations/2021_01_20_113912_bump_version040201.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_01_24_231904_fix-rotation.php
+++ b/database/migrations/2021_01_24_231904_fix-rotation.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_01_27_085903_config_map_display_direction.php
+++ b/database/migrations/2021_01_27_085903_config_map_display_direction.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_01_30_111736_display_takedate.php
+++ b/database/migrations/2021_01_30_111736_display_takedate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_02_12_222948_config_upload_processing_limit.php
+++ b/database/migrations/2021_02_12_222948_config_upload_processing_limit.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_02_13_132245_bump_version040202.php
+++ b/database/migrations/2021_02_13_132245_bump_version040202.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_02_18_232639_config_public_photos_hidden.php
+++ b/database/migrations/2021_02_18_232639_config_public_photos_hidden.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_03_03_175555_config_remove_image_overlay.php
+++ b/database/migrations/2021_03_03_175555_config_remove_image_overlay.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_04_17_135924_bump_version040300.php
+++ b/database/migrations/2021_04_17_135924_bump_version040300.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_05_02_174300_add_filesize_raw_col.php
+++ b/database/migrations/2021_05_02_174300_add_filesize_raw_col.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_05_12_185726_bump_version040301.php
+++ b/database/migrations/2021_05_12_185726_bump_version040301.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_05_13_140700_refactor_size_variants.php
+++ b/database/migrations/2021_05_13_140700_refactor_size_variants.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_05_16_171615_bump_version040302.php
+++ b/database/migrations/2021_05_16_171615_bump_version040302.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_05_25_160600_post_revert_fixes.php
+++ b/database/migrations/2021_05_25_160600_post_revert_fixes.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_05_31_201000_convert_filesize_to_bigint.php
+++ b/database/migrations/2021_05_31_201000_convert_filesize_to_bigint.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_06_01_181900_refactor_timestamps_anew.php
+++ b/database/migrations/2021_06_01_181900_refactor_timestamps_anew.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_06_01_182000_bump_version040304.php
+++ b/database/migrations/2021_06_01_182000_bump_version040304.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_06_06_151613_fix-takedate.php
+++ b/database/migrations/2021_06_06_151613_fix-takedate.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_06_23_105939_create_notifications_table.php
+++ b/database/migrations/2021_06_23_105939_create_notifications_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_06_30_121651_add_email_to_users_table.php
+++ b/database/migrations/2021_06_30_121651_add_email_to_users_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_06_30_122229_config_new_photos_notification.php
+++ b/database/migrations/2021_06_30_122229_config_new_photos_notification.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_07_19_134617_bump_version040305.php
+++ b/database/migrations/2021_07_19_134617_bump_version040305.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_10_27_133121_fix_confidentiality.php
+++ b/database/migrations/2021_10_27_133121_fix_confidentiality.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_11_16_162058_bump_version040306.php
+++ b/database/migrations/2021_11_16_162058_bump_version040306.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_12_03_201242_bump_version040400.php
+++ b/database/migrations/2021_12_03_201242_bump_version040400.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2021_12_04_181200_refactor_models.php
+++ b/database/migrations/2021_12_04_181200_refactor_models.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_01_13_183131_bump_version040500.php
+++ b/database/migrations/2022_01_13_183131_bump_version040500.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_01_16_181337_optimize_tables.php
+++ b/database/migrations/2022_01_16_181337_optimize_tables.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_02_02_203008_filesize_size_variants.php
+++ b/database/migrations/2022_02_02_203008_filesize_size_variants.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_02_22_194700_fix_sorting_config.php
+++ b/database/migrations/2022_02_22_194700_fix_sorting_config.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_04_06_091900_drop_objectionable_indices.php
+++ b/database/migrations/2022_04_06_091900_drop_objectionable_indices.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_04_13_094611_add_track_short_path_to_album_table.php
+++ b/database/migrations/2022_04_13_094611_add_track_short_path_to_album_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_04_16_170724_add_missing_indices.php
+++ b/database/migrations/2022_04_16_170724_add_missing_indices.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_04_16_174503_bump_version040501.php
+++ b/database/migrations/2022_04_16_174503_bump_version040501.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_04_18_150400_add_index_for_delete.php
+++ b/database/migrations/2022_04_18_150400_add_index_for_delete.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_04_18_174417_fix_live_photo_short_path.php
+++ b/database/migrations/2022_04_18_174417_fix_live_photo_short_path.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_06_12_075709_add_token_to_user_table.php
+++ b/database/migrations/2022_06_12_075709_add_token_to_user_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_07_09_130303_create_webauthn_credentials.php
+++ b/database/migrations/2022_07_09_130303_create_webauthn_credentials.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_07_13_174800_permission_test.php
+++ b/database/migrations/2022_07_13_174800_permission_test.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_07_24_102214_bump_version040502.php
+++ b/database/migrations/2022_07_24_102214_bump_version040502.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_08_03_184746_add_zip_options.php
+++ b/database/migrations/2022_08_03_184746_add_zip_options.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_08_06_205701_bump_version040503.php
+++ b/database/migrations/2022_08_06_205701_bump_version040503.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_08_06_210757_bump_version040600.php
+++ b/database/migrations/2022_08_06_210757_bump_version040600.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_08_27_103010_drop_page_support.php
+++ b/database/migrations/2022_08_27_103010_drop_page_support.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_08_27_110209_drop_admin_user_config.php
+++ b/database/migrations/2022_08_27_110209_drop_admin_user_config.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_09_27_103710_bump_version040601.php
+++ b/database/migrations/2022_09_27_103710_bump_version040601.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_10_23_143201_make_wui_settings_public.php
+++ b/database/migrations/2022_10_23_143201_make_wui_settings_public.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_10_28_232159_bump_version040602.php
+++ b/database/migrations/2022_10_28_232159_bump_version040602.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_11_07_171403_add_config_descriptions.php
+++ b/database/migrations/2022_11_07_171403_add_config_descriptions.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_11_27_143608_bump_version040603.php
+++ b/database/migrations/2022_11_27_143608_bump_version040603.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_12_05_195600_enable_disable_smart_albums.php
+++ b/database/migrations/2022_12_05_195600_enable_disable_smart_albums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_12_07_141854_rename_capabilities.php
+++ b/database/migrations/2022_12_07_141854_rename_capabilities.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_12_07_143755_add_default_protection_option.php
+++ b/database/migrations/2022_12_07_143755_add_default_protection_option.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_12_07_164417_config_uniformize_rights.php
+++ b/database/migrations/2022_12_07_164417_config_uniformize_rights.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_12_07_175257_rename_attributes_grants.php
+++ b/database/migrations/2022_12_07_175257_rename_attributes_grants.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_12_10_183251_increment_user_i_ds.php
+++ b/database/migrations/2022_12_10_183251_increment_user_i_ds.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_12_12_100000_enable_disable_album_photo_counters.php
+++ b/database/migrations/2022_12_12_100000_enable_disable_album_photo_counters.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_12_21_212143_use_webp_for_example.php
+++ b/database/migrations/2022_12_21_212143_use_webp_for_example.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_12_25_103052_bump_version040604.php
+++ b/database/migrations/2022_12_25_103052_bump_version040604.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_12_26_101639_allow_username_change.php
+++ b/database/migrations/2022_12_26_101639_allow_username_change.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_12_26_111139_bump_version040605.php
+++ b/database/migrations/2022_12_26_111139_bump_version040605.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_12_28_164844_remove-demo.php
+++ b/database/migrations/2022_12_28_164844_remove-demo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2022_12_31_103416_bump_version040700.php
+++ b/database/migrations/2022_12_31_103416_bump_version040700.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_01_09_133603_public_on_this_day.php
+++ b/database/migrations/2023_01_09_133603_public_on_this_day.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_01_25_140614_change-locale.php
+++ b/database/migrations/2023_01_25_140614_change-locale.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_02_05_155552_bump_version040701.php
+++ b/database/migrations/2023_02_05_155552_bump_version040701.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_02_23_192505_add_auto_fix_orientation_setting.php
+++ b/database/migrations/2023_02_23_192505_add_auto_fix_orientation_setting.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_03_08_103109_bump_version040702.php
+++ b/database/migrations/2023_03_08_103109_bump_version040702.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_04_05_150337_create_jobs_table.php
+++ b/database/migrations/2023_04_05_150337_create_jobs_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_04_05_150625_queue-processing.php
+++ b/database/migrations/2023_04_05_150625_queue-processing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_04_05_220214_create_failed_jobs_table.php
+++ b/database/migrations/2023_04_05_220214_create_failed_jobs_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_04_09_142907_create_job_history_table.php
+++ b/database/migrations/2023_04_09_142907_create_job_history_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_04_18_065457_bump_version040703.php
+++ b/database/migrations/2023_04_18_065457_bump_version040703.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_05_01_165730_add_random_photo_settings.php
+++ b/database/migrations/2023_05_01_165730_add_random_photo_settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_05_04_070132_bump_version040704.php
+++ b/database/migrations/2023_05_04_070132_bump_version040704.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_05_04_193000_add_use_last_modified_date_when_no_exit_date_setting.php
+++ b/database/migrations/2023_05_04_193000_add_use_last_modified_date_when_no_exit_date_setting.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_05_05_052254_create_access_permissions.php
+++ b/database/migrations/2023_05_05_052254_create_access_permissions.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_05_05_052255_simplify_user_base_album.php
+++ b/database/migrations/2023_05_05_052255_simplify_user_base_album.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_05_05_052256_simplify_base_album.php
+++ b/database/migrations/2023_05_05_052256_simplify_base_album.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_05_05_052257_create_access_permissions_for_smart_albums.php
+++ b/database/migrations/2023_05_05_052257_create_access_permissions_for_smart_albums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_05_05_123230_bump_version040800.php
+++ b/database/migrations/2023_05_05_123230_bump_version040800.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_05_15_081406_bump_version040801.php
+++ b/database/migrations/2023_05_15_081406_bump_version040801.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_05_15_211448_remove_is_public_album_sorting.php
+++ b/database/migrations/2023_05_15_211448_remove_is_public_album_sorting.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_05_18_103903_bump_version040900.php
+++ b/database/migrations/2023_05_18_103903_bump_version040900.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_05_19_131139_bump_version040901.php
+++ b/database/migrations/2023_05_19_131139_bump_version040901.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_05_21_225616_bump_version040902.php
+++ b/database/migrations/2023_05_21_225616_bump_version040902.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_06_20_174639_bump_version040903.php
+++ b/database/migrations/2023_06_20_174639_bump_version040903.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_06_24_161541_add_indexes.php
+++ b/database/migrations/2023_06_24_161541_add_indexes.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_06_28_144440_bump_version040904.php
+++ b/database/migrations/2023_06_28_144440_bump_version040904.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_07_07_143908_add_ratio_size_variants.php
+++ b/database/migrations/2023_07_07_143908_add_ratio_size_variants.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_07_16_110146_bump_version041000.php
+++ b/database/migrations/2023_07_16_110146_bump_version041000.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_08_07_182802_add_config_ffmpeg_path.php
+++ b/database/migrations/2023_08_07_182802_add_config_ffmpeg_path.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_08_11_134652_bump_version041100.php
+++ b/database/migrations/2023_08_11_134652_bump_version041100.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_09_03_124836_bump_version041101.php
+++ b/database/migrations/2023_09_03_124836_bump_version041101.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_09_16_070405_refactor_type_layout.php
+++ b/database/migrations/2023_09_16_070405_refactor_type_layout.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_09_16_074731_bump_version041200.php
+++ b/database/migrations/2023_09_16_074731_bump_version041200.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_09_16_234050_require_single_key_in_config.php
+++ b/database/migrations/2023_09_16_234050_require_single_key_in_config.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_09_23_204910_bump_version041300.php
+++ b/database/migrations/2023_09_23_204910_bump_version041300.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_09_24_110932_add_date_display_configurations.php
+++ b/database/migrations/2023_09_24_110932_add_date_display_configurations.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_09_24_223901_add_config_livewire_chunk_size.php
+++ b/database/migrations/2023_09_24_223901_add_config_livewire_chunk_size.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_09_24_233717_refactor_type_layout_livewire.php
+++ b/database/migrations/2023_09_24_233717_refactor_type_layout_livewire.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_09_25_123925_config_blur_nsfw.php
+++ b/database/migrations/2023_09_25_123925_config_blur_nsfw.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_10_01_143159_config_map_provider.php
+++ b/database/migrations/2023_10_01_143159_config_map_provider.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_12_18_191723_config_public_search.php
+++ b/database/migrations/2023_12_18_191723_config_public_search.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_12_18_232500_config_pagination_search_limit.php
+++ b/database/migrations/2023_12_18_232500_config_pagination_search_limit.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_12_19_115547_search_characters_limit.php
+++ b/database/migrations/2023_12_19_115547_search_characters_limit.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_12_19_122408_add_positive_requirements.php
+++ b/database/migrations/2023_12_19_122408_add_positive_requirements.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_12_20_180854_add_setting_height_width_gallery.php
+++ b/database/migrations/2023_12_20_180854_add_setting_height_width_gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_12_23_160356_bump_version050000.php
+++ b/database/migrations/2023_12_23_160356_bump_version050000.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_12_25_115454_add_setting_display_thumb_overlay.php
+++ b/database/migrations/2023_12_25_115454_add_setting_display_thumb_overlay.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_12_27_163004_bump_version050001.php
+++ b/database/migrations/2023_12_27_163004_bump_version050001.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_12_28_144906_bump_version050002.php
+++ b/database/migrations/2023_12_28_144906_bump_version050002.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_12_28_165358_add_subalbum_sorting_per_album.php
+++ b/database/migrations/2023_12_28_165358_add_subalbum_sorting_per_album.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_12_30_220515_add_thumbs_albums_aspect_ratio.php
+++ b/database/migrations/2023_12_30_220515_add_thumbs_albums_aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2023_12_30_221215_add_thumbs_albums_aspect_ratio_per_album.php
+++ b/database/migrations/2023_12_30_221215_add_thumbs_albums_aspect_ratio_per_album.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_01_03_154055_add_album_no_header_setting.php
+++ b/database/migrations/2024_01_03_154055_add_album_no_header_setting.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_01_08_155917_bump_version050003.php
+++ b/database/migrations/2024_01_08_155917_bump_version050003.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_01_08_163328_left_right_login_and_back.php
+++ b/database/migrations/2024_01_08_163328_left_right_login_and_back.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_01_13_124937_create_oauth_credentials_table.php
+++ b/database/migrations/2024_01_13_124937_create_oauth_credentials_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_01_17_101240_bump_version050100.php
+++ b/database/migrations/2024_01_17_101240_bump_version050100.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_01_22_121406_bump_version050101.php
+++ b/database/migrations/2024_01_22_121406_bump_version050101.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_01_23_190637_bump_version050102.php
+++ b/database/migrations/2024_01_23_190637_bump_version050102.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_01_23_192800_remove_is_public_photo_sorting.php
+++ b/database/migrations/2024_01_23_192800_remove_is_public_photo_sorting.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_01_23_192814_remove_keys_and_column.php
+++ b/database/migrations/2024_01_23_192814_remove_keys_and_column.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_01_23_232103_remove_album_id_from_jobhistory.php
+++ b/database/migrations/2024_01_23_232103_remove_album_id_from_jobhistory.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_01_24_063519_job_feedback_options.php
+++ b/database/migrations/2024_01_24_063519_job_feedback_options.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_02_28_004535_add_header_id_col.php
+++ b/database/migrations/2024_02_28_004535_add_header_id_col.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_04_06_165355_bump_version050200.php
+++ b/database/migrations/2024_04_06_165355_bump_version050200.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_04_09_121410_decrease_noise_diagnostics.php
+++ b/database/migrations/2024_04_09_121410_decrease_noise_diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_04_14_103639_bump_version050201.php
+++ b/database/migrations/2024_04_14_103639_bump_version050201.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_04_19_141432_fix_license.php
+++ b/database/migrations/2024_04_19_141432_fix_license.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_04_20_132955_bump_version050202.php
+++ b/database/migrations/2024_04_20_132955_bump_version050202.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_04_26_201931_add_storate_disk_to_size_variants.php
+++ b/database/migrations/2024_04_26_201931_add_storate_disk_to_size_variants.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_04_28_135546_fix_license_again.php
+++ b/database/migrations/2024_04_28_135546_fix_license_again.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_04_28_172241_add_album_copyright.php
+++ b/database/migrations/2024_04_28_172241_add_album_copyright.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_04_28_191004_bump_version050300.php
+++ b/database/migrations/2024_04_28_191004_bump_version050300.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_05_13_175529_config_random_thumb_smart_album.php
+++ b/database/migrations/2024_05_13_175529_config_random_thumb_smart_album.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_06_08_093403_primary_key_job_history.php
+++ b/database/migrations/2024_06_08_093403_primary_key_job_history.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_06_08_103842_add_config_display_processing_queue.php
+++ b/database/migrations/2024_06_08_103842_add_config_display_processing_queue.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_06_08_183427_bump_version050301.php
+++ b/database/migrations/2024_06_08_183427_bump_version050301.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_06_10_103843_add_login_required_option.php
+++ b/database/migrations/2024_06_10_103843_add_login_required_option.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_06_11_204410_bump_version050400.php
+++ b/database/migrations/2024_06_11_204410_bump_version050400.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_06_17_171051_disable_per_smart_album_config.php
+++ b/database/migrations/2024_06_17_171051_disable_per_smart_album_config.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_06_17_172448_remove_global_disable_smart_albums.php
+++ b/database/migrations/2024_06_17_172448_remove_global_disable_smart_albums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_06_21_154247_create_user_if_not_exists_on_oauth.php
+++ b/database/migrations/2024_06_21_154247_create_user_if_not_exists_on_oauth.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_06_23_201042_enforce_login_on_gallery_only.php
+++ b/database/migrations/2024_06_23_201042_enforce_login_on_gallery_only.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_06_25_153527_bump_version050500.php
+++ b/database/migrations/2024_06_25_153527_bump_version050500.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_07_01_231053_path_for_exiftool.php
+++ b/database/migrations/2024_07_01_231053_path_for_exiftool.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_07_03_170506_bump_version050501.php
+++ b/database/migrations/2024_07_03_170506_bump_version050501.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_07_06_214241_thumb_min_max_take_date_order.php
+++ b/database/migrations/2024_07_06_214241_thumb_min_max_take_date_order.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_07_12_183751_add_auto_play_config.php
+++ b/database/migrations/2024_07_12_183751_add_auto_play_config.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_07_26_120007_simplify_config.php
+++ b/database/migrations/2024_07_26_120007_simplify_config.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_07_29_172018_fix_settings.php
+++ b/database/migrations/2024_07_29_172018_fix_settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_08_09_205532_white_theme.php
+++ b/database/migrations/2024_08_09_205532_white_theme.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_08_15_163203_config_low_quality_image_placeholder.php
+++ b/database/migrations/2024_08_15_163203_config_low_quality_image_placeholder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_08_31_090626_config_help_popup.php
+++ b/database/migrations/2024_08_31_090626_config_help_popup.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_08_31_090740_fix_description_always_hover_hidden_photo.php
+++ b/database/migrations/2024_08_31_090740_fix_description_always_hover_hidden_photo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_09_14_143949_add_settings_level.php
+++ b/database/migrations/2024_09_14_143949_add_settings_level.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_09_14_153948_fix_more_descriptions.php
+++ b/database/migrations/2024_09_14_153948_fix_more_descriptions.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_09_27_144741_add_supporter_fields.php
+++ b/database/migrations/2024_09_27_144741_add_supporter_fields.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_05_125328_add_slideshow_timeout.php
+++ b/database/migrations/2024_10_05_125328_add_slideshow_timeout.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_05_125833_lang_is_admin_setting.php
+++ b/database/migrations/2024_10_05_125833_lang_is_admin_setting.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_05_184315_bump_version060000.php
+++ b/database/migrations/2024_10_05_184315_bump_version060000.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_09_191528_image_processing_backup.php
+++ b/database/migrations/2024_10_09_191528_image_processing_backup.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_09_194010_image_processing_details_and_others.php
+++ b/database/migrations/2024_10_09_194010_image_processing_details_and_others.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_10_101333_set_dropbox_disabled.php
+++ b/database/migrations/2024_10_10_101333_set_dropbox_disabled.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_11_173054_add_space_quota_per_user.php
+++ b/database/migrations/2024_10_11_173054_add_space_quota_per_user.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_11_173106_add_space_quota_configuration.php
+++ b/database/migrations/2024_10_11_173106_add_space_quota_configuration.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_13_134419_oath_group_to_users.php
+++ b/database/migrations/2024_10_13_134419_oath_group_to_users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_14_104644_show_nsfw_in_smart_albums.php
+++ b/database/migrations/2024_10_14_104644_show_nsfw_in_smart_albums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_14_104823_refine_text_enable_unsorted_smart_album.php
+++ b/database/migrations/2024_10_14_104823_refine_text_enable_unsorted_smart_album.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_20_125449_move-socials-to-footer.php
+++ b/database/migrations/2024_10_20_125449_move-socials-to-footer.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_20_173904_add_photo_layout_per_album.php
+++ b/database/migrations/2024_10_20_173904_add_photo_layout_per_album.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_23_222857_change_header.php
+++ b/database/migrations/2024_10_23_222857_change_header.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_23_225332_warning_html_content.php
+++ b/database/migrations/2024_10_23_225332_warning_html_content.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_29_184020_bump_version060001.php
+++ b/database/migrations/2024_10_29_184020_bump_version060001.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_10_30_064336_timeline_options.php
+++ b/database/migrations/2024_10_30_064336_timeline_options.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_11_10_171126_timeline_in_albums.php
+++ b/database/migrations/2024_11_10_171126_timeline_in_albums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_11_11_141241_remove_config_hide_nsfw_in_smart_albums_and_search.php
+++ b/database/migrations/2024_11_11_141241_remove_config_hide_nsfw_in_smart_albums_and_search.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_11_11_141334_add_hide_nsfw_smart_search_config.php
+++ b/database/migrations/2024_11_11_141334_add_hide_nsfw_smart_search_config.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_11_25_211912_bump_version060100.php
+++ b/database/migrations/2024_11_25_211912_bump_version060100.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_11_26_125145_improve_info_timeline.php
+++ b/database/migrations/2024_11_26_125145_improve_info_timeline.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_11_26_131136_bump_version060101.php
+++ b/database/migrations/2024_11_26_131136_bump_version060101.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_11_27_085119_bump_version060102.php
+++ b/database/migrations/2024_11_27_085119_bump_version060102.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_12_03_221445_set_number_icons_mobile.php
+++ b/database/migrations/2024_12_03_221445_set_number_icons_mobile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_12_16_132422_bump_version060200.php
+++ b/database/migrations/2024_12_16_132422_bump_version060200.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2024_12_28_190150_caching_config.php
+++ b/database/migrations/2024_12_28_190150_caching_config.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_01_24_200235_add_initial_taken_at.php
+++ b/database/migrations/2025_01_24_200235_add_initial_taken_at.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_02_02_220404_config_punch_card.php
+++ b/database/migrations/2025_02_02_220404_config_punch_card.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_02_06_181434_bump_version060300.php
+++ b/database/migrations/2025_02_06_181434_bump_version060300.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_02_15_090409_bump_version060301.php
+++ b/database/migrations/2025_02_15_090409_bump_version060301.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_02_16_214804_bump_version060302.php
+++ b/database/migrations/2025_02_16_214804_bump_version060302.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_02_17_073346_add_config_generation_bounds.php
+++ b/database/migrations/2025_02_17_073346_add_config_generation_bounds.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_02_17_075553_add_disable_recursive_permission_check.php
+++ b/database/migrations/2025_02_17_075553_add_disable_recursive_permission_check.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_02_17_080713_more_privacy_options.php
+++ b/database/migrations/2025_02_17_080713_more_privacy_options.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_02_21_105541_bump_version060303.php
+++ b/database/migrations/2025_02_21_105541_bump_version060303.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_02_27_172817_bump_version060304.php
+++ b/database/migrations/2025_02_27_172817_bump_version060304.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_03_01_154728_search_pagination_limit_reduction.php
+++ b/database/migrations/2025_03_01_154728_search_pagination_limit_reduction.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_03_16_100923_add-note-mod-frame.php
+++ b/database/migrations/2025_03_16_100923_add-note-mod-frame.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_03_19_122649_bump_version060305.php
+++ b/database/migrations/2025_03_19_122649_bump_version060305.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_03_20_173343_create_config_categories_table.php
+++ b/database/migrations/2025_03_20_173343_create_config_categories_table.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_03_20_194811_set_expert_option.php
+++ b/database/migrations/2025_03_20_194811_set_expert_option.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_03_20_200832_expert_all_settings_options.php
+++ b/database/migrations/2025_03_20_200832_expert_all_settings_options.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_03_20_214811_move_configs.php
+++ b/database/migrations/2025_03_20_214811_move_configs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_03_23_105010_config_favourite.php
+++ b/database/migrations/2025_03_23_105010_config_favourite.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_03_23_154340_bump_version060400.php
+++ b/database/migrations/2025_03_23_154340_bump_version060400.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_03_23_185517_bump_version060401.php
+++ b/database/migrations/2025_03_23_185517_bump_version060401.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_03_31_151648_create_new_category.php
+++ b/database/migrations/2025_03_31_151648_create_new_category.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_03_31_160547_limit_download_options.php
+++ b/database/migrations/2025_03_31_160547_limit_download_options.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_04_04_075837_bump_version060402.php
+++ b/database/migrations/2025_04_04_075837_bump_version060402.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_04_06_200147_portrait_landscape_landing_background.php
+++ b/database/migrations/2025_04_06_200147_portrait_landscape_landing_background.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_04_06_200737_remove_landing_background.php
+++ b/database/migrations/2025_04_06_200737_remove_landing_background.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_04_07_211144_add_stats_columns.php
+++ b/database/migrations/2025_04_07_211144_add_stats_columns.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_04_07_211147_metrics_config.php
+++ b/database/migrations/2025_04_07_211147_metrics_config.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_04_20_143503_bump_version060500.php
+++ b/database/migrations/2025_04_20_143503_bump_version060500.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_04_21_150310_bump_version060501.php
+++ b/database/migrations/2025_04_21_150310_bump_version060501.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_04_21_185527_config_description_thumbs.php
+++ b/database/migrations/2025_04_21_185527_config_description_thumbs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_04_24_082940_bump_version060502.php
+++ b/database/migrations/2025_04_24_082940_bump_version060502.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/TemporaryModels/MovePhotos_Photo.php
+++ b/database/migrations/TemporaryModels/MovePhotos_Photo.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/TemporaryModels/NestedSetForAlbums_AlbumModel.php
+++ b/database/migrations/TemporaryModels/NestedSetForAlbums_AlbumModel.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/TemporaryModels/OptimizeTables.php
+++ b/database/migrations/TemporaryModels/OptimizeTables.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/TemporaryModels/RefactorAlbumModel_AlbumModel.php
+++ b/database/migrations/TemporaryModels/RefactorAlbumModel_AlbumModel.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/aspect_ratio.php
+++ b/lang/cz/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/changelogs.php
+++ b/lang/cz/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/diagnostics.php
+++ b/lang/cz/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/dialogs.php
+++ b/lang/cz/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/duplicate-finder.php
+++ b/lang/cz/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/fix-tree.php
+++ b/lang/cz/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/gallery.php
+++ b/lang/cz/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/jobs.php
+++ b/lang/cz/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/landing.php
+++ b/lang/cz/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/left-menu.php
+++ b/lang/cz/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/maintenance.php
+++ b/lang/cz/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/profile.php
+++ b/lang/cz/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/settings.php
+++ b/lang/cz/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/sharing.php
+++ b/lang/cz/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/statistics.php
+++ b/lang/cz/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/toasts.php
+++ b/lang/cz/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/cz/users.php
+++ b/lang/cz/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/aspect_ratio.php
+++ b/lang/de/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/changelogs.php
+++ b/lang/de/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/diagnostics.php
+++ b/lang/de/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/dialogs.php
+++ b/lang/de/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/duplicate-finder.php
+++ b/lang/de/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/fix-tree.php
+++ b/lang/de/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/gallery.php
+++ b/lang/de/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/jobs.php
+++ b/lang/de/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/landing.php
+++ b/lang/de/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/left-menu.php
+++ b/lang/de/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/maintenance.php
+++ b/lang/de/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/profile.php
+++ b/lang/de/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/sharing.php
+++ b/lang/de/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/statistics.php
+++ b/lang/de/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/toasts.php
+++ b/lang/de/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/de/users.php
+++ b/lang/de/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/aspect_ratio.php
+++ b/lang/el/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/changelogs.php
+++ b/lang/el/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/diagnostics.php
+++ b/lang/el/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/dialogs.php
+++ b/lang/el/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/duplicate-finder.php
+++ b/lang/el/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/fix-tree.php
+++ b/lang/el/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/gallery.php
+++ b/lang/el/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/jobs.php
+++ b/lang/el/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/landing.php
+++ b/lang/el/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/left-menu.php
+++ b/lang/el/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/maintenance.php
+++ b/lang/el/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/profile.php
+++ b/lang/el/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/settings.php
+++ b/lang/el/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/sharing.php
+++ b/lang/el/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/statistics.php
+++ b/lang/el/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/toasts.php
+++ b/lang/el/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/el/users.php
+++ b/lang/el/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/aspect_ratio.php
+++ b/lang/en/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/changelogs.php
+++ b/lang/en/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/diagnostics.php
+++ b/lang/en/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/dialogs.php
+++ b/lang/en/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/duplicate-finder.php
+++ b/lang/en/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/fix-tree.php
+++ b/lang/en/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/gallery.php
+++ b/lang/en/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/jobs.php
+++ b/lang/en/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/landing.php
+++ b/lang/en/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/left-menu.php
+++ b/lang/en/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/maintenance.php
+++ b/lang/en/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/sharing.php
+++ b/lang/en/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/statistics.php
+++ b/lang/en/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/toasts.php
+++ b/lang/en/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/en/users.php
+++ b/lang/en/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/aspect_ratio.php
+++ b/lang/es/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/changelogs.php
+++ b/lang/es/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/diagnostics.php
+++ b/lang/es/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/dialogs.php
+++ b/lang/es/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/duplicate-finder.php
+++ b/lang/es/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/fix-tree.php
+++ b/lang/es/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/gallery.php
+++ b/lang/es/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/jobs.php
+++ b/lang/es/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/landing.php
+++ b/lang/es/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/left-menu.php
+++ b/lang/es/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/maintenance.php
+++ b/lang/es/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/profile.php
+++ b/lang/es/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/settings.php
+++ b/lang/es/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/sharing.php
+++ b/lang/es/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/statistics.php
+++ b/lang/es/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/toasts.php
+++ b/lang/es/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/es/users.php
+++ b/lang/es/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/aspect_ratio.php
+++ b/lang/fr/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/changelogs.php
+++ b/lang/fr/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/diagnostics.php
+++ b/lang/fr/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/dialogs.php
+++ b/lang/fr/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/duplicate-finder.php
+++ b/lang/fr/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/fix-tree.php
+++ b/lang/fr/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/gallery.php
+++ b/lang/fr/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/jobs.php
+++ b/lang/fr/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/landing.php
+++ b/lang/fr/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/left-menu.php
+++ b/lang/fr/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/maintenance.php
+++ b/lang/fr/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/profile.php
+++ b/lang/fr/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/sharing.php
+++ b/lang/fr/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/statistics.php
+++ b/lang/fr/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/toasts.php
+++ b/lang/fr/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/fr/users.php
+++ b/lang/fr/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/aspect_ratio.php
+++ b/lang/hu/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/changelogs.php
+++ b/lang/hu/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/diagnostics.php
+++ b/lang/hu/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/dialogs.php
+++ b/lang/hu/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/duplicate-finder.php
+++ b/lang/hu/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/fix-tree.php
+++ b/lang/hu/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/gallery.php
+++ b/lang/hu/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/jobs.php
+++ b/lang/hu/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/landing.php
+++ b/lang/hu/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/left-menu.php
+++ b/lang/hu/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/maintenance.php
+++ b/lang/hu/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/profile.php
+++ b/lang/hu/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/settings.php
+++ b/lang/hu/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/sharing.php
+++ b/lang/hu/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/statistics.php
+++ b/lang/hu/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/toasts.php
+++ b/lang/hu/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/hu/users.php
+++ b/lang/hu/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/aspect_ratio.php
+++ b/lang/it/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/changelogs.php
+++ b/lang/it/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/diagnostics.php
+++ b/lang/it/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/dialogs.php
+++ b/lang/it/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/duplicate-finder.php
+++ b/lang/it/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/fix-tree.php
+++ b/lang/it/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/gallery.php
+++ b/lang/it/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/jobs.php
+++ b/lang/it/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/landing.php
+++ b/lang/it/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/left-menu.php
+++ b/lang/it/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/maintenance.php
+++ b/lang/it/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/profile.php
+++ b/lang/it/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/settings.php
+++ b/lang/it/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/sharing.php
+++ b/lang/it/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/statistics.php
+++ b/lang/it/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/toasts.php
+++ b/lang/it/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/it/users.php
+++ b/lang/it/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/aspect_ratio.php
+++ b/lang/ja/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/changelogs.php
+++ b/lang/ja/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/diagnostics.php
+++ b/lang/ja/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/dialogs.php
+++ b/lang/ja/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/duplicate-finder.php
+++ b/lang/ja/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/fix-tree.php
+++ b/lang/ja/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/gallery.php
+++ b/lang/ja/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/jobs.php
+++ b/lang/ja/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/landing.php
+++ b/lang/ja/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/left-menu.php
+++ b/lang/ja/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/maintenance.php
+++ b/lang/ja/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/profile.php
+++ b/lang/ja/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/settings.php
+++ b/lang/ja/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/sharing.php
+++ b/lang/ja/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/statistics.php
+++ b/lang/ja/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/toasts.php
+++ b/lang/ja/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ja/users.php
+++ b/lang/ja/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/aspect_ratio.php
+++ b/lang/nl/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/changelogs.php
+++ b/lang/nl/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/diagnostics.php
+++ b/lang/nl/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/dialogs.php
+++ b/lang/nl/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/duplicate-finder.php
+++ b/lang/nl/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/fix-tree.php
+++ b/lang/nl/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/gallery.php
+++ b/lang/nl/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/jobs.php
+++ b/lang/nl/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/landing.php
+++ b/lang/nl/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/left-menu.php
+++ b/lang/nl/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/maintenance.php
+++ b/lang/nl/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/profile.php
+++ b/lang/nl/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/settings.php
+++ b/lang/nl/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/sharing.php
+++ b/lang/nl/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/statistics.php
+++ b/lang/nl/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/toasts.php
+++ b/lang/nl/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/nl/users.php
+++ b/lang/nl/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/aspect_ratio.php
+++ b/lang/no/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/changelogs.php
+++ b/lang/no/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/diagnostics.php
+++ b/lang/no/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/dialogs.php
+++ b/lang/no/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/duplicate-finder.php
+++ b/lang/no/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/fix-tree.php
+++ b/lang/no/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/gallery.php
+++ b/lang/no/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/jobs.php
+++ b/lang/no/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/landing.php
+++ b/lang/no/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/left-menu.php
+++ b/lang/no/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/maintenance.php
+++ b/lang/no/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/profile.php
+++ b/lang/no/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/settings.php
+++ b/lang/no/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/sharing.php
+++ b/lang/no/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/statistics.php
+++ b/lang/no/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/toasts.php
+++ b/lang/no/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/no/users.php
+++ b/lang/no/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/aspect_ratio.php
+++ b/lang/pl/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/changelogs.php
+++ b/lang/pl/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/diagnostics.php
+++ b/lang/pl/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/dialogs.php
+++ b/lang/pl/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/duplicate-finder.php
+++ b/lang/pl/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/fix-tree.php
+++ b/lang/pl/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/gallery.php
+++ b/lang/pl/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/jobs.php
+++ b/lang/pl/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/landing.php
+++ b/lang/pl/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/left-menu.php
+++ b/lang/pl/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/maintenance.php
+++ b/lang/pl/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/profile.php
+++ b/lang/pl/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/settings.php
+++ b/lang/pl/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/sharing.php
+++ b/lang/pl/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/statistics.php
+++ b/lang/pl/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/toasts.php
+++ b/lang/pl/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pl/users.php
+++ b/lang/pl/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/aspect_ratio.php
+++ b/lang/pt/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/changelogs.php
+++ b/lang/pt/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/diagnostics.php
+++ b/lang/pt/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/dialogs.php
+++ b/lang/pt/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/duplicate-finder.php
+++ b/lang/pt/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/fix-tree.php
+++ b/lang/pt/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/gallery.php
+++ b/lang/pt/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/jobs.php
+++ b/lang/pt/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/landing.php
+++ b/lang/pt/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/left-menu.php
+++ b/lang/pt/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/maintenance.php
+++ b/lang/pt/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/profile.php
+++ b/lang/pt/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/settings.php
+++ b/lang/pt/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/sharing.php
+++ b/lang/pt/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/statistics.php
+++ b/lang/pt/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/toasts.php
+++ b/lang/pt/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/pt/users.php
+++ b/lang/pt/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/aspect_ratio.php
+++ b/lang/ru/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/changelogs.php
+++ b/lang/ru/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/diagnostics.php
+++ b/lang/ru/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/dialogs.php
+++ b/lang/ru/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/duplicate-finder.php
+++ b/lang/ru/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/fix-tree.php
+++ b/lang/ru/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/gallery.php
+++ b/lang/ru/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/jobs.php
+++ b/lang/ru/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/landing.php
+++ b/lang/ru/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/left-menu.php
+++ b/lang/ru/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/maintenance.php
+++ b/lang/ru/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/profile.php
+++ b/lang/ru/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/settings.php
+++ b/lang/ru/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/sharing.php
+++ b/lang/ru/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/statistics.php
+++ b/lang/ru/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/toasts.php
+++ b/lang/ru/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/ru/users.php
+++ b/lang/ru/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/aspect_ratio.php
+++ b/lang/sk/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/changelogs.php
+++ b/lang/sk/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/diagnostics.php
+++ b/lang/sk/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/dialogs.php
+++ b/lang/sk/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/duplicate-finder.php
+++ b/lang/sk/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/fix-tree.php
+++ b/lang/sk/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/gallery.php
+++ b/lang/sk/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/jobs.php
+++ b/lang/sk/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/landing.php
+++ b/lang/sk/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/left-menu.php
+++ b/lang/sk/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/maintenance.php
+++ b/lang/sk/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/profile.php
+++ b/lang/sk/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/settings.php
+++ b/lang/sk/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/sharing.php
+++ b/lang/sk/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/statistics.php
+++ b/lang/sk/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/toasts.php
+++ b/lang/sk/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sk/users.php
+++ b/lang/sk/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/aspect_ratio.php
+++ b/lang/sv/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/changelogs.php
+++ b/lang/sv/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/diagnostics.php
+++ b/lang/sv/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/dialogs.php
+++ b/lang/sv/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/duplicate-finder.php
+++ b/lang/sv/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/fix-tree.php
+++ b/lang/sv/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/gallery.php
+++ b/lang/sv/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/jobs.php
+++ b/lang/sv/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/landing.php
+++ b/lang/sv/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/left-menu.php
+++ b/lang/sv/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/maintenance.php
+++ b/lang/sv/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/profile.php
+++ b/lang/sv/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/settings.php
+++ b/lang/sv/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/sharing.php
+++ b/lang/sv/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/statistics.php
+++ b/lang/sv/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/toasts.php
+++ b/lang/sv/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/sv/users.php
+++ b/lang/sv/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/aspect_ratio.php
+++ b/lang/vi/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/changelogs.php
+++ b/lang/vi/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/diagnostics.php
+++ b/lang/vi/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/dialogs.php
+++ b/lang/vi/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/duplicate-finder.php
+++ b/lang/vi/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/fix-tree.php
+++ b/lang/vi/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/gallery.php
+++ b/lang/vi/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/jobs.php
+++ b/lang/vi/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/landing.php
+++ b/lang/vi/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/left-menu.php
+++ b/lang/vi/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/maintenance.php
+++ b/lang/vi/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/profile.php
+++ b/lang/vi/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/settings.php
+++ b/lang/vi/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/sharing.php
+++ b/lang/vi/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/statistics.php
+++ b/lang/vi/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/toasts.php
+++ b/lang/vi/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/vi/users.php
+++ b/lang/vi/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/aspect_ratio.php
+++ b/lang/zh_CN/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/changelogs.php
+++ b/lang/zh_CN/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/diagnostics.php
+++ b/lang/zh_CN/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/dialogs.php
+++ b/lang/zh_CN/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/duplicate-finder.php
+++ b/lang/zh_CN/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/fix-tree.php
+++ b/lang/zh_CN/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/gallery.php
+++ b/lang/zh_CN/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/jobs.php
+++ b/lang/zh_CN/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/landing.php
+++ b/lang/zh_CN/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/left-menu.php
+++ b/lang/zh_CN/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/maintenance.php
+++ b/lang/zh_CN/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/profile.php
+++ b/lang/zh_CN/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/settings.php
+++ b/lang/zh_CN/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/sharing.php
+++ b/lang/zh_CN/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/statistics.php
+++ b/lang/zh_CN/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/toasts.php
+++ b/lang/zh_CN/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_CN/users.php
+++ b/lang/zh_CN/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/aspect_ratio.php
+++ b/lang/zh_TW/aspect_ratio.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/changelogs.php
+++ b/lang/zh_TW/changelogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/diagnostics.php
+++ b/lang/zh_TW/diagnostics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/dialogs.php
+++ b/lang/zh_TW/dialogs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/duplicate-finder.php
+++ b/lang/zh_TW/duplicate-finder.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/fix-tree.php
+++ b/lang/zh_TW/fix-tree.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/gallery.php
+++ b/lang/zh_TW/gallery.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/jobs.php
+++ b/lang/zh_TW/jobs.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/landing.php
+++ b/lang/zh_TW/landing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/left-menu.php
+++ b/lang/zh_TW/left-menu.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/maintenance.php
+++ b/lang/zh_TW/maintenance.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/profile.php
+++ b/lang/zh_TW/profile.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/settings.php
+++ b/lang/zh_TW/settings.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/sharing.php
+++ b/lang/zh_TW/sharing.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/statistics.php
+++ b/lang/zh_TW/statistics.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/toasts.php
+++ b/lang/zh_TW/toasts.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/lang/zh_TW/users.php
+++ b/lang/zh_TW/users.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/routes/web-admin-v2.php
+++ b/routes/web-admin-v2.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/routes/web-install.php
+++ b/routes/web-install.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/routes/web_v2.php
+++ b/routes/web_v2.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/scripts/gen_release.php
+++ b/scripts/gen_release.php
@@ -3,7 +3,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 
@@ -22,7 +21,6 @@ $template = "<?php
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/scripts/install_files.php
+++ b/scripts/install_files.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/BootExtension.php
+++ b/tests/BootExtension.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Constants/FreeVerifyier.php
+++ b/tests/Constants/FreeVerifyier.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Constants/SupporterVerifyier.php
+++ b/tests/Constants/SupporterVerifyier.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Constants/TestConstants.php
+++ b/tests/Constants/TestConstants.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/AlbumCreateTagTest.php
+++ b/tests/Feature_v2/Album/AlbumCreateTagTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/AlbumCreateTest.php
+++ b/tests/Feature_v2/Album/AlbumCreateTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/AlbumDeleteTest.php
+++ b/tests/Feature_v2/Album/AlbumDeleteTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/AlbumListTest.php
+++ b/tests/Feature_v2/Album/AlbumListTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/AlbumMergeTest.php
+++ b/tests/Feature_v2/Album/AlbumMergeTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/AlbumMoveTest.php
+++ b/tests/Feature_v2/Album/AlbumMoveTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/AlbumRenameTest.php
+++ b/tests/Feature_v2/Album/AlbumRenameTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/AlbumSetCoverTest.php
+++ b/tests/Feature_v2/Album/AlbumSetCoverTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/AlbumSetHeaderTest.php
+++ b/tests/Feature_v2/Album/AlbumSetHeaderTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/AlbumTest.php
+++ b/tests/Feature_v2/Album/AlbumTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/AlbumTransferTest.php
+++ b/tests/Feature_v2/Album/AlbumTransferTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/AlbumUpdateTest.php
+++ b/tests/Feature_v2/Album/AlbumUpdateTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/AlbumsTest.php
+++ b/tests/Feature_v2/Album/AlbumsTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/ConfigTest.php
+++ b/tests/Feature_v2/Album/ConfigTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Album/SharingTest.php
+++ b/tests/Feature_v2/Album/SharingTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/AuthTest.php
+++ b/tests/Feature_v2/AuthTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Base/BaseApiV2Test.php
+++ b/tests/Feature_v2/Base/BaseApiV2Test.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Base/BaseV2Test.php
+++ b/tests/Feature_v2/Base/BaseV2Test.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Caching/CachingConfigTest.php
+++ b/tests/Feature_v2/Caching/CachingConfigTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Diagnostics/ConfigTest.php
+++ b/tests/Feature_v2/Diagnostics/ConfigTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Diagnostics/ErrorsTest.php
+++ b/tests/Feature_v2/Diagnostics/ErrorsTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Diagnostics/InfoTest.php
+++ b/tests/Feature_v2/Diagnostics/InfoTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Diagnostics/PermissionTest.php
+++ b/tests/Feature_v2/Diagnostics/PermissionTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Diagnostics/SpaceTest.php
+++ b/tests/Feature_v2/Diagnostics/SpaceTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Frame/FrameTest.php
+++ b/tests/Feature_v2/Frame/FrameTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Jobs/GetJobTest.php
+++ b/tests/Feature_v2/Jobs/GetJobTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/LandingTest.php
+++ b/tests/Feature_v2/LandingTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Maintenance/CleaningTest.php
+++ b/tests/Feature_v2/Maintenance/CleaningTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Maintenance/DuplicateFinderTest.php
+++ b/tests/Feature_v2/Maintenance/DuplicateFinderTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Maintenance/FlushTest.php
+++ b/tests/Feature_v2/Maintenance/FlushTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Maintenance/FullTreeTest.php
+++ b/tests/Feature_v2/Maintenance/FullTreeTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Maintenance/GenSizeVariantsTest.php
+++ b/tests/Feature_v2/Maintenance/GenSizeVariantsTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Maintenance/JobsTest.php
+++ b/tests/Feature_v2/Maintenance/JobsTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Maintenance/MissingFileSizeTest.php
+++ b/tests/Feature_v2/Maintenance/MissingFileSizeTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Maintenance/OptimizeTest.php
+++ b/tests/Feature_v2/Maintenance/OptimizeTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Maintenance/RegisterTest.php
+++ b/tests/Feature_v2/Maintenance/RegisterTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Maintenance/TreeTest.php
+++ b/tests/Feature_v2/Maintenance/TreeTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Maintenance/UpdateTest.php
+++ b/tests/Feature_v2/Maintenance/UpdateTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Map/MapTest.php
+++ b/tests/Feature_v2/Map/MapTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Metrics/EventsFiredTest.php
+++ b/tests/Feature_v2/Metrics/EventsFiredTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Oauth/OauthTest.php
+++ b/tests/Feature_v2/Oauth/OauthTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/PagesTest.php
+++ b/tests/Feature_v2/PagesTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Photo/PhotoCopyTest.php
+++ b/tests/Feature_v2/Photo/PhotoCopyTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Photo/PhotoDeleteTest.php
+++ b/tests/Feature_v2/Photo/PhotoDeleteTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Photo/PhotoEditTest.php
+++ b/tests/Feature_v2/Photo/PhotoEditTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Photo/PhotoMoveTest.php
+++ b/tests/Feature_v2/Photo/PhotoMoveTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Photo/PhotoRenameTest.php
+++ b/tests/Feature_v2/Photo/PhotoRenameTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Photo/PhotoStarTest.php
+++ b/tests/Feature_v2/Photo/PhotoStarTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Photo/PhotoTagsTest.php
+++ b/tests/Feature_v2/Photo/PhotoTagsTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/ProfileTest.php
+++ b/tests/Feature_v2/ProfileTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Search/SearchTest.php
+++ b/tests/Feature_v2/Search/SearchTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Settings/GetAllSettingsTest.php
+++ b/tests/Feature_v2/Settings/GetAllSettingsTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Settings/UpdateSettingsTest.php
+++ b/tests/Feature_v2/Settings/UpdateSettingsTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Statistics/AlbumSpaceTest.php
+++ b/tests/Feature_v2/Statistics/AlbumSpaceTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Statistics/CountsOverTimeTest.php
+++ b/tests/Feature_v2/Statistics/CountsOverTimeTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Statistics/SizeVariantSpaceTest.php
+++ b/tests/Feature_v2/Statistics/SizeVariantSpaceTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Statistics/TotalAlbumSpaceTest.php
+++ b/tests/Feature_v2/Statistics/TotalAlbumSpaceTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/Statistics/UserSpaceTest.php
+++ b/tests/Feature_v2/Statistics/UserSpaceTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/UpTest.php
+++ b/tests/Feature_v2/UpTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/UserManagement/CreateUserTest.php
+++ b/tests/Feature_v2/UserManagement/CreateUserTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/UserManagement/DeleteUserTest.php
+++ b/tests/Feature_v2/UserManagement/DeleteUserTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/UserManagement/EditUserTest.php
+++ b/tests/Feature_v2/UserManagement/EditUserTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/UserManagement/ListUserTest.php
+++ b/tests/Feature_v2/UserManagement/ListUserTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/UsersTest.php
+++ b/tests/Feature_v2/UsersTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/VersionTest.php
+++ b/tests/Feature_v2/VersionTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Feature_v2/WebAuthTest.php
+++ b/tests/Feature_v2/WebAuthTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/LoadedSubscriber.php
+++ b/tests/LoadedSubscriber.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/MigrateApplication.php
+++ b/tests/MigrateApplication.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Traits/CatchFailures.php
+++ b/tests/Traits/CatchFailures.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Traits/InteractWithSmartAlbums.php
+++ b/tests/Traits/InteractWithSmartAlbums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Traits/InteractsWithFilesystemPermissions.php
+++ b/tests/Traits/InteractsWithFilesystemPermissions.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Traits/InteractsWithRaw.php
+++ b/tests/Traits/InteractsWithRaw.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Traits/RequireSE.php
+++ b/tests/Traits/RequireSE.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Traits/RequireSupport.php
+++ b/tests/Traits/RequireSupport.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Traits/RequiresEmptyAlbums.php
+++ b/tests/Traits/RequiresEmptyAlbums.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Traits/RequiresEmptyPhotos.php
+++ b/tests/Traits/RequiresEmptyPhotos.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Traits/RequiresEmptyUsers.php
+++ b/tests/Traits/RequiresEmptyUsers.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Traits/RequiresEmptyWebAuthnCredentials.php
+++ b/tests/Traits/RequiresEmptyWebAuthnCredentials.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Traits/RequiresExifTool.php
+++ b/tests/Traits/RequiresExifTool.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Traits/RequiresFFMpeg.php
+++ b/tests/Traits/RequiresFFMpeg.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Traits/RequiresImageHandler.php
+++ b/tests/Traits/RequiresImageHandler.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Caching/CacheListenerTest.php
+++ b/tests/Unit/Caching/CacheListenerTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Caching/RouteCacherTest.php
+++ b/tests/Unit/Caching/RouteCacherTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Casts/DateTimeWithTimezoneCastTest.php
+++ b/tests/Unit/Casts/DateTimeWithTimezoneCastTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/CopyrightTest.php
+++ b/tests/Unit/CopyrightTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/CopyrightTest.php
+++ b/tests/Unit/CopyrightTest.php
@@ -24,7 +24,7 @@ use Tests\AbstractTestCase;
 
 class CopyrightTest extends AbstractTestCase
 {
-	public const COPYRIGHT = "<?php\n\n/**\n * SPDX-License-Identifier: MIT\n * Copyright (c) 2017-2018 Tobias Reich\n * Copyright (c) 2018-2025 LycheeOrg.\n */\n";
+	public const COPYRIGHT = "<?php\n\n/**\n * SPDX-License-Identifier: MIT\n * Copyright (c) 2018-2025 LycheeOrg.\n */\n";
 	private ConsoleSectionOutput $msgSection;
 	private bool $failed = false;
 	private int $length = 0;

--- a/tests/Unit/CoverageTest.php
+++ b/tests/Unit/CoverageTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/FeaturesUnitTest.php
+++ b/tests/Unit/FeaturesUnitTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/GitRemoteTest.php
+++ b/tests/Unit/GitRemoteTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/HelpersUnitTest.php
+++ b/tests/Unit/HelpersUnitTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/HoneyPotTest.php
+++ b/tests/Unit/HoneyPotTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/AddAlbumRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/AddAlbumRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/AddTagAlbumRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/AddTagAlbumRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/DeleteAlbumsRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/DeleteAlbumsRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/DeleteTrackRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/DeleteTrackRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/GetAlbumRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/GetAlbumRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/MergeAlbumRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/MergeAlbumRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/MoveAlbumsRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/MoveAlbumsRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/RenameAlbumRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/RenameAlbumRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/SetAlbumProtectionPolicyRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/SetAlbumProtectionPolicyRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/SetAlbumTrackRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/SetAlbumTrackRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/SetAsCoverRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/SetAsCoverRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/SetAsHeaderRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/SetAsHeaderRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/TargetListAlbumRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/TargetListAlbumRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/TransferAlbumRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/TransferAlbumRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/UnlockAlbumRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/UnlockAlbumRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/UpdateAlbumRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/UpdateAlbumRequestTest.php
@@ -71,7 +71,7 @@ class UpdateAlbumRequestTest extends BaseRequestTest
 			RequestAttribute::ALBUM_SORTING_ORDER_ATTRIBUTE => OrderSortingType::ASC->value,
 			RequestAttribute::ALBUM_ASPECT_RATIO_ATTRIBUTE => AspectRatioType::aspect1byx9->value,
 			RequestAttribute::ALBUM_PHOTO_LAYOUT => PhotoLayoutType::JUSTIFIED->value,
-			RequestAttribute::COPYRIGHT_ATTRIBUTE => 'Copyright (c) 2017-2018 Tobias Reich',
+			RequestAttribute::COPYRIGHT_ATTRIBUTE => 'Copyright (c) 2018-2024 LycheeOrg',
 			RequestAttribute::ALBUM_TIMELINE_ALBUM => TimelineAlbumGranularity::DEFAULT->value,
 			RequestAttribute::ALBUM_TIMELINE_PHOTO => TimelineAlbumGranularity::DAY->value,
 			//			RequestAttribute::ALBUM_PHOTO_LAYOUT => PhotoSortingCriterion::ALBUM_PHOTO_LAYOUT_GRID->value,

--- a/tests/Unit/Http/Requests/Album/UpdateAlbumRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/UpdateAlbumRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/UpdateTagAlbumRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/UpdateTagAlbumRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Album/UpdateTagAlbumRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/UpdateTagAlbumRequestTest.php
@@ -62,7 +62,7 @@ class UpdateTagAlbumRequestTest extends BaseRequestTest
 			RequestAttribute::PHOTO_SORTING_ORDER_ATTRIBUTE => OrderSortingType::ASC->value,
 			RequestAttribute::ALBUM_PHOTO_LAYOUT => PhotoLayoutType::JUSTIFIED->value,
 			RequestAttribute::ALBUM_TIMELINE_PHOTO => TimelinePhotoGranularity::DEFAULT->value,
-			RequestAttribute::COPYRIGHT_ATTRIBUTE => 'Copyright (c) 2017-2018 Tobias Reich',
+			RequestAttribute::COPYRIGHT_ATTRIBUTE => 'Copyright (c) 2018-2024 LycheeOrg',
 			RequestAttribute::TAGS_ATTRIBUTE => ['tag1', 'tag2'],
 		]);
 

--- a/tests/Unit/Http/Requests/Album/ZipRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/ZipRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Http/Requests/Base/BaseRequestTest.php
+++ b/tests/Unit/Http/Requests/Base/BaseRequestTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/LangTest.php
+++ b/tests/Unit/LangTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Metadata/Cache/RouteCacheManagerTest.php
+++ b/tests/Unit/Metadata/Cache/RouteCacheManagerTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Middleware/ConfigIntegrityTest.php
+++ b/tests/Unit/Middleware/ConfigIntegrityTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Middleware/HasAdminUserTest.php
+++ b/tests/Unit/Middleware/HasAdminUserTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Middleware/LatencyTest.php
+++ b/tests/Unit/Middleware/LatencyTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Middleware/LoginRequiredTest.php
+++ b/tests/Unit/Middleware/LoginRequiredTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Middleware/MigrationStatusTest.php
+++ b/tests/Unit/Middleware/MigrationStatusTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Models/AccessPermissionTest.php
+++ b/tests/Unit/Models/AccessPermissionTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Models/AlbumTest.php
+++ b/tests/Unit/Models/AlbumTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Models/ConfigsTest.php
+++ b/tests/Unit/Models/ConfigsTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Models/PhotoTest.php
+++ b/tests/Unit/Models/PhotoTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Redirections/ToAdminSetterTest.php
+++ b/tests/Unit/Redirections/ToAdminSetterTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Redirections/ToHomeTest.php
+++ b/tests/Unit/Redirections/ToHomeTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Redirections/ToMigrationTest.php
+++ b/tests/Unit/Redirections/ToMigrationTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/RootTest.php
+++ b/tests/Unit/RootTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Rules/AlbumIDListRuleTest.php
+++ b/tests/Unit/Rules/AlbumIDListRuleTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Rules/AlbumIDRuleTest.php
+++ b/tests/Unit/Rules/AlbumIDRuleTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Rules/ConfigKeyRequireSupportRuleTest.php
+++ b/tests/Unit/Rules/ConfigKeyRequireSupportRuleTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Rules/ConfigKeyRuleTest.php
+++ b/tests/Unit/Rules/ConfigKeyRuleTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Rules/ConfigValueRuleTest.php
+++ b/tests/Unit/Rules/ConfigValueRuleTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Rules/CurrentPasswordRuleTest.php
+++ b/tests/Unit/Rules/CurrentPasswordRuleTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Rules/EnumRequireSupportRuleTest.php
+++ b/tests/Unit/Rules/EnumRequireSupportRuleTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Rules/ExtensionRuleTest.php
+++ b/tests/Unit/Rules/ExtensionRuleTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Rules/FileUuidRuleTest.php
+++ b/tests/Unit/Rules/FileUuidRuleTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Rules/RandomIDListRuleTest.php
+++ b/tests/Unit/Rules/RandomIDListRuleTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Rules/RequireSupportRuleTest.php
+++ b/tests/Unit/Rules/RequireSupportRuleTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/Rules/StringRuleTest.php
+++ b/tests/Unit/Rules/StringRuleTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/tests/Unit/VersionDTOUnitTest.php
+++ b/tests/Unit/VersionDTOUnitTest.php
@@ -2,7 +2,6 @@
 
 /**
  * SPDX-License-Identifier: MIT
- * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 


### PR DESCRIPTION
The totality of Lychee has been rewritten, not a single line of code from electerious is left in the current code base.
As a consequence, the MIT copyright requirement no longer applies.