### PR TITLE
Use Medium image size for OpenGraph metadata

### DIFF
--- a/app/View/Components/Meta.php
+++ b/app/View/Components/Meta.php
@@ -91,7 +91,7 @@ class Meta extends Component
 		if ($this->photo !== null) {
 			$this->page_title = $this->photo->title;
 			$this->page_description = $this->photo->description ?? Configs::getValueAsString('site_title');
-			$this->image_url = $this->photo->size_variants->getMedium()?->url ?? $this->image_url;
+			$this->image_url = $this->photo->size_variants->getMedium()?->url ?? $this->photo->size_variants->getSmall()?->url ?? $this->image_url;
 		}
 	}
 

--- a/app/View/Components/Meta.php
+++ b/app/View/Components/Meta.php
@@ -91,7 +91,7 @@ class Meta extends Component
 		if ($this->photo !== null) {
 			$this->page_title = $this->photo->title;
 			$this->page_description = $this->photo->description ?? Configs::getValueAsString('site_title');
-			$this->image_url = $this->photo->size_variants->getSmall()?->url ?? $this->image_url;
+			$this->image_url = $this->photo->size_variants->getMedium()?->url ?? $this->image_url;
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the [Feedbin feed reader](https://feedbin.com) not displaying images from Lychee RSS feeds.

I've been trying to figure out why Feedbin doesn't show images from my Lychee installation's RSS feed. Per Ben from Feedbin, via email:

> Feedbin looks for these image sources in this order:
> - meta twitter:image and og:image tags on the linked web page
> - img tags found in the content of the rss feed
>
> There are some minimum size checks also:
>
> width >= 542
> height >= 304
> size >= 20kb

Regarding my Lychee feed, he said:

> I think that the meta images are too small and there are no img tags in the RSS content.

I've confirmed on my site that switching the OpenGraph metadata to medium-size image causes Feedbin to display images as expected.