### PR TITLE
Add fail safe for non-existing statistics & maintenance option

### DIFF
--- a/app/Actions/Diagnostics/Errors.php
+++ b/app/Actions/Diagnostics/Errors.php
@@ -28,6 +28,7 @@ use App\Actions\Diagnostics\Pipes\Checks\OpCacheCheck;
 use App\Actions\Diagnostics\Pipes\Checks\PHPVersionCheck;
 use App\Actions\Diagnostics\Pipes\Checks\PlaceholderExistsCheck;
 use App\Actions\Diagnostics\Pipes\Checks\SmallMediumExistsCheck;
+use App\Actions\Diagnostics\Pipes\Checks\StatisticsIntegrityCheck;
 use App\Actions\Diagnostics\Pipes\Checks\SupporterCheck;
 use App\Actions\Diagnostics\Pipes\Checks\TimezoneCheck;
 use App\Actions\Diagnostics\Pipes\Checks\UpdatableCheck;
@@ -65,6 +66,7 @@ class Errors
 		CacheTemporaryUrlCheck::class,
 		SupporterCheck::class,
 		ImagickPdfCheck::class,
+		StatisticsIntegrityCheck::class,
 	];
 
 	/**

--- a/app/Actions/Diagnostics/Pipes/Checks/StatisticsIntegrityCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/StatisticsIntegrityCheck.php
@@ -24,11 +24,6 @@ class StatisticsIntegrityCheck implements DiagnosticPipe
 	 */
 	public function handle(array &$data, \Closure $next): array
 	{
-		// Just skip the check, we don't care.
-		if (!Configs::getValueAsBool('metrics_enabled')) {
-			return $next($data);
-		}
-
 		$check = $this->get();
 
 		if ($check->missing_albums > 0) {
@@ -46,6 +41,11 @@ class StatisticsIntegrityCheck implements DiagnosticPipe
 
 	public function get(): StatisticsCheckResource
 	{
+		// Just skip the check, we don't care.
+		if (!Configs::getValueAsBool('metrics_enabled')) {
+			return new StatisticsCheckResource(0, 0);
+		}
+
 		$num_albums = DB::table('base_albums')->leftJoin('statistics', 'base_albums.id', '=', 'statistics.album_id')
 				->whereNull('statistics.id')
 				->count();

--- a/app/Actions/Diagnostics/Pipes/Checks/StatisticsIntegrityCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/StatisticsIntegrityCheck.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Diagnostics\Pipes\Checks;
+
+use App\Contracts\DiagnosticPipe;
+use App\DTO\DiagnosticData;
+use App\Http\Resources\Diagnostics\StatisticsCheckResource;
+use App\Models\Configs;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Check whether or not there are photos or albums without statistics.
+ */
+class StatisticsIntegrityCheck implements DiagnosticPipe
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function handle(array &$data, \Closure $next): array
+	{
+		// Just skip the check, we don't care.
+		if (!Configs::getValueAsBool('metrics_enabled')) {
+			return $next($data);
+		}
+
+		$check = $this->get();
+
+		if ($check->missing_albums > 0) {
+			$data[] = DiagnosticData::warn(sprintf('There are %d albums without statistics.', $check->missing_albums), self::class,
+				['Go to the maintenance page to fix this.']);
+		}
+
+		if ($check->missing_albums > 0) {
+			$data[] = DiagnosticData::warn(sprintf('There are %d photos without statistics.', $check->missing_photos), self::class,
+				['Go to the maintenance page to fix this.']);
+		}
+
+		return $next($data);
+	}
+
+	public function get(): StatisticsCheckResource
+	{
+		$num_albums = DB::table('base_albums')->leftJoin('statistics', 'base_albums.id', '=', 'statistics.album_id')
+				->whereNull('statistics.id')
+				->count();
+		$num_photos = DB::table('photos')->leftJoin('statistics', 'photos.id', '=', 'statistics.photo_id')
+			->whereNull('statistics.id')
+			->count();
+
+		return new StatisticsCheckResource($num_albums, $num_photos);
+	}
+}

--- a/app/Http/Controllers/Admin/Maintenance/StatisticsCheck.php
+++ b/app/Http/Controllers/Admin/Maintenance/StatisticsCheck.php
@@ -51,11 +51,6 @@ class StatisticsCheck extends Controller
 	 */
 	public function check(MaintenanceRequest $request): StatisticsCheckResource
 	{
-		// Just skip the check, we don't care.
-		if (!Configs::getValueAsBool('metrics_enabled')) {
-			return new StatisticsCheckResource(0, 0);
-		}
-
 		return $this->check->get();
 	}
 }

--- a/app/Http/Controllers/Admin/Maintenance/StatisticsCheck.php
+++ b/app/Http/Controllers/Admin/Maintenance/StatisticsCheck.php
@@ -27,9 +27,9 @@ class StatisticsCheck extends Controller
 	}
 
 	/**
-	 * Generates missing size variants by chunk of 100.
+	 * Create th emissing statistics.
 	 *
-	 * @return void
+	 * @return StatisticsCheckResource
 	 */
 	public function do(MaintenanceRequest $request): StatisticsCheckResource
 	{
@@ -45,7 +45,7 @@ class StatisticsCheck extends Controller
 	}
 
 	/**
-	 * Check how many images need to be created.
+	 * Check how many statistics are missing for photos and albums.
 	 *
 	 * @return StatisticsCheckResource
 	 */

--- a/app/Http/Controllers/Admin/Maintenance/StatisticsCheck.php
+++ b/app/Http/Controllers/Admin/Maintenance/StatisticsCheck.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Controllers\Admin\Maintenance;
+
+use App\Actions\Diagnostics\Pipes\Checks\StatisticsIntegrityCheck;
+use App\Http\Requests\Maintenance\MaintenanceRequest;
+use App\Http\Resources\Diagnostics\StatisticsCheckResource;
+use App\Models\Configs;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * We may miss some statistics because of generation problem.
+ * This module aims to solve this issue.
+ */
+class StatisticsCheck extends Controller
+{
+	public function __construct(
+		private StatisticsIntegrityCheck $check,
+	) {
+	}
+
+	/**
+	 * Generates missing size variants by chunk of 100.
+	 *
+	 * @return void
+	 */
+	public function do(MaintenanceRequest $request): StatisticsCheckResource
+	{
+		// Just skip the check, we don't care.
+		if (!Configs::getValueAsBool('metrics_enabled')) {
+			return new StatisticsCheckResource(0, 0);
+		}
+
+		DB::statement('INSERT INTO statistics (photo_id) SELECT photos.id FROM photos LEFT OUTER JOIN statistics ON photos.id = photo_id WHERE statistics.id IS NULL');
+		DB::statement('INSERT INTO statistics (album_id) SELECT base_albums.id FROM base_albums LEFT OUTER JOIN statistics ON base_albums.id = album_id WHERE statistics.id IS NULL');
+
+		return $this->check->get();
+	}
+
+	/**
+	 * Check how many images need to be created.
+	 *
+	 * @return StatisticsCheckResource
+	 */
+	public function check(MaintenanceRequest $request): StatisticsCheckResource
+	{
+		// Just skip the check, we don't care.
+		if (!Configs::getValueAsBool('metrics_enabled')) {
+			return new StatisticsCheckResource(0, 0);
+		}
+
+		return $this->check->get();
+	}
+}

--- a/app/Http/Resources/Diagnostics/StatisticsCheckResource.php
+++ b/app/Http/Resources/Diagnostics/StatisticsCheckResource.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Diagnostics;
+
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class StatisticsCheckResource extends Data
+{
+	public function __construct(
+		public int $missing_photos,
+		public int $missing_albums,
+	) {
+	}
+}

--- a/app/Http/Resources/Models/PhotoStatisticsResource.php
+++ b/app/Http/Resources/Models/PhotoStatisticsResource.php
@@ -23,8 +23,12 @@ class PhotoStatisticsResource extends Data
 	) {
 	}
 
-	public static function fromModel(Statistics $stats): PhotoStatisticsResource
+	public static function fromModel(Statistics|null $stats): PhotoStatisticsResource|null
 	{
+		if ($stats === null) {
+			return null;
+		}
+
 		return new self(
 			$stats->visit_count,
 			$stats->download_count,

--- a/app/Metadata/Cache/RouteCacheManager.php
+++ b/app/Metadata/Cache/RouteCacheManager.php
@@ -71,6 +71,7 @@ final readonly class RouteCacheManager
 			'api/v2/Maintenance::update' => false,
 			'api/v2/Maintenance::countDuplicates' => false,
 			'api/v2/Maintenance::searchDuplicates' => false,
+			'api/v2/Maintenance::statisticsIntegrity' => false,
 
 			'api/v2/Map' => new RouteCacheConfig(tag: CacheTag::GALLERY, user_dependant: true, extra: [RequestAttribute::ALBUM_ID_ATTRIBUTE]),
 			'api/v2/Map::provider' => new RouteCacheConfig(tag: CacheTag::SETTINGS),

--- a/lang/ar/maintenance.php
+++ b/lang/ar/maintenance.php
@@ -60,7 +60,6 @@ return [
     ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/ar/maintenance.php
+++ b/lang/ar/maintenance.php
@@ -58,6 +58,13 @@ return [
         'update-button' => '',
         'no-pending-updates' => '',
     ],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
     'flush-cache' => [
         'title' => '',
         'description' => '',

--- a/lang/cz/maintenance.php
+++ b/lang/cz/maintenance.php
@@ -61,7 +61,6 @@ return [
 	],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/cz/maintenance.php
+++ b/lang/cz/maintenance.php
@@ -59,6 +59,13 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
 	'flush-cache' => [
 		'title' => 'Flush Cache',
 		'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/lang/de/maintenance.php
+++ b/lang/de/maintenance.php
@@ -57,6 +57,13 @@ return [
         'update-button' => 'Update',
         'no-pending-updates' => 'Keine Updates verfügbar.',
     ],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
     'flush-cache' => [
         'title' => 'Cache leeren',
         'description' => 'Leeren Sie den Cache jedes Benutzers, um Ungültigkeitsprobleme zu lösen.',

--- a/lang/de/maintenance.php
+++ b/lang/de/maintenance.php
@@ -59,7 +59,6 @@ return [
     ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/el/maintenance.php
+++ b/lang/el/maintenance.php
@@ -61,7 +61,6 @@ return [
 	],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/el/maintenance.php
+++ b/lang/el/maintenance.php
@@ -59,6 +59,13 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
 	'flush-cache' => [
 		'title' => 'Flush Cache',
 		'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/lang/en/maintenance.php
+++ b/lang/en/maintenance.php
@@ -60,7 +60,6 @@ return [
     ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/en/maintenance.php
+++ b/lang/en/maintenance.php
@@ -58,6 +58,13 @@ return [
         'update-button' => 'Update',
         'no-pending-updates' => 'No pending update.',
     ],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
     'flush-cache' => [
         'title' => 'Flush Cache',
         'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/lang/es/maintenance.php
+++ b/lang/es/maintenance.php
@@ -61,7 +61,6 @@ return [
 	],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/es/maintenance.php
+++ b/lang/es/maintenance.php
@@ -59,6 +59,13 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
 	'flush-cache' => [
 		'title' => 'Flush Cache',
 		'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/lang/fr/maintenance.php
+++ b/lang/fr/maintenance.php
@@ -59,11 +59,10 @@ return [
         'no-pending-updates' => 'Aucune mise à jour en attente.',
     ],
     'statistics-check' => [
-        'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
-        'missing_photos' => '%d photo statistics missing.',
-        'missing_albums' => '%d album statistics missing.',
-        'button' => 'Create missing',
+        'title' => 'Check de l’intégrité des Statistiques',
+        'missing_photos' => '%d statistiques de photos manquantes.',
+        'missing_albums' => '%d statistiques d’albums manquantes.',
+        'button' => 'Créer les statistiques manquantes',
     ],
     'flush-cache' => [
         'title' => 'Vider le cache',

--- a/lang/fr/maintenance.php
+++ b/lang/fr/maintenance.php
@@ -58,6 +58,13 @@ return [
         'update-button' => 'Mettre à jour',
         'no-pending-updates' => 'Aucune mise à jour en attente.',
     ],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
     'flush-cache' => [
         'title' => 'Vider le cache',
         'description' => 'Vider le cache de tous les utilisateurs pour résoudre les problèmes d’invalidation.',

--- a/lang/hu/maintenance.php
+++ b/lang/hu/maintenance.php
@@ -61,7 +61,6 @@ return [
 	],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/hu/maintenance.php
+++ b/lang/hu/maintenance.php
@@ -59,6 +59,13 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
 	'flush-cache' => [
 		'title' => 'Flush Cache',
 		'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/lang/it/maintenance.php
+++ b/lang/it/maintenance.php
@@ -61,7 +61,6 @@ return [
 	],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/it/maintenance.php
+++ b/lang/it/maintenance.php
@@ -59,6 +59,13 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
 	'flush-cache' => [
 		'title' => 'Flush Cache',
 		'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/lang/ja/maintenance.php
+++ b/lang/ja/maintenance.php
@@ -60,7 +60,6 @@ return [
     ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/ja/maintenance.php
+++ b/lang/ja/maintenance.php
@@ -58,6 +58,13 @@ return [
         'update-button' => '更新',
         'no-pending-updates' => '保留中の更新はありません',
     ],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
     'flush-cache' => [
         'title' => 'Flush Cache',
         'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/lang/nl/maintenance.php
+++ b/lang/nl/maintenance.php
@@ -61,7 +61,6 @@ return [
 	],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/nl/maintenance.php
+++ b/lang/nl/maintenance.php
@@ -59,6 +59,13 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
 	'flush-cache' => [
 		'title' => 'Flush Cache',
 		'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/lang/no/maintenance.php
+++ b/lang/no/maintenance.php
@@ -61,7 +61,6 @@ return [
 	],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/no/maintenance.php
+++ b/lang/no/maintenance.php
@@ -59,6 +59,13 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
 	'flush-cache' => [
 		'title' => 'Flush Cache',
 		'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/lang/pl/maintenance.php
+++ b/lang/pl/maintenance.php
@@ -61,7 +61,6 @@ return [
     ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/pl/maintenance.php
+++ b/lang/pl/maintenance.php
@@ -59,6 +59,13 @@ return [
         'update-button' => 'Aktualizacja',
         'no-pending-updates' => 'Brak oczekujących aktualizacji.',
     ],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
     'flush-cache' => [
         'title' => 'Opróżnianie pamięci podręcznej',
         'description' => 'Opróżnianie pamięci podręcznej każdego użytkownika w celu rozwiązania problemów z unieważnianiem.',

--- a/lang/pt/maintenance.php
+++ b/lang/pt/maintenance.php
@@ -61,7 +61,6 @@ return [
 	],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/pt/maintenance.php
+++ b/lang/pt/maintenance.php
@@ -59,6 +59,13 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
 	'flush-cache' => [
 		'title' => 'Flush Cache',
 		'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/lang/ru/maintenance.php
+++ b/lang/ru/maintenance.php
@@ -60,7 +60,6 @@ return [
     ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/ru/maintenance.php
+++ b/lang/ru/maintenance.php
@@ -58,6 +58,13 @@ return [
         'update-button' => 'Обновить',
         'no-pending-updates' => 'Нет ожидающих обновлений.',
     ],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
     'flush-cache' => [
         'title' => 'Очистить кэш',
         'description' => 'Очистить кэш каждого пользователя для решения проблем с устаревшими данными.',

--- a/lang/sk/maintenance.php
+++ b/lang/sk/maintenance.php
@@ -61,7 +61,6 @@ return [
 	],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/sk/maintenance.php
+++ b/lang/sk/maintenance.php
@@ -59,6 +59,13 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
 	'flush-cache' => [
 		'title' => 'Flush Cache',
 		'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/lang/sv/maintenance.php
+++ b/lang/sv/maintenance.php
@@ -61,7 +61,6 @@ return [
 	],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/sv/maintenance.php
+++ b/lang/sv/maintenance.php
@@ -59,6 +59,13 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
 	'flush-cache' => [
 		'title' => 'Flush Cache',
 		'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/lang/vi/maintenance.php
+++ b/lang/vi/maintenance.php
@@ -61,7 +61,6 @@ return [
 	],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/vi/maintenance.php
+++ b/lang/vi/maintenance.php
@@ -59,6 +59,13 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
 	'flush-cache' => [
 		'title' => 'Flush Cache',
 		'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/lang/zh_CN/maintenance.php
+++ b/lang/zh_CN/maintenance.php
@@ -60,7 +60,6 @@ return [
     ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/zh_CN/maintenance.php
+++ b/lang/zh_CN/maintenance.php
@@ -58,6 +58,13 @@ return [
         'update-button' => '更新',
         'no-pending-updates' => '没有待处理的更新。',
     ],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
     'flush-cache' => [
         'title' => '清除缓存',
         'description' => '清除所有用户的缓存以解决失效问题。',

--- a/lang/zh_TW/maintenance.php
+++ b/lang/zh_TW/maintenance.php
@@ -61,7 +61,6 @@ return [
 	],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
-        'description' => 'Check the statistics of your albums and photos.',
         'missing_photos' => '%d photo statistics missing.',
         'missing_albums' => '%d album statistics missing.',
         'button' => 'Create missing',

--- a/lang/zh_TW/maintenance.php
+++ b/lang/zh_TW/maintenance.php
@@ -59,6 +59,13 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'statistics-check' => [
+        'title' => 'Statistics integrity Check',
+        'description' => 'Check the statistics of your albums and photos.',
+        'missing_photos' => '%d photo statistics missing.',
+        'missing_albums' => '%d album statistics missing.',
+        'button' => 'Create missing',
+    ],
 	'flush-cache' => [
 		'title' => 'Flush Cache',
 		'description' => 'Flush the cache of every user to solve invalidation problems.',

--- a/resources/js/components/maintenance/StatisticsIntegrity.vue
+++ b/resources/js/components/maintenance/StatisticsIntegrity.vue
@@ -1,0 +1,79 @@
+<template>
+	<Card
+		v-if="data !== undefined && data.missing_albums !== 0 && data.missing_photos !== 0"
+		class="min-h-40 dark:bg-surface-800 shadow shadow-surface-950/30 rounded-lg relative"
+		pt:body:class="min-h-40 h-full"
+		pt:content:class="h-full flex justify-between flex-col"
+	>
+		<template #title>
+			<div class="text-center">
+				{{ $t("maintenance.statistics-check.title") }}
+			</div>
+		</template>
+		<template #content>
+			<ScrollPanel class="w-full h-40 text-sm text-muted-color">
+				<div class="w-full text-left" v-if="!loading">
+					{{ sprintf($t("maintenance.statistics-check.missing_albums"), data.missing_albums) }}<br />
+					{{ sprintf($t("maintenance.statistics-check.missing_photos"), data.missing_photos) }}<br />
+				</div>
+				<ProgressSpinner v-if="loading" class="w-full"></ProgressSpinner>
+			</ScrollPanel>
+			<div class="flex gap-4 mt-1">
+				<Button severity="primary" v-if="!loading" class="w-full font-bold border-none" @click="exec">{{
+					$t("maintenance.statistics-check.button")
+				}}</Button>
+			</div>
+		</template>
+	</Card>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import Button from "primevue/button";
+import Card from "primevue/card";
+import { useToast } from "primevue/usetoast";
+import ProgressSpinner from "primevue/progressspinner";
+import ScrollPanel from "primevue/scrollpanel";
+import MaintenanceService from "@/services/maintenance-service";
+import { trans } from "laravel-vue-i18n";
+import { sprintf } from "sprintf-js";
+
+const data = ref<App.Http.Resources.Diagnostics.StatisticsCheckResource | undefined>(undefined);
+const loading = ref(false);
+const toast = useToast();
+
+function load() {
+	loading.value = true;
+	MaintenanceService.statisticsIntegrityCheckGet()
+		.then((response) => {
+			data.value = response.data;
+			loading.value = false;
+		})
+		.catch((e) => {
+			toast.add({ severity: "error", summary: trans("toasts.error"), detail: e.response.data.message, life: 3000 });
+			loading.value = false;
+		});
+}
+
+function exec() {
+	loading.value = true;
+	MaintenanceService.statisticsIntegrityCheckDo()
+		.then((response) => {
+			toast.add({ severity: "success", summary: trans("toasts.success"), life: 3000 });
+			data.value = response.data;
+			loading.value = false;
+		})
+		.catch((e) => {
+			toast.add({ severity: "error", summary: trans("toasts.error"), detail: e.response.data.message, life: 3000 });
+			loading.value = false;
+		});
+}
+
+load();
+</script>
+
+<style lang="css" scoped>
+.lychee-dark .p-card {
+	--p-card-background: var(--p-surface-800);
+}
+</style>

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -148,6 +148,10 @@ declare namespace App.Http.Resources.Diagnostics {
 		left: string;
 		right: string;
 	};
+	export type StatisticsCheckResource = {
+		missing_photos: number;
+		missing_albums: number;
+	};
 	export type TreeState = {
 		oddness: number;
 		duplicates: number;

--- a/resources/js/services/maintenance-service.ts
+++ b/resources/js/services/maintenance-service.ts
@@ -88,6 +88,14 @@ const MaintenanceService = {
 			},
 		});
 	},
+
+	statisticsIntegrityCheckGet(): Promise<AxiosResponse<App.Http.Resources.Diagnostics.StatisticsCheckResource>> {
+		return axios.get(`${Constants.getApiUrl()}Maintenance::statisticsIntegrity`, { data: {} });
+	},
+
+	statisticsIntegrityCheckDo(): Promise<AxiosResponse> {
+		return axios.post(`${Constants.getApiUrl()}Maintenance::statisticsIntegrity`, {});
+	},
 };
 
 export default MaintenanceService;

--- a/resources/js/views/Maintenance.vue
+++ b/resources/js/views/Maintenance.vue
@@ -28,6 +28,7 @@
 		<MaintenanceFixJobs />
 		<MaintenanceFixTree />
 		<MaintenanceFilesize />
+		<StatisticsIntegrity />
 		<MaintenanceCleaning path="filesystems.disks.extract-jobs.root" />
 		<MaintenanceCleaning path="filesystems.disks.image-jobs.root" />
 		<MaintenanceCleaning path="filesystems.disks.image-upload.root" />
@@ -45,4 +46,5 @@ import MaintenanceOptimize from "@/components/maintenance/MaintenanceOptimize.vu
 import MaintenanceUpdate from "@/components/maintenance/MaintenanceUpdate.vue";
 import MaintenanceFlushCache from "@/components/maintenance/MaintenanceFlushCache.vue";
 import OpenLeftMenu from "@/components/headers/OpenLeftMenu.vue";
+import StatisticsIntegrity from "@/components/maintenance/StatisticsIntegrity.vue";
 </script>

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -221,6 +221,8 @@ Route::get('/Maintenance::fullTree', [Admin\Maintenance\FullTree::class, 'check'
 Route::post('/Maintenance::fullTree', [Admin\Maintenance\FullTree::class, 'do']);
 Route::get('/Maintenance::countDuplicates', [Admin\Maintenance\DuplicateFinder::class, 'check']);
 Route::get('/Maintenance::searchDuplicates', [Admin\Maintenance\DuplicateFinder::class, 'get']);
+Route::get('/Maintenance::statisticsIntegrity', [Admin\Maintenance\StatisticsCheck::class, 'check']);
+Route::post('/Maintenance::statisticsIntegrity', [Admin\Maintenance\StatisticsCheck::class, 'do']);
 
 /**
  * STATISTICS.

--- a/tests/Feature_v2/Maintenance/StatisticsIntegrityTest.php
+++ b/tests/Feature_v2/Maintenance/StatisticsIntegrityTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\Maintenance;
+
+use App\Models\Configs;
+use Illuminate\Support\Facades\DB;
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+
+class StatisticsIntegrityTest extends BaseApiWithDataTest
+{
+	public function setUp(): void
+	{
+		parent::setUp();
+		Configs::set('metrics_enabled', true);
+	}
+
+	public function tearDown(): void
+	{
+		Configs::set('metrics_enabled', false);
+		parent::tearDown();
+	}
+
+	public function testGuest(): void
+	{
+		$response = $this->getJsonWithData('Maintenance::statisticsIntegrity', []);
+		$this->assertUnauthorized($response);
+
+		$response = $this->postJson('Maintenance::statisticsIntegrity', []);
+		$this->assertUnauthorized($response);
+	}
+
+	public function testUser(): void
+	{
+		$response = $this->actingAs($this->userLocked)->getJsonWithData('Maintenance::statisticsIntegrity', []);
+		$this->assertForbidden($response);
+
+		$response = $this->actingAs($this->userLocked)->postJson('Maintenance::statisticsIntegrity', []);
+		$this->assertForbidden($response);
+	}
+
+	public function testAdmin(): void
+	{
+		DB::table('statistics')->truncate();
+		$response = $this->actingAs($this->admin)->getJsonWithData('Maintenance::statisticsIntegrity', []);
+		$this->assertOk($response);
+		$response->assertJsonPath('missing_albums', 9);
+		$response->assertJsonPath('missing_photos', 9);
+	
+		$response = $this->actingAs($this->admin)->postJson('Maintenance::statisticsIntegrity', []);
+		$this->assertCreated($response);
+		$response->assertJsonPath('missing_albums', 0);
+		$response->assertJsonPath('missing_photos', 0);
+	}
+}

--- a/tests/Feature_v2/Maintenance/StatisticsIntegrityTest.php
+++ b/tests/Feature_v2/Maintenance/StatisticsIntegrityTest.php
@@ -61,7 +61,7 @@ class StatisticsIntegrityTest extends BaseApiWithDataTest
 		$this->assertOk($response);
 		$response->assertJsonPath('missing_albums', 9);
 		$response->assertJsonPath('missing_photos', 9);
-	
+
 		$response = $this->actingAs($this->admin)->postJson('Maintenance::statisticsIntegrity', []);
 		$this->assertCreated($response);
 		$response->assertJsonPath('missing_albums', 0);


### PR DESCRIPTION
This pull request introduces functionality to check and fix missing statistics for photos and albums, along with related updates to resources and translations. The most important changes include adding a new diagnostic check for statistics integrity, implementing a maintenance controller for fixing missing statistics, and updating translations for multiple languages to support this feature.

### New Functionality for Statistics Integrity:

* **Added `StatisticsIntegrityCheck` class**: Implements a diagnostic pipe to identify albums and photos without associated statistics and provides warnings for missing statistics. (`app/Actions/Diagnostics/Pipes/Checks/StatisticsIntegrityCheck.php`)
* **Created `StatisticsCheck` controller**: Provides endpoints to check and generate missing statistics for albums and photos. (`app/Http/Controllers/Admin/Maintenance/StatisticsCheck.php`)

### Resource Updates:

* **Added `StatisticsCheckResource`**: A new resource class to encapsulate the results of the statistics integrity check. (`app/Http/Resources/Diagnostics/StatisticsCheckResource.php`)
* **Modified `PhotoStatisticsResource`**: Updated the `fromModel` method to handle null statistics gracefully. (`app/Http/Resources/Models/PhotoStatisticsResource.php`)

### Translation Updates:

* **Added translations for statistics integrity check**: Updated language files to include strings for the new feature in multiple languages, including English, German, French, Japanese, and others. (`lang/{ar,cz,de,el,en,es,fr,hu,it,ja,nl,no,pl,pt,ru,sk}/maintenance.php`) (e.g., [[1]](diffhunk://#diff-fb369b0debedc39ff2cfa32419800b20d3f36b9e6888019f7c409916094a8524R61-R67) [[2]](diffhunk://#diff-156bbc1c2b27f2f6e2f7810e5b78aea2e9488b196bd61a43f53b2bed0581a8f6R60-R66) [[3]](diffhunk://#diff-89ec1e53bf9f9afe8568db5d065a53dfa684d23724e068a7d68aa3ecd594de44R61-R67)