### PR TITLE
Add slider description in Settings

### DIFF
--- a/resources/js/components/forms/settings/SliderField.vue
+++ b/resources/js/components/forms/settings/SliderField.vue
@@ -1,13 +1,28 @@
 <template>
-	<div class="items-center justify-between gap-4 hidden sm:flex">
+	<div>
+		<div class="items-center justify-between gap-4 hidden sm:flex">
+			<div
+				:class="{
+					'text-primary-emphasis': props.config.require_se,
+					'text-muted-color-emphasis': !props.config.require_se,
+				}"
+				v-html="props.label ?? props.config.documentation"
+			/>
+			<div class="items-center flex gap-2">
+				<InputIcon
+					class="pi pi-exclamation-circle text-warning-600 cursor-pointer"
+					@click="reset"
+					v-if="changed"
+					v-tooltip="'Click me to reset!'"
+				/>
+				<SelectButton class="border-none" v-model="val" :options="options" aria-labelledby="basic" @update:modelValue="update" />
+			</div>
+		</div>
 		<div
-			:class="{
-				'text-primary-emphasis': props.config.require_se,
-				'text-muted-color-emphasis': !props.config.require_se,
-			}"
-			v-html="props.label ?? props.config.documentation"
+			v-if="props.config.details || details !== undefined"
+			class="text-muted-color text-sm hidden sm:block"
+			v-html="props.details ?? props.config.details"
 		/>
-		<SelectButton class="border-none" v-model="val" :options="options" aria-labelledby="basic" @update:modelValue="update" />
 	</div>
 </template>
 
@@ -18,6 +33,7 @@ import SelectButton from "primevue/selectbutton";
 const props = defineProps<{
 	label?: string;
 	config: App.Http.Resources.Models.ConfigResource;
+	details?: string;
 }>();
 
 const val = ref<string>(props.config.value);


### PR DESCRIPTION
Add missing slider + reset icon.

This pull request introduces enhancements to the `SliderField.vue` component to improve its functionality and user experience. The key changes include the addition of a reset button with a tooltip, support for displaying additional details, and updates to the component's props to accommodate these new features.

### Enhancements to `SliderField.vue`:

* **Reset Button with Tooltip**: Added a reset button (`InputIcon`) that appears when the value has changed. The button includes a tooltip with the text "Click me to reset!" and triggers the `reset` method when clicked. (`[resources/js/components/forms/settings/SliderField.vueR11-R26](diffhunk://#diff-6e0a3b3170b2f5b2cddee0e8ff55f4087877162aabca8596a5e1759a165ba764R11-R26)`)
* **Support for Additional Details**: Introduced a new optional `details` prop and added a section to display these details or those from the `config` object. This section is styled and conditionally rendered based on the presence of details. (`[[1]](diffhunk://#diff-6e0a3b3170b2f5b2cddee0e8ff55f4087877162aabca8596a5e1759a165ba764R11-R26)`, `[[2]](diffhunk://#diff-6e0a3b3170b2f5b2cddee0e8ff55f4087877162aabca8596a5e1759a165ba764R36)`)