### PR TITLE
Add copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,4 @@
+Any new php file should contain the license header and has a single blank line after the opening PHP tag.
+The variable name should be in snake_case.
+In Requests, if a user is provided by the query it is placed in the $this->user2.
+In Requests, $this->user is reserved for the user making the request.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,3 +2,7 @@ Any new php file should contain the license header and has a single blank line a
 The variable name should be in snake_case.
 In Requests, if a user is provided by the query it is placed in the $this->user2.
 In Requests, $this->user is reserved for the user making the request.
+We do not use blade view, we use Vue3 instead.
+Use Typescript in composition API for Vue3. Use PrimeVue for UI components.
+Do not use await async calls in Vue3, use .then() instead.
+Do not use const function = () => {}, use function functionName() {} instead.


### PR DESCRIPTION
This pull request updates the coding guidelines in the `.github/copilot-instructions.md` file to clarify standards for PHP files and variable usage in requests.

Updates to coding guidelines:

* Added a requirement for all new PHP files to include a license header and a single blank line after the opening PHP tag.
* Specified that variable names should follow the `snake_case` naming convention.
* Clarified that in requests, if a user is provided by the query, it should be assigned to `$this->user2`, while `$this->user` is reserved for the user making the request.