### PR TITLE
Fix 422 error on Photo Metrics

### DIFF
--- a/resources/js/services/metrics-service.ts
+++ b/resources/js/services/metrics-service.ts
@@ -6,7 +6,7 @@ const MetricsService = {
 		return axios.get(`${Constants.getApiUrl()}Metrics`, { data: {} });
 	},
 
-	photo(photo_id: string): Promise<AxiosResponse<null>|null> {
+	photo(photo_id: string): Promise<AxiosResponse<null> | null> {
 		if (!photo_id) {
 			// TODO: figure out why this sometimes happens...
 			// Do not send a request if no photo_id is provided, otherwise it breaks in front-end.

--- a/resources/js/services/metrics-service.ts
+++ b/resources/js/services/metrics-service.ts
@@ -6,7 +6,12 @@ const MetricsService = {
 		return axios.get(`${Constants.getApiUrl()}Metrics`, { data: {} });
 	},
 
-	photo(photo_id: string): Promise<AxiosResponse<null>> {
+	photo(photo_id: string): Promise<AxiosResponse<null>|null> {
+		if (!photo_id) {
+			// TODO: figure out why this sometimes happens...
+			// Do not send a request if no photo_id is provided, otherwise it breaks in front-end.
+			return Promise.resolve(null);
+		}
 		return axios.post(`${Constants.getApiUrl()}Metrics::photo`, { photo_ids: [photo_id] });
 	},
 


### PR DESCRIPTION
This pull request introduces a small but important change to the `photo` method in the `MetricsService`. The method now includes a safeguard to handle cases where `photo_id` is not provided, preventing unnecessary API calls and potential front-end issues.

* [`resources/js/services/metrics-service.ts`](diffhunk://#diff-e081103bbf5b4a618c2510746556b2a0d3f16d3eb95f48d1066d9f8847590b9eL9-R14): Updated the `photo` method to return `null` if `photo_id` is not provided, avoiding a request that could cause front-end errors. Added a `TODO` comment to investigate why `photo_id` might sometimes be missing.