### PR TITLE
Forgot to add 'self' to csp object policies. 

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -629,7 +629,18 @@ return [
 
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src
 		'object-src' => [
-			'none' => 'self', // Needed to display embeded pdf files.
+			'self' => true, // needed to display embeded pdf files
+			'allow' => array_merge(
+				[
+					'blob:', // required for "live" photos
+				],
+				// Add the S3 URL to the list of allowed media sources
+				env('AWS_ACCESS_KEY_ID', '') === '' ? [] :
+				[
+					str_replace(parse_url(env('AWS_URL'), PHP_URL_PATH), '', env('AWS_URL')),
+				],
+				explode(',', (string) env('SECURITY_HEADER_CSP_MEDIA_SRC', ''))
+			),
 		],
 
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types

--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -629,7 +629,7 @@ return [
 
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src
 		'object-src' => [
-			'none' => true,
+			'none' => 'self', // Needed to display embeded pdf files.
 		],
 
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types


### PR DESCRIPTION
Fixes pdf integration:
![image](https://github.com/user-attachments/assets/1a43ffb4-85e0-4535-a96e-1f9281037995)

@mitpjones this should be the reason why it was not working...
Expected display.
![image](https://github.com/user-attachments/assets/54d8ceba-51ef-419e-b233-d00ed817bd84)

This pull request updates the Content Security Policy (CSP) configuration in `config/secure-headers.php` to allow embedded PDF files and improve support for media sources such as live photos and S3-hosted content.

### Content Security Policy updates:
* Modified the `object-src` directive to allow `self` for embedded PDF files and added support for `blob:` URLs to enable "live" photos.
* Dynamically included the S3 URL and additional media sources from the `SECURITY_HEADER_CSP_MEDIA_SRC` environment variable in the `object-src` directive.