### PR TITLE
Add option to override the album visibility for smart and tag albums

### DIFF
--- a/app/Relations/HasManyPhotosByTag.php
+++ b/app/Relations/HasManyPhotosByTag.php
@@ -69,18 +69,33 @@ class HasManyPhotosByTag extends BaseHasManyPhotos
 		$album = $albums[0];
 		$tags = $album->show_tags;
 
-		$this->photo_query_policy
-			->applySearchabilityFilter(
-				$this->getRelationQuery(),
-				origin: null,
-				include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums')
-			)
-			->where(function (Builder $q) use ($tags): void {
-				// Filter for requested tags
-				foreach ($tags as $tag) {
-					$q->where('tags', 'like', '%' . trim($tag) . '%');
-				}
-			});
+		if (Configs::getValueAsBool('TA_override_visibility')) {
+			$this->photo_query_policy
+				->applySensitivityFilter(
+					$this->getRelationQuery(),
+					origin: null,
+					include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums')
+				)
+				->where(function (Builder $q) use ($tags): void {
+					// Filter for requested tags
+					foreach ($tags as $tag) {
+						$q->where('tags', 'like', '%' . trim($tag) . '%');
+					}
+				});
+		} else {
+			$this->photo_query_policy
+				->applySearchabilityFilter(
+					$this->getRelationQuery(),
+					origin: null,
+					include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums')
+				)
+				->where(function (Builder $q) use ($tags): void {
+					// Filter for requested tags
+					foreach ($tags as $tag) {
+						$q->where('tags', 'like', '%' . trim($tag) . '%');
+					}
+				});
+		}
 	}
 
 	/**

--- a/app/SmartAlbums/BaseSmartAlbum.php
+++ b/app/SmartAlbums/BaseSmartAlbum.php
@@ -113,14 +113,18 @@ abstract class BaseSmartAlbum implements AbstractAlbum
 	 */
 	public function photos(): Builder
 	{
-		$query = $this->photo_query_policy
-			->applySearchabilityFilter(
-				query: Photo::query()->with(['album', 'size_variants', 'statistics']),
-				origin: null,
-				include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums')
-			)->where($this->smart_photo_condition);
+		$base_query = Photo::query()->with(['album', 'size_variants', 'statistics']);
 
-		return $query;
+		if (!Configs::getValueAsBool('SA_override_visibility')) {
+			return $this->photo_query_policy
+				->applySearchabilityFilter(query: $base_query, origin: null, include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums'))
+				->where($this->smart_photo_condition);
+		}
+
+		// If the smart album visibility override is enabled, we do not need to apply any security filter, as all photos are visible
+		// in this smart album. We still need to apply the smart album condition, though.
+		return $this->photo_query_policy->applySensitivityFilter(query: $base_query, origin: null, include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums'))
+			->where($this->smart_photo_condition);
 	}
 
 	/**

--- a/database/migrations/2025_05_28_174009_add_visibility_override_smart_album.php
+++ b/database/migrations/2025_05_28_174009_add_visibility_override_smart_album.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const CAT = 'Smart Albums';
+
+	public function getConfigs(): array
+	{
+		return [
+			[
+				'key' => 'SA_override_visibility',
+				'value' => '0',
+				'cat' => self::CAT,
+				'type_range' => self::BOOL,
+				'description' => 'Smart album visibility overrides the photo visibility.',
+				'details' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will make any photos matching the smart album condition visible.',
+				'is_expert' => true,
+				'is_secret' => false,
+				'level' => 0,
+				'order' => 10,
+			],
+			[
+				'key' => 'TA_override_visibility',
+				'value' => '0',
+				'cat' => self::CAT,
+				'type_range' => self::BOOL,
+				'description' => 'Tag album visibility overrides the photo visibility.',
+				'details' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will make any photos matching the tag album condition visible.',
+				'is_expert' => true,
+				'is_secret' => false,
+				'level' => 0,
+				'order' => 11,
+			],
+		];
+	}
+};


### PR DESCRIPTION
This pull request introduces a new sensitivity filter for photo queries and adds configuration options to override photo visibility in smart and tag albums. The changes primarily focus on enhancing the flexibility of visibility settings and improving query handling for sensitive content.

### New Sensitivity Filter and Visibility Handling

* Added a new `applySensitivityFilter` method in `PhotoQueryPolicy` to restrict photo queries based on sensitivity settings. This method allows filtering out sensitive photos unless explicitly included (`include_nsfw` parameter). It also applies additional album-based restrictions if an origin album is provided.

* Updated `HasManyPhotosByTag` to use the new `applySensitivityFilter` when the `TA_override_visibility` configuration is enabled, allowing tag albums to override photo visibility settings. [[1]](diffhunk://#diff-2ecea7bf53336db3d43f80b4d21a6c4bf750b3659575fdbaf88341b2b7519a04R72-R85) [[2]](diffhunk://#diff-2ecea7bf53336db3d43f80b4d21a6c4bf750b3659575fdbaf88341b2b7519a04R99)

* Modified `BaseSmartAlbum` to apply the `applySensitivityFilter` when the `SA_override_visibility` configuration is enabled, ensuring smart albums can override visibility settings while still applying album-specific conditions.

### Configuration for Visibility Overrides

* Added a new database migration to introduce two configuration options: `SA_override_visibility` and `TA_override_visibility`. These options allow administrators to enable visibility overrides for smart and tag albums, respectively.