### PR TITLE
Add display colour palette in front-end

### DIFF
--- a/app/Actions/Album/PositionData.php
+++ b/app/Actions/Album/PositionData.php
@@ -42,6 +42,7 @@ class PositionData
 					// variants per photo
 					$r->whereBetween('type', [SizeVariantType::SMALL2X, SizeVariantType::THUMB]);
 				},
+				'palette',
 			])
 			->whereNotNull('latitude')
 			->whereNotNull('longitude');

--- a/app/Actions/Albums/PositionData.php
+++ b/app/Actions/Albums/PositionData.php
@@ -55,6 +55,7 @@ class PositionData
 						// variants per photo
 						$r->whereBetween('type', [SizeVariantType::SMALL2X, SizeVariantType::THUMB]);
 					},
+					'palette',
 				])
 				->whereNotNull('latitude')
 				->whereNotNull('longitude'),

--- a/app/Actions/Search/PhotoSearch.php
+++ b/app/Actions/Search/PhotoSearch.php
@@ -57,7 +57,7 @@ class PhotoSearch
 	public function sqlQuery(array $terms, ?Album $album = null): Builder
 	{
 		$query = $this->photoQueryPolicy->applySearchabilityFilter(
-			query: Photo::query()->with(['album', 'statistics', 'size_variants']),
+			query: Photo::query()->with(['album', 'statistics', 'size_variants', 'palette']),
 			origin: $album,
 			include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_search')
 		);

--- a/app/Console/Commands/ImageProcessing/ExtractColourPalette.php
+++ b/app/Console/Commands/ImageProcessing/ExtractColourPalette.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Console\Commands\ImageProcessing;
+
+use App\Exceptions\UnexpectedException;
+use App\Jobs\ExtractColoursJob;
+use App\Models\Photo;
+use Illuminate\Console\Command;
+use Safe\Exceptions\InfoException;
+use function Safe\set_time_limit;
+
+class ExtractColourPalette extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'lychee:extract_colour_palette {limit=5 : number of photos to extract the colour palette for} {tm=600 : timeout time requirement}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Extract the colour palette if it has not been extracted yet';
+
+	/**
+	 * Execute the console command.
+	 */
+	public function handle(): int
+	{
+		try {
+			$limit = (int) $this->argument('limit');
+			$timeout = (int) $this->argument('tm');
+
+			try {
+				set_time_limit($timeout);
+			} catch (InfoException) {
+				// Silently do nothing, if `set_time_limit` is denied.
+			}
+
+			$photos = Photo::with(['size_variants'])
+				->whereDoesntHave('palette')
+				->where('type', 'like', 'image/%')
+				->orderBy('id')
+				->lazyById($limit);
+
+			if (count($photos) === 0) {
+				$this->line('No photos require palette extraction.');
+
+				return 0;
+			}
+
+			foreach ($photos as $photo) {
+				$this->line(sprintf('Extracting Color Palette for %s [%s].', $photo->title, $photo->id));
+				ExtractColoursJob::dispatchSync($photo);
+			}
+
+			return 0;
+		} catch (\Throwable $e) {
+			throw new UnexpectedException($e);
+		}
+	}
+}

--- a/app/Factories/AlbumFactory.php
+++ b/app/Factories/AlbumFactory.php
@@ -96,7 +96,7 @@ class AlbumFactory
 		$tag_album_query = TagAlbum::query();
 
 		if ($with_relations) {
-			$album_query->with(['access_permissions', 'photos', 'children', 'children.owner', 'photos.size_variants', 'photos.statistics']);
+			$album_query->with(['access_permissions', 'photos', 'children', 'children.owner', 'photos.size_variants', 'photos.statistics', 'photos.palette']);
 			$tag_album_query->with(['photos']);
 		}
 

--- a/app/Http/Controllers/Gallery/FrameController.php
+++ b/app/Http/Controllers/Gallery/FrameController.php
@@ -86,12 +86,12 @@ class FrameController extends Controller
 		// default query
 		if ($album === null) {
 			$query = $this->photo_query_policy->applySearchabilityFilter(
-				query: Photo::query()->with(['album', 'size_variants']),
+				query: Photo::query()->with(['album', 'size_variants', 'palette']),
 				origin: null,
 				include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_frame')
 			);
 		} else {
-			$query = $album->photos()->with(['album', 'size_variants']);
+			$query = $album->photos()->with(['album', 'size_variants', 'palette']);
 		}
 
 		/** @var ?Photo $photo */

--- a/app/Http/Resources/Models/ColourPaletteResource.php
+++ b/app/Http/Resources/Models/ColourPaletteResource.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Models;
+
+use App\Models\Palette;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class ColourPaletteResource extends Data
+{
+	public string $colour_1;
+	public string $colour_2;
+	public string $colour_3;
+	public string $colour_4;
+	public string $colour_5;
+
+	public function __construct(Palette $palette)
+	{
+		$this->colour_1 = Palette::toHex($palette->colour_1);
+		$this->colour_2 = Palette::toHex($palette->colour_2);
+		$this->colour_3 = Palette::toHex($palette->colour_3);
+		$this->colour_4 = Palette::toHex($palette->colour_4);
+		$this->colour_5 = Palette::toHex($palette->colour_5);
+	}
+
+	public static function fromModel(?Palette $p): ?ColourPaletteResource
+	{
+		if ($p === null) {
+			return null;
+		}
+
+		return new self($p);
+	}
+}

--- a/app/Http/Resources/Models/PhotoResource.php
+++ b/app/Http/Resources/Models/PhotoResource.php
@@ -61,6 +61,7 @@ class PhotoResource extends Data
 	public PreformattedPhotoData $preformatted;
 	public PreComputedPhotoData $precomputed;
 	public ?TimelineData $timeline = null;
+	public ?ColourPaletteResource $palette = null;
 
 	private Carbon $timeline_data_carbon;
 
@@ -102,6 +103,7 @@ class PhotoResource extends Data
 		$this->previous_photo_id = null;
 		$this->preformatted = new PreformattedPhotoData($photo, $this->size_variants->original);
 		$this->precomputed = new PreComputedPhotoData($photo);
+		$this->palette = ColourPaletteResource::fromModel($photo->palette);
 
 		$this->timeline_data_carbon = $photo->taken_at ?? $photo->created_at;
 

--- a/app/Models/Palette.php
+++ b/app/Models/Palette.php
@@ -35,20 +35,6 @@ class Palette extends Model
 	];
 
 	/**
-	 * @return array{colour_1:string,colour_2:string,colour_3:string,colour_4:string,colour_5:string}
-	 */
-	public function toHexColours(): array
-	{
-		return [
-			'colour_1' => self::toHex($this->colour_1),
-			'colour_2' => self::toHex($this->colour_2),
-			'colour_3' => self::toHex($this->colour_3),
-			'colour_4' => self::toHex($this->colour_4),
-			'colour_5' => self::toHex($this->colour_5),
-		];
-	}
-
-	/**
 	 * Convert a colour integer to a hex string.
 	 *
 	 * @param int $colour The colour in integer format (0xRRGGBB)

--- a/app/Relations/BaseHasManyPhotos.php
+++ b/app/Relations/BaseHasManyPhotos.php
@@ -65,7 +65,7 @@ abstract class BaseHasManyPhotos extends Relation
 			// indirect condition.
 			// Hence, the actually owning albums of the photos are not
 			// necessarily loaded.
-			Photo::query()->with(['album', 'size_variants']),
+			Photo::query()->with(['album', 'size_variants', 'palette']),
 			$owning_album
 		);
 	}

--- a/app/SmartAlbums/BaseSmartAlbum.php
+++ b/app/SmartAlbums/BaseSmartAlbum.php
@@ -115,7 +115,7 @@ abstract class BaseSmartAlbum implements AbstractAlbum
 	{
 		$query = $this->photo_query_policy
 			->applySearchabilityFilter(
-				query: Photo::query()->with(['album', 'size_variants', 'statistics']),
+				query: Photo::query()->with(['album', 'size_variants', 'statistics', 'palette']),
 				origin: null,
 				include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums')
 			)->where($this->smart_photo_condition);

--- a/app/SmartAlbums/UnsortedAlbum.php
+++ b/app/SmartAlbums/UnsortedAlbum.php
@@ -45,7 +45,7 @@ class UnsortedAlbum extends BaseSmartAlbum
 	public function photos(): Builder
 	{
 		if ($this->public_permissions !== null) {
-			return Photo::query()->with(['album', 'size_variants', 'statistics'])
+			return Photo::query()->with(['album', 'size_variants', 'statistics', 'palette'])
 			->where($this->smart_photo_condition);
 		}
 

--- a/database/factories/PhotoFactory.php
+++ b/database/factories/PhotoFactory.php
@@ -181,6 +181,7 @@ class PhotoFactory extends Factory
 				$photo->load('size_variants');
 			}
 
+			$photo->load('palette');
 			$photo->load('statistics');
 
 			// Reset the value if it was disabled.

--- a/lang/ar/maintenance.php
+++ b/lang/ar/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'تحديث',
         'no-pending-updates' => 'لا توجد تحديثات معلقة.',
     ],
+    'missing-palettes' => [
+        'title' => 'لوحات الألوان المفقودة',
+        'description' => 'تم العثور على %d لوحة ألوان مفقودة.',
+        'button' => 'إنشاء المفقود',
+    ],
     'statistics-check' => [
         'title' => 'فحص سلامة الإحصائيات',
         'missing_photos' => 'إحصائيات %d صورة مفقودة.',

--- a/lang/cz/maintenance.php
+++ b/lang/cz/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/de/maintenance.php
+++ b/lang/de/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'Update',
         'no-pending-updates' => 'Keine Updates verfügbar.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Integritätsprüfung der Statistik',
         'missing_photos' => '%d Fotostatistiken fehlen.',

--- a/lang/el/maintenance.php
+++ b/lang/el/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/en/maintenance.php
+++ b/lang/en/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'Update',
         'no-pending-updates' => 'No pending update.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/es/maintenance.php
+++ b/lang/es/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/fr/maintenance.php
+++ b/lang/fr/maintenance.php
@@ -58,6 +58,11 @@ return [
         'update-button' => 'Mettre à jour',
         'no-pending-updates' => 'Aucune mise à jour en attente.',
     ],
+    'missing-palettes' => [
+        'title' => 'Palettes manquantes',
+        'description' => '%d palettes manquantes trouvées.',
+        'button' => 'Créer les palettes manquantes',
+    ],
     'statistics-check' => [
         'title' => 'Check de l’intégrité des Statistiques',
         'missing_photos' => '%d statistiques de photos manquantes.',

--- a/lang/hu/maintenance.php
+++ b/lang/hu/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/it/maintenance.php
+++ b/lang/it/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/ja/maintenance.php
+++ b/lang/ja/maintenance.php
@@ -58,6 +58,11 @@ return [
         'update-button' => '更新',
         'no-pending-updates' => '保留中の更新はありません',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/nl/maintenance.php
+++ b/lang/nl/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'Bijwerken',
         'no-pending-updates' => 'Geen updates in behandeling.',
     ],
+    'missing-palettes' => [
+        'title' => 'Ontbrekende paletten',
+        'description' => '%d ontbrekende paletten gevonden.',
+        'button' => 'Ontbrekende aanmaken',
+    ],
     'statistics-check' => [
         'title' => 'Controle op statistische integriteit',
         'missing_photos' => '%d fotostatistieken ontbreken.',

--- a/lang/no/maintenance.php
+++ b/lang/no/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'Oppdater',
         'no-pending-updates' => 'Ingen ventende oppdateringer.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistikk integritetskontroll',
         'missing_photos' => '%d fotostatistikk mangler.',

--- a/lang/pl/maintenance.php
+++ b/lang/pl/maintenance.php
@@ -59,6 +59,11 @@ return [
         'update-button' => 'Aktualizacja',
         'no-pending-updates' => 'Brak oczekujących aktualizacji.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/pt/maintenance.php
+++ b/lang/pt/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/ru/maintenance.php
+++ b/lang/ru/maintenance.php
@@ -58,6 +58,11 @@ return [
         'update-button' => 'Обновить',
         'no-pending-updates' => 'Нет ожидающих обновлений.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/sk/maintenance.php
+++ b/lang/sk/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/sv/maintenance.php
+++ b/lang/sv/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/vi/maintenance.php
+++ b/lang/vi/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/zh_CN/maintenance.php
+++ b/lang/zh_CN/maintenance.php
@@ -58,6 +58,11 @@ return [
         'update-button' => '更新',
         'no-pending-updates' => '没有待处理的更新。',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/zh_TW/maintenance.php
+++ b/lang/zh_TW/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/resources/js/components/drawers/PhotoDetails.vue
+++ b/resources/js/components/drawers/PhotoDetails.vue
@@ -30,6 +30,13 @@
 								}}</span>
 								<span>{{ props.photo.preformatted.filesize }}</span>
 							</div>
+							<div v-if="props.photo.palette" class="flex gap-2">
+								<ColourSquare :colour="props.photo.palette.colour_1" />
+								<ColourSquare :colour="props.photo.palette.colour_2" />
+								<ColourSquare :colour="props.photo.palette.colour_3" />
+								<ColourSquare :colour="props.photo.palette.colour_4" />
+								<ColourSquare :colour="props.photo.palette.colour_5" />
+							</div>
 						</div>
 					</div>
 					<!-- Dates stuff -->
@@ -175,10 +182,10 @@
 </template>
 <script setup lang="ts">
 import { Ref } from "vue";
-import Tag from "primevue/tag";
 import Card from "primevue/card";
 import MapInclude from "../gallery/photoModule/MapInclude.vue";
 import MiniIcon from "../icons/MiniIcon.vue";
+import ColourSquare from "../gallery/photoModule/ColourSquare.vue";
 
 const props = defineProps<{
 	photo: App.Http.Resources.Models.PhotoResource | undefined;

--- a/resources/js/components/drawers/PhotoDetails.vue
+++ b/resources/js/components/drawers/PhotoDetails.vue
@@ -14,7 +14,7 @@
 						{{ $t("gallery.photo.details.about") }}
 					</h1>
 					<!-- Title etc info -->
-					<div class="flex gap-3 mb-4">
+					<div class="flex gap-3 mb-2">
 						<div>
 							<MiniIcon icon="image" class="h-12 w-12" />
 						</div>
@@ -30,14 +30,14 @@
 								}}</span>
 								<span>{{ props.photo.preformatted.filesize }}</span>
 							</div>
-							<div v-if="props.photo.palette" class="flex gap-2">
-								<ColourSquare :colour="props.photo.palette.colour_1" />
-								<ColourSquare :colour="props.photo.palette.colour_2" />
-								<ColourSquare :colour="props.photo.palette.colour_3" />
-								<ColourSquare :colour="props.photo.palette.colour_4" />
-								<ColourSquare :colour="props.photo.palette.colour_5" />
-							</div>
 						</div>
+					</div>
+					<div v-if="props.photo.palette" class="flex gap-2 mb-4 ml-15">
+						<ColourSquare :colour="props.photo.palette.colour_1" />
+						<ColourSquare :colour="props.photo.palette.colour_2" />
+						<ColourSquare :colour="props.photo.palette.colour_3" />
+						<ColourSquare :colour="props.photo.palette.colour_4" />
+						<ColourSquare :colour="props.photo.palette.colour_5" />
 					</div>
 					<!-- Dates stuff -->
 					<div class="flex-col text-muted-color">
@@ -60,7 +60,7 @@
 
 					<!-- Description stuff -->
 					<template v-if="props.photo.preformatted.description">
-						<h2 class="text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+						<h2 class="text-muted-color-emphasis text-base font-bold mt-4 mb-1">
 							{{ $t("gallery.photo.details.description") }}
 						</h2>
 						<div class="prose dark:prose-invert prose-sm mb-4" v-html="props.photo.preformatted.description"></div>
@@ -68,7 +68,7 @@
 
 					<!-- Tags stuff -->
 					<template v-if="props.photo.tags.length > 0">
-						<h2 v-if="props.photo.tags.length > 0" class="text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+						<h2 v-if="props.photo.tags.length > 0" class="text-muted-color-emphasis text-base font-bold mt-4 mb-1">
 							{{ $t("gallery.photo.details.tags") }}
 						</h2>
 						<span class="pb-2">
@@ -80,7 +80,7 @@
 
 					<!-- Exif stuff -->
 					<template v-if="props.photo.precomputed.has_exif">
-						<h2 class="text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+						<h2 class="text-muted-color-emphasis text-base font-bold mt-4 mb-1">
 							{{ $t("gallery.photo.details.exif_data") }}
 						</h2>
 						<div class="flex flex-wrap text-muted-color gap-y-0.5">
@@ -130,7 +130,7 @@
 					<!-- <span class="py-0.5 px-3 text-sm" v-if="props.photo.type">{{ $t("gallery.photo.details.format") }}</span>
 					<span class="py-0.5 pl-0 text-sm" v-if="props.photo.type">{{ props.photo.type }}</span> -->
 
-					<h2 v-if="props.photo.precomputed.has_location" class="col-span-2 text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+					<h2 v-if="props.photo.precomputed.has_location" class="col-span-2 text-muted-color-emphasis text-base font-bold mt-4 mb-1">
 						{{ $t("gallery.photo.details.location") }}
 					</h2>
 					<MapInclude :latitude="props.photo.latitude" :longitude="props.photo.longitude" v-if="props.isMapVisible" />
@@ -146,14 +146,14 @@
 					</template>
 
 					<template v-if="props.photo.preformatted.license">
-						<h2 class="text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+						<h2 class="text-muted-color-emphasis text-base font-bold mt-4 mb-1">
 							{{ $t("gallery.photo.details.license") }}
 						</h2>
 						<span class="py-0.5 pl-0 text-sm text-muted-color">{{ props.photo.preformatted.license }}</span>
 					</template>
 
 					<template v-if="props.photo.statistics">
-						<h2 class="text-muted-color-emphasis text-base font-bold pt-4 pb-1">
+						<h2 class="text-muted-color-emphasis text-base font-bold mt-4 mb-1">
 							{{ $t("gallery.photo.details.stats.header") }}
 						</h2>
 						<div class="flex flex-wrap text-muted-color text-sm gap-y-0.5">

--- a/resources/js/components/gallery/photoModule/ColourSquare.vue
+++ b/resources/js/components/gallery/photoModule/ColourSquare.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="aspect h-4 w-4 border-surface-700 border"
+		class="aspect h-6 w-6 border-surface-700 border"
 		:style="`background-color: ${props.colour}`"
 		v-tooltip.bottom="props.colour"
 		@click="copyToClipboard"

--- a/resources/js/components/gallery/photoModule/ColourSquare.vue
+++ b/resources/js/components/gallery/photoModule/ColourSquare.vue
@@ -1,0 +1,18 @@
+<template>
+	<div
+		class="aspect h-4 w-4 border-surface-700 border"
+		:style="`background-color: ${props.colour}`"
+		v-tooltip.bottom="props.colour"
+		@click="copyToClipboard"
+	></div>
+</template>
+<script setup lang="ts">
+import { useToast } from "primevue/usetoast";
+
+const props = defineProps<{ colour: string }>();
+const toast = useToast();
+
+function copyToClipboard() {
+	navigator.clipboard.writeText(props.colour).then(() => toast.add({ severity: "info", summary: props.colour, life: 3000 }));
+}
+</script>

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -363,6 +363,13 @@ declare namespace App.Http.Resources.Models {
 		download_count: number;
 		shared_count: number;
 	};
+	export type ColourPaletteResource = {
+		colour_1: string;
+		colour_2: string;
+		colour_3: string;
+		colour_4: string;
+		colour_5: string;
+	};
 	export type ConfigCategoryResource = {
 		cat: string;
 		name: string;
@@ -436,6 +443,7 @@ declare namespace App.Http.Resources.Models {
 		preformatted: App.Http.Resources.Models.Utils.PreformattedPhotoData;
 		precomputed: App.Http.Resources.Models.Utils.PreComputedPhotoData;
 		timeline: App.Http.Resources.Models.Utils.TimelineData | null;
+		palette: App.Http.Resources.Models.ColourPaletteResource | null;
 		statistics: App.Http.Resources.Models.PhotoStatisticsResource | null;
 	};
 	export type PhotoStatisticsResource = {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/59d12f24-7224-46e8-b46a-c34ecfbc19d5)

This pull request introduces a new feature to support color palettes for photos, enabling the display and manipulation of palette data throughout the application. The changes include backend adjustments to load and expose palette data, a new resource class for palettes, and frontend updates to display color palettes in the photo details view.

### Backend Changes

* **Added palette data loading and exposure:**
  * Updated photo queries in various methods to include the `palette` relationship, ensuring palettes are loaded alongside other photo data. (`PositionData.php` - [[1]](diffhunk://#diff-233cfc4cf31a7891d3f0af90dfd0cf25f190c35a513d87c47b40ba2c843dd78bR45) [[2]](diffhunk://#diff-84e38b36fe0dc355f3e21db8dcf94db3f4f04771ab9bc454684ade4cb1ef4fc0R58); `PhotoSearch.php` - [[3]](diffhunk://#diff-45f06492bdc74d226624e896561719193313c5b5aa92ad86de084b3ab167f883L60-R60); `AlbumFactory.php` - [[4]](diffhunk://#diff-3a764911217fa81fec6c8ef209628001d4dff178b33daed7ed544be6afd0f7e1L99-R99); `FrameController.php` - [[5]](diffhunk://#diff-086ad1efe54793d4486a671b1c6e508d41fd088604607e29d2b1b2712f0c39bdL89-R94); `BaseHasManyPhotos.php` - [[6]](diffhunk://#diff-68663260a248cdb8082258ef30f1e3fc55ae5b573c89caed2e14c3c8b1e3274eL68-R68); `BaseSmartAlbum.php` - [[7]](diffhunk://#diff-30bb1c9d4ab165ae015d2b57302bf044c5f138105bb144c887b196d3b1f6e6d2L118-R118); `UnsortedAlbum.php` - [[8]](diffhunk://#diff-459dc5eb715df52ef4987e97a9f7403c2b91016d2826e0fdc6eae146337db743L48-R48); `PhotoFactory.php` - [[9]](diffhunk://#diff-edcb09b4e80cb15552eab36edeb2e8c2be6a86ac422501feb41f2fd6f9e1faeaR184)
  * Removed the `toHexColours` method from the `Palette` model as its functionality is now handled by the new resource class. (`Palette.php` - [app/Models/Palette.phpL37-L50](diffhunk://#diff-d42674e50118b77c420e120c4bd2a874d0a0a39a56a6c10fc7b1e0b33b0d9352L37-L50))

* **Introduced `ColourPaletteResource`:**
  * Created a new resource class to transform palette data into a structured format, including conversion of color integers to hex strings. (`ColourPaletteResource.php` - [app/Http/Resources/Models/ColourPaletteResource.phpR1-R41](diffhunk://#diff-5a28ccef0d39c90eabf7750990dcb22e6a1be4c476373f018e4ea0a3d6f8ae3eR1-R41))

* **Updated `PhotoResource`:**
  * Added a new property, `palette`, to expose palette data as part of the photo resource. (`PhotoResource.php` - [[1]](diffhunk://#diff-799502cd5e91f491e54316f1b4eeb8c485a8e60c7d42028520ed4ebc4a4c9a86R64) [[2]](diffhunk://#diff-799502cd5e91f491e54316f1b4eeb8c485a8e60c7d42028520ed4ebc4a4c9a86R106)

### Frontend Changes

* **Photo details view enhancements:**
  * Added a new section to display the photo's color palette using a grid of color squares. (`PhotoDetails.vue` - [[1]](diffhunk://#diff-4dbf72dfdeb259d1bf26e1a458dc16ee9c688581644178ee03be7c4c4b3acf9fR33-R39) [[2]](diffhunk://#diff-4dbf72dfdeb259d1bf26e1a458dc16ee9c688581644178ee03be7c4c4b3acf9fL178-R188)
  * Introduced a new `ColourSquare` component to render individual colors with a tooltip and copy-to-clipboard functionality. (`ColourSquare.vue` - [resources/js/components/gallery/photoModule/ColourSquare.vueR1-R18](diffhunk://#diff-5adf4726acd2390d2366fda283326fb60dbd0f068a7f007a1db93e568f93dd7eR1-R18))