### PR TITLE
Revert part of #3373

### DIFF
--- a/app/Http/Controllers/SecurePathController.php
+++ b/app/Http/Controllers/SecurePathController.php
@@ -33,18 +33,12 @@ class SecurePathController extends Controller
 
 	public function __invoke(Request $request, ?string $path)
 	{
-		// In theory we should use the `$request->hasCorrectSignature()` method here.
-		// However, for some stupid unknown reason, the path value is added to the server Query String.
-		// This completely invalidates the signature check.
-		// For example the url http://localhost:8000/image/small2x/c3/3d/c661c594a5a781cd44db06828783.png?expires=1748380289
-		// will be verified as :
-		// http://localhost:8000/image/small2x/c3/3d/c661c594a5a781cd44db06828783.png?/image/small2x/c3/3d/c661c594a5a781cd44db06828783.png&expires=1748380289
-		// which makes the signature check fail as the hmac does not match.
-		// On the bright side, we can now differentiate between a missing/failed signature and an expired one.
+		// First we verify that the request has not expired.
 		if (!self::shouldNotUseSignedUrl() && !$this->signatureHasNotExpired($request)) {
 			throw new SignatureExpiredException();
 		}
 
+		// Then we verify that the request has a valid signature.
 		if (!self::shouldNotUseSignedUrl() && !$request->hasValidSignature()) {
 			Log::error('Invalid signature for secure path request. Verify that the url generated for the image match.', [
 				'candidate url' => $this->getUrl($request),
@@ -86,28 +80,6 @@ class SecurePathController extends Controller
 
 		return rtrim($url . '?' . $query_string, '?');
 	}
-
-	// /**
-	//  * Determine if the signature from the given request matches the URL.
-	//  *
-	//  * @param \Illuminate\Http\Request $request
-	//  * @param bool                     $absolute
-	//  *
-	//  * @return bool
-	//  */
-	// private function hasCorrectSignature(Request $request, bool $absolute = true): bool
-	// {
-	// 	$original = $this->getUrl($request, $absolute);
-	// 	$key = new \SensitiveParameterValue(config('app.key'));
-	// 	if (hash_equals(
-	// 		hash_hmac('sha256', $original, $key->getValue()),
-	// 		$request->query('signature', '')
-	// 	)) {
-	// 		return true;
-	// 	}
-
-	// 	return false;
-	// }
 
 	/**
 	 * Determine if the expires timestamp from the given request is not from the past.

--- a/app/Http/Controllers/SecurePathController.php
+++ b/app/Http/Controllers/SecurePathController.php
@@ -66,19 +66,16 @@ class SecurePathController extends Controller
 		return response()->file($file);
 	}
 
-	private function getUrl(Request $request, bool $absolute = true): string
+	private function getUrl(Request $request): string
 	{
 		$ignore_query = ['signature'];
-
-		$url = $absolute ? $request->url() : ('/' . $request->path());
 
 		$query_string = '';
 		$query_string = (new Collection(explode('&', (string) $request->server->get('QUERY_STRING'))))
 			->reject(fn ($parameter) => in_array(\Str::before($parameter, '='), $ignore_query, true))
-			->reject(fn ($parameter) => count(explode('=', $parameter)) === 1) // Ignore parameters without value => avoid problem above mentionned.
 			->join('&');
 
-		return rtrim($url . '?' . $query_string, '?');
+		return rtrim($request->url() . '?' . $query_string, '?');
 	}
 
 	/**


### PR DESCRIPTION
This pull request refactors the `SecurePathController` to improve the handling of signed URL validation by separating signature expiration and validity checks, and simplifies the `getUrl` method by removing unnecessary parameters and logic. Additionally, the `hasCorrectSignature` method has been removed in favor of using Laravel's built-in `hasValidSignature` method.

**Note that this new functionality relies ENTIRELY on a proper Nginx configuration.**

### Improvements to signed URL validation:

* Refactored the signature validation logic in `SecurePathController` to first check for signature expiration using `signatureHasNotExpired` and then validate the signature using Laravel's `hasValidSignature` method. This improves clarity and leverages framework capabilities. (`app/Http/Controllers/SecurePathController.php`, [app/Http/Controllers/SecurePathController.phpL36-L54](diffhunk://#diff-559199f1a5214ace02e0d4b5bc0170fb65a309be675f4da71df8f60746d04d62L36-L54))

### Simplification of URL generation:

* Simplified the `getUrl` method by removing the `$absolute` parameter and redundant logic for handling query strings. The method now directly uses `$request->url()` combined with filtered query strings. (`app/Http/Controllers/SecurePathController.php`, [app/Http/Controllers/SecurePathController.phpL75-R78](diffhunk://#diff-559199f1a5214ace02e0d4b5bc0170fb65a309be675f4da71df8f60746d04d62L75-R78))

### Code cleanup:

* Removed the custom `hasCorrectSignature` method, as its functionality is now replaced by Laravel's `hasValidSignature` method, reducing duplication and improving maintainability. (`app/Http/Controllers/SecurePathController.php`, [app/Http/Controllers/SecurePathController.phpL75-R78](diffhunk://#diff-559199f1a5214ace02e0d4b5bc0170fb65a309be675f4da71df8f60746d04d62L75-R78))

