### PR TITLE
Refactoring LiveMetrics to avoid photo.album_id requirement.

### DIFF
--- a/app/Contracts/Http/Requests/HasFromId.php
+++ b/app/Contracts/Http/Requests/HasFromId.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Contracts\Http\Requests;
+
+interface HasFromId
+{
+	/**
+	 * @return string|null
+	 */
+	public function from_id(): ?string;
+}

--- a/app/Contracts/Http/Requests/RequestAttribute.php
+++ b/app/Contracts/Http/Requests/RequestAttribute.php
@@ -22,6 +22,7 @@ class RequestAttribute
 
 	public const PARENT_ID_ATTRIBUTE = 'parent_id';
 
+	public const FROM_ID_ATTRIBUTE = 'from_id';
 	public const ALBUM_ID_ATTRIBUTE = 'album_id';
 	public const ALBUM_IDS_ATTRIBUTE = 'album_ids';
 	public const ALBUM_DECORATION_ATTRIBUTE = 'album_decoration';

--- a/app/Events/Metrics/AlbumDownload.php
+++ b/app/Events/Metrics/AlbumDownload.php
@@ -13,13 +13,8 @@ use App\Enum\MetricsAction;
 /**
  * This event is fired when an album is downloaded.
  */
-final class AlbumDownload extends BaseMetricsEvent
+final class AlbumDownload extends BaseAlbumMetricsEvent
 {
-	public function key(): string
-	{
-		return 'album_id';
-	}
-
 	public function metricAction(): MetricsAction
 	{
 		return MetricsAction::DOWNLOAD;

--- a/app/Events/Metrics/AlbumShared.php
+++ b/app/Events/Metrics/AlbumShared.php
@@ -13,13 +13,8 @@ use App\Enum\MetricsAction;
 /**
  * This event is fired when a direct link to an album is used.
  */
-final class AlbumShared extends BaseMetricsEvent
+final class AlbumShared extends BaseAlbumMetricsEvent
 {
-	public function key(): string
-	{
-		return 'album_id';
-	}
-
 	public function metricAction(): MetricsAction
 	{
 		return MetricsAction::SHARED;

--- a/app/Events/Metrics/AlbumVisit.php
+++ b/app/Events/Metrics/AlbumVisit.php
@@ -13,13 +13,8 @@ use App\Enum\MetricsAction;
 /**
  * This event is fired when an album is open.
  */
-final class AlbumVisit extends BaseMetricsEvent
+final class AlbumVisit extends BaseAlbumMetricsEvent
 {
-	public function key(): string
-	{
-		return 'album_id';
-	}
-
 	public function metricAction(): MetricsAction
 	{
 		return MetricsAction::VISIT;

--- a/app/Events/Metrics/BaseAlbumMetricsEvent.php
+++ b/app/Events/Metrics/BaseAlbumMetricsEvent.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Events\Metrics;
+
+use App\Enum\MetricsAction;
+use Illuminate\Support\Carbon;
+
+abstract class BaseAlbumMetricsEvent extends BaseMetricsEvent
+{
+	/**
+	 * Return the type of key : photo_id or album_id.
+	 *
+	 * @return string
+	 *
+	 * @codeCoverageIgnore, abstract method can't be covered
+	 */
+	final public function key(): string
+	{
+		return 'album_id';
+	}
+
+	/**
+	 * Convert the event to an array for insertion into the database.
+	 *
+	 * @return array{visitor_id:string,action:MetricsAction,album_id:string,created_at:Carbon}
+	 */
+	final public function toArray(): array
+	{
+		return [
+			'visitor_id' => $this->visitor_id,
+			'action' => $this->metricAction(),
+			'album_id' => $this->id,
+			'created_at' => now(),
+		];
+	}
+}

--- a/app/Events/Metrics/BaseMetricsEvent.php
+++ b/app/Events/Metrics/BaseMetricsEvent.php
@@ -11,6 +11,7 @@ namespace App\Events\Metrics;
 use App\Enum\MetricsAction;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Support\Carbon;
 
 abstract class BaseMetricsEvent
 {
@@ -40,4 +41,11 @@ abstract class BaseMetricsEvent
 	 * @codeCoverageIgnore, abstract method can't be covered
 	 */
 	abstract public function metricAction(): MetricsAction;
+
+	/**
+	 * Convert the event to an array for insertion into the database.
+	 *
+	 * @return array<string,string|MetricsAction|Carbon>
+	 */
+	abstract public function toArray(): array;
 }

--- a/app/Events/Metrics/BasePhotoMetricsEvent.php
+++ b/app/Events/Metrics/BasePhotoMetricsEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Events\Metrics;
+
+use App\Enum\MetricsAction;
+use Illuminate\Support\Carbon;
+
+abstract class BasePhotoMetricsEvent extends BaseMetricsEvent
+{
+	public readonly string $album_id;
+
+	public function __construct(
+		string $visitor_id,
+		string $id,
+		string $album_id,
+	) {
+		parent::__construct($visitor_id, $id);
+		$this->album_id = $album_id;
+	}
+
+	/**
+	 * Return the type of key : photo_id or album_id.
+	 *
+	 * @return string
+	 *
+	 * @codeCoverageIgnore, abstract method can't be covered
+	 */
+	final public function key(): string
+	{
+		return 'photo_id';
+	}
+
+	/**
+	 * Convert the event to an array for insertion into the database.
+	 *
+	 * @return array{visitor_id:string,action:MetricsAction,album_id:string,photo_id:string,created_at:Carbon}
+	 */
+	final public function toArray(): array
+	{
+		return [
+			'visitor_id' => $this->visitor_id,
+			'action' => $this->metricAction(),
+			'album_id' => $this->album_id,
+			'photo_id' => $this->id,
+			'created_at' => now(),
+		];
+	}
+}

--- a/app/Events/Metrics/PhotoDownload.php
+++ b/app/Events/Metrics/PhotoDownload.php
@@ -13,13 +13,8 @@ use App\Enum\MetricsAction;
 /**
  * This event is fired when one or multiple photos are downloaded.
  */
-final class PhotoDownload extends BaseMetricsEvent
+final class PhotoDownload extends BasePhotoMetricsEvent
 {
-	public function key(): string
-	{
-		return 'photo_id';
-	}
-
 	public function metricAction(): MetricsAction
 	{
 		return MetricsAction::DOWNLOAD;

--- a/app/Events/Metrics/PhotoFavourite.php
+++ b/app/Events/Metrics/PhotoFavourite.php
@@ -13,13 +13,8 @@ use App\Enum\MetricsAction;
 /**
  * This event is fired when a photo is visited.
  */
-class PhotoFavourite extends BaseMetricsEvent
+class PhotoFavourite extends BasePhotoMetricsEvent
 {
-	public function key(): string
-	{
-		return 'photo_id';
-	}
-
 	public function metricAction(): MetricsAction
 	{
 		return MetricsAction::FAVOURITE;

--- a/app/Events/Metrics/PhotoShared.php
+++ b/app/Events/Metrics/PhotoShared.php
@@ -13,13 +13,8 @@ use App\Enum\MetricsAction;
 /**
  * This event is fired when a direct link to a photo is used.
  */
-class PhotoShared extends BaseMetricsEvent
+class PhotoShared extends BasePhotoMetricsEvent
 {
-	public function key(): string
-	{
-		return 'photo_id';
-	}
-
 	public function metricAction(): MetricsAction
 	{
 		return MetricsAction::SHARED;

--- a/app/Events/Metrics/PhotoVisit.php
+++ b/app/Events/Metrics/PhotoVisit.php
@@ -13,13 +13,8 @@ use App\Enum\MetricsAction;
 /**
  * This event is fired when a photo is visited.
  */
-final class PhotoVisit extends BaseMetricsEvent
+final class PhotoVisit extends BasePhotoMetricsEvent
 {
-	public function key(): string
-	{
-		return 'photo_id';
-	}
-
 	public function metricAction(): MetricsAction
 	{
 		return MetricsAction::VISIT;

--- a/app/Http/Controllers/Gallery/AlbumController.php
+++ b/app/Http/Controllers/Gallery/AlbumController.php
@@ -320,7 +320,7 @@ class AlbumController extends Controller
 
 		// We dispatch one event per photo.
 		foreach ($request->photos() as $photo) {
-			PhotoDownload::dispatchIf($should_measure, $this->visitorId(), $photo->id);
+			PhotoDownload::dispatchIf($should_measure && $request->from_id() !== null, $this->visitorId(), $photo->id, $request->from_id());
 		}
 
 		return PhotoBaseArchive::resolve()->do($request->photos(), $request->sizeVariant());

--- a/app/Http/Controllers/MetricsController.php
+++ b/app/Http/Controllers/MetricsController.php
@@ -45,7 +45,7 @@ class MetricsController extends Controller
 	 */
 	public function photo(PhotoMetricsRequest $request): void
 	{
-		PhotoVisit::dispatchIf(self::shouldMeasure(), $request->visitorId(), $request->photoIds()[0]);
+		PhotoVisit::dispatchIf(self::shouldMeasure() && $request->from_id() !== null, $request->visitorId(), $request->photoIds()[0], $request->from_id());
 
 		return;
 	}
@@ -59,7 +59,7 @@ class MetricsController extends Controller
 	 */
 	public function favourite(PhotoMetricsRequest $request): void
 	{
-		PhotoFavourite::dispatchIf(self::shouldMeasure(), $request->visitorId(), $request->photoIds()[0]);
+		PhotoFavourite::dispatchIf(self::shouldMeasure() && $request->from_id() !== null, $request->visitorId(), $request->photoIds()[0], $request->from_id());
 
 		return;
 	}

--- a/app/Http/Controllers/VueController.php
+++ b/app/Http/Controllers/VueController.php
@@ -67,7 +67,7 @@ class VueController extends Controller
 		}
 
 		if ($photo !== null) {
-			PhotoShared::dispatchIf(MetricsController::shouldMeasure(), $this->visitorId(), $photo->id);
+			PhotoShared::dispatchIf(MetricsController::shouldMeasure() && $album_id !== null, $this->visitorId(), $photo->id, $album_id);
 		} elseif ($album !== null) {
 			AlbumShared::dispatchIf(MetricsController::shouldMeasure(), $this->visitorId(), $album->get_id());
 		}

--- a/app/Http/Requests/Metrics/PhotoMetricsRequest.php
+++ b/app/Http/Requests/Metrics/PhotoMetricsRequest.php
@@ -8,17 +8,20 @@
 
 namespace App\Http\Requests\Metrics;
 
+use App\Contracts\Http\Requests\HasFromId;
 use App\Contracts\Http\Requests\HasPhotoIds;
 use App\Contracts\Http\Requests\HasVisitorId;
 use App\Contracts\Http\Requests\RequestAttribute;
 use App\Http\Requests\BaseApiRequest;
+use App\Http\Requests\Traits\HasFromIdTrait;
 use App\Http\Requests\Traits\HasPhotoIdsTrait;
 use App\Http\Requests\Traits\HasVisitorIdTrait;
 use App\Rules\RandomIDRule;
 
-class PhotoMetricsRequest extends BaseApiRequest implements HasPhotoIds, HasVisitorId
+class PhotoMetricsRequest extends BaseApiRequest implements HasPhotoIds, HasVisitorId, HasFromId
 {
 	use HasPhotoIdsTrait;
+	use HasFromIdTrait;
 	use HasVisitorIdTrait;
 
 	// No need to authorize this request as it is only used for metrics purposes
@@ -33,6 +36,7 @@ class PhotoMetricsRequest extends BaseApiRequest implements HasPhotoIds, HasVisi
 	public function rules(): array
 	{
 		return [
+			RequestAttribute::FROM_ID_ATTRIBUTE => ['required', new RandomIDRule(true)],
 			RequestAttribute::PHOTO_IDS_ATTRIBUTE => 'required|array|min:1',
 			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
 		];
@@ -44,5 +48,6 @@ class PhotoMetricsRequest extends BaseApiRequest implements HasPhotoIds, HasVisi
 	protected function processValidatedValues(array $values, array $files): void
 	{
 		$this->photo_ids = $values[RequestAttribute::PHOTO_IDS_ATTRIBUTE];
+		$this->from_id = $values[RequestAttribute::FROM_ID_ATTRIBUTE] ?? null;
 	}
 }

--- a/app/Http/Requests/Traits/HasFromIdTrait.php
+++ b/app/Http/Requests/Traits/HasFromIdTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Traits;
+
+trait HasFromIdTrait
+{
+	protected ?string $from_id = null;
+
+	/**
+	 * @return string|null
+	 */
+	public function from_id(): ?string
+	{
+		return $this->from_id;
+	}
+}

--- a/app/Http/Resources/Models/LiveMetricsResource.php
+++ b/app/Http/Resources/Models/LiveMetricsResource.php
@@ -33,14 +33,14 @@ class LiveMetricsResource extends Data
 	public static function fromModel(LiveMetrics $a): LiveMetricsResource
 	{
 		$title = $a->photo_id !== null ? $a->photo->title : $a->album_impl->title;
-		$url = $a->photo_id !== null ? $a->photo->size_variants?->getSmall()?->url ?? $a->photo->size_variants?->getThumb()?->url : $a->album?->thumb?->thumbUrl;
+		$url = $a->photo_id !== null ? $a->photo->size_variants?->getThumb()?->url : $a->album?->thumb?->thumbUrl;
 
 		return new self(
 			created_at: $a->created_at->toIso8601String(), // toIso8601String() is used to ensure the date has the correct timezone
 			visitor_id: $a->visitor_id,
 			action: $a->action,
 			photo_id: $a->photo_id,
-			album_id: $a->album_id ?? $a->photo->album_id,
+			album_id: $a->album_id,
 			title: $title,
 			url: $url,
 		);

--- a/app/Listeners/MetricsListener.php
+++ b/app/Listeners/MetricsListener.php
@@ -31,15 +31,7 @@ class MetricsListener
 
 		if (Configs::getValueAsBool('live_metrics_enabled') === true) {
 			// Add event to the live metrics table
-			DB::table('live_metrics')
-				->insert([
-					[
-						'visitor_id' => $event->visitor_id,
-						'action' => $event->metricAction(),
-						$event->key() => $event->id,
-						'created_at' => now(),
-					],
-				]);
+			DB::table('live_metrics')->insert([$event->toArray()]);
 		}
 	}
 }

--- a/database/migrations/2025_05_28_194147_fix_livemetrics_album_id.php
+++ b/database/migrations/2025_05_28_194147_fix_livemetrics_album_id.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class() extends Migration {
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		DB::statement('UPDATE live_metrics SET album_id = (SELECT album_id FROM photos WHERE photos.id = live_metrics.photo_id) WHERE photo_id IS NOT NULL');
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		// Reset the albums to null for the photos that have an associated album.
+		DB::table('live_metrics')->whereNotNull('photo_id')->update(['album_id' => null]);
+	}
+};

--- a/resources/js/components/gallery/albumModule/AlbumPanel.vue
+++ b/resources/js/components/gallery/albumModule/AlbumPanel.vue
@@ -188,7 +188,7 @@ const {
 	albumClick,
 } = useSelection(photos, children, togglableStore);
 
-const { photoRoute } = usePhotoRoute(router);
+const { photoRoute, getParentId } = usePhotoRoute(router);
 
 function photoClick(idx: number, e: MouseEvent) {
 	router.push(photoRoute(photos.value[idx].id));
@@ -238,7 +238,7 @@ const photoCallbacks = {
 	toggleMove: toggleMove,
 	toggleDelete: toggleDelete,
 	toggleDownload: () => {
-		PhotoService.download(selectedPhotosIds.value);
+		PhotoService.download(selectedPhotosIds.value, getParentId());
 	},
 };
 

--- a/resources/js/components/gallery/albumModule/thumbs/PhotoThumb.vue
+++ b/resources/js/components/gallery/albumModule/thumbs/PhotoThumb.vue
@@ -87,6 +87,8 @@ import { storeToRefs } from "pinia";
 import { useImageHelpers } from "@/utils/Helpers";
 import { useFavouriteStore } from "@/stores/FavouriteState";
 import ThumbFavourite from "./ThumbFavourite.vue";
+import { useRouter } from "vue-router";
+import { usePhotoRoute } from "@/composables/photo/photoRoute";
 
 const { getNoImageIcon, getPlayIcon } = useImageHelpers();
 
@@ -101,6 +103,8 @@ const props = defineProps<{
 	photo: App.Http.Resources.Models.PhotoResource;
 }>();
 
+const router = useRouter();
+const { getParentId } = usePhotoRoute(router);
 const auth = useAuthStore();
 const { user } = storeToRefs(auth);
 const favourites = useFavouriteStore();
@@ -112,7 +116,7 @@ const srcNoImage = ref(getNoImageIcon());
 const isImageLoaded = ref(false);
 
 function toggleFavourite() {
-	favourites.toggle(props.photo);
+	favourites.toggle(props.photo, getParentId());
 }
 
 function onImageLoad() {

--- a/resources/js/services/metrics-service.ts
+++ b/resources/js/services/metrics-service.ts
@@ -6,17 +6,27 @@ const MetricsService = {
 		return axios.get(`${Constants.getApiUrl()}Metrics`, { data: {} });
 	},
 
-	photo(photo_id: string): Promise<AxiosResponse<null> | null> {
+	photo(photo_id: string, album_id: string | undefined): Promise<AxiosResponse<null> | null> {
 		if (!photo_id) {
 			// TODO: figure out why this sometimes happens...
 			// Do not send a request if no photo_id is provided, otherwise it breaks in front-end.
 			return Promise.resolve(null);
 		}
-		return axios.post(`${Constants.getApiUrl()}Metrics::photo`, { photo_ids: [photo_id] });
+		// This is the case if we are in global search mode.
+		if (album_id === undefined) {
+			return Promise.resolve(null);
+		}
+
+		return axios.post(`${Constants.getApiUrl()}Metrics::photo`, { photo_ids: [photo_id], from_id: album_id });
 	},
 
-	favourite(photo_id: string): Promise<AxiosResponse<null>> {
-		return axios.post(`${Constants.getApiUrl()}Metrics::favourite`, { photo_ids: [photo_id] });
+	favourite(photo_id: string, album_id: string | undefined): Promise<AxiosResponse<null> | null> {
+		// This is the case if we are in global search mode.
+		if (album_id === undefined) {
+			return Promise.resolve(null);
+		}
+
+		return axios.post(`${Constants.getApiUrl()}Metrics::favourite`, { photo_ids: [photo_id], from_id: album_id });
 	},
 };
 

--- a/resources/js/services/photo-service.ts
+++ b/resources/js/services/photo-service.ts
@@ -68,8 +68,8 @@ const PhotoService = {
 		return axios.post(`${Constants.getApiUrl()}Album::header`, { header_id: photo_id, album_id: album_id, is_compact: is_compact });
 	},
 
-	download(photo_ids: string[], download_type: App.Enum.DownloadVariantType = "ORIGINAL"): void {
-		location.href = `${Constants.getApiUrl()}Zip?photo_ids=${photo_ids.join(",")}&variant=${download_type}`;
+	download(photo_ids: string[], from_id: string | undefined, download_type: App.Enum.DownloadVariantType = "ORIGINAL"): void {
+		location.href = `${Constants.getApiUrl()}Zip?photo_ids=${photo_ids.join(",")}&variant=${download_type}&from_id=${from_id ?? null}`;
 	},
 };
 

--- a/resources/js/stores/FavouriteState.ts
+++ b/resources/js/stores/FavouriteState.ts
@@ -35,7 +35,7 @@ export const useFavouriteStore = defineStore("favourite-store", {
 			}
 			this.photos = this.photos.filter((p: App.Http.Resources.Models.PhotoResource) => p.id !== photoId);
 		},
-		toggle(photo: App.Http.Resources.Models.PhotoResource) {
+		toggle(photo: App.Http.Resources.Models.PhotoResource, albumId: string | undefined) {
 			if (!this.photos) {
 				this.photos = [];
 			}
@@ -44,7 +44,7 @@ export const useFavouriteStore = defineStore("favourite-store", {
 				this.removePhoto(photo.id);
 			} else {
 				this.addPhoto(photo);
-				MetricsService.favourite(photo.id);
+				MetricsService.favourite(photo.id, albumId);
 			}
 		},
 	},

--- a/resources/js/views/gallery-panels/Album.vue
+++ b/resources/js/views/gallery-panels/Album.vue
@@ -171,6 +171,7 @@ import { useHasNextPreviousPhoto } from "@/composables/photo/hasNextPreviousPhot
 import { getNextPreviousPhoto } from "@/composables/photo/getNextPreviousPhoto";
 import { usePhotoRefresher } from "@/composables/photo/hasRefresher";
 import MetricsService from "@/services/metrics-service";
+import { usePhotoRoute } from "@/composables/photo/photoRoute";
 
 const route = useRoute();
 const router = useRouter();
@@ -216,6 +217,7 @@ const { isPasswordProtected, isLoading, user, modelAlbum, album, photo, transiti
 	useAlbumRefresher(albumId, photoId, auth, is_login_open);
 
 const { refreshPhoto } = usePhotoRefresher(photo, photos, photoId);
+const { getParentId } = usePhotoRoute(router);
 
 const children = computed<App.Http.Resources.Models.ThumbAlbumResource[]>(() => modelAlbum.value?.albums ?? []);
 
@@ -413,7 +415,7 @@ onUnmounted(() => {
 
 const debouncedPhotoMetrics = useDebounceFn(() => {
 	if (photoId.value !== undefined) {
-		MetricsService.photo(photoId.value);
+		MetricsService.photo(photoId.value, getParentId());
 		return;
 	}
 }, 100);

--- a/resources/js/views/gallery-panels/Search.vue
+++ b/resources/js/views/gallery-panels/Search.vue
@@ -165,6 +165,7 @@ import LoadingProgress from "@/components/loading/LoadingProgress.vue";
 import { shouldIgnoreKeystroke } from "@/utils/keybindings-utils";
 import { useHasNextPreviousPhoto } from "@/composables/photo/hasNextPreviousPhoto";
 import MetricsService from "@/services/metrics-service";
+import { usePhotoRoute } from "@/composables/photo/photoRoute";
 
 const route = useRoute();
 const router = useRouter();
@@ -212,6 +213,7 @@ const {
 	refresh,
 } = useSearch(albumId, search_term, search_page);
 
+const { getParentId } = usePhotoRoute(router);
 const { refreshPhoto } = usePhotoRefresher(photo, photos, photoId);
 const { albumsForSelection, photosForSelection, noData, configForMenu, title } = useSearchComputed(config, album, albums, photos, lycheeStore);
 
@@ -423,7 +425,7 @@ onMounted(() => {
 
 const debouncedPhotoMetrics = useDebounceFn(() => {
 	if (photoId.value !== undefined) {
-		MetricsService.photo(photoId.value);
+		MetricsService.photo(photoId.value, getParentId());
 		return;
 	}
 }, 100);

--- a/tests/Feature_v2/Album/DownloadTest.php
+++ b/tests/Feature_v2/Album/DownloadTest.php
@@ -68,7 +68,9 @@ class DownloadTest extends BaseApiWithDataTest
 
 		$photoArchiveResponse = $this->download(
 			photo_ids: [$photo['id']],
-			kind: DownloadVariantType::ORIGINAL);
+			from_id: $this->album5->id,
+			kind: DownloadVariantType::ORIGINAL
+		);
 
 		// Stream the response in a temporary file
 		$memoryBlob = new InMemoryBuffer();
@@ -105,7 +107,9 @@ class DownloadTest extends BaseApiWithDataTest
 
 		$photoArchiveResponse = $this->download(
 			photo_ids: [$response->json('resource.photos.0.id'), $response->json('resource.photos.1.id')],
-			kind: DownloadVariantType::ORIGINAL);
+			from_id: $this->album5->id,
+			kind: DownloadVariantType::ORIGINAL
+		);
 
 		$zipArchive = AssertableZipArchive::createFromResponse($photoArchiveResponse);
 		$zipArchive->assertContainsFilesExactly([
@@ -129,6 +133,7 @@ class DownloadTest extends BaseApiWithDataTest
 
 		$photoArchiveResponse = $this->download(
 			photo_ids: [$photo['id']],
+			from_id: $this->album5->id,
 			kind: DownloadVariantType::LIVEPHOTOVIDEO
 		);
 
@@ -158,7 +163,8 @@ class DownloadTest extends BaseApiWithDataTest
 			'Photo',
 			filename: TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE,
 			album_id: $this->album5->id,
-			file_name: TestConstants::PHOTO_MONGOLIA_TITLE . '.jpeg');
+			file_name: TestConstants::PHOTO_MONGOLIA_TITLE . '.jpeg'
+		);
 		$this->assertCreated($response);
 
 		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
@@ -179,7 +185,8 @@ class DownloadTest extends BaseApiWithDataTest
 			'Photo',
 			filename: TestConstants::SAMPLE_FILE_NIGHT_IMAGE,
 			album_id: $this->album5->id,
-			file_name: TestConstants::PHOTO_NIGHT_TITLE . '.jpg');
+			file_name: TestConstants::PHOTO_NIGHT_TITLE . '.jpg'
+		);
 		$this->assertCreated($response);
 
 		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
@@ -190,7 +197,11 @@ class DownloadTest extends BaseApiWithDataTest
 		$photoID2a = $response->json('resource.photos.1.id');
 		$photoID2b = $response->json('resource.photos.2.id');
 
-		$photoArchiveResponse = $this->download([$photoID1, $photoID2a, $photoID2b], kind: DownloadVariantType::ORIGINAL);
+		$photoArchiveResponse = $this->download(
+			photo_ids: [$photoID1, $photoID2a, $photoID2b],
+			from_id: $this->album5->id,
+			kind: DownloadVariantType::ORIGINAL
+		);
 
 		$zipArchive = AssertableZipArchive::createFromResponse($photoArchiveResponse);
 		$zipArchive->assertContainsFilesExactly([
@@ -206,7 +217,8 @@ class DownloadTest extends BaseApiWithDataTest
 			'Photo',
 			filename: TestConstants::SAMPLE_FILE_SUNSET_IMAGE,
 			album_id: $this->album5->id,
-			file_name: 'fin de journée.jpg');
+			file_name: 'fin de journée.jpg'
+		);
 		$this->assertCreated($response);
 
 		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
@@ -215,7 +227,11 @@ class DownloadTest extends BaseApiWithDataTest
 
 		$id = $response->json('resource.photos.0.id');
 
-		$download = $this->download([$id], kind: DownloadVariantType::ORIGINAL);
+		$download = $this->download(
+			photo_ids: [$id],
+			from_id: $this->album5->id,
+			kind: DownloadVariantType::ORIGINAL
+		);
 		$download->assertHeader('Content-Type', TestConstants::MIME_TYPE_IMG_JPEG);
 		$download->assertHeader('Content-Length', filesize(base_path(TestConstants::SAMPLE_FILE_SUNSET_IMAGE)));
 		$download->assertHeader('Content-Disposition', HeaderUtils::makeDisposition(
@@ -239,7 +255,8 @@ class DownloadTest extends BaseApiWithDataTest
 			'Photo',
 			filename: TestConstants::SAMPLE_FILE_SUNSET_IMAGE,
 			album_id: $this->album5->id,
-			file_name: 'fin de journée.jpg');
+			file_name: 'fin de journée.jpg'
+		);
 		$this->assertCreated($response);
 
 		$album6 = Album::factory()->children_of($this->album5)->owned_by($this->admin)->create();
@@ -248,7 +265,8 @@ class DownloadTest extends BaseApiWithDataTest
 			'Photo',
 			filename: TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE,
 			album_id: $album6->id,
-			file_name: TestConstants::PHOTO_MONGOLIA_TITLE . '.jpeg');
+			file_name: TestConstants::PHOTO_MONGOLIA_TITLE . '.jpeg'
+		);
 		$this->assertCreated($response);
 
 		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);

--- a/tests/Feature_v2/Base/BaseApiTest.php
+++ b/tests/Feature_v2/Base/BaseApiTest.php
@@ -178,6 +178,7 @@ abstract class BaseApiTest extends AbstractTestCase
 	public function download(
 		array $photo_ids = [],
 		array $album_ids = [],
+		string $from_id = '',
 		DownloadVariantType $kind = DownloadVariantType::ORIGINAL,
 		$expectedStatusCode = 200,
 	): TestResponse {
@@ -188,6 +189,9 @@ abstract class BaseApiTest extends AbstractTestCase
 		}
 		if ($album_ids !== []) {
 			$params['album_ids'] = implode(',', $album_ids);
+		}
+		if ($from_id !== '') {
+			$params['from_id'] = $from_id;
 		}
 
 		$response = $this->getWithParameters(self::API_PREFIX . 'Zip', $params, [

--- a/tests/Feature_v2/Metrics/EventsFiredTest.php
+++ b/tests/Feature_v2/Metrics/EventsFiredTest.php
@@ -53,11 +53,11 @@ class EventsFiredTest extends BaseApiWithDataTest
 
 	public function testVisitSharedPhoto(): void
 	{
-		$response = $this->postJson('Metrics::photo', ['photo_ids' => [$this->photo4->id]]);
+		$response = $this->postJson('Metrics::photo', ['photo_ids' => [$this->photo4->id], 'from_id' => $this->album4->id]);
 		$this->assertNoContent($response);
 		$this->assertEquals(1, Statistics::where('photo_id', $this->photo4->id)->firstOrFail()->visit_count);
 
-		$response = $this->postJson('Metrics::favourite', ['photo_ids' => [$this->photo4->id]]);
+		$response = $this->postJson('Metrics::favourite', ['photo_ids' => [$this->photo4->id], 'from_id' => $this->album4->id]);
 		$this->assertNoContent($response);
 		$this->assertEquals(1, Statistics::where('photo_id', $this->photo4->id)->firstOrFail()->favourite_count);
 

--- a/tests/Feature_v2/Metrics/MetricsGetTest.php
+++ b/tests/Feature_v2/Metrics/MetricsGetTest.php
@@ -73,9 +73,9 @@ class MetricsGetTest extends BaseApiWithDataTest
 		$this->assertOk($response); // 1: - viewed album4
 		$response = $this->get('gallery/' . $this->album4->id);
 		$this->assertOk($response); // 2: - shared album4
-		$response = $this->postJson('Metrics::photo', ['photo_ids' => [$this->photo4->id]]);
+		$response = $this->postJson('Metrics::photo', ['photo_ids' => [$this->photo4->id], 'from_id' => $this->album4->id]);
 		$this->assertNoContent($response); // 3: viewed photo4
-		$response = $this->postJson('Metrics::favourite', ['photo_ids' => [$this->photo4->id]]);
+		$response = $this->postJson('Metrics::favourite', ['photo_ids' => [$this->photo4->id], 'from_id' => $this->album4->id]);
 		$this->assertNoContent($response); // 4: favourite photo4
 		$response = $this->get('gallery/' . $this->album4->id . '/' . $this->photo4->id);
 		$this->assertOk($response); // 5: shared photo4

--- a/tests/Unit/Http/Requests/Album/ZipRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/ZipRequestTest.php
@@ -18,6 +18,7 @@ use App\Models\TagAlbum;
 use App\Policies\AlbumPolicy;
 use App\Rules\AlbumIDListRule;
 use App\Rules\RandomIDListRule;
+use App\Rules\RandomIDRule;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rules\Enum;
 use Tests\Unit\Http\Requests\Base\BaseRequestTest;
@@ -62,6 +63,7 @@ class ZipRequestTest extends BaseRequestTest
 			RequestAttribute::ALBUM_IDS_ATTRIBUTE => ['sometimes', new AlbumIDListRule()],
 			RequestAttribute::PHOTO_IDS_ATTRIBUTE => ['sometimes', new RandomIDListRule()],
 			RequestAttribute::SIZE_VARIANT_ATTRIBUTE => ['required_if_accepted:photos_ids', new Enum(DownloadVariantType::class)],
+			RequestAttribute::FROM_ID_ATTRIBUTE => ['required_if_accepted:photos_ids', new RandomIDRule(true)],
 		];
 		$this->assertCount(count($expectedRuleMap), $rules); // only validating the first 7 rules & the GRANTS_UPLOAD_ATTRIBUTE is tested afterwards
 


### PR DESCRIPTION
This pull request introduces significant changes to the metrics and event handling system, alongside updates to request handling for improved flexibility and consistency. Key changes include the creation of base classes for metrics events, the addition of a `from_id` attribute for better tracking, and refactoring of query logic in metrics retrieval.

### Event System Refactoring:
* Introduced `BaseAlbumMetricsEvent` and `BasePhotoMetricsEvent` classes to centralize shared logic for album and photo-related metrics events, such as the `key()` method and `toArray()` method. [[1]](diffhunk://#diff-cad2d72c4c8e7f952bcf6d263d5e967575179c3c1cd102780b0e26461a1c3878R1-R42) [[2]](diffhunk://#diff-dfb635d29ce3508d728800c3c1c8a2d3da191e93bed0db45d6db97b1faf2635cR1-R54)
* Updated existing event classes (`AlbumDownload`, `AlbumShared`, `AlbumVisit`, `PhotoDownload`, `PhotoFavourite`, `PhotoShared`, `PhotoVisit`) to extend the new base classes, removing redundant `key()` method implementations. [[1]](diffhunk://#diff-c8c80dce9aef032bcbe3deb8a47d009013b54cddd57a9a6d1e64d8d8737a92ceL16-L22) [[2]](diffhunk://#diff-4f9fc12aa528bd5fe35fcb82256911fa77f587402caac641d8ab69df8b2f93fdL16-L22) [[3]](diffhunk://#diff-cb5fe5e9a00b43266eedb510cda96d0ff57ea32666395f724a89050381240ca3L16-L22) [[4]](diffhunk://#diff-1f8cf4aa8b9020a37566820e7844d4d7d5c641c90887fd3247d5dcfc9d7ca5d2L16-L22) [[5]](diffhunk://#diff-ddcbb658ff62e7d0d256915bd23d13636abc91bf3b6a8e09a2f43d45a8570991L16-L22) [[6]](diffhunk://#diff-c3d361ef5d4b99952377465bf5b2031bd2d930f1576b268279330f514ec857ccL16-L22) [[7]](diffhunk://#diff-aa2e8e0c87605da8eb398c2d5a5c052b2a98b579fbeac351a24f5771eeac5f93L16-L22)

### Request Handling Enhancements:
* Added a new `HasFromId` interface and `HasFromIdTrait` to standardize the handling of a `from_id` attribute in requests. [[1]](diffhunk://#diff-e50f38390592992202a00123a3b9405c9eaa017606d5e85c51304440b7ecc4b4R1-R17) [[2]](diffhunk://#diff-5f23395544528801cecc2028b0f6f7028c63ff66b4c715c028f4321288c1d8abR1-R22)
* Updated `ZipRequest` and `PhotoMetricsRequest` to implement `HasFromId`, enabling the use of `from_id` for additional context in metrics-related operations. [[1]](diffhunk://#diff-556f99a53da07a7730709d85abdcec78003ef3f63707abc8a2ca68168a21cb71R12-R40) [[2]](diffhunk://#diff-c976af406915578fcd5f3d73ebf0fe815733eee04247ea4a5ddf6141bddb3d3dR11-R24)

### Metrics Query Optimization:
* Improved query logic in `GetMetrics.php` by adding a safeguard to exclude null `album_id` values and simplifying conditions for `visit` actions.
* Removed unused commented-out code in the `select` clause for cleaner and more maintainable queries.

### Controller Updates:
* Updated controllers to include `from_id` in event dispatch calls, ensuring that this additional context is passed to metrics events. [[1]](diffhunk://#diff-f394122b1fa83e350f325feb732e5db83b9667adc38132dfd49293072ccadf76L323-R323) [[2]](diffhunk://#diff-bcceea8e72d4763f5b7fb06d4390ea6ca737a9cf829b07db40a1093345bf1a06L48-R48) [[3]](diffhunk://#diff-bcceea8e72d4763f5b7fb06d4390ea6ca737a9cf829b07db40a1093345bf1a06L62-R62) [[4]](diffhunk://#diff-14114934584327716ef1afd7084b8b2138c895d7acfce95d2bc0483dd6c2cae6L70-R70)

### Miscellaneous:
* Simplified the logic in `LiveMetricsResource` by removing fallback logic for `album_id` and photo URLs, assuming data consistency.