### PR TITLE
Fix 500 when the imagick config file does not exists

### DIFF
--- a/app/Actions/Diagnostics/Pipes/Checks/ImagickPdfCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/ImagickPdfCheck.php
@@ -22,7 +22,7 @@ use function Safe\preg_match;
  */
 class ImagickPdfCheck implements DiagnosticPipe
 {
-	const DETAILS = [
+	public const DETAILS = [
 		'Make sure to have the policy.xml file in `/etc/ImageMagick-6/policy.xml`.',
 		'Verify that the file contains the line <policy domain="coder" rights="read|write" pattern="PDF"/> .',
 	];
@@ -44,10 +44,10 @@ class ImagickPdfCheck implements DiagnosticPipe
 			return $next($data);
 		}
 
-
 		try {
 			if (!file_exists('/etc/ImageMagick-6/policy.xml')) {
 				$data[] = DiagnosticData::warn('The policy.xml file does not exist at the expected location: /etc/ImageMagick-6/policy.xml.', self::class, self::DETAILS);
+
 				return $next($data);
 			}
 


### PR DESCRIPTION
This pull request enhances the diagnostic checks for Imagick's PDF support in the `ImagickPdfCheck` class. It introduces a new constant for reusable diagnostic details, adds a check for the existence of the `policy.xml` file, and improves error handling by catching unexpected exceptions.

### Enhancements to diagnostic checks:

* **Reusable diagnostic details**: Added a `DETAILS` constant to centralize the diagnostic instructions for verifying the `policy.xml` file configuration. (`[app/Actions/Diagnostics/Pipes/Checks/ImagickPdfCheck.phpR25-R29](diffhunk://#diff-aea50fbc9331d0a6b5cc5dc077c827f4d35256623e6de442bedfd123c25f0d39R25-R29)`)

* **File existence check**: Introduced a check to verify if the `policy.xml` file exists at the expected location (`/etc/ImageMagick-6/policy.xml`). If it does not, a warning is added to the diagnostic data. (`[app/Actions/Diagnostics/Pipes/Checks/ImagickPdfCheck.phpR48-R65](diffhunk://#diff-aea50fbc9331d0a6b5cc5dc077c827f4d35256623e6de442bedfd123c25f0d39R48-R65)`)

* **Improved error handling**: Added a catch block for generic exceptions to handle unexpected errors gracefully and log them as diagnostic errors. (`[app/Actions/Diagnostics/Pipes/Checks/ImagickPdfCheck.phpR48-R65](diffhunk://#diff-aea50fbc9331d0a6b5cc5dc077c827f4d35256623e6de442bedfd123c25f0d39R48-R65)`)