### PR TITLE
Support User groups in permissions listing

### DIFF
--- a/app/Actions/Sharing/Propagate.php
+++ b/app/Actions/Sharing/Propagate.php
@@ -49,7 +49,7 @@ final class Propagate
 		// for each descendant, create a new permission if it does not exist.
 		// or update the existing permission.
 		$descendants = $album->descendants()->getQuery()->select('id')->pluck('id');
-		$permissions = $album->access_permissions()->whereNotNull('user_id')->get();
+		$permissions = $album->access_permissions()->whereNotNull('user_id')->orWhereNotNull('user_group_id')->get();
 
 		// This is super inefficient.
 		// It would be better to do it in a single query...
@@ -59,6 +59,7 @@ final class Propagate
 				$perm = AccessPermission::updateOrCreate([
 					APC::BASE_ALBUM_ID => $descendant,
 					APC::USER_ID => $permission->user_id,
+					APC::USER_GROUP_ID => $permission->user_group_id,
 				], [
 					APC::GRANTS_FULL_PHOTO_ACCESS => $permission->grants_full_photo_access,
 					APC::GRANTS_DOWNLOAD => $permission->grants_download,
@@ -122,7 +123,7 @@ final class Propagate
 			->where('_rgt', '<', $album->_rgt)
 			->pluck('id');
 
-		$access_permissions = $album->access_permissions()->whereNotNull('user_id')->get();
+		$access_permissions = $album->access_permissions()->whereNotNull('user_id')->orWhereNotNull('user_group_id')->get();
 
 		$new_perm = $access_permissions->reduce(
 			fn (?array $acc, AccessPermission $permission) => array_merge(
@@ -131,6 +132,7 @@ final class Propagate
 					fn ($descendant_id) => [
 						APC::BASE_ALBUM_ID => $descendant_id,
 						APC::USER_ID => $permission->user_id,
+						APC::USER_GROUP_ID => $permission->user_group_id,
 						APC::GRANTS_FULL_PHOTO_ACCESS => $permission->grants_full_photo_access,
 						APC::GRANTS_DOWNLOAD => $permission->grants_download,
 						APC::GRANTS_UPLOAD => $permission->grants_upload,

--- a/app/Actions/Sharing/Propagate.php
+++ b/app/Actions/Sharing/Propagate.php
@@ -49,7 +49,7 @@ final class Propagate
 		// for each descendant, create a new permission if it does not exist.
 		// or update the existing permission.
 		$descendants = $album->descendants()->getQuery()->select('id')->pluck('id');
-		$permissions = $album->access_permissions()->whereNotNull('user_id')->orWhereNotNull('user_group_id')->get();
+		$permissions = $album->access_permissions()->whereNotNull(APC::USER_ID)->orWhereNotNull(APC::USER_GROUP_ID)->get();
 
 		// This is super inefficient.
 		// It would be better to do it in a single query...
@@ -107,7 +107,10 @@ final class Propagate
 		// 2. applying the new permissions.
 
 		DB::table(APC::ACCESS_PERMISSIONS)
-			->whereNotNull('user_id')
+			->where(fn ($q) => $q
+				->whereNotNull(APC::USER_ID)
+				->orWhereNotNull(APC::USER_GROUP_ID)
+			)
 			->whereIn(
 				'base_album_id',
 				DB::table('albums')

--- a/app/Actions/Sharing/Share.php
+++ b/app/Actions/Sharing/Share.php
@@ -17,14 +17,21 @@ class Share
 	 * Create an access permission from a resource.
 	 *
 	 * @param AccessPermissionResource $access_permission_resource
+	 * @param int|null                 $user_id
+	 * @param int|null                 $user_group_id
 	 * @param string                   $base_album_id
 	 *
 	 * @return AccessPermission
 	 */
-	public function do(AccessPermissionResource $access_permission_resource, int $user_id, string $base_album_id): AccessPermission
-	{
+	public function do(
+		AccessPermissionResource $access_permission_resource,
+		string $base_album_id,
+		?int $user_id = null,
+		?int $user_group_id = null,
+	): AccessPermission {
 		$perm = new AccessPermission();
 		$perm->user_id = $user_id;
+		$perm->user_group_id = $user_group_id;
 		$perm->base_album_id = $base_album_id;
 		$perm->grants_full_photo_access = $access_permission_resource->grants_full_photo_access;
 		$perm->grants_download = $access_permission_resource->grants_download;
@@ -33,6 +40,7 @@ class Share
 		$perm->grants_delete = $access_permission_resource->grants_delete;
 		$perm->load('user');
 		$perm->load('album');
+		$perm->load('user_group');
 		$perm->save();
 
 		return $perm;

--- a/app/Contracts/Http/Requests/HasUserGroupIds.php
+++ b/app/Contracts/Http/Requests/HasUserGroupIds.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Contracts\Http\Requests;
+
+interface HasUserGroupIds
+{
+	/**
+	 * @return int[]
+	 */
+	public function userGroupIds(): array;
+}

--- a/app/Contracts/Http/Requests/RequestAttribute.php
+++ b/app/Contracts/Http/Requests/RequestAttribute.php
@@ -14,6 +14,7 @@ class RequestAttribute
 
 	public const USER_ID_ATTRIBUTE = 'user_id';
 	public const USER_IDS_ATTRIBUTE = 'user_ids';
+	public const USER_GROUP_IDS_ATTRIBUTE = 'group_ids';
 
 	public const GROUP_ID = 'group_id';
 	public const NAME_ATTRIBUTE = 'name';

--- a/app/Http/Controllers/Gallery/SharingController.php
+++ b/app/Http/Controllers/Gallery/SharingController.php
@@ -46,16 +46,35 @@ class SharingController extends Controller
 	public function create(AddSharingRequest $request, Share $share): array
 	{
 		// delete any already created.
-		AccessPermission::whereIn('user_id', $request->userIds())
-			->whereIn('base_album_id', $request->albumIds())
+		AccessPermission::whereIn('base_album_id', $request->albumIds())
+			->where(fn ($q) => $q->whereIn('user_id', $request->userIds())
+				->orWhereIn(APC::USER_GROUP_ID, $request->userGroupIds()))
 			->delete();
 
 		$access_permissions = [];
+
 		// Not optimal, but this is barely used, so who cares.
 		// A better approach would be to do a massive insert in a single SQL query from the cross product.
-		foreach ($request->userIds() as $user_id) {
-			foreach ($request->albumIds() as $album_id) {
-				$access_permissions[] = $share->do($request->permResource(), $user_id, $album_id);
+		foreach ($request->albumIds() as $album_id) {
+			foreach ($request->userIds() as $user_id) {
+				// Create a new sharing permission for each user and album combination.
+				// This is not optimal, but it is simple and works.
+				// A better approach would be to do a massive insert in a single SQL query from the cross product.
+				$access_permissions[] = $share->do(
+					access_permission_resource: $request->permResource(),
+					user_id: $user_id,
+					base_album_id: $album_id
+				);
+			}
+			foreach ($request->userGroupIds() as $user_group_id) {
+				// Create a new sharing permission for each user group and album combination.
+				// This is not optimal, but it is simple and works.
+				// A better approach would be to do a massive insert in a single SQL query from the cross product.
+				$access_permissions[] = $share->do(
+					access_permission_resource: $request->permResource(),
+					user_group_id: $user_group_id,
+					base_album_id: $album_id
+				);
 			}
 		}
 
@@ -92,9 +111,10 @@ class SharingController extends Controller
 	 */
 	public function list(ListSharingRequest $request): Collection
 	{
-		$query = AccessPermission::with(['album', 'user']);
-		$query = $query->whereNotNull(APC::USER_ID);
+		$query = AccessPermission::with(['album', 'user', 'user_group']);
 		$query = $query->where(APC::BASE_ALBUM_ID, '=', $request->album()->id);
+		$query = $query->where(fn ($q) => $q->whereNotNull(APC::USER_ID)
+			->orWhereNotNull(APC::USER_GROUP_ID));
 
 		return AccessPermissionResource::collect($query->get());
 	}
@@ -108,12 +128,14 @@ class SharingController extends Controller
 	 */
 	public function listAll(ListAllSharingRequest $request): Collection
 	{
-		$query = AccessPermission::with(['album', 'user']);
+		$query = AccessPermission::with(['album', 'user', 'user_group']);
 		$query = $query->when(
 			!Auth::user()->may_administrate,
 			fn ($q) => $q->whereIn('base_album_id', BaseAlbumImpl::select('id')
-						->where('owner_id', '=', Auth::id())));
-		$query = $query->whereNotNull('user_id');
+				->where('owner_id', '=', Auth::id()))
+		);
+		$query = $query->whereNotNull(APC::USER_ID);
+		$query = $query->orWhereNotNull(APC::USER_GROUP_ID);
 		$query = $query->orderBy('base_album_id', 'asc');
 
 		return AccessPermissionResource::collect($query->get());
@@ -134,10 +156,12 @@ class SharingController extends Controller
 			$owner_id = $user->id;
 		}
 
-		return TargetAlbumResource::collect($list_albums->do(
-			albums_filtering: resolve(Collection::class),
-			parent_id: null,
-			owner_id: $owner_id)
+		return TargetAlbumResource::collect(
+			$list_albums->do(
+				albums_filtering: resolve(Collection::class),
+				parent_id: null,
+				owner_id: $owner_id
+			)
 		);
 	}
 

--- a/app/Http/Controllers/Gallery/SharingController.php
+++ b/app/Http/Controllers/Gallery/SharingController.php
@@ -46,8 +46,8 @@ class SharingController extends Controller
 	public function create(AddSharingRequest $request, Share $share): array
 	{
 		// delete any already created.
-		AccessPermission::whereIn('base_album_id', $request->albumIds())
-			->where(fn ($q) => $q->whereIn('user_id', $request->userIds())
+		AccessPermission::whereIn(APC::BASE_ALBUM_ID, $request->albumIds())
+			->where(fn ($q) => $q->whereIn(APC::USER_ID, $request->userIds())
 				->orWhereIn(APC::USER_GROUP_ID, $request->userGroupIds()))
 			->delete();
 

--- a/app/Http/Requests/Sharing/AddSharingRequest.php
+++ b/app/Http/Requests/Sharing/AddSharingRequest.php
@@ -16,12 +16,14 @@ use App\Contracts\Models\AbstractAlbum;
 use App\Http\Requests\BaseApiRequest;
 use App\Http\Requests\Traits\HasAccessPermissionResourceTrait;
 use App\Http\Requests\Traits\HasAlbumIdsTrait;
+use App\Http\Requests\Traits\HasUserGroupIdsTrait;
 use App\Http\Requests\Traits\HasUserIdsTrait;
 use App\Http\Resources\Models\AccessPermissionResource;
 use App\Policies\AlbumPolicy;
 use App\Rules\IntegerIDRule;
 use App\Rules\RandomIDRule;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
 
 /**
  * Represents a request for setting the shares of specific albums.
@@ -32,6 +34,7 @@ class AddSharingRequest extends BaseApiRequest implements HasAlbumIds, HasUserId
 {
 	use HasAlbumIdsTrait;
 	use HasUserIdsTrait;
+	use HasUserGroupIdsTrait;
 	use HasAccessPermissionResourceTrait;
 
 	/**
@@ -50,8 +53,10 @@ class AddSharingRequest extends BaseApiRequest implements HasAlbumIds, HasUserId
 		return [
 			RequestAttribute::ALBUM_IDS_ATTRIBUTE => 'required|array|min:1',
 			RequestAttribute::ALBUM_IDS_ATTRIBUTE . '.*' => ['required', new RandomIDRule(false)],
-			RequestAttribute::USER_IDS_ATTRIBUTE => 'required|array|min:1',
+			RequestAttribute::USER_IDS_ATTRIBUTE => 'present|array',
 			RequestAttribute::USER_IDS_ATTRIBUTE . '.*' => ['required', new IntegerIDRule(false)],
+			RequestAttribute::USER_GROUP_IDS_ATTRIBUTE => 'present|array',
+			RequestAttribute::USER_GROUP_IDS_ATTRIBUTE . '.*' => ['required', new IntegerIDRule(false)],
 			RequestAttribute::GRANTS_DOWNLOAD_ATTRIBUTE => ['required', 'boolean'],
 			RequestAttribute::GRANTS_FULL_PHOTO_ACCESS_ATTRIBUTE => ['required', 'boolean'],
 			RequestAttribute::GRANTS_UPLOAD_ATTRIBUTE => ['required', 'boolean'],
@@ -67,6 +72,13 @@ class AddSharingRequest extends BaseApiRequest implements HasAlbumIds, HasUserId
 	{
 		$this->album_ids = $values[RequestAttribute::ALBUM_IDS_ATTRIBUTE];
 		$this->user_ids = $values[RequestAttribute::USER_IDS_ATTRIBUTE];
+		$this->user_group_ids = $values[RequestAttribute::USER_GROUP_IDS_ATTRIBUTE];
+
+		if ($this->user_ids === [] && $this->user_group_ids === []) {
+			// If no users or groups are specified, we do not create a permission.
+			throw new ValidationException('You must specify at least one user or group to share with.', 422);
+		}
+
 		$this->perm_resource = new AccessPermissionResource(
 			grants_edit: static::toBoolean($values[RequestAttribute::GRANTS_EDIT_ATTRIBUTE]),
 			grants_delete: static::toBoolean($values[RequestAttribute::GRANTS_DELETE_ATTRIBUTE]),

--- a/app/Http/Requests/Sharing/AddSharingRequest.php
+++ b/app/Http/Requests/Sharing/AddSharingRequest.php
@@ -10,6 +10,7 @@ namespace App\Http\Requests\Sharing;
 
 use App\Contracts\Http\Requests\HasAccessPermissionResource;
 use App\Contracts\Http\Requests\HasAlbumIds;
+use App\Contracts\Http\Requests\HasUserGroupIds;
 use App\Contracts\Http\Requests\HasUserIds;
 use App\Contracts\Http\Requests\RequestAttribute;
 use App\Contracts\Models\AbstractAlbum;
@@ -30,7 +31,7 @@ use Illuminate\Validation\ValidationException;
  *
  * Only the owner of the album (or the admin) can set the shares.
  */
-class AddSharingRequest extends BaseApiRequest implements HasAlbumIds, HasUserIds, HasAccessPermissionResource
+class AddSharingRequest extends BaseApiRequest implements HasAlbumIds, HasUserIds, HasAccessPermissionResource, HasUserGroupIds
 {
 	use HasAlbumIdsTrait;
 	use HasUserIdsTrait;
@@ -67,6 +68,8 @@ class AddSharingRequest extends BaseApiRequest implements HasAlbumIds, HasUserId
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @throws ValidationException if no users or groups are specified
 	 */
 	protected function processValidatedValues(array $values, array $files): void
 	{

--- a/app/Http/Requests/Sharing/EditSharingRequest.php
+++ b/app/Http/Requests/Sharing/EditSharingRequest.php
@@ -64,7 +64,7 @@ class EditSharingRequest extends BaseApiRequest implements HasAlbumIds, HasAcces
 	{
 		/** @var int $id */
 		$id = $values[RequestAttribute::PERMISSION_ID];
-		$this->perm = AccessPermission::with(['album', 'user'])->findOrFail($id);
+		$this->perm = AccessPermission::with(['album', 'user', 'user_group'])->findOrFail($id);
 
 		$this->perm_resource = new AccessPermissionResource(
 			grants_edit: static::toBoolean($values[RequestAttribute::GRANTS_EDIT_ATTRIBUTE]),

--- a/app/Http/Requests/Traits/HasUserGroupIdsTrait.php
+++ b/app/Http/Requests/Traits/HasUserGroupIdsTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Traits;
+
+trait HasUserGroupIdsTrait
+{
+	/**
+	 * @var array<int,int>
+	 */
+	protected array $user_group_ids = [];
+
+	/**
+	 * @return array<int,int>
+	 */
+	public function userGroupIds(): array
+	{
+		return $this->user_group_ids;
+	}
+}

--- a/app/Http/Resources/Models/AccessPermissionResource.php
+++ b/app/Http/Resources/Models/AccessPermissionResource.php
@@ -18,7 +18,9 @@ class AccessPermissionResource extends Data
 	public function __construct(
 		public ?int $id = null,
 		public ?int $user_id = null,
+		public ?int $user_group_id = null,
 		public ?string $username = null,
+		public ?string $user_group_name = null,
 		public ?string $album_title = null,
 		public ?string $album_id = null,
 		public bool $grants_full_photo_access = false,
@@ -33,8 +35,10 @@ class AccessPermissionResource extends Data
 	{
 		return new AccessPermissionResource(
 			id: $access_permission->id,
-			user_id: $access_permission->user_id,
-			username: $access_permission->user->name,
+			user_id: $access_permission->user?->id,
+			username: $access_permission->user?->name,
+			user_group_id: $access_permission->user_group?->id,
+			user_group_name: $access_permission->user_group?->name,
 			album_title: $access_permission->album->title,
 			album_id: $access_permission->base_album_id,
 			grants_full_photo_access: $access_permission->grants_full_photo_access,

--- a/app/Http/Resources/Rights/SettingsRightsResource.php
+++ b/app/Http/Resources/Rights/SettingsRightsResource.php
@@ -34,6 +34,6 @@ class SettingsRightsResource extends Data
 		$this->can_see_diagnostics = Gate::check(SettingsPolicy::CAN_SEE_DIAGNOSTICS, [Configs::class]);
 		$this->can_update = Gate::check(SettingsPolicy::CAN_UPDATE, [Configs::class]);
 		$this->can_access_dev_tools = Gate::check(SettingsPolicy::CAN_ACCESS_DEV_TOOLS, [Configs::class]);
-		$this->can_acess_user_groups = resolve(Verify::class)->check() && Gate::check(UserGroupPolicy::CAN_LIST, [UserGroup::class]) && config('features.user-groups') === true;
+		$this->can_acess_user_groups = resolve(Verify::class)->check() && Gate::check(UserGroupPolicy::CAN_LIST, [UserGroup::class]);
 	}
 }

--- a/app/Models/AccessPermission.php
+++ b/app/Models/AccessPermission.php
@@ -73,6 +73,7 @@ class AccessPermission extends Model
 		'created_at' => 'datetime',
 		'updated_at' => 'datetime',
 		APC::USER_ID => 'integer',
+		APC::USER_GROUP_ID => 'integer',
 		APC::IS_LINK_REQUIRED => 'boolean',
 		APC::GRANTS_FULL_PHOTO_ACCESS => 'boolean',
 		APC::GRANTS_DOWNLOAD => 'boolean',
@@ -86,6 +87,7 @@ class AccessPermission extends Model
 	 */
 	protected $fillable = [
 		APC::USER_ID,
+		APC::USER_GROUP_ID,
 		APC::BASE_ALBUM_ID,
 		APC::IS_LINK_REQUIRED,
 		APC::GRANTS_FULL_PHOTO_ACCESS,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -120,6 +120,14 @@ class User extends Authenticatable implements WebAuthnAuthenticatable
 
 	protected $hidden = [];
 
+	/**
+	 * We always want to load the user groups when loading a user.
+	 * So that we can use the groups to determine the permissions without having to do intersection in the db.
+	 *
+	 * Furthermore, that way it is also provided when using Auth::user()
+	 *
+	 * @var list<string>
+	 */
 	protected $with = [
 		'user_groups',
 	];

--- a/config/features.php
+++ b/config/features.php
@@ -85,16 +85,6 @@ return [
 	'require-content-type' => (bool) env('REQUIRE_CONTENT_TYPE_ENABLED', true),
 
 	/*
-	 |--------------------------------------------------------------------------
-	 | Require the API requests to have the header "content-type: application/json"
-	 | or "content-type: multipart/form-data" depending on the type.
-	 |
-	 | Note that this prevents the use of the API from the API documentation page.
-	 |--------------------------------------------------------------------------
-	 */
-	'user-groups' => (bool) env('USER_GROUPS_ENABLED', false),
-
-	/*
 	|--------------------------------------------------------------------------
 	| Vite http proxy
 	|--------------------------------------------------------------------------

--- a/resources/js/components/forms/album/AlbumCreateShareDialog.vue
+++ b/resources/js/components/forms/album/AlbumCreateShareDialog.vue
@@ -17,11 +17,14 @@
 				</div>
 				<div class="flex text-muted-color-emphasis w-full px-9">
 					<div class="w-1/2 flex items-center" v-if="newShareUser">
-						<span class="w-full">{{ newShareUser.username }}</span>
+						<span class="w-full">
+							<i class="pi pi-users ltr:mr-1 rtl:ml-1" v-if="newShareUser.type === 'group'" />
+							{{ newShareUser.name }}
+						</span>
 						<span @click="newShareUser = undefined"><i class="pi pi-times" /></span>
 					</div>
 					<div class="w-1/2" v-if="!newShareUser">
-						<SearchTargetUser @selected="selectUser" :filtered-users-ids="props.filteredUsersIds" />
+						<SearchTargetUser @selected="selectUser" :filtered-users-ids="props.filteredUsersIds" :with-groups="true" />
 					</div>
 					<div class="w-1/2 flex items-center justify-around">
 						<Checkbox v-model="grantsReadAccess" :binary="true" disabled />
@@ -57,16 +60,12 @@ import { ref } from "vue";
 import SearchTargetUser from "./SearchTargetUser.vue";
 import Checkbox from "primevue/checkbox";
 import Button from "primevue/button";
+import { UserOrGroup, UserOrGroupId } from "@/composables/search/searchUserGroupComputed";
 
-const props = withDefaults(
-	defineProps<{
-		album: App.Http.Resources.Models.AlbumResource | App.Http.Resources.Models.TagAlbumResource;
-		filteredUsersIds?: number[];
-	}>(),
-	{
-		filteredUsersIds: () => [],
-	},
-);
+const props = defineProps<{
+	album: App.Http.Resources.Models.AlbumResource | App.Http.Resources.Models.TagAlbumResource;
+	filteredUsersIds?: UserOrGroupId[];
+}>();
 
 const visible = defineModel("visible", { type: Boolean, required: true });
 
@@ -75,7 +74,7 @@ const emits = defineEmits<{
 	createdPermission: [];
 }>();
 
-const newShareUser = ref<App.Http.Resources.Models.LightUserResource | undefined>(undefined);
+const newShareUser = ref<UserOrGroup | undefined>(undefined);
 const grantsFullPhotoAccess = ref(false);
 const grantsDownload = ref(false);
 const grantsUpload = ref(false);
@@ -83,7 +82,7 @@ const grantsEdit = ref(false);
 const grantsDelete = ref(false);
 const grantsReadAccess = ref(true);
 
-function selectUser(target: App.Http.Resources.Models.LightUserResource) {
+function selectUser(target: UserOrGroup) {
 	newShareUser.value = target;
 }
 
@@ -102,13 +101,20 @@ function create() {
 	}
 	const data = {
 		album_ids: [props.album.id],
-		user_ids: [newShareUser.value.id],
+		user_ids: [] as number[],
+		group_ids: [] as number[],
 		grants_download: grantsDownload.value,
 		grants_full_photo_access: grantsFullPhotoAccess.value,
 		grants_upload: grantsUpload.value,
 		grants_edit: grantsEdit.value,
 		grants_delete: grantsDelete.value,
 	};
+
+	if (newShareUser.value.type === "group") {
+		data.group_ids = [newShareUser.value.id];
+	} else {
+		data.user_ids = [newShareUser.value.id];
+	}
 
 	SharingService.add(data).then(() => {
 		toast.add({ severity: "success", summary: trans("toasts.success"), detail: trans("sharing.permission_created"), life: 3000 });

--- a/resources/js/components/forms/album/AlbumShare.vue
+++ b/resources/js/components/forms/album/AlbumShare.vue
@@ -56,6 +56,7 @@ import AlbumCreateShareDialog from "./AlbumCreateShareDialog.vue";
 import Button from "primevue/button";
 import ProgressSpinner from "primevue/progressspinner";
 import ConfirmSharingDialog from "./ConfirmSharingDialog.vue";
+import { UserOrGroupId } from "@/composables/search/searchUserGroupComputed";
 
 const props = defineProps<{
 	album: App.Http.Resources.Models.AlbumResource | App.Http.Resources.Models.TagAlbumResource;
@@ -74,11 +75,22 @@ function load() {
 	});
 }
 
-const sharedUserIds = computed((): number[] => {
+const sharedUserIds = computed((): UserOrGroupId[] => {
 	if (perms.value === undefined) {
 		return [];
 	}
-	return perms.value.map((perm) => perm.user_id) as number[];
+	return perms.value.map((perm) => {
+		if (perm.user_group_id !== null) {
+			return {
+				id: perm.user_group_id,
+				type: "group",
+			};
+		}
+		return {
+			id: perm.user_id,
+			type: "user",
+		};
+	}) as UserOrGroupId[];
 });
 
 function deletePermission(id: number) {

--- a/resources/js/components/forms/album/AlbumTransfer.vue
+++ b/resources/js/components/forms/album/AlbumTransfer.vue
@@ -3,7 +3,7 @@
 		<template #content>
 			<div v-if="newOwner !== undefined">
 				<p class="w-full mb-4 text-center text-muted-color-emphasis">
-					{{ sprintf($t("dialogs.transfer.confirmation"), newOwner.username, props.album.title) }}<br />
+					{{ sprintf($t("dialogs.transfer.confirmation"), newOwner.name, props.album.title) }}<br />
 					<span class="text-warning-700">
 						<i class="pi pi-exclamation-triangle ltr:mr-2 rtl:ml-2" />
 						{{ $t("dialogs.transfer.lost_access_warning") }} </span
@@ -16,7 +16,7 @@
 			</div>
 			<div v-else class="text-center w-full">
 				<span class="font-bold">{{ $t("dialogs.transfer.query") }}</span>
-				<SearchTargetUser :album="album" @selected="selected" />
+				<SearchTargetUser :album="album" @selected="selected" :with-groups="false" />
 			</div>
 			<Button
 				class="text-danger-800 font-bold hover:text-white hover:bg-danger-800 w-full bg-transparent border-none"
@@ -37,13 +37,14 @@ import Card from "primevue/card";
 import AlbumService from "@/services/album-service";
 import { sprintf } from "sprintf-js";
 import SearchTargetUser from "@/components/forms/album/SearchTargetUser.vue";
+import { type UserOrGroup } from "@/composables/search/searchUserGroupComputed";
 
 const props = defineProps<{
 	album: App.Http.Resources.Models.AlbumResource | App.Http.Resources.Models.TagAlbumResource;
 }>();
 
 const router = useRouter();
-const newOwner = ref<App.Http.Resources.Models.LightUserResource | undefined>(undefined);
+const newOwner = ref<UserOrGroup | undefined>(undefined);
 
 function execute() {
 	if (newOwner.value === undefined) {
@@ -56,7 +57,7 @@ function execute() {
 	});
 }
 
-function selected(target: App.Http.Resources.Models.LightUserResource) {
+function selected(target: UserOrGroup) {
 	newOwner.value = target;
 }
 </script>

--- a/resources/js/components/forms/album/SearchTargetUser.vue
+++ b/resources/js/components/forms/album/SearchTargetUser.vue
@@ -8,70 +8,54 @@
 		:placeholder="$t('dialogs.target_user.placeholder')"
 		:loading="options === undefined"
 		:options="options"
-		optionLabel="username"
+		optionLabel="name"
 		showClear
 	>
 		<template #value="slotProps">
 			<div v-if="slotProps.value" class="flex items-center">
-				<div>{{ $t(slotProps.value.username) }}</div>
+				<div>
+					<i class="pi pi-users ltr:mr-1 rtl:ml-1" v-if="slotProps.value.type === 'group'" />
+					{{ $t(slotProps.value.name) }}
+				</div>
 			</div>
 		</template>
 		<template #option="slotProps">
 			<div class="flex items-center">
-				<span class="text-left">{{ slotProps.option.username }}</span>
+				<span>
+					<i class="pi pi-users ltr:mr-1 rtl:ml-1" v-if="slotProps.option.type === 'group'" />
+					{{ slotProps.option.name }}
+				</span>
 			</div>
 		</template>
 	</Select>
 </template>
 <script setup lang="ts">
-import { onMounted, ref, watch } from "vue";
+import { onMounted, watch } from "vue";
 import Select from "primevue/select";
-import UsersService from "@/services/users-service";
+import { type UserOrGroup, type UserOrGroupId, useSearchUserGroupComputed } from "@/composables/search/searchUserGroupComputed";
+import { useLycheeStateStore } from "@/stores/LycheeState";
+import { storeToRefs } from "pinia";
 
-const props = withDefaults(
-	defineProps<{
-		filteredUsersIds?: number[];
-	}>(),
-	{
-		filteredUsersIds: () => [],
-	},
-);
+const lycheeStore = useLycheeStateStore();
+lycheeStore.init();
+const { is_se_enabled } = storeToRefs(lycheeStore);
+
+const props = defineProps<{
+	filteredUsersIds?: UserOrGroupId[];
+	withGroups?: boolean;
+}>();
+
 const emits = defineEmits<{
-	selected: [user: App.Http.Resources.Models.LightUserResource];
+	selected: [user: UserOrGroup];
 	"no-target": [];
 }>();
 
-const options = ref<App.Http.Resources.Models.LightUserResource[] | undefined>(undefined);
-const selectedTarget = ref<App.Http.Resources.Models.LightUserResource | undefined>(undefined);
-const userList = ref<App.Http.Resources.Models.LightUserResource[] | undefined>(undefined);
-
-function load() {
-	UsersService.get().then((response) => {
-		userList.value = response.data;
-		filterUsers();
-	});
-}
-
-function selected() {
-	if (selectedTarget.value === undefined) {
-		return;
-	}
-
-	emits("selected", selectedTarget.value);
-}
-
-function filterUsers() {
-	if (userList.value === undefined) {
-		return;
-	}
-
-	options.value = userList.value.filter((user) => !props.filteredUsersIds.includes(user.id));
-	if (options.value.length === 0) {
-		emits("no-target");
-	}
-}
+const { options, selectedTarget, load, selected, filterUserGroups } = useSearchUserGroupComputed(is_se_enabled, emits);
 
 onMounted(load);
 
-watch(() => props.filteredUsersIds, filterUsers);
+watch(
+	() => props.filteredUsersIds,
+	(v) => filterUserGroups(v),
+);
 </script>

--- a/resources/js/components/forms/sharing/ShareLine.vue
+++ b/resources/js/components/forms/sharing/ShareLine.vue
@@ -6,7 +6,10 @@
 					props.perm.album_title
 				}}</router-link>
 			</span>
-			<span class="w-full">{{ props.perm.username }}</span>
+			<span class="w-full">
+				<i class="pi pi-users ltr:mr-1 rtl:ml-1" v-if="props.perm.user_group_id !== null" />
+				{{ props.perm.username ?? props.perm.user_group_name }}
+			</span>
 		</div>
 		<div class="w-1/2 flex items-center justify-around">
 			<Checkbox v-model="grantsReadAccess" :binary="true" disabled />

--- a/resources/js/composables/search/searchUserGroupComputed.ts
+++ b/resources/js/composables/search/searchUserGroupComputed.ts
@@ -1,0 +1,103 @@
+import { UserGroupService } from "@/services/user-group-service";
+import UsersService from "@/services/users-service";
+import { Ref, ref } from "vue";
+
+export type User = {
+	id: number;
+	name: string;
+	type: "user";
+};
+
+export type Group = {
+	id: number;
+	name: string;
+	type: "group";
+};
+
+export type UserOrGroup = User | Group;
+export type UserOrGroupId = { id: number; type: "user" | "group" };
+
+export function useSearchUserGroupComputed(
+	is_supporter: Ref<boolean>,
+	emits: (((evt: "selected", userOrGroup: UserOrGroup) => void) & ((evt: "no-target") => void)) | undefined,
+) {
+	const options = ref<UserOrGroup[] | undefined>(undefined);
+	const selectedTarget = ref<UserOrGroup | undefined>(undefined);
+	const usersGroupsList = ref<UserOrGroup[] | undefined>(undefined);
+
+	function loadUsers(): Promise<void> {
+		return UsersService.get().then((response) => {
+			if (response.data.length === 0) {
+				return;
+			}
+
+			response.data.forEach((user) => {
+				usersGroupsList.value?.push({ id: user.id, name: user.username, type: "user" as const });
+			});
+		});
+	}
+
+	function loadGroups(): Promise<void> {
+		if (!is_supporter.value) {
+			return Promise.resolve();
+		}
+
+		return UserGroupService.listUserGroups().then((response) => {
+			if (response.data.user_groups.length === 0) {
+				return;
+			}
+
+			response.data.user_groups.forEach((group) => {
+				usersGroupsList.value?.push({
+					id: group.id,
+					name: group.name,
+					type: "group" as const,
+				});
+			});
+		});
+	}
+
+	function load() {
+		usersGroupsList.value = [];
+
+		Promise.all([loadUsers(), loadGroups()]).then(() => {
+			filterUserGroups();
+		});
+	}
+
+	function selected() {
+		if (selectedTarget.value === undefined) {
+			return;
+		}
+
+		if (emits !== undefined) {
+			emits("selected", selectedTarget.value);
+		}
+	}
+
+	function filterUserGroups(filteredUsersIds: UserOrGroupId[] = []) {
+		if (usersGroupsList.value === undefined) {
+			return;
+		}
+		const userIds = filteredUsersIds.filter((user) => user.type === "user").map((user) => user.id);
+		const groupIds = filteredUsersIds.filter((group) => group.type === "group").map((group) => group.id);
+
+		options.value = usersGroupsList.value.filter(
+			(userGroup) =>
+				(userGroup.type === "user" && !userIds.includes(userGroup.id)) || (userGroup.type === "group" && !groupIds.includes(userGroup.id)),
+		);
+
+		if (options.value.length === 0 && emits !== undefined) {
+			emits("no-target");
+		}
+	}
+
+	return {
+		options,
+		selectedTarget,
+		usersGroupsList,
+		load,
+		selected,
+		filterUserGroups,
+	};
+}

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -378,7 +378,9 @@ declare namespace App.Http.Resources.Models {
 	export type AccessPermissionResource = {
 		id: number | null;
 		user_id: number | null;
+		user_group_id: number | null;
 		username: string | null;
+		user_group_name: string | null;
 		album_title: string | null;
 		album_id: string | null;
 		grants_full_photo_access: boolean;

--- a/tests/Feature_v2/Album/SharingTest.php
+++ b/tests/Feature_v2/Album/SharingTest.php
@@ -170,7 +170,7 @@ class SharingTest extends BaseApiWithDataTest
 			'shall_override' => false,
 		]);
 		$this->assertNoContent($response);
-		// Verify the count is still 1.
+		// Verify the count is still 2.
 		self::assertEquals(2, AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->count());
 
 		// Verify the permission

--- a/tests/Feature_v2/Album/SharingTest.php
+++ b/tests/Feature_v2/Album/SharingTest.php
@@ -88,6 +88,7 @@ class SharingTest extends BaseApiWithDataTest
 
 		$response = $this->actingAs($this->userMayUpload2)->postJson('Sharing', [
 			'user_ids' => [$this->userMayUpload1->id],
+			'group_ids' => [],
 			'album_ids' => [$this->album2->id],
 			'grants_edit' => true,
 			'grants_delete' => true,
@@ -141,8 +142,8 @@ class SharingTest extends BaseApiWithDataTest
 			'shall_override' => false,
 		]);
 		$this->assertNoContent($response);
-		self::assertEquals(1, AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->count());
-		$perm = AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->first();
+		self::assertEquals(2, AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->count());
+		$perm = AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->whereNull(APC::USER_GROUP_ID)->first();
 
 		// Update the permission with false
 		$response = $this->actingAs($this->userMayUpload1)->patchJson('Sharing', [
@@ -156,7 +157,7 @@ class SharingTest extends BaseApiWithDataTest
 		$this->assertOk($response);
 
 		// Verify the permission
-		$perm = AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->first();
+		$perm = AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->whereNull(APC::USER_GROUP_ID)->first();
 		self::assertFalse($perm->grants_edit);
 		self::assertFalse($perm->grants_delete);
 		self::assertFalse($perm->grants_download);
@@ -170,10 +171,10 @@ class SharingTest extends BaseApiWithDataTest
 		]);
 		$this->assertNoContent($response);
 		// Verify the count is still 1.
-		self::assertEquals(1, AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->count());
+		self::assertEquals(2, AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->count());
 
 		// Verify the permission
-		$perm = AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->first();
+		$perm = AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->whereNull(APC::USER_GROUP_ID)->first();
 		self::assertTrue($perm->grants_edit);
 		self::assertTrue($perm->grants_delete);
 		self::assertTrue($perm->grants_download);
@@ -186,6 +187,7 @@ class SharingTest extends BaseApiWithDataTest
 		// Set up the permission in subSlbum
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Sharing', [
 			'user_ids' => [$this->userLocked->id],
+			'group_ids' => [],
 			'album_ids' => [$this->subAlbum1->id],
 			'grants_edit' => true,
 			'grants_delete' => true,
@@ -198,6 +200,7 @@ class SharingTest extends BaseApiWithDataTest
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Sharing', [
 			'user_ids' => [$this->userNoUpload->id],
+			'group_ids' => [],
 			'album_ids' => [$this->album1->id],
 			'grants_edit' => true,
 			'grants_delete' => true,

--- a/tests/Feature_v2/Photo/PhotoRotateTest.php
+++ b/tests/Feature_v2/Photo/PhotoRotateTest.php
@@ -103,6 +103,7 @@ class PhotoRotateTest extends BaseApiWithDataTest
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Sharing', [
 			'user_ids' => [$this->userMayUpload2->id],
+			'group_ids' => [],
 			'album_ids' => [$new_album_id],
 			'grants_edit' => true,
 			'grants_delete' => true,

--- a/tests/Traits/CatchFailures.php
+++ b/tests/Traits/CatchFailures.php
@@ -85,11 +85,11 @@ trait CatchFailures
 	 * Additionally, this transformation is applied recursively on the previous_exception in the case of
 	 * exception encapsulation.
 	 *
-	 * @param null|array $exception
+	 * @param array|null $exception
 	 *
 	 * @return void
 	 */
-	private function trimException(null|array &$exception): void
+	private function trimException(array|null &$exception): void
 	{
 		if (!is_array($exception)) {
 			return;

--- a/tests/Traits/CatchFailures.php
+++ b/tests/Traits/CatchFailures.php
@@ -68,6 +68,7 @@ trait CatchFailures
 		// We remove 204 as it does not have content
 		// We remove 302 because it does not have json data.
 		} elseif (!in_array($response->getStatusCode(), [204, 302, ...$expectedStatusCodeArray], true)) {
+			$exception = $response->json();
 			$this->trimException($exception);
 		}
 		PHPUnit::assertContains($response->getStatusCode(), $expectedStatusCodeArray);
@@ -84,12 +85,16 @@ trait CatchFailures
 	 * Additionally, this transformation is applied recursively on the previous_exception in the case of
 	 * exception encapsulation.
 	 *
-	 * @param array $exception
+	 * @param null|array $exception
 	 *
 	 * @return void
 	 */
-	private function trimException(array &$exception): void
+	private function trimException(null|array &$exception): void
 	{
+		if (!is_array($exception)) {
+			return;
+		}
+
 		if (isset($exception['trace'])) {
 			$exception['trace'] = array_values(array_filter($exception['trace'], fn ($t) => !in_array($t['class'] ?? '', $this->exception_noise, true)));
 			$exception['trace'] = array_slice($exception['trace'], 0, 3);


### PR DESCRIPTION
This pull request introduces support for sharing albums with user groups in addition to individual users. The changes span multiple files to extend the existing sharing functionality, update the database model, and enhance validation and testing. Below is a summary of the most important changes:

### Sharing Functionality Enhancements:
* Updated `applyUpdate` and `applyOverwrite` methods in `app/Actions/Sharing/Propagate.php` to handle permissions for user groups alongside individual users. (`[[1]](diffhunk://#diff-099be4abba0aef41c0c3e3f139f6df0d8b52fcf573d6bc2fe8b120f4be446720L52-R52)`, `[[2]](diffhunk://#diff-099be4abba0aef41c0c3e3f139f6df0d8b52fcf573d6bc2fe8b120f4be446720R62)`, `[[3]](diffhunk://#diff-099be4abba0aef41c0c3e3f139f6df0d8b52fcf573d6bc2fe8b120f4be446720L125-R126)`, `[[4]](diffhunk://#diff-099be4abba0aef41c0c3e3f139f6df0d8b52fcf573d6bc2fe8b120f4be446720R135)`)
* Modified the `Share::do` method in `app/Actions/Sharing/Share.php` to accept both `user_id` and `user_group_id` parameters, and added logic to load the associated user group. (`[[1]](diffhunk://#diff-ea159f4821c75cf6a4d3b3271e6273686592607be806df7d3cbfb0719f18dbe2R20-R34)`, `[[2]](diffhunk://#diff-ea159f4821c75cf6a4d3b3271e6273686592607be806df7d3cbfb0719f18dbe2R43)`)

### Database Model Updates:
* Added `user_group_id` support to the `AccessPermission` model, including new fillable attributes and type casting. (`[[1]](diffhunk://#diff-1dd7e2eab43d6518186bdf310214c9587a2942a7c98054107001c05054e7422aR76)`, `[[2]](diffhunk://#diff-1dd7e2eab43d6518186bdf310214c9587a2942a7c98054107001c05054e7422aR90)`)
* Automatically load user groups when retrieving a `User` model for consistent permission checks. (`[app/Models/User.phpR123-R130](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR123-R130)`)

### API and Validation Enhancements:
* Introduced `HasUserGroupIds` interface and trait to manage user group IDs in requests. (`[[1]](diffhunk://#diff-05b81c40be218dbe45d50a24dd501994bbec1247a72c366620554a1b2eafde89R1-R17)`, `[[2]](diffhunk://#diff-90b1d5bd6c3b34b6b303932b9761844cea879eb038795dbcb8e532f5b20be7f2R1-R25)`)
* Updated `AddSharingRequest` to validate `user_group_ids` and ensure at least one user or group is specified. (`[[1]](diffhunk://#diff-088c4204a668f60ad82325c3f0b14d9d963cf16c242f7acbbb9c938f7e55024eR19-R26)`, `[[2]](diffhunk://#diff-088c4204a668f60ad82325c3f0b14d9d963cf16c242f7acbbb9c938f7e55024eR37)`, `[[3]](diffhunk://#diff-088c4204a668f60ad82325c3f0b14d9d963cf16c242f7acbbb9c938f7e55024eL53-R59)`, `[[4]](diffhunk://#diff-088c4204a668f60ad82325c3f0b14d9d963cf16c242f7acbbb9c938f7e55024eR75-R81)`)

### Controller and Query Updates:
* Enhanced `SharingController` methods to support user groups in sharing logic, including `create`, `list`, and `listAll`. (`[[1]](diffhunk://#diff-600f9aa425dff07d96b096d9f9dc193ebd32ebfd8b6cacd23dd944f2c53a83dfL49-R77)`, `[[2]](diffhunk://#diff-600f9aa425dff07d96b096d9f9dc193ebd32ebfd8b6cacd23dd944f2c53a83dfL95-R117)`, `[[3]](diffhunk://#diff-600f9aa425dff07d96b096d9f9dc193ebd32ebfd8b6cacd23dd944f2c53a83dfL111-R138)`, `[[4]](diffhunk://#diff-600f9aa425dff07d96b096d9f9dc193ebd32ebfd8b6cacd23dd944f2c53a83dfL137-R164)`)

### Test Coverage:
* Updated and extended tests in `tests/Feature_v2/Album/SharingTest.php` to cover user group sharing scenarios. (`[[1]](diffhunk://#diff-a352400531c5477c8773e977ade7e2893623e8766740ca40c918b59f1963a0a7R91)`, `[[2]](diffhunk://#diff-a352400531c5477c8773e977ade7e2893623e8766740ca40c918b59f1963a0a7L144-R146)`, `[[3]](diffhunk://#diff-a352400531c5477c8773e977ade7e2893623e8766740ca40c918b59f1963a0a7L159-R160)`, `[[4]](diffhunk://#diff-a352400531c5477c8773e977ade7e2893623e8766740ca40c918b59f1963a0a7L173-R177)`, `[[5]](diffhunk://#diff-a352400531c5477c8773e977ade7e2893623e8766740ca40c918b59f1963a0a7R190)`, `[[6]](diffhunk://#diff-a352400531c5477c8773e977ade7e2893623e8766740ca40c918b59f1963a0a7R203)`)