### PR TITLE
Add option to disable slideshow

### DIFF
--- a/app/Http/Resources/GalleryConfigs/InitConfig.php
+++ b/app/Http/Resources/GalleryConfigs/InitConfig.php
@@ -69,6 +69,7 @@ class InitConfig extends Data
 
 	// Slideshow setting
 	public int $slideshow_timeout;
+	public bool $is_slideshow_enabled;
 
 	// Timeline settings
 	public bool $is_timeline_left_border_visible;
@@ -132,6 +133,7 @@ class InitConfig extends Data
 
 		// Slideshow settings
 		$this->slideshow_timeout = Configs::getValueAsInt('slideshow_timeout');
+		$this->is_slideshow_enabled = Configs::getValueAsBool('slideshow_enabled');
 
 		// Timeline settings
 		$this->is_timeline_left_border_visible = Configs::getValueAsBool('timeline_left_border_enabled');

--- a/database/migrations/2025_05_29_174832_add_slideshow_enabled.php
+++ b/database/migrations/2025_05_29_174832_add_slideshow_enabled.php
@@ -13,7 +13,6 @@ return new class() extends BaseConfigMigration {
 
 	public function getConfigs(): array
 	{
-		// landing_background
 		return [
 			[
 				'key' => 'slideshow_enabled',

--- a/database/migrations/2025_05_29_174832_add_slideshow_enabled.php
+++ b/database/migrations/2025_05_29_174832_add_slideshow_enabled.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const CAT = 'Gallery';
+
+	public function getConfigs(): array
+	{
+		// landing_background
+		return [
+			[
+				'key' => 'slideshow_enabled',
+				'value' => '1',
+				'cat' => self::CAT,
+				'type_range' => self::BOOL,
+				'description' => 'Enable the slideshow functionality.',
+				'details' => '',
+				'is_expert' => true,
+				'is_secret' => true,
+				'level' => 0,
+				'order' => 37,
+			],
+		];
+	}
+};

--- a/resources/js/components/gallery/albumModule/AlbumHero.vue
+++ b/resources/js/components/gallery/albumModule/AlbumHero.vue
@@ -79,7 +79,7 @@
 						<a
 							v-tooltip.bottom="'Start slideshow'"
 							@click="emits('toggleSlideShow')"
-							v-if="props.album.photos.length > 0"
+							v-if="props.album.photos.length > 0 && is_slideshow_enabled"
 							class="shrink-0 px-3 cursor-pointer text-muted-color inline-block transform duration-300 hover:scale-150 hover:text-color"
 						>
 							<i class="pi pi-play" />
@@ -136,7 +136,7 @@ import { computed } from "vue";
 
 const auth = useAuthStore();
 const lycheeStore = useLycheeStateStore();
-const { is_se_enabled, is_se_preview_enabled, are_nsfw_visible } = storeToRefs(lycheeStore);
+const { is_se_enabled, is_se_preview_enabled, are_nsfw_visible, is_slideshow_enabled } = storeToRefs(lycheeStore);
 const { user } = storeToRefs(auth);
 
 const props = defineProps<{

--- a/resources/js/components/headers/PhotoHeader.vue
+++ b/resources/js/components/headers/PhotoHeader.vue
@@ -13,7 +13,7 @@
 			</template>
 			<template #end>
 				<div :class="is_slideshow_active ? 'hidden' : 'flex'">
-					<Button text icon="pi pi-play" class="mr-2" severity="secondary" @click="emits('toggleSlideShow')" />
+					<Button v-if="is_slideshow_enabled" text icon="pi pi-play" class="mr-2" severity="secondary" @click="emits('toggleSlideShow')" />
 					<Button
 						v-if="props.photo.rights.can_access_full_photo && props.photo.size_variants.original?.url"
 						text
@@ -76,7 +76,7 @@ const togglableStore = useTogglablesStateStore();
 const { is_full_screen, is_photo_edit_open, are_details_open, is_slideshow_active } = storeToRefs(togglableStore);
 const isDownloadOpen = ref(false);
 const lycheeStore = useLycheeStateStore();
-const { is_exif_disabled } = storeToRefs(lycheeStore);
+const { is_exif_disabled, is_slideshow_enabled } = storeToRefs(lycheeStore);
 
 function openInNewTab(url: string) {
 	window?.open(url, "_blank")?.focus();

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -262,6 +262,7 @@ declare namespace App.Http.Resources.GalleryConfigs {
 		is_medium2x_download_enabled: boolean;
 		clockwork_url: string | null;
 		slideshow_timeout: number;
+		is_slideshow_enabled: boolean;
 		is_timeline_left_border_visible: boolean;
 		title: string;
 		dropbox_api_key: string;

--- a/resources/js/stores/LycheeState.ts
+++ b/resources/js/stores/LycheeState.ts
@@ -14,6 +14,7 @@ export const useLycheeStateStore = defineStore("lychee-store", {
 
 		// Photo config
 		slideshow_timeout: 5,
+		is_slideshow_enabled: true,
 
 		// configs for nsfw
 		are_nsfw_visible: false,
@@ -119,6 +120,7 @@ export const useLycheeStateStore = defineStore("lychee-store", {
 					this.clockwork_url = data.clockwork_url;
 
 					this.slideshow_timeout = data.slideshow_timeout;
+					this.is_slideshow_enabled = data.is_slideshow_enabled;
 
 					this.is_timeline_left_border_visible = data.is_timeline_left_border_visible;
 

--- a/resources/js/views/gallery-panels/Album.vue
+++ b/resources/js/views/gallery-panels/Album.vue
@@ -194,7 +194,7 @@ const lycheeStore = useLycheeStateStore();
 
 lycheeStore.init();
 
-const { are_nsfw_visible, slideshow_timeout } = storeToRefs(lycheeStore);
+const { are_nsfw_visible, slideshow_timeout, is_slideshow_enabled } = storeToRefs(lycheeStore);
 const {
 	is_photo_edit_open,
 	are_details_open,
@@ -307,7 +307,7 @@ onKeyStroke([getModKey(), "a"], () => !shouldIgnoreKeystroke() && photo.value ==
 onKeyStroke("ArrowLeft", () => !shouldIgnoreKeystroke() && photo.value !== undefined && hasPrevious() && previous(true));
 onKeyStroke("ArrowRight", () => !shouldIgnoreKeystroke() && photo.value !== undefined && hasNext() && next(true));
 onKeyStroke("o", () => !shouldIgnoreKeystroke() && photo.value !== undefined && rotateOverlay());
-onKeyStroke(" ", () => !shouldIgnoreKeystroke() && photo.value !== undefined && slideshow());
+onKeyStroke(" ", () => !shouldIgnoreKeystroke() && photo.value !== undefined && is_slideshow_enabled.value && slideshow());
 onKeyStroke("i", () => !shouldIgnoreKeystroke() && photo.value !== undefined && toggleDetails());
 onKeyStroke("f", () => !shouldIgnoreKeystroke() && photo.value !== undefined && togglableStore.toggleFullScreen());
 onKeyStroke("Escape", () => !shouldIgnoreKeystroke() && photo.value !== undefined && is_slideshow_active.value && stop());


### PR DESCRIPTION
This pull request introduces a new feature to enable or disable the slideshow functionality in the gallery application. The changes include backend updates to store and retrieve the slideshow setting, as well as frontend modifications to respect this setting when rendering UI components or handling user interactions.

### Backend Changes:
* **`InitConfig` class updates**: Added a new property `is_slideshow_enabled` to the `InitConfig` class and initialized it in the constructor by fetching the value from the configuration. (`app/Http/Resources/GalleryConfigs/InitConfig.php`, [[1]](diffhunk://#diff-d31771d798b76463dc8bb0c03d41ab098b9600d38beeae4bb84cbb34c118d86fR72) [[2]](diffhunk://#diff-d31771d798b76463dc8bb0c03d41ab098b9600d38beeae4bb84cbb34c118d86fR136)
* **Database migration**: Added a migration file to introduce the `slideshow_enabled` configuration with default value `1` (enabled). (`database/migrations/2025_05_29_174832_add_slideshow_enabled.php`, [database/migrations/2025_05_29_174832_add_slideshow_enabled.phpR1-R32](diffhunk://#diff-b38a3273139cb341a51cf94dfafca769e1401a7b112aa34d338284906206b3eaR1-R32))

### Frontend Changes:
* **UI adjustments**: Updated components like `AlbumHero.vue` and `PhotoHeader.vue` to conditionally display slideshow-related buttons based on the `is_slideshow_enabled` setting. (`resources/js/components/gallery/albumModule/AlbumHero.vue`, [[1]](diffhunk://#diff-9be5751687fc3866426c0508141eee931c75e7fd469339b643867f68634eb47fL82-R82) [[2]](diffhunk://#diff-9be5751687fc3866426c0508141eee931c75e7fd469339b643867f68634eb47fL139-R139); `resources/js/components/headers/PhotoHeader.vue`, [[3]](diffhunk://#diff-ae53e2b94c40918a523bec16c70c07ad316109aa6c7899834b5987ab95c86ebdL16-R16) [[4]](diffhunk://#diff-ae53e2b94c40918a523bec16c70c07ad316109aa6c7899834b5987ab95c86ebdL79-R79)
* **State management**: Added `is_slideshow_enabled` to the Lychee state store and ensured it is updated during initialization. (`resources/js/stores/LycheeState.ts`, [[1]](diffhunk://#diff-5585be2db0c41adcd345e27400e1476598e1979d611d3030d032d049f64f12e4R17) [[2]](diffhunk://#diff-5585be2db0c41adcd345e27400e1476598e1979d611d3030d032d049f64f12e4R123)
* **Keyboard shortcuts**: Modified the slideshow keyboard shortcut (`space` key) to respect the `is_slideshow_enabled` setting. (`resources/js/views/gallery-panels/Album.vue`, [[1]](diffhunk://#diff-88a848123a6b43d2f9695bb217b0d435421b52774f19ea9cc79388f46de23c3cL197-R197) [[2]](diffhunk://#diff-88a848123a6b43d2f9695bb217b0d435421b52774f19ea9cc79388f46de23c3cL310-R310)