### PR TITLE
Add missing translation for colour palette.

### DIFF
--- a/lang/ar/maintenance.php
+++ b/lang/ar/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'تحديث',
         'no-pending-updates' => 'لا توجد تحديثات معلقة.',
     ],
+    'missing-palettes' => [
+        'title' => 'لوحات الألوان المفقودة',
+        'description' => 'تم العثور على %d لوحة ألوان مفقودة.',
+        'button' => 'إنشاء المفقود',
+    ],
     'statistics-check' => [
         'title' => 'فحص سلامة الإحصائيات',
         'missing_photos' => 'إحصائيات %d صورة مفقودة.',

--- a/lang/cz/maintenance.php
+++ b/lang/cz/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/de/maintenance.php
+++ b/lang/de/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'Update',
         'no-pending-updates' => 'Keine Updates verfügbar.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Integritätsprüfung der Statistik',
         'missing_photos' => '%d Fotostatistiken fehlen.',

--- a/lang/el/maintenance.php
+++ b/lang/el/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/en/maintenance.php
+++ b/lang/en/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'Update',
         'no-pending-updates' => 'No pending update.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/es/maintenance.php
+++ b/lang/es/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/fr/maintenance.php
+++ b/lang/fr/maintenance.php
@@ -58,6 +58,11 @@ return [
         'update-button' => 'Mettre à jour',
         'no-pending-updates' => 'Aucune mise à jour en attente.',
     ],
+    'missing-palettes' => [
+        'title' => 'Palettes manquantes',
+        'description' => '%d palettes manquantes trouvées.',
+        'button' => 'Créer les palettes manquantes',
+    ],
     'statistics-check' => [
         'title' => 'Check de l’intégrité des Statistiques',
         'missing_photos' => '%d statistiques de photos manquantes.',

--- a/lang/hu/maintenance.php
+++ b/lang/hu/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/it/maintenance.php
+++ b/lang/it/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/ja/maintenance.php
+++ b/lang/ja/maintenance.php
@@ -58,6 +58,11 @@ return [
         'update-button' => '更新',
         'no-pending-updates' => '保留中の更新はありません',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/nl/maintenance.php
+++ b/lang/nl/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'Bijwerken',
         'no-pending-updates' => 'Geen updates in behandeling.',
     ],
+    'missing-palettes' => [
+        'title' => 'Ontbrekende paletten',
+        'description' => '%d ontbrekende paletten gevonden.',
+        'button' => 'Ontbrekende aanmaken',
+    ],
     'statistics-check' => [
         'title' => 'Controle op statistische integriteit',
         'missing_photos' => '%d fotostatistieken ontbreken.',

--- a/lang/no/maintenance.php
+++ b/lang/no/maintenance.php
@@ -57,6 +57,11 @@ return [
         'update-button' => 'Oppdater',
         'no-pending-updates' => 'Ingen ventende oppdateringer.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistikk integritetskontroll',
         'missing_photos' => '%d fotostatistikk mangler.',

--- a/lang/pl/maintenance.php
+++ b/lang/pl/maintenance.php
@@ -59,6 +59,11 @@ return [
         'update-button' => 'Aktualizacja',
         'no-pending-updates' => 'Brak oczekujących aktualizacji.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/pt/maintenance.php
+++ b/lang/pt/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/ru/maintenance.php
+++ b/lang/ru/maintenance.php
@@ -58,6 +58,11 @@ return [
         'update-button' => 'Обновить',
         'no-pending-updates' => 'Нет ожидающих обновлений.',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/sk/maintenance.php
+++ b/lang/sk/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/sv/maintenance.php
+++ b/lang/sv/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/vi/maintenance.php
+++ b/lang/vi/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/zh_CN/maintenance.php
+++ b/lang/zh_CN/maintenance.php
@@ -58,6 +58,11 @@ return [
         'update-button' => '更新',
         'no-pending-updates' => '没有待处理的更新。',
     ],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',

--- a/lang/zh_TW/maintenance.php
+++ b/lang/zh_TW/maintenance.php
@@ -59,6 +59,11 @@ return [
 		'update-button' => 'Update',
 		'no-pending-updates' => 'No pending update.',
 	],
+    'missing-palettes' => [
+        'title' => 'Missing Palettes',
+        'description' => 'Found %d missing palettes.',
+        'button' => 'Create missing',
+    ],
     'statistics-check' => [
         'title' => 'Statistics integrity Check',
         'missing_photos' => '%d photo statistics missing.',


### PR DESCRIPTION
This pull request adds translations for a new feature related to missing palettes across multiple languages in the `maintenance.php` files. The feature includes a title, description, and button text to handle missing palettes.

