### PR TITLE
Add check in maintenance page.

### DIFF
--- a/app/Actions/Album/PositionData.php
+++ b/app/Actions/Album/PositionData.php
@@ -42,6 +42,7 @@ class PositionData
 					// variants per photo
 					$r->whereBetween('type', [SizeVariantType::SMALL2X, SizeVariantType::THUMB]);
 				},
+				'palette',
 			])
 			->whereNotNull('latitude')
 			->whereNotNull('longitude');

--- a/app/Actions/Albums/PositionData.php
+++ b/app/Actions/Albums/PositionData.php
@@ -55,6 +55,7 @@ class PositionData
 						// variants per photo
 						$r->whereBetween('type', [SizeVariantType::SMALL2X, SizeVariantType::THUMB]);
 					},
+					'palette',
 				])
 				->whereNotNull('latitude')
 				->whereNotNull('longitude'),

--- a/app/Actions/Search/PhotoSearch.php
+++ b/app/Actions/Search/PhotoSearch.php
@@ -57,7 +57,7 @@ class PhotoSearch
 	public function sqlQuery(array $terms, ?Album $album = null): Builder
 	{
 		$query = $this->photoQueryPolicy->applySearchabilityFilter(
-			query: Photo::query()->with(['album', 'statistics', 'size_variants']),
+			query: Photo::query()->with(['album', 'statistics', 'size_variants', 'palette']),
 			origin: $album,
 			include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_search')
 		);

--- a/app/Console/Commands/ImageProcessing/ExtractColourPalette.php
+++ b/app/Console/Commands/ImageProcessing/ExtractColourPalette.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Console\Commands\ImageProcessing;
+
+use App\Exceptions\UnexpectedException;
+use App\Jobs\ExtractColoursJob;
+use App\Models\Photo;
+use Illuminate\Console\Command;
+use Safe\Exceptions\InfoException;
+use function Safe\set_time_limit;
+
+class ExtractColourPalette extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'lychee:extract_colour_palette {limit=5 : number of photos to extract the colour palette for} {tm=600 : timeout time requirement}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Extract the colour palette if it has not been extracted yet';
+
+	/**
+	 * Execute the console command.
+	 */
+	public function handle(): int
+	{
+		try {
+			$limit = (int) $this->argument('limit');
+			$timeout = (int) $this->argument('tm');
+
+			try {
+				set_time_limit($timeout);
+			} catch (InfoException) {
+				// Silently do nothing, if `set_time_limit` is denied.
+			}
+
+			$photos = Photo::with(['size_variants'])
+				->whereDoesntHave('palette')
+				->where('type', 'like', 'image/%')
+				->orderBy('id')
+				->lazyById($limit);
+
+			if (count($photos) === 0) {
+				$this->line('No photos require palette extraction.');
+
+				return 0;
+			}
+
+			foreach ($photos as $photo) {
+				$this->line(sprintf('Extracting Color Palette for %s [%s].', $photo->title, $photo->id));
+				ExtractColoursJob::dispatchSync($photo);
+			}
+
+			return 0;
+		} catch (\Throwable $e) {
+			throw new UnexpectedException($e);
+		}
+	}
+}

--- a/app/Factories/AlbumFactory.php
+++ b/app/Factories/AlbumFactory.php
@@ -96,7 +96,7 @@ class AlbumFactory
 		$tag_album_query = TagAlbum::query();
 
 		if ($with_relations) {
-			$album_query->with(['access_permissions', 'photos', 'children', 'children.owner', 'photos.size_variants', 'photos.statistics']);
+			$album_query->with(['access_permissions', 'photos', 'children', 'children.owner', 'photos.size_variants', 'photos.statistics', 'photos.palette']);
 			$tag_album_query->with(['photos']);
 		}
 

--- a/app/Http/Controllers/Admin/Maintenance/MissingPalettes.php
+++ b/app/Http/Controllers/Admin/Maintenance/MissingPalettes.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Controllers\Admin\Maintenance;
+
+use App\Http\Requests\Maintenance\MaintenanceRequest;
+use App\Jobs\ExtractColoursJob;
+use App\Models\Configs;
+use App\Models\Photo;
+use Illuminate\Routing\Controller;
+use LycheeVerify\Verify;
+
+/**
+ * Handles missing palettes for photos.
+ */
+class MissingPalettes extends Controller
+{
+	/**
+	 * Count photos without a palette.
+	 *
+	 * @return int
+	 */
+	public function check(MaintenanceRequest $request): int
+	{
+		if (!resolve(Verify::class)->check() || !Configs::getValueAsBool('enable_colour_extractions')) {
+			return 0;
+		}
+
+		return Photo::query()
+			->where('type', 'like', 'image/%')
+			->whereDoesntHave('palette')
+			->count();
+	}
+
+	/**
+	 * Generate missing palettes for photos in chunks.
+	 *
+	 * @return void
+	 */
+	public function do(MaintenanceRequest $request): void
+	{
+		if (!resolve(Verify::class)->check() || !Configs::getValueAsBool('enable_colour_extractions')) {
+			return;
+		}
+
+		$limit = Configs::getValueAsInt('maintenance_processing_limit');
+		$photos = Photo::with(['size_variants'])
+			->whereDoesntHave('palette')
+			->where('type', 'like', 'image/%')
+			->orderBy('id')
+			->lazyById($limit);
+
+		foreach ($photos as $photo) {
+			ExtractColoursJob::dispatchSync($photo);
+		}
+	}
+}

--- a/app/Http/Controllers/Gallery/FrameController.php
+++ b/app/Http/Controllers/Gallery/FrameController.php
@@ -86,12 +86,12 @@ class FrameController extends Controller
 		// default query
 		if ($album === null) {
 			$query = $this->photo_query_policy->applySearchabilityFilter(
-				query: Photo::query()->with(['album', 'size_variants']),
+				query: Photo::query()->with(['album', 'size_variants', 'palette']),
 				origin: null,
 				include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_frame')
 			);
 		} else {
-			$query = $album->photos()->with(['album', 'size_variants']);
+			$query = $album->photos()->with(['album', 'size_variants', 'palette']);
 		}
 
 		/** @var ?Photo $photo */

--- a/app/Http/Resources/Models/ColourPaletteResource.php
+++ b/app/Http/Resources/Models/ColourPaletteResource.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Models;
+
+use App\Models\Palette;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class ColourPaletteResource extends Data
+{
+	public string $colour_1;
+	public string $colour_2;
+	public string $colour_3;
+	public string $colour_4;
+	public string $colour_5;
+
+	public function __construct(Palette $palette)
+	{
+		$this->colour_1 = Palette::toHex($palette->colour_1);
+		$this->colour_2 = Palette::toHex($palette->colour_2);
+		$this->colour_3 = Palette::toHex($palette->colour_3);
+		$this->colour_4 = Palette::toHex($palette->colour_4);
+		$this->colour_5 = Palette::toHex($palette->colour_5);
+	}
+
+	public static function fromModel(?Palette $p): ?ColourPaletteResource
+	{
+		if ($p === null) {
+			return null;
+		}
+
+		return new self($p);
+	}
+}

--- a/app/Http/Resources/Models/PhotoResource.php
+++ b/app/Http/Resources/Models/PhotoResource.php
@@ -61,6 +61,7 @@ class PhotoResource extends Data
 	public PreformattedPhotoData $preformatted;
 	public PreComputedPhotoData $precomputed;
 	public ?TimelineData $timeline = null;
+	public ?ColourPaletteResource $palette = null;
 
 	private Carbon $timeline_data_carbon;
 
@@ -102,6 +103,7 @@ class PhotoResource extends Data
 		$this->previous_photo_id = null;
 		$this->preformatted = new PreformattedPhotoData($photo, $this->size_variants->original);
 		$this->precomputed = new PreComputedPhotoData($photo);
+		$this->palette = ColourPaletteResource::fromModel($photo->palette);
 
 		$this->timeline_data_carbon = $photo->taken_at ?? $photo->created_at;
 

--- a/app/Metadata/Cache/RouteCacheManager.php
+++ b/app/Metadata/Cache/RouteCacheManager.php
@@ -72,6 +72,7 @@ final readonly class RouteCacheManager
 			'api/v2/Maintenance::countDuplicates' => false,
 			'api/v2/Maintenance::searchDuplicates' => false,
 			'api/v2/Maintenance::statisticsIntegrity' => false,
+			'api/v2/Maintenance::missingPalettes' => false,
 
 			'api/v2/Map' => new RouteCacheConfig(tag: CacheTag::GALLERY, user_dependant: true, extra: [RequestAttribute::ALBUM_ID_ATTRIBUTE]),
 			'api/v2/Map::provider' => new RouteCacheConfig(tag: CacheTag::SETTINGS),

--- a/app/Models/Palette.php
+++ b/app/Models/Palette.php
@@ -35,20 +35,6 @@ class Palette extends Model
 	];
 
 	/**
-	 * @return array{colour_1:string,colour_2:string,colour_3:string,colour_4:string,colour_5:string}
-	 */
-	public function toHexColours(): array
-	{
-		return [
-			'colour_1' => self::toHex($this->colour_1),
-			'colour_2' => self::toHex($this->colour_2),
-			'colour_3' => self::toHex($this->colour_3),
-			'colour_4' => self::toHex($this->colour_4),
-			'colour_5' => self::toHex($this->colour_5),
-		];
-	}
-
-	/**
 	 * Convert a colour integer to a hex string.
 	 *
 	 * @param int $colour The colour in integer format (0xRRGGBB)

--- a/app/Relations/BaseHasManyPhotos.php
+++ b/app/Relations/BaseHasManyPhotos.php
@@ -65,7 +65,7 @@ abstract class BaseHasManyPhotos extends Relation
 			// indirect condition.
 			// Hence, the actually owning albums of the photos are not
 			// necessarily loaded.
-			Photo::query()->with(['album', 'size_variants']),
+			Photo::query()->with(['album', 'size_variants', 'palette']),
 			$owning_album
 		);
 	}

--- a/app/SmartAlbums/BaseSmartAlbum.php
+++ b/app/SmartAlbums/BaseSmartAlbum.php
@@ -115,7 +115,7 @@ abstract class BaseSmartAlbum implements AbstractAlbum
 	{
 		$query = $this->photo_query_policy
 			->applySearchabilityFilter(
-				query: Photo::query()->with(['album', 'size_variants', 'statistics']),
+				query: Photo::query()->with(['album', 'size_variants', 'statistics', 'palette']),
 				origin: null,
 				include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums')
 			)->where($this->smart_photo_condition);

--- a/app/SmartAlbums/UnsortedAlbum.php
+++ b/app/SmartAlbums/UnsortedAlbum.php
@@ -45,7 +45,7 @@ class UnsortedAlbum extends BaseSmartAlbum
 	public function photos(): Builder
 	{
 		if ($this->public_permissions !== null) {
-			return Photo::query()->with(['album', 'size_variants', 'statistics'])
+			return Photo::query()->with(['album', 'size_variants', 'statistics', 'palette'])
 			->where($this->smart_photo_condition);
 		}
 

--- a/database/factories/PhotoFactory.php
+++ b/database/factories/PhotoFactory.php
@@ -181,6 +181,7 @@ class PhotoFactory extends Factory
 				$photo->load('size_variants');
 			}
 
+			$photo->load('palette');
 			$photo->load('statistics');
 
 			// Reset the value if it was disabled.

--- a/lang/ar/maintenance.php
+++ b/lang/ar/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'تحديث',
         'no-pending-updates' => 'لا توجد تحديثات معلقة.',
     ],
+    'missing-palettes' => [
+        'title' => 'لوحات الألوان المفقودة',
+        'description' => 'تم العثور على %d لوحة ألوان مفقودة.',
+        'button' => 'إنشاء المفقود',
+    ],
     'statistics-check' => [
         'title' => 'فحص سلامة الإحصائيات',
         'missing_photos' => 'إحصائيات %d صورة مفقودة.',

--- a/lang/cz/maintenance.php
+++ b/lang/cz/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/de/maintenance.php
+++ b/lang/de/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'Update',
         'no-pending-updates' => 'Keine Updates verfügbar.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Integritätsprüfung der Statistik',
         'missing_photos' => '%d Fotostatistiken fehlen.',

--- a/lang/el/maintenance.php
+++ b/lang/el/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/en/maintenance.php
+++ b/lang/en/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'Update',
         'no-pending-updates' => 'No pending update.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/es/maintenance.php
+++ b/lang/es/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/fr/maintenance.php
+++ b/lang/fr/maintenance.php
@@ -58,6 +58,11 @@ return [
         'update-button' => 'Mettre à jour',
         'no-pending-updates' => 'Aucune mise à jour en attente.',
     ],
+    'missing-palettes' => [
+        'title' => 'Palettes manquantes',
+        'description' => '%d palettes manquantes trouvées.',
+        'button' => 'Créer les palettes manquantes',
+    ],
     'statistics-check' => [
         'title' => 'Check de l’intégrité des Statistiques',
         'missing_photos' => '%d statistiques de photos manquantes.',

--- a/lang/hu/maintenance.php
+++ b/lang/hu/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/it/maintenance.php
+++ b/lang/it/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/ja/maintenance.php
+++ b/lang/ja/maintenance.php
@@ -58,6 +58,11 @@ return [
         'update-button' => '更新',
         'no-pending-updates' => '保留中の更新はありません',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/nl/maintenance.php
+++ b/lang/nl/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'Bijwerken',
         'no-pending-updates' => 'Geen updates in behandeling.',
     ],
+    'missing-palettes' => [
+        'title' => 'Ontbrekende paletten',
+        'description' => '%d ontbrekende paletten gevonden.',
+        'button' => 'Ontbrekende aanmaken',
+    ],
     'statistics-check' => [
         'title' => 'Controle op statistische integriteit',
         'missing_photos' => '%d fotostatistieken ontbreken.',

--- a/lang/no/maintenance.php
+++ b/lang/no/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'Oppdater',
         'no-pending-updates' => 'Ingen ventende oppdateringer.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistikk integritetskontroll',
         'missing_photos' => '%d fotostatistikk mangler.',

--- a/lang/pl/maintenance.php
+++ b/lang/pl/maintenance.php
@@ -59,6 +59,11 @@ return [
         'update-button' => 'Aktualizacja',
         'no-pending-updates' => 'Brak oczekujących aktualizacji.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/pt/maintenance.php
+++ b/lang/pt/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/ru/maintenance.php
+++ b/lang/ru/maintenance.php
@@ -58,6 +58,11 @@ return [
         'update-button' => 'Обновить',
         'no-pending-updates' => 'Нет ожидающих обновлений.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/sk/maintenance.php
+++ b/lang/sk/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/sv/maintenance.php
+++ b/lang/sv/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/vi/maintenance.php
+++ b/lang/vi/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/zh_CN/maintenance.php
+++ b/lang/zh_CN/maintenance.php
@@ -58,6 +58,11 @@ return [
         'update-button' => '更新',
         'no-pending-updates' => '没有待处理的更新。',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/zh_TW/maintenance.php
+++ b/lang/zh_TW/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/resources/js/components/drawers/PhotoDetails.vue
+++ b/resources/js/components/drawers/PhotoDetails.vue
@@ -14,7 +14,7 @@
 						{{ $t("gallery.photo.details.about") }}
 					</h1>
 					<!-- Title etc info -->
-					<div class="flex gap-3 mb-4">
+					<div class="flex gap-3 mb-2">
 						<div>
 							<MiniIcon icon="image" class="h-12 w-12" />
 						</div>
@@ -31,6 +31,13 @@
 								<span>{{ props.photo.preformatted.filesize }}</span>
 							</div>
 						</div>
+					</div>
+					<div v-if="props.photo.palette" class="flex gap-2 mb-4 ml-15">
+						<ColourSquare :colour="props.photo.palette.colour_1" />
+						<ColourSquare :colour="props.photo.palette.colour_2" />
+						<ColourSquare :colour="props.photo.palette.colour_3" />
+						<ColourSquare :colour="props.photo.palette.colour_4" />
+						<ColourSquare :colour="props.photo.palette.colour_5" />
 					</div>
 					<!-- Dates stuff -->
 					<div class="flex-col text-muted-color">
@@ -53,7 +60,7 @@
 
 					<!-- Description stuff -->
 					<template v-if="props.photo.preformatted.description">
-						<h2 class="text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+						<h2 class="text-muted-color-emphasis text-base font-bold mt-4 mb-1">
 							{{ $t("gallery.photo.details.description") }}
 						</h2>
 						<div class="prose dark:prose-invert prose-sm mb-4" v-html="props.photo.preformatted.description"></div>
@@ -61,7 +68,7 @@
 
 					<!-- Tags stuff -->
 					<template v-if="props.photo.tags.length > 0">
-						<h2 v-if="props.photo.tags.length > 0" class="text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+						<h2 v-if="props.photo.tags.length > 0" class="text-muted-color-emphasis text-base font-bold mt-4 mb-1">
 							{{ $t("gallery.photo.details.tags") }}
 						</h2>
 						<span class="pb-2">
@@ -73,7 +80,7 @@
 
 					<!-- Exif stuff -->
 					<template v-if="props.photo.precomputed.has_exif">
-						<h2 class="text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+						<h2 class="text-muted-color-emphasis text-base font-bold mt-4 mb-1">
 							{{ $t("gallery.photo.details.exif_data") }}
 						</h2>
 						<div class="flex flex-wrap text-muted-color gap-y-0.5">
@@ -123,7 +130,7 @@
 					<!-- <span class="py-0.5 px-3 text-sm" v-if="props.photo.type">{{ $t("gallery.photo.details.format") }}</span>
 					<span class="py-0.5 pl-0 text-sm" v-if="props.photo.type">{{ props.photo.type }}</span> -->
 
-					<h2 v-if="props.photo.precomputed.has_location" class="col-span-2 text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+					<h2 v-if="props.photo.precomputed.has_location" class="col-span-2 text-muted-color-emphasis text-base font-bold mt-4 mb-1">
 						{{ $t("gallery.photo.details.location") }}
 					</h2>
 					<MapInclude :latitude="props.photo.latitude" :longitude="props.photo.longitude" v-if="props.isMapVisible" />
@@ -139,14 +146,14 @@
 					</template>
 
 					<template v-if="props.photo.preformatted.license">
-						<h2 class="text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+						<h2 class="text-muted-color-emphasis text-base font-bold mt-4 mb-1">
 							{{ $t("gallery.photo.details.license") }}
 						</h2>
 						<span class="py-0.5 pl-0 text-sm text-muted-color">{{ props.photo.preformatted.license }}</span>
 					</template>
 
 					<template v-if="props.photo.statistics">
-						<h2 class="text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+						<h2 class="text-muted-color-emphasis text-base font-bold mt-4 mb-1">
 							{{ $t("gallery.photo.details.stats.header") }}
 						</h2>
 						<div class="flex flex-wrap text-muted-color text-sm gap-y-0.5">
@@ -175,10 +182,10 @@
 </template>
 <script setup lang="ts">
 import { Ref } from "vue";
-import Tag from "primevue/tag";
 import Card from "primevue/card";
 import MapInclude from "../gallery/photoModule/MapInclude.vue";
 import MiniIcon from "../icons/MiniIcon.vue";
+import ColourSquare from "../gallery/photoModule/ColourSquare.vue";
 
 const props = defineProps<{
 	photo: App.Http.Resources.Models.PhotoResource | undefined;

--- a/resources/js/components/gallery/photoModule/ColourSquare.vue
+++ b/resources/js/components/gallery/photoModule/ColourSquare.vue
@@ -1,0 +1,18 @@
+<template>
+	<div
+		class="aspect h-6 w-6 border-surface-700 border"
+		:style="`background-color: ${props.colour}`"
+		v-tooltip.bottom="props.colour"
+		@click="copyToClipboard"
+	></div>
+</template>
+<script setup lang="ts">
+import { useToast } from "primevue/usetoast";
+
+const props = defineProps<{ colour: string }>();
+const toast = useToast();
+
+function copyToClipboard() {
+	navigator.clipboard.writeText(props.colour).then(() => toast.add({ severity: "info", summary: props.colour, life: 3000 }));
+}
+</script>

--- a/resources/js/components/maintenance/MaintenanceMissingPalettes.vue
+++ b/resources/js/components/maintenance/MaintenanceMissingPalettes.vue
@@ -1,0 +1,79 @@
+<template>
+	<Card
+		v-if="data !== undefined && data > 0"
+		class="min-h-40 dark:bg-surface-800 shadow shadow-surface-950/30 rounded-lg relative"
+		pt:body:class="min-h-40 h-full"
+		pt:content:class="h-full flex justify-between flex-col"
+	>
+		<template #title>
+			<div class="text-center">
+				{{ $t("maintenance.missing-palettes.title") }}
+			</div>
+		</template>
+		<template #content>
+			<ScrollPanel class="w-full h-40 text-sm text-muted-color">
+				<div class="w-full text-center" v-if="!loading" v-html="description"></div>
+				<ProgressSpinner v-if="loading" class="w-full"></ProgressSpinner>
+			</ScrollPanel>
+			<div class="flex gap-4 mt-1">
+				<Button v-if="data > 0 && !loading" severity="primary" class="w-full border-none" @click="exec">{{
+					$t("maintenance.missing-palettes.button")
+				}}</Button>
+			</div>
+		</template>
+	</Card>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import Button from "primevue/button";
+import Card from "primevue/card";
+import { useToast } from "primevue/usetoast";
+import ProgressSpinner from "primevue/progressspinner";
+import ScrollPanel from "primevue/scrollpanel";
+import MaintenanceService from "@/services/maintenance-service";
+import { sprintf } from "sprintf-js";
+import { trans } from "laravel-vue-i18n";
+
+const data = ref<number | undefined>(undefined);
+const loading = ref(false);
+const toast = useToast();
+
+const description = computed(() => {
+	return sprintf(trans("maintenance.missing-palettes.description"), data.value);
+});
+
+function load() {
+	loading.value = true;
+	MaintenanceService.missingPalettesCheck()
+		.then((response) => {
+			data.value = response.data;
+			loading.value = false;
+		})
+		.catch((e) => {
+			toast.add({ severity: "error", summary: trans("toasts.error"), detail: e.response.data.message, life: 3000 });
+			loading.value = false;
+		});
+}
+
+function exec() {
+	loading.value = true;
+	MaintenanceService.missingPalettesDo()
+		.then(() => {
+			toast.add({ severity: "success", summary: trans("toasts.success"), life: 3000 });
+			loading.value = false;
+		})
+		.catch((e) => {
+			toast.add({ severity: "error", summary: trans("toasts.error"), detail: e.response.data.message, life: 3000 });
+			loading.value = false;
+		});
+}
+
+load();
+</script>
+
+<style lang="css" scoped>
+.lychee-dark .p-card {
+	--p-card-background: var(--p-surface-800);
+}
+</style>

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -363,6 +363,13 @@ declare namespace App.Http.Resources.Models {
 		download_count: number;
 		shared_count: number;
 	};
+	export type ColourPaletteResource = {
+		colour_1: string;
+		colour_2: string;
+		colour_3: string;
+		colour_4: string;
+		colour_5: string;
+	};
 	export type ConfigCategoryResource = {
 		cat: string;
 		name: string;
@@ -436,6 +443,7 @@ declare namespace App.Http.Resources.Models {
 		preformatted: App.Http.Resources.Models.Utils.PreformattedPhotoData;
 		precomputed: App.Http.Resources.Models.Utils.PreComputedPhotoData;
 		timeline: App.Http.Resources.Models.Utils.TimelineData | null;
+		palette: App.Http.Resources.Models.ColourPaletteResource | null;
 		statistics: App.Http.Resources.Models.PhotoStatisticsResource | null;
 	};
 	export type PhotoStatisticsResource = {

--- a/resources/js/services/maintenance-service.ts
+++ b/resources/js/services/maintenance-service.ts
@@ -50,6 +50,13 @@ const MaintenanceService = {
 		return axios.post(`${Constants.getApiUrl()}Maintenance::missingFileSize`, {});
 	},
 
+	missingPalettesCheck(): Promise<AxiosResponse<number>> {
+		return axios.get(`${Constants.getApiUrl()}Maintenance::missingPalettes`, { data: {} });
+	},
+	missingPalettesDo(): Promise<AxiosResponse> {
+		return axios.post(`${Constants.getApiUrl()}Maintenance::missingPalettes`, {});
+	},
+
 	optimizeDo(): Promise<AxiosResponse<string[]>> {
 		return axios.post(`${Constants.getApiUrl()}Maintenance::optimize`, {});
 	},

--- a/resources/js/views/Maintenance.vue
+++ b/resources/js/views/Maintenance.vue
@@ -28,6 +28,7 @@
 		<MaintenanceFixJobs />
 		<MaintenanceFixTree />
 		<MaintenanceFilesize />
+		<MaintenanceMissingPalettes />
 		<StatisticsIntegrity />
 		<MaintenanceCleaning path="filesystems.disks.extract-jobs.root" />
 		<MaintenanceCleaning path="filesystems.disks.image-jobs.root" />
@@ -47,4 +48,5 @@ import MaintenanceUpdate from "@/components/maintenance/MaintenanceUpdate.vue";
 import MaintenanceFlushCache from "@/components/maintenance/MaintenanceFlushCache.vue";
 import OpenLeftMenu from "@/components/headers/OpenLeftMenu.vue";
 import StatisticsIntegrity from "@/components/maintenance/StatisticsIntegrity.vue";
+import MaintenanceMissingPalettes from "@/components/maintenance/MaintenanceMissingPalettes.vue";
 </script>

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -223,6 +223,8 @@ Route::get('/Maintenance::countDuplicates', [Admin\Maintenance\DuplicateFinder::
 Route::get('/Maintenance::searchDuplicates', [Admin\Maintenance\DuplicateFinder::class, 'get']);
 Route::get('/Maintenance::statisticsIntegrity', [Admin\Maintenance\StatisticsCheck::class, 'check']);
 Route::post('/Maintenance::statisticsIntegrity', [Admin\Maintenance\StatisticsCheck::class, 'do']);
+Route::get('/Maintenance::missingPalettes', [Admin\Maintenance\MissingPalettes::class, 'check']);
+Route::post('/Maintenance::missingPalettes', [Admin\Maintenance\MissingPalettes::class, 'do']);
 
 /**
  * STATISTICS.


### PR DESCRIPTION
This pull request introduces functionality for detecting and generating missing color palettes for photos, along with associated UI and backend changes. It also includes a minor update to the configuration migration file. Below is a breakdown of the most important changes:

### Backend Changes:
* Added a new `MissingPalettes` controller to handle the detection and processing of missing color palettes for photos. This includes two methods: `check` for counting photos without palettes and `do` for generating palettes in chunks using the `ExtractColoursJob`. (`app/Http/Controllers/Admin/Maintenance/MissingPalettes.php`)
* Updated API routes to include endpoints for checking and generating missing palettes. (`routes/api_v2.php`)

### Frontend Changes:
* Added a new Vue component `MissingPalettes.vue` to display and manage missing palette tasks in the maintenance view. It includes a card UI with a button to trigger palette generation and a progress spinner for feedback. (`resources/js/components/maintenance/MissingPalettes.vue`)
* Updated the `MaintenanceService` to include methods for interacting with the new missing palettes API endpoints. (`resources/js/services/maintenance-service.ts`)
* Integrated the `MissingPalettes` component into the main maintenance view. (`resources/js/views/Maintenance.vue`) [[1]](diffhunk://#diff-47f5cb6873bc52083e08da09c6c0ec152036d6a563102efedff881c8c4bebf33R31) [[2]](diffhunk://#diff-47f5cb6873bc52083e08da09c6c0ec152036d6a563102efedff881c8c4bebf33R51)

