### PR TITLE
Remove dependency on parent-id and directly extract from the url

### DIFF
--- a/resources/js/components/forms/album/AlbumCreateDialog.vue
+++ b/resources/js/components/forms/album/AlbumCreateDialog.vue
@@ -31,7 +31,7 @@
 import AlbumService from "@/services/album-service";
 import Dialog from "primevue/dialog";
 import InputText from "@/components/forms/basic/InputText.vue";
-import { computed, ref, watch } from "vue";
+import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 import FloatLabel from "primevue/floatlabel";
 import Button from "primevue/button";
@@ -39,18 +39,14 @@ import { useToast } from "primevue/usetoast";
 import { useTogglablesStateStore } from "@/stores/ModalsState";
 import { storeToRefs } from "pinia";
 import { onKeyPressed } from "@vueuse/core";
-
-const props = defineProps<{
-	parentId: string | null;
-}>();
+import { usePhotoRoute } from "@/composables/photo/photoRoute";
 
 const togglableStore = useTogglablesStateStore();
 const { is_create_album_visible } = storeToRefs(togglableStore);
-
-const parentId = ref(props.parentId);
+const router = useRouter();
+const { getParentId } = usePhotoRoute(router);
 
 const toast = useToast();
-const router = useRouter();
 
 const title = ref<string | undefined>(undefined);
 
@@ -63,12 +59,12 @@ function create() {
 
 	AlbumService.createAlbum({
 		title: title.value as string,
-		parent_id: parentId.value,
+		parent_id: getParentId() ?? null,
 	})
 		.then((response) => {
 			title.value = undefined;
 			is_create_album_visible.value = false;
-			AlbumService.clearCache(parentId.value);
+			AlbumService.clearCache(getParentId());
 			router.push(`/gallery/${response.data}`);
 		})
 		.catch((error) => {
@@ -77,12 +73,4 @@ function create() {
 }
 
 onKeyPressed("Enter", () => is_create_album_visible.value && isValid.value && create());
-
-watch(
-	() => props.parentId,
-	(newAlbumID, _oldAlbumID) => {
-		title.value = undefined;
-		parentId.value = newAlbumID as string | null;
-	},
-);
 </script>

--- a/resources/js/components/forms/gallery-dialogs/AlbumMergeDialog.vue
+++ b/resources/js/components/forms/gallery-dialogs/AlbumMergeDialog.vue
@@ -41,13 +41,16 @@ import SearchTargetAlbum from "@/components/forms/album/SearchTargetAlbum.vue";
 import AlbumService from "@/services/album-service";
 import { useToast } from "primevue/usetoast";
 import Dialog from "primevue/dialog";
+import { useRouter } from "vue-router";
+import { usePhotoRoute } from "@/composables/photo/photoRoute";
 
 const props = defineProps<{
-	parentId: string | undefined;
 	album?: App.Http.Resources.Models.ThumbAlbumResource;
 	albumIds: string[];
 }>();
 
+const router = useRouter();
+const { getParentId } = usePhotoRoute(router);
 const visible = defineModel<boolean>("visible", { default: false });
 
 const emits = defineEmits<{
@@ -100,10 +103,10 @@ function execute() {
 		for (const id in albumMergedIds) {
 			AlbumService.clearCache(id);
 		}
-		if (props.parentId === undefined) {
+		if (getParentId() === undefined) {
 			AlbumService.clearAlbums();
 		} else {
-			AlbumService.clearCache(props.parentId);
+			AlbumService.clearCache(getParentId());
 		}
 
 		// RESET !

--- a/resources/js/components/forms/gallery-dialogs/DeleteDialog.vue
+++ b/resources/js/components/forms/gallery-dialogs/DeleteDialog.vue
@@ -27,15 +27,19 @@ import { sprintf } from "sprintf-js";
 import Dialog from "primevue/dialog";
 import Button from "primevue/button";
 import { useToast } from "primevue/usetoast";
-const toast = useToast();
+import { useRouter } from "vue-router";
+import { usePhotoRoute } from "@/composables/photo/photoRoute";
 
+const toast = useToast();
 const props = defineProps<{
-	parentId: string | undefined;
 	photo?: App.Http.Resources.Models.PhotoResource;
 	photoIds?: string[];
 	album?: App.Http.Resources.Models.ThumbAlbumResource;
 	albumIds?: string[];
 }>();
+
+const router = useRouter();
+const { getParentId } = usePhotoRoute(router);
 
 const visible = defineModel<boolean>("visible", { default: false });
 const emits = defineEmits<{
@@ -83,10 +87,10 @@ function executeDeleteAlbum() {
 	}
 
 	AlbumService.delete(albumDeletedIds).then(() => {
-		if (props.parentId === undefined) {
+		if (getParentId() === undefined) {
 			AlbumService.clearAlbums();
 		} else {
-			AlbumService.clearCache(props.parentId);
+			AlbumService.clearCache(getParentId());
 		}
 		emits("deleted");
 	});
@@ -105,7 +109,7 @@ function executeDeletePhoto() {
 			summary: trans("dialogs.photo_delete.deleted"),
 			life: 3000,
 		});
-		AlbumService.clearCache(props.parentId);
+		AlbumService.clearCache(getParentId());
 		emits("deleted");
 	});
 }

--- a/resources/js/components/forms/photo/PhotoCopyDialog.vue
+++ b/resources/js/components/forms/photo/PhotoCopyDialog.vue
@@ -41,7 +41,6 @@ import Dialog from "primevue/dialog";
 import { trans } from "laravel-vue-i18n";
 
 const props = defineProps<{
-	parentId: string | undefined;
 	photo?: App.Http.Resources.Models.PhotoResource;
 	photoIds?: string[];
 }>();

--- a/resources/js/components/headers/AlbumHeader.vue
+++ b/resources/js/components/headers/AlbumHeader.vue
@@ -1,5 +1,5 @@
 <template>
-	<ImportFromLink v-if="canUpload" v-model:visible="is_import_from_link_open" :parent-id="props.album.id" @refresh="emits('refresh')" />
+	<ImportFromLink v-if="canUpload" v-model:visible="is_import_from_link_open" @refresh="emits('refresh')" />
 	<DropBox v-if="canUpload" v-model:visible="is_import_from_dropbox_open" :album-id="props.album.id" />
 	<Toolbar class="w-full border-0 h-14" v-if="album">
 		<template #start>

--- a/resources/js/components/headers/AlbumsHeader.vue
+++ b/resources/js/components/headers/AlbumsHeader.vue
@@ -1,5 +1,5 @@
 <template>
-	<ImportFromLink v-if="canUpload" v-model:visible="is_import_from_link_open" :parent-id="null" />
+	<ImportFromLink v-if="canUpload" v-model:visible="is_import_from_link_open" />
 	<DropBox v-if="canUpload" v-model:visible="is_import_from_dropbox_open" :album-id="null" />
 	<Toolbar
 		class="w-full border-0 h-14"

--- a/resources/js/components/modals/ImportFromLink.vue
+++ b/resources/js/components/modals/ImportFromLink.vue
@@ -40,15 +40,19 @@ import Button from "primevue/button";
 import Dialog from "primevue/dialog";
 import PhotoService from "@/services/photo-service";
 import Textarea from "primevue/textarea";
+import { useRouter } from "vue-router";
+import { usePhotoRoute } from "@/composables/photo/photoRoute";
 
 const visible = defineModel("visible", { default: false }) as Ref<boolean>;
-const props = defineProps<{ parentId: string | null }>();
 const emits = defineEmits<{ refresh: [] }>();
+
+const router = useRouter();
+const { getParentId } = usePhotoRoute(router);
 
 const urls = ref<string>("");
 
 function submit() {
-	PhotoService.importFromUrl(urls.value.split("\n"), props.parentId).then(() => {
+	PhotoService.importFromUrl(urls.value.split("\n"), getParentId() ?? null).then(() => {
 		urls.value = "";
 		visible.value = false;
 		emits("refresh");

--- a/resources/js/composables/photo/photoRoute.ts
+++ b/resources/js/composables/photo/photoRoute.ts
@@ -2,9 +2,13 @@ import { ALL } from "@/config/constants";
 import { Router } from "vue-router";
 
 export function usePhotoRoute(router: Router) {
+	function getParentId(): string | undefined {
+		return router.currentRoute.value.params.albumId as string | undefined;
+	}
+
 	function photoRoute(photoId: string) {
 		const currentRoute = router.currentRoute.value.name as string;
-		const albumId = router.currentRoute.value.params.albumId as string | undefined;
+		const albumId = getParentId();
 
 		if (currentRoute.startsWith("search")) {
 			return { name: "search", params: { albumId: albumId ?? ALL, photoId: photoId } };
@@ -13,5 +17,5 @@ export function usePhotoRoute(router: Router) {
 		return { name: "album", params: { albumId: albumId ?? ALL, photoId: photoId } };
 	}
 
-	return { photoRoute };
+	return { getParentId, photoRoute };
 }

--- a/resources/js/services/photo-service.ts
+++ b/resources/js/services/photo-service.ts
@@ -10,6 +10,11 @@ export type PhotoUpdateRequest = {
 	taken_at: string | null;
 };
 
+export type PhotoMove = {
+	photo_ids: string[];
+	album_id: string | null;
+};
+
 const PhotoService = {
 	get(photo_id: string): Promise<AxiosResponse<App.Http.Resources.Models.PhotoResource>> {
 		return axios.get(`${Constants.getApiUrl()}Photo`, { params: { photo_id: photo_id }, data: {} });
@@ -27,8 +32,8 @@ const PhotoService = {
 		return axios.patch(`${Constants.getApiUrl()}Photo::rename`, { photo_id: photo_id, title: title });
 	},
 
-	move(destination_id: string | null, photo_ids: string[]): Promise<AxiosResponse> {
-		return axios.post(`${Constants.getApiUrl()}Photo::move`, { album_id: destination_id, photo_ids: photo_ids });
+	move(data: PhotoMove): Promise<AxiosResponse> {
+		return axios.post(`${Constants.getApiUrl()}Photo::move`, data);
 	},
 
 	tags(photo_ids: string[], tags: string[], shall_override: boolean): Promise<AxiosResponse> {

--- a/resources/js/views/DuplicatesFinder.vue
+++ b/resources/js/views/DuplicatesFinder.vue
@@ -88,13 +88,13 @@
 				</div>
 			</div>
 			<VirtualScroller :items="groupedDuplicates" :itemSize="50" class="h-screen w-full">
-				<template v-slot:item="{ item, options }">
+				<template v-slot:item="{ item }">
 					<DuplicateLine :duplicates="item" :selected-ids="selectedIds" @hover="onHover" @click="onClick" />
 				</template>
 			</VirtualScroller>
 		</div>
 	</div>
-	<DeleteDialog v-model:visible="isDeleteVisible" :parent-id="undefined" :photo-ids="selectedIds" @deleted="onDeleted" />
+	<DeleteDialog v-model:visible="isDeleteVisible" :photo-ids="selectedIds" @deleted="onDeleted" />
 </template>
 <script setup lang="ts">
 import { ref, computed, onMounted } from "vue";

--- a/resources/js/views/gallery-panels/Album.vue
+++ b/resources/js/views/gallery-panels/Album.vue
@@ -5,7 +5,7 @@
 	<UploadPanel v-if="album?.rights.can_upload" @refresh="refresh" key="upload_modal" />
 	<LoginModal v-if="user?.id === null" @logged-in="refresh" />
 	<WebauthnModal v-if="user?.id === null" @logged-in="refresh" />
-	<AlbumCreateDialog v-if="album?.rights.can_upload && config?.is_model_album" v-model:parent-id="album.id" key="create_album_modal" />
+	<AlbumCreateDialog v-if="album?.rights.can_upload && config?.is_model_album" key="create_album_modal" />
 
 	<!-- Warnings & Locks -->
 	<SensitiveWarning v-if="config?.is_nsfw_warning_visible" :album-id="albumId" />
@@ -54,8 +54,8 @@
 	<!-- Dialogs -->
 	<template v-if="photo">
 		<PhotoEdit v-if="photo?.rights.can_edit" :photo="photo" v-model:visible="is_photo_edit_open" />
-		<MoveDialog :photo="photo" v-model:visible="is_move_visible" :parent-id="props.albumId" @moved="refresh" />
-		<DeleteDialog :photo="photo" v-model:visible="is_delete_visible" :parent-id="props.albumId" @deleted="refresh" />
+		<MoveDialog :photo="photo" v-model:visible="is_move_visible" @moved="refresh" />
+		<DeleteDialog :photo="photo" v-model:visible="is_delete_visible" @deleted="refresh" />
 	</template>
 	<template v-else>
 		<PhotoTagDialog
@@ -72,7 +72,6 @@
 		/>
 		<PhotoCopyDialog
 			v-model:visible="is_copy_visible"
-			:parent-id="albumId"
 			:photo="selectedPhoto"
 			:photo-ids="selectedPhotosIds"
 			@copied="
@@ -84,7 +83,6 @@
 		/>
 		<MoveDialog
 			v-model:visible="is_move_visible"
-			:parent-id="albumId"
 			:photo="selectedPhoto"
 			:photo-ids="selectedPhotosIds"
 			:album="selectedAlbum"
@@ -98,7 +96,6 @@
 		/>
 		<DeleteDialog
 			v-model:visible="is_delete_visible"
-			:parent-id="albumId"
 			:photo="selectedPhoto"
 			:photo-ids="selectedPhotosIds"
 			:album="selectedAlbum"
@@ -114,7 +111,6 @@
 		<!-- Dialogs for albums -->
 		<RenameDialog
 			v-model:visible="is_rename_visible"
-			:parent-id="undefined"
 			:album="selectedAlbum"
 			:photo="selectedPhoto"
 			@renamed="
@@ -126,7 +122,6 @@
 		/>
 		<AlbumMergeDialog
 			v-model:visible="is_merge_album_visible"
-			:parent-id="albumId"
 			:album="selectedAlbum"
 			:album-ids="selectedAlbumsIds"
 			@merged="

--- a/resources/js/views/gallery-panels/Albums.vue
+++ b/resources/js/views/gallery-panels/Albums.vue
@@ -2,7 +2,7 @@
 	<LoadingProgress v-model:loading="isLoading" />
 	<UploadPanel v-if="rootRights?.can_upload" @refresh="refresh" key="upload_modal" />
 	<KeybindingsHelp v-model:visible="isKeybindingsHelpOpen" v-if="user?.id" />
-	<AlbumCreateDialog v-if="rootRights?.can_upload" :parent-id="null" key="create_album_modal" />
+	<AlbumCreateDialog v-if="rootRights?.can_upload" key="create_album_modal" />
 	<AlbumCreateTagDialog v-if="rootRights?.can_upload" key="create_tag_album_modal" />
 	<LoginModal v-if="user?.id === null" @logged-in="refresh" />
 	<WebauthnModal v-if="user?.id === null" @logged-in="refresh" />
@@ -48,7 +48,7 @@
 				@contexted="albumMenuOpen"
 			/>
 		</template>
-		<template v-for="sharedAlbum in sharedAlbums">
+		<template v-for="sharedAlbum in sharedAlbums" :key="sharedAlbum.header">
 			<AlbumThumbPanel
 				v-if="sharedAlbums.length > 0"
 				:header="sharedAlbum.header"
@@ -82,7 +82,6 @@
 	<!-- Dialogs for albums -->
 	<MoveDialog
 		v-model:visible="is_move_visible"
-		:parent-id="undefined"
 		:album="selectedAlbum"
 		:album-ids="selectedAlbumsIds"
 		@moved="
@@ -94,7 +93,6 @@
 	/>
 	<AlbumMergeDialog
 		v-model:visible="is_merge_album_visible"
-		:parent-id="undefined"
 		:album="selectedAlbum"
 		:album-ids="selectedAlbumsIds"
 		@merged="
@@ -106,7 +104,6 @@
 	/>
 	<DeleteDialog
 		v-model:visible="is_delete_visible"
-		:parent-id="undefined"
 		:album="selectedAlbum"
 		:album-ids="selectedAlbumsIds"
 		@deleted="

--- a/resources/js/views/gallery-panels/Search.vue
+++ b/resources/js/views/gallery-panels/Search.vue
@@ -81,7 +81,6 @@
 		/>
 		<PhotoCopyDialog
 			v-model:visible="is_copy_visible"
-			:parent-id="albumId"
 			:photo="selectedPhoto"
 			:photo-ids="selectedPhotosIds"
 			@copied="
@@ -92,8 +91,8 @@
 			"
 		/>
 		<PhotoEdit v-if="photo?.rights.can_edit" :photo="photo" v-model:visible="is_photo_edit_open" />
-		<MoveDialog :photo="photo" v-model:visible="is_move_visible" :parent-id="props.albumId" @moved="refresh" />
-		<DeleteDialog :photo="photo" v-model:visible="is_delete_visible" :parent-id="props.albumId" @deleted="refresh" />
+		<MoveDialog :photo="photo" v-model:visible="is_move_visible" @moved="refresh" />
+		<DeleteDialog :photo="photo" v-model:visible="is_delete_visible" @deleted="refresh" />
 	</template>
 	<template v-else-if="!noData">
 		<!-- Dialogs -->
@@ -104,16 +103,9 @@
 			:photo-ids="selectedPhotosIds"
 			@tagged="refresh"
 		/>
-		<PhotoCopyDialog
-			v-model:visible="is_copy_visible"
-			:parent-id="albumId"
-			:photo="selectedPhoto"
-			:photo-ids="selectedPhotosIds"
-			@copied="refresh"
-		/>
+		<PhotoCopyDialog v-model:visible="is_copy_visible" :photo="selectedPhoto" :photo-ids="selectedPhotosIds" @copied="refresh" />
 		<MoveDialog
 			v-model:visible="is_move_visible"
-			:parent-id="albumId"
 			:photo="selectedPhoto"
 			:photo-ids="selectedPhotosIds"
 			:album="selectedAlbum"
@@ -122,21 +114,14 @@
 		/>
 		<DeleteDialog
 			v-model:visible="is_delete_visible"
-			:parent-id="albumId"
 			:photo="selectedPhoto"
 			:photo-ids="selectedPhotosIds"
 			:album="selectedAlbum"
 			:album-ids="selectedAlbumsIds"
 			@deleted="refresh"
 		/>
-		<RenameDialog v-model:visible="is_rename_visible" :parent-id="undefined" :album="selectedAlbum" :photo="selectedPhoto" @renamed="refresh" />
-		<AlbumMergeDialog
-			v-model:visible="is_merge_album_visible"
-			:parent-id="albumId"
-			:album="selectedAlbum"
-			:album-ids="selectedAlbumsIds"
-			@merged="refresh"
-		/>
+		<RenameDialog v-model:visible="is_rename_visible" :album="selectedAlbum" :photo="selectedPhoto" @renamed="refresh" />
+		<AlbumMergeDialog v-model:visible="is_merge_album_visible" :album="selectedAlbum" :album-ids="selectedAlbumsIds" @merged="refresh" />
 	</template>
 </template>
 <script setup lang="ts">
@@ -322,7 +307,7 @@ const albumPanelConfig = computed<AlbumThumbConfig>(() => ({
 	album_decoration_orientation: lycheeStore.album_decoration_orientation,
 }));
 
-const { scrollToTop, setScroll } = useScrollable(togglableStore, albumId);
+const { setScroll } = useScrollable(togglableStore, albumId);
 
 function goBack() {
 	if (is_slideshow_active.value) {


### PR DESCRIPTION
This pull request refactors the handling of `parentId` in various Vue components by replacing the `parentId` prop with a new `getParentId` method from the `usePhotoRoute` composable. This change simplifies the codebase by centralizing the logic for determining the current parent album ID and removes the need to pass `parentId` as a prop across multiple components. Additionally, minor improvements and cleanups are included.

### Refactoring of `parentId` handling:

* **Centralized `parentId` logic**:
  - Introduced the `getParentId` method in the `usePhotoRoute` composable to fetch the current album ID from the router's `currentRoute` params. [[1]](diffhunk://#diff-33434ce2434a15ec927b1b2109789e472136e439ec0554454dd4822060ecc7ebR5-R11) [[2]](diffhunk://#diff-33434ce2434a15ec927b1b2109789e472136e439ec0554454dd4822060ecc7ebL16-R20)
  - Updated components such as `AlbumCreateDialog`, `AlbumMergeDialog`, `DeleteDialog`, `MoveDialog`, and others to use `getParentId` instead of relying on the `parentId` prop. [[1]](diffhunk://#diff-2a942995f7957dc8700e547d0895228153d55e0fe1918434ac9512b215432359L34-L53) [[2]](diffhunk://#diff-62765e9a050f8ceb8abea2145c22c46d4b038c26c04d05ddede924e492d382abR44-R53) [[3]](diffhunk://#diff-9353b9d66186994e96f22c605d32cd44b884af9e8244f787e3e3cd70bb94880dL30-R43) [[4]](diffhunk://#diff-88c7af55ecebd0df9020a3d74bd58d0c2cb4b3fc2cf882d46f3771795c7fdb49R42-R53) [[5]](diffhunk://#diff-cf0f1aebb8cb2a33d4d355de6b58057b421643a71e334f8fc6a16519ba82167eL44)

* **Removal of `parentId` prop**:
  - Removed the `parentId` prop from components where it was previously passed, simplifying their interfaces. [[1]](diffhunk://#diff-7a27e2df04f5bd1b033dcd73f45e106e3a9393a31a301bbbef57b835e93a47b6L2-R2) [[2]](diffhunk://#diff-36954f066edc20366a3e9bc63ddafb3162b3d35ddbb989292e3e1009a69aea1cL2-R2) [[3]](diffhunk://#diff-88a848123a6b43d2f9695bb217b0d435421b52774f19ea9cc79388f46de23c3cL8-R8) [[4]](diffhunk://#diff-2ddfe21738ea4ed7b8d4370902edd893a5921143729843c759f675773289daf6L5-R5)

* **Updated service calls**:
  - Replaced direct references to `parentId` with calls to `getParentId` in service methods like album creation, deletion, moving, and merging. [[1]](diffhunk://#diff-2a942995f7957dc8700e547d0895228153d55e0fe1918434ac9512b215432359L66-R67) [[2]](diffhunk://#diff-62765e9a050f8ceb8abea2145c22c46d4b038c26c04d05ddede924e492d382abL103-R109) [[3]](diffhunk://#diff-9353b9d66186994e96f22c605d32cd44b884af9e8244f787e3e3cd70bb94880dL86-R93) [[4]](diffhunk://#diff-88c7af55ecebd0df9020a3d74bd58d0c2cb4b3fc2cf882d46f3771795c7fdb49L145-R153) [[5]](diffhunk://#diff-88c7af55ecebd0df9020a3d74bd58d0c2cb4b3fc2cf882d46f3771795c7fdb49L164-R179)

### Code cleanup and minor improvements:

* **Improved `PhotoService.move` method**:
  - Refactored the `PhotoService.move` method to accept a structured `PhotoMove` object for better clarity and type safety. [[1]](diffhunk://#diff-0cca065f44a89f01b1878ba90d15fa2b7eed213f11e47e86b8954e0e03a8b151R13-R17) [[2]](diffhunk://#diff-0cca065f44a89f01b1878ba90d15fa2b7eed213f11e47e86b8954e0e03a8b151L30-R36)

* **Removed unnecessary watchers**:
  - Removed watchers on `props.parentId` that are no longer needed due to the centralized `getParentId` logic.

* **UI adjustments**:
  - Removed unused `parentId` bindings in templates across various components, reducing redundancy. [[1]](diffhunk://#diff-dbd0476a0ee7455bf243502939d93ad5c7a8cfebade0831756222edd78f01315L91-R97) [[2]](diffhunk://#diff-88a848123a6b43d2f9695bb217b0d435421b52774f19ea9cc79388f46de23c3cL55-R56) [[3]](diffhunk://#diff-2ddfe21738ea4ed7b8d4370902edd893a5921143729843c759f675773289daf6L85)

This refactor improves maintainability by consolidating logic, reducing prop dependencies, and simplifying component interfaces.