### PR TITLE
Fix user factory uniqueness problem

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -36,11 +36,11 @@ class UserFactory extends Factory
 	public function definition(): array
 	{
 		return [
-			'username' => $this->get_name(),
+			'username' => $this->faker->unique()->name(),
 			'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
 			'may_administrate' => false,
 			'may_upload' => false,
-			'email' => $this->get_email(),
+			'email' => $this->faker->unique()->email(),
 			'token' => null,
 			'remember_token' => null,
 			'may_edit_own_settings' => true,
@@ -85,43 +85,6 @@ class UserFactory extends Factory
 		return $this->state(function (array $attributes) {
 			return ['may_edit_own_settings' => false];
 		});
-	}
-
-	/**
-	 * Avoid collision of generated names.
-	 *
-	 * @return string
-	 */
-	private function get_name(): string
-	{
-		$candidate = fake()->name();
-		$i = 5;
-		while ($i > 0 && in_array($candidate, $this->name_generated, true)) {
-			$candidate = fake()->name();
-			$i--;
-		}
-		if ($i === 0) {
-			throw new \TypeError('Could not generate unique name');
-		}
-		$this->name_generated[] = $candidate;
-
-		return $candidate;
-	}
-
-	private function get_email(): string
-	{
-		$candidate = fake()->email();
-		$i = 5;
-		while ($i > 0 && in_array($candidate, $this->email_generated, true)) {
-			$candidate = fake()->email();
-			$i--;
-		}
-		if ($i === 0) {
-			throw new \TypeError('Could not generate unique email');
-		}
-		$this->email_generated[] = $candidate;
-
-		return $candidate;
 	}
 
 	/**


### PR DESCRIPTION
This pull request simplifies the `UserFactory` class by removing custom methods for generating unique names and emails and replacing them with the built-in Faker library's functionality. This change improves code readability and reduces complexity.

### Simplifications in `UserFactory`:

* [`database/factories/UserFactory.php`](diffhunk://#diff-0db00302e9c3c5ad4fd47629fe517d343a414c5667b897b5ae2caa6dc2e37692L39-R43): Replaced the `get_name()` method with `faker->unique()->name()` for generating unique usernames.
* [`database/factories/UserFactory.php`](diffhunk://#diff-0db00302e9c3c5ad4fd47629fe517d343a414c5667b897b5ae2caa6dc2e37692L39-R43): Replaced the `get_email()` method with `faker->unique()->email()` for generating unique email addresses.
* [`database/factories/UserFactory.php`](diffhunk://#diff-0db00302e9c3c5ad4fd47629fe517d343a414c5667b897b5ae2caa6dc2e37692L90-L126): Removed the custom `get_name()` and `get_email()` methods entirely, along with their associated logic for avoiding collisions.