### PR TITLE
Option for bigger sized previous/next buttons

### DIFF
--- a/app/Enum/SmallLargeType.php
+++ b/app/Enum/SmallLargeType.php
@@ -14,5 +14,5 @@ namespace App\Enum;
 enum SmallLargeType: string
 {
 	case SMALL = 'small';
-	case LARGE = 'large'; // 1
+	case LARGE = 'large';
 }

--- a/app/Enum/SmallLargeType.php
+++ b/app/Enum/SmallLargeType.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Enum;
+
+/**
+ * Enum SmallLargeType.
+ */
+enum SmallLargeType: string
+{
+	case SMALL = 'small';
+	case LARGE = 'large'; // 1
+}

--- a/app/Http/Resources/GalleryConfigs/InitConfig.php
+++ b/app/Http/Resources/GalleryConfigs/InitConfig.php
@@ -12,6 +12,7 @@ use App\Enum\AlbumDecorationOrientation;
 use App\Enum\AlbumDecorationType;
 use App\Enum\ImageOverlayType;
 use App\Enum\PhotoThumbInfoType;
+use App\Enum\SmallLargeType;
 use App\Enum\ThumbAlbumSubtitleType;
 use App\Enum\ThumbOverlayVisibilityType;
 use App\Models\Configs;
@@ -43,6 +44,7 @@ class InitConfig extends Data
 	public bool $can_autoplay;
 	public bool $is_exif_disabled;
 	public bool $is_favourite_enabled;
+	public SmallLargeType $photo_previous_next_size;
 
 	// Thumbs configuration
 	public ThumbOverlayVisibilityType $display_thumb_album_overlay;
@@ -106,6 +108,7 @@ class InitConfig extends Data
 		$this->can_autoplay = Configs::getValueAsBool('autoplay_enabled');
 		$this->is_exif_disabled = Configs::getValueAsBool('exif_disabled_for_all');
 		$this->is_favourite_enabled = Configs::getValueAsBool('client_side_favourite_enabled');
+		$this->photo_previous_next_size = Configs::getValueAsEnum('photo_previous_next_size', SmallLargeType::class);
 
 		// Thumbs configuration
 		$this->display_thumb_album_overlay = Configs::getValueAsEnum('display_thumb_album_overlay', ThumbOverlayVisibilityType::class);

--- a/database/migrations/2025_05_17_075632_optional-bigger-left-right-icons.php
+++ b/database/migrations/2025_05_17_075632_optional-bigger-left-right-icons.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const CAT = 'Gallery';
+
+	public function getConfigs(): array
+	{
+		// landing_background
+		return [
+			[
+				'key' => 'photo_previous_next_size',
+				'value' => 'small',
+				'cat' => self::CAT,
+				'type_range' => 'small|large',
+				'description' => 'Select the size of the previous/next buttons in photo view.',
+				'details' => 'Those buttons are hidden by default and only visible when the mouse get close to the left/right side of the screen.',
+				'is_expert' => true,
+				'is_secret' => true,
+				'level' => 0,
+				'order' => 36,
+			],
+		];
+	}
+};

--- a/resources/js/components/gallery/photoModule/NextPrevious.vue
+++ b/resources/js/components/gallery/photoModule/NextPrevious.vue
@@ -4,13 +4,17 @@
 			:to="photoRoute(props.photoId)"
 			:id="props.is_next ? 'nextButton' : 'previousButton'"
 			:class="{
-				'absolute top-1/2 border border-solid border-neutral-200 -mt-5 py-2 px-3 transition-all opacity-0 group-hover:opacity-100 bg-cover': true,
+				'absolute top-1/2 border border-solid border-neutral-200 dark:border-neutral-700': true,
+				'-mt-5 transition-all opacity-0 group-hover:opacity-100 bg-cover': true,
+				'py-10.75 px-11': photo_previous_next_size === 'large',
+				'py-2 px-3': photo_previous_next_size === 'small',
+				'hover:border-primary-400 fill-neutral-400 hover:fill-primary-400': true,
 				'-right-px group-hover:translate-x-0 translate-x-full': props.is_next,
 				'-left-px group-hover:translate-x-0 -translate-x-full': !props.is_next,
 			}"
 			:style="props.style"
 		>
-			<MiniIcon :icon="props.is_next ? 'caret-right' : 'caret-left'" class="my-0 h-6 w-5 mr-0 ml-0" />
+			<MiniIcon :icon="props.is_next ? 'caret-right' : 'caret-left'" :fill="''" class="m-0 h-6 w-5" />
 		</router-link>
 	</div>
 </template>
@@ -18,6 +22,11 @@
 import MiniIcon from "@/components/icons/MiniIcon.vue";
 import { usePhotoRoute } from "@/composables/photo/photoRoute";
 import { useRouter } from "vue-router";
+import { useLycheeStateStore } from "@/stores/LycheeState";
+import { storeToRefs } from "pinia";
+
+const lycheeStateStore = useLycheeStateStore();
+const { photo_previous_next_size } = storeToRefs(lycheeStateStore);
 
 const props = defineProps<{
 	is_next: boolean;

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -95,6 +95,7 @@ declare namespace App.Enum {
 	export type PhotoThumbInfoType = "title" | "description";
 	export type SeverityType = "emergency" | "alert" | "critical" | "error" | "warning" | "notice" | "info" | "debug";
 	export type SizeVariantType = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+	export type SmallLargeType = "small" | "large";
 	export type SmartAlbumType = "unsorted" | "starred" | "recent" | "on_this_day";
 	export type StorageDiskType = "images" | "s3";
 	export type ThumbAlbumSubtitleType = "description" | "takedate" | "creation" | "oldstyle";
@@ -241,6 +242,7 @@ declare namespace App.Http.Resources.GalleryConfigs {
 		can_autoplay: boolean;
 		is_exif_disabled: boolean;
 		is_favourite_enabled: boolean;
+		photo_previous_next_size: App.Enum.SmallLargeType;
 		display_thumb_album_overlay: App.Enum.ThumbOverlayVisibilityType;
 		display_thumb_photo_overlay: App.Enum.ThumbOverlayVisibilityType;
 		album_subtitle_type: App.Enum.ThumbAlbumSubtitleType;

--- a/resources/js/stores/LycheeState.ts
+++ b/resources/js/stores/LycheeState.ts
@@ -29,6 +29,7 @@ export const useLycheeStateStore = defineStore("lychee-store", {
 		can_autoplay: false,
 		is_exif_disabled: false,
 		is_favourite_enabled: false,
+		photo_previous_next_size: "small" as App.Enum.SmallLargeType,
 
 		// keybinding help
 		show_keybinding_help_popup: false,
@@ -137,6 +138,7 @@ export const useLycheeStateStore = defineStore("lychee-store", {
 					this.is_small2x_download_enabled = data.is_small2x_download_enabled;
 					this.is_medium_download_enabled = data.is_medium_download_enabled;
 					this.is_medium2x_download_enabled = data.is_medium2x_download_enabled;
+					this.photo_previous_next_size = data.photo_previous_next_size;
 				})
 				.catch((error) => {
 					// In this specific case, even though it has been possibly disabled, we really need to see the error.


### PR DESCRIPTION
This pull request introduces a new configuration option for customizing the size of the "previous" and "next" buttons in the photo view. It includes changes to both the backend and frontend to support this feature, leveraging a new `SmallLargeType` enum to manage the size options.

### Backend Changes:

* **New Enum for Button Size**: Added a `SmallLargeType` enum with `SMALL` and `LARGE` options to represent button sizes. (`app/Enum/SmallLargeType.php`)
* **Configuration Support**: Updated `InitConfig` to include the `photo_previous_next_size` property, reading its value from the configuration. (`app/Http/Resources/GalleryConfigs/InitConfig.php`) [[1]](diffhunk://#diff-d31771d798b76463dc8bb0c03d41ab098b9600d38beeae4bb84cbb34c118d86fR15) [[2]](diffhunk://#diff-d31771d798b76463dc8bb0c03d41ab098b9600d38beeae4bb84cbb34c118d86fR47) [[3]](diffhunk://#diff-d31771d798b76463dc8bb0c03d41ab098b9600d38beeae4bb84cbb34c118d86fR111)
* **Database Migration**: Added a migration to introduce the `photo_previous_next_size` configuration option, with a default value of `small`. (`database/migrations/2025_05_17_075632_optional-bigger-left-right-icons.php`)

### Frontend Changes:

* **Dynamic Button Styling**: Updated the `NextPrevious.vue` component to apply size-specific styles based on the `photo_previous_next_size` value. (`resources/js/components/gallery/photoModule/NextPrevious.vue`)
* **State Management**: Modified the `LycheeState` store to include `photo_previous_next_size` and synchronize it with the backend configuration. (`resources/js/stores/LycheeState.ts`) [[1]](diffhunk://#diff-5585be2db0c41adcd345e27400e1476598e1979d611d3030d032d049f64f12e4R32) [[2]](diffhunk://#diff-5585be2db0c41adcd345e27400e1476598e1979d611d3030d032d049f64f12e4R141)