### PR TITLE
Avoid displaying the live-metrics icon if not enabled

### DIFF
--- a/app/Http/Resources/GalleryConfigs/InitConfig.php
+++ b/app/Http/Resources/GalleryConfigs/InitConfig.php
@@ -83,6 +83,10 @@ class InitConfig extends Data
 	// or if they asked to hide it (because we are nice :) ).
 	public bool $is_se_info_hidden;
 
+	// Live Metrics settings
+	public bool $is_live_metrics_enabled;
+
+
 	public function __construct()
 	{
 		// Debug mode
@@ -174,5 +178,7 @@ class InitConfig extends Data
 
 		// We hide the info if we are already a supporter (or the user requests it).
 		$this->is_se_info_hidden = $is_supporter || Configs::getValueAsBool('disable_se_call_for_actions');
+
+		$this->is_live_metrics_enabled = $this->is_se_enabled && Configs::getValueAsBool('live_metrics_enabled');
 	}
 }

--- a/app/Http/Resources/GalleryConfigs/InitConfig.php
+++ b/app/Http/Resources/GalleryConfigs/InitConfig.php
@@ -86,7 +86,6 @@ class InitConfig extends Data
 	// Live Metrics settings
 	public bool $is_live_metrics_enabled;
 
-
 	public function __construct()
 	{
 		// Debug mode

--- a/lang/ar/statistics.php
+++ b/lang/ar/statistics.php
@@ -39,6 +39,7 @@ return [
     ],
     'metrics' => [
         'header' => '',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
         'a_visitor' => '',
         'visitors' => '',
         'visit_singular' => '',

--- a/lang/cz/statistics.php
+++ b/lang/cz/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/de/statistics.php
+++ b/lang/de/statistics.php
@@ -38,6 +38,7 @@ return [
     ],
     'metrics' => [
         'header' => 'Live-Metriken',
+        'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
         'a_visitor' => 'Ein Besucher',
         'visitors' => '%d Besucher',
         'visit_singular' => '%1$s angesehen %2$s',

--- a/lang/el/statistics.php
+++ b/lang/el/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/en/statistics.php
+++ b/lang/en/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/es/statistics.php
+++ b/lang/es/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/fr/statistics.php
+++ b/lang/fr/statistics.php
@@ -39,6 +39,7 @@ return [
     ],
     'metrics' => [
         'header' => 'Données en temps réel',
+		'preview_text' => 'Ceci est un aperçu des données en temps réel disponible dans Lychee <span class="text-primary-emphasis font-bold">SE</span>. Les données affichées ici sont générées aléatoirement et ne reflètent pas votre serveur.',
         'a_visitor' => 'Un visiteur',
         'visitors' => '%d visiteurs',
         'visit_singular' => '%1$s a vu %2$s',

--- a/lang/hu/statistics.php
+++ b/lang/hu/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/it/statistics.php
+++ b/lang/it/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/ja/statistics.php
+++ b/lang/ja/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/nl/statistics.php
+++ b/lang/nl/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/no/statistics.php
+++ b/lang/no/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/pl/statistics.php
+++ b/lang/pl/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/pt/statistics.php
+++ b/lang/pt/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/ru/statistics.php
+++ b/lang/ru/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/sk/statistics.php
+++ b/lang/sk/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/sv/statistics.php
+++ b/lang/sv/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/vi/statistics.php
+++ b/lang/vi/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/zh_CN/statistics.php
+++ b/lang/zh_CN/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/lang/zh_TW/statistics.php
+++ b/lang/zh_TW/statistics.php
@@ -41,6 +41,7 @@ return [
 	],
 	'metrics' => [
 		'header' => 'Live metrics',
+		'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
 		'a_visitor' => 'A visitor',
 		'visitors' => '%d visitors',
 		'visit_singular' => '%1$s viewed %2$s',

--- a/resources/js/components/headers/AlbumsHeader.vue
+++ b/resources/js/components/headers/AlbumsHeader.vue
@@ -126,7 +126,7 @@ const lycheeStore = useLycheeStateStore();
 const togglableStore = useTogglablesStateStore();
 const favourites = useFavouriteStore();
 
-const { dropbox_api_key, is_favourite_enabled } = storeToRefs(lycheeStore);
+const { dropbox_api_key, is_favourite_enabled, is_se_preview_enabled, is_live_metrics_enabled } = storeToRefs(lycheeStore);
 const { is_login_open, is_upload_visible, is_create_album_visible, is_create_tag_album_visible, is_metrics_open } = storeToRefs(togglableStore);
 
 const router = useRouter();
@@ -236,7 +236,13 @@ const menu = computed(() =>
 			icon: "pi pi-bell",
 			type: "fn",
 			callback: () => (is_metrics_open.value = true),
-			if: props.rights.can_see_live_metrics,
+			if: is_live_metrics_enabled.value && props.rights.can_see_live_metrics,
+		},
+		{
+			icon: "pi pi-bell text-primary-emphasis",
+			type: "fn",
+			callback: () => (is_metrics_open.value = true),
+			if: is_se_preview_enabled.value && props.rights.can_see_live_metrics,
 		},
 		{
 			icon: "pi pi-sign-in",

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -109,7 +109,7 @@ declare namespace App.Http.Resources.Collections {
 		id: string | null;
 		title: string | null;
 		track_url: string | null;
-		photos: App.Http.Resources.Models.PhotoResource[] | Array<any>;
+		photos: App.Http.Resources.Models.PhotoResource[];
 	};
 	export type RootAlbumResource = {
 		smart_albums: { [key: number]: App.Http.Resources.Models.ThumbAlbumResource } | Array<any>;
@@ -262,6 +262,7 @@ declare namespace App.Http.Resources.GalleryConfigs {
 		is_se_enabled: boolean;
 		is_se_preview_enabled: boolean;
 		is_se_info_hidden: boolean;
+		is_live_metrics_enabled: boolean;
 	};
 	export type LandingPageResource = {
 		landing_page_enable: boolean;
@@ -340,8 +341,8 @@ declare namespace App.Http.Resources.Models {
 		header_id: string | null;
 		parent_id: string | null;
 		has_albums: boolean;
-		albums: App.Http.Resources.Models.ThumbAlbumResource[] | Array<any>;
-		photos: App.Http.Resources.Models.PhotoResource[] | Array<any>;
+		albums: App.Http.Resources.Models.ThumbAlbumResource[];
+		photos: App.Http.Resources.Models.PhotoResource[];
 		cover_id: string | null;
 		thumb: App.Http.Resources.Models.ThumbResource | null;
 		policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
@@ -359,7 +360,7 @@ declare namespace App.Http.Resources.Models {
 		cat: string;
 		name: string;
 		description: string;
-		configs: App.Http.Resources.Models.ConfigResource[] | Array<any>;
+		configs: App.Http.Resources.Models.ConfigResource[];
 		priority: number;
 	};
 	export type ConfigResource = {
@@ -457,7 +458,7 @@ declare namespace App.Http.Resources.Models {
 	export type SmartAlbumResource = {
 		id: string;
 		title: string;
-		photos: App.Http.Resources.Models.PhotoResource[] | Array<any>;
+		photos: App.Http.Resources.Models.PhotoResource[];
 		thumb: App.Http.Resources.Models.ThumbResource | null;
 		policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
 		rights: App.Http.Resources.Rights.AlbumRightsResource;
@@ -471,7 +472,7 @@ declare namespace App.Http.Resources.Models {
 		copyright: string | null;
 		is_tag_album: boolean;
 		show_tags: Array<string>;
-		photos: App.Http.Resources.Models.PhotoResource[] | Array<any>;
+		photos: App.Http.Resources.Models.PhotoResource[];
 		thumb: App.Http.Resources.Models.ThumbResource | null;
 		policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
 		rights: App.Http.Resources.Rights.AlbumRightsResource;
@@ -683,27 +684,14 @@ declare namespace App.Http.Resources.Search {
 		photo_layout: App.Enum.PhotoLayoutType;
 	};
 	export type ResultsResource = {
-		albums: App.Http.Resources.Models.ThumbAlbumResource[] | Array<any>;
-		photos: App.Http.Resources.Models.PhotoResource[] | Array<any>;
+		albums: App.Http.Resources.Models.ThumbAlbumResource[];
+		photos: App.Http.Resources.Models.PhotoResource[];
 		current_page: number;
 		from: number;
 		last_page: number;
 		per_page: number;
 		to: number;
 		total: number;
-	};
-}
-declare namespace App.Http.Resources.Sharing {
-	export type ListedAlbumsResource = {
-		id: string;
-		title: string;
-	};
-	export type SharedAlbumResource = {
-		id: number;
-		user_id: number;
-		album_id: string;
-		username: string;
-		title: string;
 	};
 }
 declare namespace App.Http.Resources.Statistics {

--- a/resources/js/stores/LycheeState.ts
+++ b/resources/js/stores/LycheeState.ts
@@ -64,6 +64,7 @@ export const useLycheeStateStore = defineStore("lychee-store", {
 		is_se_enabled: false,
 		is_se_preview_enabled: false,
 		is_se_info_hidden: false,
+		is_live_metrics_enabled: false,
 
 		// Settings toggles
 		is_old_style: false,
@@ -126,6 +127,7 @@ export const useLycheeStateStore = defineStore("lychee-store", {
 					this.is_se_enabled = data.is_se_enabled;
 					this.is_se_preview_enabled = data.is_se_preview_enabled;
 					this.is_se_info_hidden = data.is_se_info_hidden;
+					this.is_live_metrics_enabled = data.is_live_metrics_enabled;
 					this.number_albums_per_row_mobile = data.number_albums_per_row_mobile;
 					this.photo_thumb_info = data.photo_thumb_info;
 


### PR DESCRIPTION
Add a flag to make sure we do not display the icon if the functionality is NOT enabled...

### Backend Changes:
* Added a new property `is_live_metrics_enabled` to the `InitConfig` class to track whether live metrics are enabled. (`app/Http/Resources/GalleryConfigs/InitConfig.php`)
* Updated the `set_supporter_properties` method in `InitConfig` to initialize `is_live_metrics_enabled` based on the configuration value `live_metrics_enabled` and the `is_se_enabled` flag. (`app/Http/Resources/GalleryConfigs/InitConfig.php`)

### Localization Changes:
* Added a `preview_text` field under the `metrics` section in language files to display a preview message for live metrics. This change was made across multiple language files, including but not limited to `ar`, `cz`, `de`, `en`, `fr`, `ja`, `ru`, and `zh_CN`. [[1]](diffhunk://#diff-f4c28edb449d29f9f17452a50dd16cd97e7fd268bf834dd6cc18c8aad548e618R42) [[2]](diffhunk://#diff-b6b510ac513f61e4a868fd4489a52a6c3e99af58a654e31206acab2a5bdb375bR44) [[3]](diffhunk://#diff-13add28f7ed91c89e9e10a7ebdabcf22f3d8942d933e8d57f81b094976073302R42) [[4]](diffhunk://#diff-8c40fda7f127c3fa28944dfa45a16754f64166b32da24af47af5a3a348daaf7cR44) [[5]](diffhunk://#diff-5fffeb52921e71cc661c53c6add599e106589673053072410ddaf208997668aaR44)

These changes ensure that the live metrics feature is properly integrated into the backend logic and is supported with localized text for a global audience.