### PR TITLE
Fix timeline mode wrong indexing.

### DIFF
--- a/resources/js/components/gallery/albumModule/AlbumPanel.vue
+++ b/resources/js/components/gallery/albumModule/AlbumPanel.vue
@@ -68,6 +68,7 @@
 					v-if="layoutConfig !== null && photos !== null && photos.length > 0"
 					header="gallery.album.header_photos"
 					:photos="photos"
+					:photos-timeline="photosTimeline"
 					:album="album"
 					:gallery-config="layoutConfig"
 					:photo-layout="config.photo_layout"
@@ -125,6 +126,7 @@ import AlbumStatistics from "@/components/drawers/AlbumStatistics.vue";
 import { useTogglablesStateStore } from "@/stores/ModalsState";
 import { usePhotoRoute } from "@/composables/photo/photoRoute";
 import { useRouter } from "vue-router";
+import { type SplitData } from "@/composables/album/splitter";
 
 const router = useRouter();
 
@@ -135,6 +137,8 @@ const props = defineProps<{
 		| App.Http.Resources.Models.TagAlbumResource
 		| App.Http.Resources.Models.SmartAlbumResource
 		| undefined;
+	photos: App.Http.Resources.Models.PhotoResource[];
+	photosTimeline: SplitData<App.Http.Resources.Models.PhotoResource>[] | undefined;
 	config: App.Http.Resources.GalleryConfigs.AlbumConfig | undefined;
 	user: App.Http.Resources.Models.UserResource | undefined;
 	layoutConfig: App.Http.Resources.GalleryConfigs.PhotoLayoutConfig;
@@ -144,7 +148,8 @@ const props = defineProps<{
 const modelAlbum = computed(() => props.modelAlbum);
 const album = computed(() => props.album);
 const hasHidden = computed(() => modelAlbum.value !== undefined && modelAlbum.value.albums.filter((album) => album.is_nsfw).length > 0);
-const photos = computed<App.Http.Resources.Models.PhotoResource[]>(() => album.value?.photos ?? []);
+const photos = computed<App.Http.Resources.Models.PhotoResource[]>(() => props.photos);
+const photosTimeline = computed(() => props.photosTimeline);
 
 const config = ref(props.config);
 

--- a/resources/js/components/gallery/albumModule/AlbumThumbPanel.vue
+++ b/resources/js/components/gallery/albumModule/AlbumThumbPanel.vue
@@ -57,7 +57,7 @@
 import Panel from "primevue/panel";
 import { AlbumThumbConfig } from "@/components/gallery/albumModule/thumbs/AlbumThumb.vue";
 import { computed, onMounted, watch } from "vue";
-import { SplitData, useSplitter } from "@/composables/album/splitter";
+import { type SplitData, useSplitter } from "@/composables/album/splitter";
 import Timeline from "primevue/timeline";
 import { useLycheeStateStore } from "@/stores/LycheeState";
 import { storeToRefs } from "pinia";

--- a/resources/js/components/gallery/albumModule/AlbumThumbPanel.vue
+++ b/resources/js/components/gallery/albumModule/AlbumThumbPanel.vue
@@ -56,7 +56,7 @@
 <script setup lang="ts">
 import Panel from "primevue/panel";
 import { AlbumThumbConfig } from "@/components/gallery/albumModule/thumbs/AlbumThumb.vue";
-import { computed } from "vue";
+import { computed, onMounted, watch } from "vue";
 import { SplitData, useSplitter } from "@/composables/album/splitter";
 import Timeline from "primevue/timeline";
 import { useLycheeStateStore } from "@/stores/LycheeState";
@@ -64,7 +64,7 @@ import { storeToRefs } from "pinia";
 import AlbumThumbPanelList from "./AlbumThumbPanelList.vue";
 
 const lycheeStore = useLycheeStateStore();
-const { are_nsfw_visible, is_timeline_left_border_visible } = storeToRefs(lycheeStore);
+const { are_nsfw_visible, is_timeline_left_border_visible, is_debug_enabled } = storeToRefs(lycheeStore);
 
 const props = defineProps<{
 	header: string;
@@ -83,7 +83,7 @@ const emits = defineEmits<{
 	contexted: [idx: number, event: MouseEvent];
 }>();
 
-const { spliter } = useSplitter();
+const { spliter, verifyOrder } = useSplitter();
 
 const propagateClicked = (idx: number, e: MouseEvent) => {
 	emits("clicked", idx, e);
@@ -94,11 +94,7 @@ const propagateMenuOpen = (idx: number, e: MouseEvent) => {
 };
 
 const albumsTimeLine = computed<SplitData<App.Http.Resources.Models.ThumbAlbumResource>[]>(() =>
-	spliter(
-		props.albums as App.Http.Resources.Models.ThumbAlbumResource[],
-		(a: App.Http.Resources.Models.ThumbAlbumResource) => a.timeline?.time_date ?? "",
-		(a: App.Http.Resources.Models.ThumbAlbumResource) => a.timeline?.format ?? "Others",
-	),
+	split(props.albums as App.Http.Resources.Models.ThumbAlbumResource[]),
 );
 
 const isTimeline = computed(() => props.isTimeline && albumsTimeLine.value.length > 1);
@@ -106,4 +102,32 @@ const isTimeline = computed(() => props.isTimeline && albumsTimeLine.value.lengt
 const headerClass = computed(() => {
 	return props.isAlone ? "hidden" : "";
 });
+
+function split(albums: App.Http.Resources.Models.ThumbAlbumResource[]) {
+	return spliter(
+		albums,
+		(a: App.Http.Resources.Models.ThumbAlbumResource) => a.timeline?.time_date ?? "",
+		(a: App.Http.Resources.Models.ThumbAlbumResource) => a.timeline?.format ?? "Others",
+	);
+}
+
+onMounted(() => {
+	validate(props.albums as App.Http.Resources.Models.ThumbAlbumResource[]);
+});
+
+function validate(albums: App.Http.Resources.Models.ThumbAlbumResource[]) {
+	if (props.isTimeline) {
+		const splitted = split(albums);
+		verifyOrder(is_debug_enabled.value, albums, splitted);
+	}
+}
+
+watch(
+	() => props.album?.id,
+	() => {
+		if (props.isTimeline) {
+			validate(props.albums as App.Http.Resources.Models.ThumbAlbumResource[]);
+		}
+	},
+);
 </script>

--- a/resources/js/components/gallery/albumModule/PhotoThumbPanelList.vue
+++ b/resources/js/components/gallery/albumModule/PhotoThumbPanelList.vue
@@ -1,13 +1,13 @@
 <template>
-	<div class="relative flex flex-wrap flex-row shrink w-full justify-start align-top" :id="'photoListing' + props.idx">
+	<div class="relative flex flex-wrap flex-row shrink w-full justify-start align-top" :id="'photoListing' + props.groupIdx">
 		<template v-for="(photo, idx) in props.photos" :key="photo.id">
 			<PhotoThumb
-				@click="maySelect(idx + iter, $event)"
-				@contextmenu.prevent="menuOpen(idx + iter, $event)"
+				@click="maySelect(idx + props.iter, $event)"
+				@contextmenu.prevent="menuOpen(idx + props.iter, $event)"
 				:is-selected="props.selectedPhotos.includes(photo.id)"
 				:photo="photo"
 				:album="props.album"
-				:is-lazy="idx + iter > 10"
+				:is-lazy="idx + props.iter > 10"
 			/>
 		</template>
 	</div>
@@ -30,7 +30,7 @@ const props = defineProps<{
 	galleryConfig: App.Http.Resources.GalleryConfigs.PhotoLayoutConfig;
 	selectedPhotos: string[];
 	iter: number;
-	idx: number;
+	groupIdx: number;
 }>();
 
 const lycheeStore = useLycheeStateStore();
@@ -48,17 +48,21 @@ const emits = defineEmits<{
 	selected: [idx: number, event: MouseEvent];
 	contexted: [idx: number, event: MouseEvent];
 }>();
-const maySelect = (idx: number, e: MouseEvent) => {
+function maySelect(idx: number, e: MouseEvent) {
+	console.log("maySelect", idx);
 	if (ctrlKeyState.value || metaKeyState.value || shiftKeyState.value) {
 		emits("selected", idx, e);
 		return;
 	}
 	emits("clicked", idx, e);
-};
-const menuOpen = (idx: number, e: MouseEvent) => emits("contexted", idx, e);
+}
+function menuOpen(idx: number, e: MouseEvent) {
+	console.log("menuOpen", idx);
+	emits("contexted", idx, e);
+}
 
 // Layouts stuff
-const { activateLayout } = useLayouts(props.galleryConfig, layout, timelineData, "photoListing" + props.idx);
+const { activateLayout } = useLayouts(props.galleryConfig, layout, timelineData, "photoListing" + props.groupIdx);
 onMounted(() => activateLayout());
 onUpdated(() => activateLayout());
 </script>

--- a/resources/js/components/gallery/albumModule/PhotoThumbPanelList.vue
+++ b/resources/js/components/gallery/albumModule/PhotoThumbPanelList.vue
@@ -49,7 +49,6 @@ const emits = defineEmits<{
 	contexted: [idx: number, event: MouseEvent];
 }>();
 function maySelect(idx: number, e: MouseEvent) {
-	console.log("maySelect", idx);
 	if (ctrlKeyState.value || metaKeyState.value || shiftKeyState.value) {
 		emits("selected", idx, e);
 		return;
@@ -57,7 +56,6 @@ function maySelect(idx: number, e: MouseEvent) {
 	emits("clicked", idx, e);
 }
 function menuOpen(idx: number, e: MouseEvent) {
-	console.log("menuOpen", idx);
 	emits("contexted", idx, e);
 }
 

--- a/resources/js/components/gallery/searchModule/ResultPanel.vue
+++ b/resources/js/components/gallery/searchModule/ResultPanel.vue
@@ -21,13 +21,14 @@
 		:photo-layout="props.layout"
 		:header="props.photoHeader"
 		:photos="props.photos"
+		:photos-timeline="undefined"
 		:album="undefined"
 		:gallery-config="props.layoutConfig"
 		:selected-photos="selectedPhotosIds"
 		@clicked="photoClick"
 		@selected="photoSelect"
 		@contexted="photoMenuOpen"
-		:is-timeline="props.isPhotoTimelineEnabled"
+		:is-timeline="false"
 		:with-control="true"
 	/>
 	<div class="flex justify-center w-full" v-if="photos.length > 0">

--- a/resources/js/composables/album/albumRefresher.ts
+++ b/resources/js/composables/album/albumRefresher.ts
@@ -2,6 +2,9 @@ import { ALL } from "@/config/constants";
 import AlbumService from "@/services/album-service";
 import { AuthStore } from "@/stores/Auth";
 import { computed, Ref, ref } from "vue";
+import { type SplitData, useSplitter } from "./splitter";
+
+const { spliter, merge } = useSplitter();
 
 export function useAlbumRefresher(albumId: Ref<string>, photoId: Ref<string | undefined>, auth: AuthStore, isLoginOpen: Ref<boolean>) {
 	const isPasswordProtected = ref(false);
@@ -15,6 +18,7 @@ export function useAlbumRefresher(albumId: Ref<string>, photoId: Ref<string | un
 
 	const photo = ref<App.Http.Resources.Models.PhotoResource | undefined>(undefined);
 	const photos = ref<App.Http.Resources.Models.PhotoResource[]>([]);
+	const photosTimeline = ref<SplitData<App.Http.Resources.Models.PhotoResource>[] | undefined>(undefined);
 
 	const config = ref<App.Http.Resources.GalleryConfigs.AlbumConfig | undefined>(undefined);
 	const rights = computed(() => album.value?.rights ?? undefined);
@@ -39,6 +43,7 @@ export function useAlbumRefresher(albumId: Ref<string>, photoId: Ref<string | un
 				modelAlbum.value = undefined;
 				tagAlbum.value = undefined;
 				smartAlbum.value = undefined;
+				photosTimeline.value = undefined;
 				if (data.data.config.is_model_album) {
 					modelAlbum.value = data.data.resource as App.Http.Resources.Models.AlbumResource;
 				} else if (data.data.config.is_base_album) {
@@ -46,7 +51,35 @@ export function useAlbumRefresher(albumId: Ref<string>, photoId: Ref<string | un
 				} else {
 					smartAlbum.value = data.data.resource as App.Http.Resources.Models.SmartAlbumResource;
 				}
-				photos.value = album.value?.photos ?? [];
+
+				// So what is going on here?
+				// The problem is that the ordering of the photos from the API is not necessarily the same 
+				// as the ordering of the photos in the timeline. The timeline is constructed from the photos
+				// taken_at data and if not provided, created_at data.
+				// This is split into different chunks based on the granularity.
+				// If the ordering is done by created_at, and the order of the photos match, we do not have problems.
+				// But if one of the photos has a different taken_at date, that does not match the order, then all the following 
+				// photos are "moved" to different place which does not match the original index ordering.
+				//
+				// When we click on a photo, the index returned refers to the original ordering of the photos.
+				// As a result, if the timeline is enabled, we first do the split and then merge the photos so that the 
+				// ordering is updated to reflect the timeline.
+				//
+				// Note that this is not something that can be fixed in the backend as we would need to assume that all the dates are 
+				// set properly. Furthermore, this would make the functionality unavailable if sorting by title is done.
+				// By doing it in the front-end, we are able to display the photos by blocks of time,
+				// and within the block, the ordering is done as expected.
+				if (data.data.config.is_photo_timeline_enabled) {
+					photosTimeline.value = spliter(
+						data.data.resource?.photos ?? [],
+						(p: App.Http.Resources.Models.PhotoResource) => p.timeline?.time_date ?? "",
+						(p: App.Http.Resources.Models.PhotoResource) => p.timeline?.format ?? "Others",
+					);
+					photos.value = merge(photosTimeline.value);
+				} else {
+					// We are not using the timeline, so we can just use the photos as is.
+					photos.value = album.value?.photos ?? [];
+				}
 			})
 			.catch((error) => {
 				if (error.response && error.response.status === 401 && error.response.data.message === "Password required") {
@@ -84,6 +117,7 @@ export function useAlbumRefresher(albumId: Ref<string>, photoId: Ref<string | un
 		rights,
 		photo,
 		photos,
+		photosTimeline,
 		config,
 		loadUser,
 		loadAlbum,

--- a/resources/js/composables/album/albumRefresher.ts
+++ b/resources/js/composables/album/albumRefresher.ts
@@ -53,19 +53,19 @@ export function useAlbumRefresher(albumId: Ref<string>, photoId: Ref<string | un
 				}
 
 				// So what is going on here?
-				// The problem is that the ordering of the photos from the API is not necessarily the same 
+				// The problem is that the ordering of the photos from the API is not necessarily the same
 				// as the ordering of the photos in the timeline. The timeline is constructed from the photos
 				// taken_at data and if not provided, created_at data.
 				// This is split into different chunks based on the granularity.
 				// If the ordering is done by created_at, and the order of the photos match, we do not have problems.
-				// But if one of the photos has a different taken_at date, that does not match the order, then all the following 
+				// But if one of the photos has a different taken_at date, that does not match the order, then all the following
 				// photos are "moved" to different place which does not match the original index ordering.
 				//
 				// When we click on a photo, the index returned refers to the original ordering of the photos.
-				// As a result, if the timeline is enabled, we first do the split and then merge the photos so that the 
+				// As a result, if the timeline is enabled, we first do the split and then merge the photos so that the
 				// ordering is updated to reflect the timeline.
 				//
-				// Note that this is not something that can be fixed in the backend as we would need to assume that all the dates are 
+				// Note that this is not something that can be fixed in the backend as we would need to assume that all the dates are
 				// set properly. Furthermore, this would make the functionality unavailable if sorting by title is done.
 				// By doing it in the front-end, we are able to display the photos by blocks of time,
 				// and within the block, the ordering is done as expected.

--- a/resources/js/composables/album/albumsRefresher.ts
+++ b/resources/js/composables/album/albumsRefresher.ts
@@ -2,7 +2,7 @@ import AlbumService from "@/services/album-service";
 import { AuthStore } from "@/stores/Auth";
 import { LycheeStateStore } from "@/stores/LycheeState";
 import { computed, ref, Ref } from "vue";
-import { SplitData, useSplitter } from "./splitter";
+import { type SplitData, useSplitter } from "./splitter";
 
 export function useAlbumsRefresher(auth: AuthStore, lycheeStore: LycheeStateStore, isLoginOpen: Ref<boolean>) {
 	const { spliter } = useSplitter();

--- a/resources/js/composables/album/splitter.ts
+++ b/resources/js/composables/album/splitter.ts
@@ -25,7 +25,39 @@ export function useSplitter() {
 		return ret;
 	}
 
+	function verifyOrder(is_debug: boolean, data: { id: string }[], splitData: SplitData<{ id: string }>[]) {
+		if (!is_debug) {
+			return;
+		}
+
+		const dataMap = new Map<string, number>();
+		data.forEach((d, i) => {
+			dataMap.set(d.id, i);
+		});
+
+		let check = false;
+		splitData.forEach((chunk) => {
+			chunk.data.forEach((d, idx) => {
+				const expected = dataMap.get(d.id);
+				if (expected === undefined) {
+					console.error(`Data not found in original data for id ${d.id} (WTF??)`);
+					check = true;
+				}
+				const candidate = chunk.iter + idx;
+				if (expected !== candidate) {
+					console.error(`Data mismatch for id ${d.id} (expected ${expected}, got ${candidate})`);
+					check = true;
+				}
+			});
+		});
+
+		if (check) {
+			alert("Data mismatch found in splitter, please check the console logs and contact the developer.");
+		}
+	}
+
 	return {
 		spliter,
+		verifyOrder,
 	};
 }

--- a/resources/js/composables/album/splitter.ts
+++ b/resources/js/composables/album/splitter.ts
@@ -25,6 +25,12 @@ export function useSplitter() {
 		return ret;
 	}
 
+	function merge<T>(data: SplitData<T>[]): T[] {
+		const ret: T[] = [];
+		data.forEach((d) => ret.push(...d.data));
+		return ret;
+	}
+
 	function verifyOrder(is_debug: boolean, data: { id: string }[], splitData: SplitData<{ id: string }>[]) {
 		if (!is_debug) {
 			return;
@@ -58,6 +64,7 @@ export function useSplitter() {
 
 	return {
 		spliter,
+		merge,
 		verifyOrder,
 	};
 }

--- a/resources/js/services/album-service.ts
+++ b/resources/js/services/album-service.ts
@@ -74,7 +74,9 @@ const AlbumService = {
 		return requester.get(`${Constants.getApiUrl()}Albums`, { data: {}, id: "albums" });
 	},
 
-	get(album_id: string): Promise<AxiosResponse<App.Http.Resources.Models.AbstractAlbumResource>> {
+	get(
+		album_id: string,
+	): Promise<AxiosResponse<App.Http.Resources.Models.AbstractAlbumResource>> | Promise<{ data: App.Http.Resources.Models.AbstractAlbumResource }> {
 		const requester = axios as unknown as AxiosCacheInstance;
 		return requester.get(`${Constants.getApiUrl()}Album`, { params: { album_id: album_id }, data: {}, id: "album_" + album_id });
 	},

--- a/resources/js/views/gallery-panels/Album.vue
+++ b/resources/js/views/gallery-panels/Album.vue
@@ -16,6 +16,8 @@
 		v-if="layoutConfig"
 		:model-album="modelAlbum"
 		:album="album"
+		:photos="photos"
+		:photos-timeline="photosTimeline"
 		:config="config"
 		:user="user"
 		:layoutConfig="layoutConfig"
@@ -215,7 +217,7 @@ const { is_delete_visible, toggleDelete, is_merge_album_visible, is_move_visible
 	useGalleryModals(togglableStore);
 
 // Set up Album ID reference. This one is updated at each page change.
-const { isPasswordProtected, isLoading, user, modelAlbum, album, photo, rights, photos, config, refresh } = useAlbumRefresher(
+const { isPasswordProtected, isLoading, user, modelAlbum, album, photo, photosTimeline, rights, photos, config, refresh } = useAlbumRefresher(
 	albumId,
 	photoId,
 	auth,

--- a/resources/js/views/gallery-panels/Favourites.vue
+++ b/resources/js/views/gallery-panels/Favourites.vue
@@ -26,6 +26,7 @@
 				:photos="photos"
 				:album="undefined"
 				:gallery-config="layoutConfig"
+				:photos-timeline="undefined"
 				:photo-layout="'square'"
 				:selected-photos="selectedPhotosIds"
 				:is-timeline="false"


### PR DESCRIPTION
Fixes #3313

## Executive summary

#### So what is going on here?

The problem is that the ordering of the photos from the API is not necessarily the same as the ordering of the photos in the timeline. The timeline is constructed from the photos `taken_at` data and if not provided, `created_at` data.
This is split into different chunks based on the granularity. If the ordering is done by `created_at`, and the order of the photos match, we do not have problems. But if one of the photos has a different `taken_at` date, that does not match the order, then all the following photos are "moved" to different place which does not match the original index ordering.

When we click on a photo, the index returned refers to the original ordering of the photos. As a result, if the timeline is enabled, we first do the split and then merge the photos so that the ordering is updated to reflect the timeline.

Note that this is not something that can be fixed in the backend as we would need to assume that all the dates are set properly. Furthermore, this would make the functionality unavailable if sorting by title is done. By doing it in the front-end, we are able to display the photos by blocks of time, and within the block, the ordering is done as expected.


## Copilot summary

This pull request introduces significant changes to enhance the handling of photo timelines and improve the modularity of the codebase. The key updates include adding support for photo timelines in various components, refactoring timeline-related logic for better maintainability, and introducing new utility functions in the `splitter` module. Below is a categorized summary of the most important changes:

### Timeline Support and Refactoring

* Added `photosTimeline` as a new prop to components like `AlbumPanel`, `PhotoThumbPanel`, and `ResultPanel` to support displaying photos grouped by timeline. This includes updating computed properties and templates to use the new timeline data. [[1]](diffhunk://#diff-2eff78eb6e94f4c6ed5e9c0ee8c80b9eaa3c02c31d6632ae76c169a51ee1e277R71) [[2]](diffhunk://#diff-2596ceca4599cbea71fdf2e25b1083093174d8e950e5bcd601983f3192ca53f6L14-R21) [[3]](diffhunk://#diff-3f2caf64193356721b4779ae57eedbdd462279ccf72b64ffb004477067bc8e07R24-R31)
* Refactored timeline splitting logic to ensure proper ordering of photos when timelines are enabled. Introduced a `merge` function to reconstruct photos from timeline chunks and a `verifyOrder` function for debugging timeline data integrity. [[1]](diffhunk://#diff-24ffd824e902635c5157c492b21f48a1031a3385c37e3fa44a7af8b5d91d0865R46-R82) [[2]](diffhunk://#diff-b43913b3d65e993f5e5e812baa09e8750b84d189494c9ee0ea14fd24f4657b6aR28-R68)

### Component Updates

* Updated `PhotoThumbPanelList` to replace `idx` with `groupIdx` for better clarity when working with grouped timeline data. Adjusted related logic for event handling and lazy loading. [[1]](diffhunk://#diff-895b0f43b22cc9f4a54339b647386357aa5a215bcfe4a788e86bbd53d38eee0dL2-R10) [[2]](diffhunk://#diff-895b0f43b22cc9f4a54339b647386357aa5a215bcfe4a788e86bbd53d38eee0dL33-R33)
* Added validation and reactivity for timeline data in `PhotoThumbPanel` and `AlbumThumbPanel`, including `onMounted` and `watch` hooks to handle changes in album or timeline state. [[1]](diffhunk://#diff-bb505213cc0710c6750dbf60459b1b0de2bb8993a9697447656ca8d2bbe8faa6L97-R132) [[2]](diffhunk://#diff-2596ceca4599cbea71fdf2e25b1083093174d8e950e5bcd601983f3192ca53f6L125-R135)

### Utility Enhancements

* Enhanced the `splitter` module with new functions: `merge` for combining split data back into a single array and `verifyOrder` for ensuring timeline data matches the original photo order. These utilities improve the robustness of timeline handling.

### Service and API Adjustments

* Updated the `AlbumService.get` method to handle different response structures, accommodating changes in how album data is retrieved.

### Codebase Integration

* Integrated timeline-related changes into the `useAlbumRefresher` composable, ensuring that photos and timelines are properly synchronized and merged when timelines are enabled. [[1]](diffhunk://#diff-24ffd824e902635c5157c492b21f48a1031a3385c37e3fa44a7af8b5d91d0865R21) [[2]](diffhunk://#diff-24ffd824e902635c5157c492b21f48a1031a3385c37e3fa44a7af8b5d91d0865R46-R82)

These changes collectively improve the user experience by introducing timeline-based photo organization while enhancing the maintainability and modularity of the codebase.