### PR TITLE
Add thumbs creation for pdf if enabled in Imagick.

### DIFF
--- a/app/Actions/Diagnostics/Errors.php
+++ b/app/Actions/Diagnostics/Errors.php
@@ -20,6 +20,7 @@ use App\Actions\Diagnostics\Pipes\Checks\DBSupportCheck;
 use App\Actions\Diagnostics\Pipes\Checks\ForeignKeyListInfo;
 use App\Actions\Diagnostics\Pipes\Checks\GDSupportCheck;
 use App\Actions\Diagnostics\Pipes\Checks\ImageOptCheck;
+use App\Actions\Diagnostics\Pipes\Checks\ImagickPdfCheck;
 use App\Actions\Diagnostics\Pipes\Checks\IniSettingsCheck;
 use App\Actions\Diagnostics\Pipes\Checks\MigrationCheck;
 use App\Actions\Diagnostics\Pipes\Checks\OpCacheCheck;
@@ -61,6 +62,7 @@ class Errors
 		CachePasswordCheck::class,
 		CacheTemporaryUrlCheck::class,
 		SupporterCheck::class,
+		ImagickPdfCheck::class,
 	];
 
 	/**

--- a/app/Actions/Diagnostics/Pipes/Checks/ImagickPdfCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/ImagickPdfCheck.php
@@ -41,7 +41,7 @@ class ImagickPdfCheck implements DiagnosticPipe
 
 		try {
 			$imagic_policy = file_get_contents('/etc/ImageMagick-6/policy.xml');
-			if (preg_match('/<policy domain="coder" rights="none" pattern="PDF"/', $imagic_policy)) {
+			if (1 === preg_match('/<policy domain="coder" rights="none" pattern="PDF"/', $imagic_policy)) {
 				$data[] = DiagnosticData::warn('Imagick is not allowed to create thumbs for pdf files.', self::class,
 					['Verify that the /etc/ImageMagick-6/policy.xml file contains the line <policy domain="coder" rights="read|write" pattern="PDF"/> .']);
 			}

--- a/app/Actions/Diagnostics/Pipes/Checks/ImagickPdfCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/ImagickPdfCheck.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Diagnostics\Pipes\Checks;
+
+use App\Contracts\DiagnosticPipe;
+use App\DTO\DiagnosticData;
+use App\Models\Configs;
+use Illuminate\Support\Facades\Schema;
+use Safe\Exceptions\FilesystemException;
+use Safe\Exceptions\PcreException;
+use function Safe\file_get_contents;
+use function Safe\preg_match;
+
+/**
+ * Verify that we have some image optimization available if enabled.
+ */
+class ImagickPdfCheck implements DiagnosticPipe
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function handle(array &$data, \Closure $next): array
+	{
+		if (!Schema::hasTable('configs')) {
+			// @codeCoverageIgnoreStart
+			return $next($data);
+			// @codeCoverageIgnoreEnd
+		}
+
+		if (!Configs::hasImagick()) {
+			$data[] = DiagnosticData::info('Imagick is not enabled. Thumbs will not be created for pdf files.', self::class);
+
+			return $next($data);
+		}
+
+		try {
+			$imagic_policy = file_get_contents('/etc/ImageMagick-6/policy.xml');
+			if (preg_match('/<policy domain="coder" rights="none" pattern="PDF"/', $imagic_policy)) {
+				$data[] = DiagnosticData::warn('Imagick is not allowed to create thumbs for pdf files.', self::class,
+					['Verify that the /etc/ImageMagick-6/policy.xml file contains the line <policy domain="coder" rights="read|write" pattern="PDF"/> .']);
+			}
+		} catch (FilesystemException) {
+			$data[] = DiagnosticData::warn('Could not determine whether Imagick is allowed to work with pdf files.', self::class, [
+				'Make sure to have the policy.xml file in `/etc/ImageMagick-6/policy.xml`.',
+				'Verify that the file contains the line <policy domain="coder" rights="read|write" pattern="PDF"/> .',
+			]);
+		} catch (PcreException) {
+			// Just ignore.
+		}
+
+		return $next($data);
+	}
+}

--- a/app/Actions/Diagnostics/Pipes/Checks/ImagickPdfCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/ImagickPdfCheck.php
@@ -18,7 +18,7 @@ use function Safe\file_get_contents;
 use function Safe\preg_match;
 
 /**
- * Verify that we have some image optimization available if enabled.
+ * Verify that if Imagick is installed, it is allowed to work with pdf files.
  */
 class ImagickPdfCheck implements DiagnosticPipe
 {

--- a/app/Image/Files/BaseMediaFile.php
+++ b/app/Image/Files/BaseMediaFile.php
@@ -272,6 +272,12 @@ abstract class BaseMediaFile extends AbstractBinaryBlob implements MediaFile
 	{
 		if (count(self::$cachedAcceptedRawFileExtensions) === 0) {
 			$tmp = explode('|', strtolower(Configs::getValueAsString('raw_formats')));
+
+			// We imagick is enabeld, then we can allow PDF files.
+			if (Configs::hasImagick()) {
+				$tmp[] = '.pdf';
+			}
+
 			// Explode may return `false` on error
 			// Our supported file extensions always take precedence over any
 			// custom configured extension

--- a/app/Image/Handlers/ImagickHandler.php
+++ b/app/Image/Handlers/ImagickHandler.php
@@ -14,6 +14,7 @@ use App\Contracts\Image\StreamStats;
 use App\DTO\ImageDimension;
 use App\Exceptions\ImageProcessingException;
 use App\Exceptions\MediaFileOperationException;
+use App\Image\Files\BaseMediaFile;
 use App\Image\Files\InMemoryBuffer;
 use Imagick;
 
@@ -65,7 +66,7 @@ class ImagickHandler extends BaseImageHandler
 			$this->im_image->readImageFile($input_stream);
 
 			// If the file is a PDF and the user has chosen to support PDF files then try to create an image from the first page
-			if ($file->getExtension() === '.pdf' && $file->isSupportedOrAcceptedFileExtension($file->getExtension())) {
+			if ($file->getExtension() === '.pdf' && BaseMediaFile::isSupportedOrAcceptedFileExtension($file->getExtension())) {
 				$this->im_image->setIteratorIndex(0);
 			}
 

--- a/app/Image/Handlers/ImagickHandler.php
+++ b/app/Image/Handlers/ImagickHandler.php
@@ -63,6 +63,12 @@ class ImagickHandler extends BaseImageHandler
 
 			$this->im_image = new \Imagick();
 			$this->im_image->readImageFile($input_stream);
+
+			// If the file is a PDF and the user has chosen to support PDF files then try to create an image from the first page
+			if ($file->getExtension() === '.pdf' && $file->isSupportedOrAcceptedFileExtension($file->getExtension())) {
+				$this->im_image->setIteratorIndex(0);
+			}
+
 			$this->autoRotate();
 		} catch (\ImagickException $e) {
 			throw new MediaFileOperationException('Failed to load image', $e);


### PR DESCRIPTION
This pull request introduces support for handling PDF files using Imagick in the application. The changes include adding a new diagnostic check for Imagick's PDF capabilities, updating file extension handling to include PDFs, and modifying the Imagick handler to process the first page of PDF files.

### Diagnostics Enhancements:
* Added a new `ImagickPdfCheck` class to verify if Imagick is enabled and configured to handle PDF files. It checks the `policy.xml` file for proper permissions and provides warnings if misconfigured. (`app/Actions/Diagnostics/Pipes/Checks/ImagickPdfCheck.php`, [app/Actions/Diagnostics/Pipes/Checks/ImagickPdfCheck.phpR1-R59](diffhunk://#diff-aea50fbc9331d0a6b5cc5dc077c827f4d35256623e6de442bedfd123c25f0d39R1-R59))
* Registered the `ImagickPdfCheck` in the `Errors` class to include it in the diagnostics pipeline. (`app/Actions/Diagnostics/Errors.php`, [[1]](diffhunk://#diff-cd0f99f20efa398dce5f099ad81b1003c76a49c69b651fa8a530cd6ce6d64c66R23) [[2]](diffhunk://#diff-cd0f99f20efa398dce5f099ad81b1003c76a49c69b651fa8a530cd6ce6d64c66R65)

### PDF File Handling:
* Updated `getSanitizedAcceptedRawFileExtensions` in `BaseMediaFile` to include `.pdf` as an accepted file extension when Imagick is enabled. (`app/Image/Files/BaseMediaFile.php`, [app/Image/Files/BaseMediaFile.phpR275-R280](diffhunk://#diff-d7e77a967116233570285e3b7281ac338f0fde0875b7872b77e7f5794952b6e1R275-R280))
* Modified the `ImagickHandler` to process the first page of PDF files when loading them, ensuring proper image generation for PDFs. (`app/Image/Handlers/ImagickHandler.php`, [app/Image/Handlers/ImagickHandler.phpR66-R71](diffhunk://#diff-802518dddf9057bc9035b61f450c0fb480be87051b2015911ce002e69f3eb877R66-R71))

@mitpjones There you go :)