### PR TITLE
Fix various issues on Search

### DIFF
--- a/app/Actions/Search/AlbumSearch.php
+++ b/app/Actions/Search/AlbumSearch.php
@@ -53,17 +53,20 @@ class AlbumSearch
 	}
 
 	/**
-	 * @param string[] $terms
+	 * @param string[]   $terms
+	 * @param Album|null $album the optional top album which is used as a search base
 	 *
 	 * @return Collection<int,Album>
 	 *
 	 * @throws InternalLycheeException
 	 */
-	public function queryAlbums(array $terms): Collection
+	public function queryAlbums(array $terms, ?Album $album = null): Collection
 	{
 		$album_query = Album::query()
 			->select(['albums.*'])
-			->join('base_albums', 'base_albums.id', '=', 'albums.id');
+			->join('base_albums', 'base_albums.id', '=', 'albums.id')
+			->when($album !== null, fn ($q) => $q->where('albums._lft', '>=', $album->_lft)
+				->where('albums._rgt', '<=', $album->_rgt));
 		$this->addSearchCondition($terms, $album_query);
 		$this->albumQueryPolicy->applyBrowsabilityFilter($album_query);
 

--- a/app/Http/Controllers/Gallery/SearchController.php
+++ b/app/Http/Controllers/Gallery/SearchController.php
@@ -51,7 +51,7 @@ class SearchController extends Controller
 			->orderBy(ColumnSortingPhotoType::TAKEN_AT->value, OrderSortingType::ASC->value)
 			->paginate(Configs::getValueAsInt('search_pagination_limit'));
 
-		$album_results = $album_search->queryAlbums($terms);
+		$album_results = $album_search->queryAlbums($terms, $album);
 
 		return ResultsResource::fromData($album_results, $photo_results);
 	}

--- a/app/Http/Requests/Search/GetSearchRequest.php
+++ b/app/Http/Requests/Search/GetSearchRequest.php
@@ -59,10 +59,18 @@ class GetSearchRequest extends BaseApiRequest implements HasAbstractAlbum, HasTe
 		$this->album = $this->album_factory->findNullalbleAbstractAlbumOrFail($album_id);
 
 		// Escape special characters for a LIKE query
-		$this->terms = explode(' ', str_replace(
+		$terms = str_replace(
 			['\\', '%', '_'],
 			['\\\\', '\\%', '\\_'],
 			base64_decode($values[RequestAttribute::TERM_ATTRIBUTE], true)
-		));
+		);
+
+		// Explode the string by spaces but keep encapsulated strings as single terms
+		// This regex matches quoted strings and unquoted words
+		// Note: This regex is not perfect and may not handle all edge cases, but it works for most common cases.
+		// It captures quoted strings as a single match and unquoted words separately.
+		// Example: "hello world" foo bar -> ["hello world", "foo", "bar"]
+		preg_match_all('/"[^"]*"|\S+/', $terms, $matches);
+		$this->terms = array_map(fn ($term) => trim($term, '"'), $matches[0]);
 	}
 }

--- a/app/Http/Requests/Search/GetSearchRequest.php
+++ b/app/Http/Requests/Search/GetSearchRequest.php
@@ -21,6 +21,7 @@ use App\Rules\RandomIDRule;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use function Safe\base64_decode;
+use function Safe\preg_match_all;
 
 class GetSearchRequest extends BaseApiRequest implements HasAbstractAlbum, HasTerms
 {

--- a/resources/js/views/gallery-panels/Search.vue
+++ b/resources/js/views/gallery-panels/Search.vue
@@ -322,7 +322,7 @@ function goBack() {
 	if (photoId.value !== undefined) {
 		photoId.value = undefined;
 		photo.value = undefined;
-		router.push({ name: "search-with-album", params: { albumId: albumId.value } });
+		router.push({ name: "search", params: { albumId: albumId.value } });
 		return;
 	}
 
@@ -410,7 +410,7 @@ onKeyStroke("Escape", () => {
 
 onMounted(() => {
 	if (photoId.value !== undefined) {
-		router.push({ name: "search-with-album", params: { albumId: albumId.value } });
+		router.push({ name: "search", params: { albumId: albumId.value } });
 	}
 
 	if (albumId.value !== "" && albumId.value !== ALL) {


### PR DESCRIPTION
Fix search route issue + add children constraint + add " " a la Google search

This pull request introduces enhancements to the album search functionality and refines the handling of search terms and navigation in the gallery panels. The most important changes include adding support for scoped album searches, improving the parsing of search terms, and adjusting navigation routes.

### Enhancements to album search functionality:

* [`app/Actions/Search/AlbumSearch.php`](diffhunk://#diff-df99a973b6ce5e35803e8ddabafa99669a45cfe80a4daefcb62dab4921316760R57-R69): Updated `queryAlbums` to accept an optional `Album` parameter, enabling searches to be scoped to a specific album and its descendants. The query now applies constraints based on the album's `_lft` and `_rgt` values.
* [`app/Http/Controllers/Gallery/SearchController.php`](diffhunk://#diff-95f0a17e5edd4808cc4eb96efd549e0d530d3fa84345f40718dc961d0653b7f9L54-R54): Modified the call to `queryAlbums` to pass the `Album` parameter, ensuring the scoped search functionality is utilized.

### Improvements to search term parsing:

* [`app/Http/Requests/Search/GetSearchRequest.php`](diffhunk://#diff-9911e1239d59c177c7d21dddbfabd8d135b4852f50a91f3799507a4c7f9582daL62-R74): Enhanced the parsing of search terms by introducing a regex-based approach that handles quoted strings as single terms while splitting unquoted text by spaces. This ensures better handling of complex search queries.

### Adjustments to navigation routes:

* [`resources/js/views/gallery-panels/Search.vue`](diffhunk://#diff-e5023252e2c9afc91608da26a88b70b3e5dc53aba16bd66087a86d3e52e409a9L325-R325): Updated navigation routes to consistently use the `search` route instead of `search-with-album` when navigating back or handling the "Escape" key, simplifying the routing logic. [[1]](diffhunk://#diff-e5023252e2c9afc91608da26a88b70b3e5dc53aba16bd66087a86d3e52e409a9L325-R325) [[2]](diffhunk://#diff-e5023252e2c9afc91608da26a88b70b3e5dc53aba16bd66087a86d3e52e409a9L413-R413)