### PR TITLE
Permission management for User group in front-end

### DIFF
--- a/app/Http/Resources/Rights/SettingsRightsResource.php
+++ b/app/Http/Resources/Rights/SettingsRightsResource.php
@@ -34,6 +34,6 @@ class SettingsRightsResource extends Data
 		$this->can_see_diagnostics = Gate::check(SettingsPolicy::CAN_SEE_DIAGNOSTICS, [Configs::class]);
 		$this->can_update = Gate::check(SettingsPolicy::CAN_UPDATE, [Configs::class]);
 		$this->can_access_dev_tools = Gate::check(SettingsPolicy::CAN_ACCESS_DEV_TOOLS, [Configs::class]);
-		$this->can_acess_user_groups = resolve(Verify::class)->check() && Gate::check(UserGroupPolicy::CAN_LIST, [UserGroup::class]) && config('features.user-groups') === true;
+		$this->can_acess_user_groups = resolve(Verify::class)->check() && Gate::check(UserGroupPolicy::CAN_LIST, [UserGroup::class]);
 	}
 }

--- a/config/features.php
+++ b/config/features.php
@@ -85,16 +85,6 @@ return [
 	'require-content-type' => (bool) env('REQUIRE_CONTENT_TYPE_ENABLED', true),
 
 	/*
-	 |--------------------------------------------------------------------------
-	 | Require the API requests to have the header "content-type: application/json"
-	 | or "content-type: multipart/form-data" depending on the type.
-	 |
-	 | Note that this prevents the use of the API from the API documentation page.
-	 |--------------------------------------------------------------------------
-	 */
-	'user-groups' => (bool) env('USER_GROUPS_ENABLED', false),
-
-	/*
 	|--------------------------------------------------------------------------
 	| Vite http proxy
 	|--------------------------------------------------------------------------

--- a/resources/js/components/forms/album/AlbumCreateShareDialog.vue
+++ b/resources/js/components/forms/album/AlbumCreateShareDialog.vue
@@ -17,7 +17,10 @@
 				</div>
 				<div class="flex text-muted-color-emphasis w-full px-9">
 					<div class="w-1/2 flex items-center" v-if="newShareUser">
-						<span :class="{ 'w-full': true, 'text-primary-emphasis': newShareUser.type === 'group' }">{{ newShareUser.name }}</span>
+						<span class="w-full">
+							<i class="pi pi-users ltr:mr-1 rtl:ml-1" v-if="newShareUser.type === 'group'" />
+							{{ newShareUser.name }}
+						</span>
 						<span @click="newShareUser = undefined"><i class="pi pi-times" /></span>
 					</div>
 					<div class="w-1/2" v-if="!newShareUser">

--- a/resources/js/components/forms/album/AlbumCreateShareDialog.vue
+++ b/resources/js/components/forms/album/AlbumCreateShareDialog.vue
@@ -17,11 +17,11 @@
 				</div>
 				<div class="flex text-muted-color-emphasis w-full px-9">
 					<div class="w-1/2 flex items-center" v-if="newShareUser">
-						<span class="w-full">{{ newShareUser.username }}</span>
+						<span :class="{ 'w-full': true, 'text-primary-emphasis': newShareUser.type === 'group' }">{{ newShareUser.name }}</span>
 						<span @click="newShareUser = undefined"><i class="pi pi-times" /></span>
 					</div>
 					<div class="w-1/2" v-if="!newShareUser">
-						<SearchTargetUser @selected="selectUser" :filtered-users-ids="props.filteredUsersIds" />
+						<SearchTargetUser @selected="selectUser" :filtered-users-ids="props.filteredUsersIds" :with-groups="true" />
 					</div>
 					<div class="w-1/2 flex items-center justify-around">
 						<Checkbox v-model="grantsReadAccess" :binary="true" disabled />
@@ -57,16 +57,12 @@ import { ref } from "vue";
 import SearchTargetUser from "./SearchTargetUser.vue";
 import Checkbox from "primevue/checkbox";
 import Button from "primevue/button";
+import { UserOrGroup, UserOrGroupId } from "@/composables/search/searchUserGroupComputed";
 
-const props = withDefaults(
-	defineProps<{
-		album: App.Http.Resources.Models.AlbumResource | App.Http.Resources.Models.TagAlbumResource;
-		filteredUsersIds?: number[];
-	}>(),
-	{
-		filteredUsersIds: () => [],
-	},
-);
+const props = defineProps<{
+	album: App.Http.Resources.Models.AlbumResource | App.Http.Resources.Models.TagAlbumResource;
+	filteredUsersIds?: UserOrGroupId[];
+}>();
 
 const visible = defineModel("visible", { type: Boolean, required: true });
 
@@ -75,7 +71,7 @@ const emits = defineEmits<{
 	createdPermission: [];
 }>();
 
-const newShareUser = ref<App.Http.Resources.Models.LightUserResource | undefined>(undefined);
+const newShareUser = ref<UserOrGroup | undefined>(undefined);
 const grantsFullPhotoAccess = ref(false);
 const grantsDownload = ref(false);
 const grantsUpload = ref(false);
@@ -83,7 +79,7 @@ const grantsEdit = ref(false);
 const grantsDelete = ref(false);
 const grantsReadAccess = ref(true);
 
-function selectUser(target: App.Http.Resources.Models.LightUserResource) {
+function selectUser(target: UserOrGroup) {
 	newShareUser.value = target;
 }
 
@@ -102,13 +98,20 @@ function create() {
 	}
 	const data = {
 		album_ids: [props.album.id],
-		user_ids: [newShareUser.value.id],
+		user_ids: [] as number[],
+		group_ids: [] as number[],
 		grants_download: grantsDownload.value,
 		grants_full_photo_access: grantsFullPhotoAccess.value,
 		grants_upload: grantsUpload.value,
 		grants_edit: grantsEdit.value,
 		grants_delete: grantsDelete.value,
 	};
+
+	if (newShareUser.value.type === "group") {
+		data.group_ids = [newShareUser.value.id];
+	} else {
+		data.user_ids = [newShareUser.value.id];
+	}
 
 	SharingService.add(data).then(() => {
 		toast.add({ severity: "success", summary: trans("toasts.success"), detail: trans("sharing.permission_created"), life: 3000 });

--- a/resources/js/components/forms/album/AlbumShare.vue
+++ b/resources/js/components/forms/album/AlbumShare.vue
@@ -56,6 +56,7 @@ import AlbumCreateShareDialog from "./AlbumCreateShareDialog.vue";
 import Button from "primevue/button";
 import ProgressSpinner from "primevue/progressspinner";
 import ConfirmSharingDialog from "./ConfirmSharingDialog.vue";
+import { UserOrGroupId } from "@/composables/search/searchUserGroupComputed";
 
 const props = defineProps<{
 	album: App.Http.Resources.Models.AlbumResource | App.Http.Resources.Models.TagAlbumResource;
@@ -74,11 +75,22 @@ function load() {
 	});
 }
 
-const sharedUserIds = computed((): number[] => {
+const sharedUserIds = computed((): UserOrGroupId[] => {
 	if (perms.value === undefined) {
 		return [];
 	}
-	return perms.value.map((perm) => perm.user_id) as number[];
+	return perms.value.map((perm) => {
+		if (perm.user_group_id !== null) {
+			return {
+				id: perm.user_group_id,
+				type: "group",
+			};
+		}
+		return {
+			id: perm.user_id,
+			type: "user",
+		};
+	}) as UserOrGroupId[];
 });
 
 function deletePermission(id: number) {

--- a/resources/js/components/forms/album/AlbumTransfer.vue
+++ b/resources/js/components/forms/album/AlbumTransfer.vue
@@ -3,7 +3,7 @@
 		<template #content>
 			<div v-if="newOwner !== undefined">
 				<p class="w-full mb-4 text-center text-muted-color-emphasis">
-					{{ sprintf($t("dialogs.transfer.confirmation"), newOwner.username, props.album.title) }}<br />
+					{{ sprintf($t("dialogs.transfer.confirmation"), newOwner.name, props.album.title) }}<br />
 					<span class="text-warning-700">
 						<i class="pi pi-exclamation-triangle ltr:mr-2 rtl:ml-2" />
 						{{ $t("dialogs.transfer.lost_access_warning") }} </span
@@ -16,7 +16,7 @@
 			</div>
 			<div v-else class="text-center w-full">
 				<span class="font-bold">{{ $t("dialogs.transfer.query") }}</span>
-				<SearchTargetUser :album="album" @selected="selected" />
+				<SearchTargetUser :album="album" @selected="selected" :with-groups="false" />
 			</div>
 			<Button
 				class="text-danger-800 font-bold hover:text-white hover:bg-danger-800 w-full bg-transparent border-none"
@@ -37,13 +37,14 @@ import Card from "primevue/card";
 import AlbumService from "@/services/album-service";
 import { sprintf } from "sprintf-js";
 import SearchTargetUser from "@/components/forms/album/SearchTargetUser.vue";
+import { type UserOrGroup } from "@/composables/search/searchUserGroupComputed";
 
 const props = defineProps<{
 	album: App.Http.Resources.Models.AlbumResource | App.Http.Resources.Models.TagAlbumResource;
 }>();
 
 const router = useRouter();
-const newOwner = ref<App.Http.Resources.Models.LightUserResource | undefined>(undefined);
+const newOwner = ref<UserOrGroup | undefined>(undefined);
 
 function execute() {
 	if (newOwner.value === undefined) {
@@ -56,7 +57,7 @@ function execute() {
 	});
 }
 
-function selected(target: App.Http.Resources.Models.LightUserResource) {
+function selected(target: UserOrGroup) {
 	newOwner.value = target;
 }
 </script>

--- a/resources/js/components/forms/album/SearchTargetUser.vue
+++ b/resources/js/components/forms/album/SearchTargetUser.vue
@@ -14,7 +14,7 @@
 		<template #value="slotProps">
 			<div v-if="slotProps.value" class="flex items-center">
 				<div>
-					<i class="pi pi-users ltr:mr-1 rtl:ml-1" v-if="slotProps.option.type === 'group'" />
+					<i class="pi pi-users ltr:mr-1 rtl:ml-1" v-if="slotProps.value.type === 'group'" />
 					{{ $t(slotProps.value.name) }}
 				</div>
 			</div>

--- a/resources/js/components/forms/album/SearchTargetUser.vue
+++ b/resources/js/components/forms/album/SearchTargetUser.vue
@@ -13,12 +13,18 @@
 	>
 		<template #value="slotProps">
 			<div v-if="slotProps.value" class="flex items-center">
-				<div :class="{ 'text-primary-emphasis': slotProps.value.type === 'group' }">{{ $t(slotProps.value.name) }}</div>
+				<div>
+					<i class="pi pi-users ltr:mr-1 rtl:ml-1" v-if="slotProps.option.type === 'group'" />
+					{{ $t(slotProps.value.name) }}
+				</div>
 			</div>
 		</template>
 		<template #option="slotProps">
 			<div class="flex items-center">
-				<span :class="{ 'text-primary-emphasis': slotProps.option.type === 'group' }">{{ slotProps.option.name }}</span>
+				<span>
+					<i class="pi pi-users ltr:mr-1 rtl:ml-1" v-if="slotProps.option.type === 'group'" />
+					{{ slotProps.option.name }}
+				</span>
 			</div>
 		</template>
 	</Select>

--- a/resources/js/components/forms/sharing/BulkSharingModal.vue
+++ b/resources/js/components/forms/sharing/BulkSharingModal.vue
@@ -55,7 +55,8 @@
 							<span class="text-muted-color-emphasis font-bold">{{ $t("sharing.users") }}</span>
 						</template>
 						<template #option="slotProps">
-							<span class="w-full" :class="{ 'text-primary-emphasis': slotProps.option.type === 'group' }">
+							<span class="w-full">
+								<i class="pi pi-users ltr:mr-1 rtl:ml-1" v-if="slotProps.option.type === 'group'" />
 								{{ slotProps.option.name }}
 							</span>
 						</template>

--- a/resources/js/components/forms/sharing/BulkSharingModal.vue
+++ b/resources/js/components/forms/sharing/BulkSharingModal.vue
@@ -40,11 +40,10 @@
 						</template>
 					</Listbox>
 					<Listbox
-						v-model="selectedUsers"
+						v-model="selectedUsersOrGroups"
 						filter
-						:options="userList"
-						optionLabel="username"
-						optionValue="id"
+						:options="usersGroupsList"
+						optionLabel="name"
 						dataKey="id"
 						:multiple="true"
 						:checkmark="true"
@@ -54,6 +53,11 @@
 					>
 						<template #header>
 							<span class="text-muted-color-emphasis font-bold">{{ $t("sharing.users") }}</span>
+						</template>
+						<template #option="slotProps">
+							<span class="w-full" :class="{ 'text-primary-emphasis': slotProps.option.type === 'group' }">
+								{{ slotProps.option.name }}
+							</span>
 						</template>
 						<template #empty>
 							<span class="text-muted-color">{{ $t("sharing.no_users") }}</span>
@@ -83,7 +87,7 @@
 						$t("dialogs.button.cancel")
 					}}</Button>
 					<Button
-						:disabled="!selectedAlbums.length || !selectedUsers.length"
+						:disabled="!selectedAlbums.length || !selectedUsersOrGroups.length"
 						@click="create"
 						severity="success"
 						class="border-0 bg-transparent text-create-600 hover:bg-create-600 hover:text-white w-full rounded-none rounded-br-xl"
@@ -98,7 +102,6 @@
 <script setup lang="ts">
 import Dialog from "primevue/dialog";
 import { ref } from "vue";
-import UsersService from "@/services/users-service";
 import { onMounted } from "vue";
 import Checkbox from "primevue/checkbox";
 import Button from "primevue/button";
@@ -106,8 +109,14 @@ import Listbox from "primevue/listbox";
 import SharingService from "@/services/sharing-service";
 import { useToast } from "primevue/usetoast";
 import { trans } from "laravel-vue-i18n";
+import { type UserOrGroup, useSearchUserGroupComputed } from "@/composables/search/searchUserGroupComputed";
+import { useLycheeStateStore } from "@/stores/LycheeState";
+import { storeToRefs } from "pinia";
 
 const visible = defineModel("visible", { default: false });
+const lycheeStore = useLycheeStateStore();
+lycheeStore.init();
+const { is_se_enabled } = storeToRefs(lycheeStore);
 
 const toast = useToast();
 const emits = defineEmits<{
@@ -115,10 +124,8 @@ const emits = defineEmits<{
 }>();
 
 const targetAlbums = ref<App.Http.Resources.Models.TargetAlbumResource[] | undefined>(undefined);
-const userList = ref<App.Http.Resources.Models.LightUserResource[] | undefined>(undefined);
-
 const selectedAlbums = ref<string[]>([]);
-const selectedUsers = ref<number[]>([]);
+const selectedUsersOrGroups = ref<UserOrGroup[]>([]);
 
 const grantsFullPhotoAccess = ref(false);
 const grantsDownload = ref(false);
@@ -143,7 +150,7 @@ function trim(str: string) {
 }
 
 function reset() {
-	selectedUsers.value = [];
+	selectedUsersOrGroups.value = [];
 	selectedAlbums.value = [];
 	grantsFullPhotoAccess.value = false;
 	grantsDownload.value = false;
@@ -163,23 +170,23 @@ function loadAlbums() {
 	});
 }
 
-function loadUsers() {
-	UsersService.get().then((response) => {
-		userList.value = response.data;
-	});
-}
+const { usersGroupsList, load } = useSearchUserGroupComputed(is_se_enabled, undefined);
 
 function create() {
-	if (selectedUsers.value === undefined || selectedUsers.value.length === 0) {
+	if (selectedUsersOrGroups.value === undefined || selectedUsersOrGroups.value.length === 0) {
 		return;
 	}
 	if (selectedAlbums.value === undefined || selectedAlbums.value.length === 0) {
 		return;
 	}
 
+	const userIds = selectedUsersOrGroups.value.filter((user) => user.type === "user").map((user) => user.id);
+	const groupIds = selectedUsersOrGroups.value.filter((group) => group.type === "group").map((group) => group.id);
+
 	const data = {
 		album_ids: selectedAlbums.value,
-		user_ids: selectedUsers.value,
+		user_ids: userIds,
+		group_ids: groupIds,
 		grants_download: grantsDownload.value,
 		grants_full_photo_access: grantsFullPhotoAccess.value,
 		grants_upload: grantsUpload.value,
@@ -196,6 +203,6 @@ function create() {
 
 onMounted(() => {
 	loadAlbums();
-	loadUsers();
+	load();
 });
 </script>

--- a/resources/js/components/forms/sharing/CreateSharing.vue
+++ b/resources/js/components/forms/sharing/CreateSharing.vue
@@ -1,7 +1,10 @@
 <template>
 	<div class="flex">
 		<div class="w-5/12 flex items-center" v-if="newShareUser">
-			<span class="w-full" :class="{ 'text-primary-emphasis': newShareUser.type === 'group' }">{{ newShareUser.name }}</span>
+			<span class="w-full">
+				<i class="pi pi-users ltr:mr-1 rtl:ml-1" v-if="newShareUser.type === 'group'" />
+				{{ newShareUser.name }}
+			</span>
 			<span @click="newShareUser = undefined"><i class="pi pi-times" /></span>
 		</div>
 		<div class="w-5/12 flex" v-if="!newShareUser">

--- a/resources/js/components/forms/sharing/CreateSharing.vue
+++ b/resources/js/components/forms/sharing/CreateSharing.vue
@@ -1,11 +1,11 @@
 <template>
 	<div class="flex">
 		<div class="w-5/12 flex items-center" v-if="newShareUser">
-			<span class="w-full">{{ newShareUser.username }}</span>
+			<span class="w-full" :class="{ 'text-primary-emphasis': newShareUser.type === 'group' }">{{ newShareUser.name }}</span>
 			<span @click="newShareUser = undefined"><i class="pi pi-times" /></span>
 		</div>
 		<div class="w-5/12 flex" v-if="!newShareUser">
-			<SearchTargetUser @selected="selectUser" :filtered-users-ids="props.filteredUsersIds" />
+			<SearchTargetUser @selected="selectUser" :filtered-users-ids="props.filteredUsersIds" :with-groups="true" />
 		</div>
 		<div class="w-1/2 flex items-center justify-around">
 			<Checkbox v-model="grantsReadAccess" :binary="true" disabled />
@@ -28,25 +28,20 @@ import { useToast } from "primevue/usetoast";
 import SearchTargetUser from "../album/SearchTargetUser.vue";
 import SharingService from "@/services/sharing-service";
 import { trans } from "laravel-vue-i18n";
+import { type UserOrGroup, type UserOrGroupId } from "@/composables/search/searchUserGroupComputed";
 
-const props = withDefaults(
-	defineProps<{
-		withAlbum?: boolean;
-		album: App.Http.Resources.Models.AlbumResource | App.Http.Resources.Models.TagAlbumResource;
-		filteredUsersIds?: number[];
-	}>(),
-	{
-		withAlbum: false,
-		filteredUsersIds: () => [],
-	},
-);
+const props = defineProps<{
+	withAlbum?: boolean;
+	album: App.Http.Resources.Models.AlbumResource | App.Http.Resources.Models.TagAlbumResource;
+	filteredUsersIds?: UserOrGroupId[];
+}>();
 
 const toast = useToast();
 const emits = defineEmits<{
 	createdPermission: [];
 }>();
 
-const newShareUser = ref<App.Http.Resources.Models.LightUserResource | undefined>(undefined);
+const newShareUser = ref<UserOrGroup | undefined>(undefined);
 const grantsFullPhotoAccess = ref(false);
 const grantsDownload = ref(false);
 const grantsUpload = ref(false);
@@ -54,7 +49,7 @@ const grantsEdit = ref(false);
 const grantsDelete = ref(false);
 const grantsReadAccess = ref(true);
 
-function selectUser(target: App.Http.Resources.Models.LightUserResource) {
+function selectUser(target: UserOrGroup) {
 	newShareUser.value = target;
 }
 
@@ -73,13 +68,20 @@ function create() {
 	}
 	const data = {
 		album_ids: [props.album.id],
-		user_ids: [newShareUser.value.id],
+		user_ids: [] as number[],
+		group_ids: [] as number[],
 		grants_download: grantsDownload.value,
 		grants_full_photo_access: grantsFullPhotoAccess.value,
 		grants_upload: grantsUpload.value,
 		grants_edit: grantsEdit.value,
 		grants_delete: grantsDelete.value,
 	};
+
+	if (newShareUser.value.type === "group") {
+		data.group_ids = [newShareUser.value.id];
+	} else {
+		data.user_ids = [newShareUser.value.id];
+	}
 
 	SharingService.add(data).then(() => {
 		toast.add({ severity: "success", summary: trans("toasts.success"), detail: trans("sharing.permission_created"), life: 3000 });

--- a/resources/js/components/forms/sharing/ShareLine.vue
+++ b/resources/js/components/forms/sharing/ShareLine.vue
@@ -6,7 +6,9 @@
 					props.perm.album_title
 				}}</router-link>
 			</span>
-			<span class="w-full">{{ props.perm.username }}</span>
+			<span :class="{ 'w-full': true, 'text-primary-emphasis': props.perm.user_group_id !== null }">{{
+				props.perm.username ?? props.perm.user_group_name
+			}}</span>
 		</div>
 		<div class="w-1/2 flex items-center justify-around">
 			<Checkbox v-model="grantsReadAccess" :binary="true" disabled />

--- a/resources/js/components/forms/sharing/ShareLine.vue
+++ b/resources/js/components/forms/sharing/ShareLine.vue
@@ -6,9 +6,10 @@
 					props.perm.album_title
 				}}</router-link>
 			</span>
-			<span :class="{ 'w-full': true, 'text-primary-emphasis': props.perm.user_group_id !== null }">{{
-				props.perm.username ?? props.perm.user_group_name
-			}}</span>
+			<span class="w-full">
+				<i class="pi pi-users ltr:mr-1 rtl:ml-1" v-if="props.perm.user_group_id !== null" />
+				{{ props.perm.username ?? props.perm.user_group_name }}
+			</span>
 		</div>
 		<div class="w-1/2 flex items-center justify-around">
 			<Checkbox v-model="grantsReadAccess" :binary="true" disabled />

--- a/resources/js/composables/search/searchUserGroupComputed.ts
+++ b/resources/js/composables/search/searchUserGroupComputed.ts
@@ -1,0 +1,103 @@
+import { UserGroupService } from "@/services/user-group-service";
+import UsersService from "@/services/users-service";
+import { Ref, ref } from "vue";
+
+export type User = {
+	id: number;
+	name: string;
+	type: "user";
+};
+
+export type Group = {
+	id: number;
+	name: string;
+	type: "group";
+};
+
+export type UserOrGroup = User | Group;
+export type UserOrGroupId = { id: number; type: "user" | "group" };
+
+export function useSearchUserGroupComputed(
+	is_supporter: Ref<boolean>,
+	emits: (((evt: "selected", userOrGroup: UserOrGroup) => void) & ((evt: "no-target") => void)) | undefined,
+) {
+	const options = ref<UserOrGroup[] | undefined>(undefined);
+	const selectedTarget = ref<UserOrGroup | undefined>(undefined);
+	const usersGroupsList = ref<UserOrGroup[] | undefined>(undefined);
+
+	function loadUsers(): Promise<void> {
+		return UsersService.get().then((response) => {
+			if (response.data.length === 0) {
+				return;
+			}
+
+			response.data.forEach((user) => {
+				usersGroupsList.value?.push({ id: user.id, name: user.username, type: "user" as const });
+			});
+		});
+	}
+
+	function loadGroups(): Promise<void> {
+		if (!is_supporter.value) {
+			return Promise.resolve();
+		}
+
+		return UserGroupService.listUserGroups().then((response) => {
+			if (response.data.user_groups.length === 0) {
+				return;
+			}
+
+			response.data.user_groups.forEach((group) => {
+				usersGroupsList.value?.push({
+					id: group.id,
+					name: group.name,
+					type: "group" as const,
+				});
+			});
+		});
+	}
+
+	function load() {
+		usersGroupsList.value = [];
+
+		Promise.all([loadUsers(), loadGroups()]).then(() => {
+			filterUserGroups();
+		});
+	}
+
+	function selected() {
+		if (selectedTarget.value === undefined) {
+			return;
+		}
+
+		if (emits !== undefined) {
+			emits("selected", selectedTarget.value);
+		}
+	}
+
+	function filterUserGroups(filteredUsersIds: UserOrGroupId[] = []) {
+		if (usersGroupsList.value === undefined) {
+			return;
+		}
+		const userIds = filteredUsersIds.filter((user) => user.type === "user").map((user) => user.id);
+		const groupIds = filteredUsersIds.filter((group) => group.type === "group").map((group) => group.id);
+
+		options.value = usersGroupsList.value.filter(
+			(userGroup) =>
+				(userGroup.type === "user" && !userIds.includes(userGroup.id)) || (userGroup.type === "group" && !groupIds.includes(userGroup.id)),
+		);
+
+		if (options.value.length === 0 && emits !== undefined) {
+			emits("no-target");
+		}
+	}
+
+	return {
+		options,
+		selectedTarget,
+		usersGroupsList,
+		load,
+		selected,
+		filterUserGroups,
+	};
+}


### PR DESCRIPTION
This pull request introduces support for sharing albums with both individual users and user groups. It refactors the sharing-related components to accommodate this new functionality by introducing a unified `UserOrGroup` type and updating the UI and logic accordingly.

### Support for User and Group Sharing:

* **New `UserOrGroup` Type and Utility Functions**: Added a new `UserOrGroup` type and `useSearchUserGroupComputed` composable to manage shared users and groups, including loading, filtering, and selecting them. (`resources/js/composables/search/searchUserGroupComputed.ts`)
* **Updated Sharing Data Structure**: Modified components like `AlbumCreateShareDialog`, `AlbumTransfer`, `BulkSharingModal`, and `CreateSharing` to handle both user and group IDs when creating sharing permissions. (`resources/js/components/forms/album/AlbumCreateShareDialog.vue`, `resources/js/components/forms/sharing/BulkSharingModal.vue`, and others) [[1]](diffhunk://#diff-d8c27c2d8de238f554d68590bd1e779892ab080a8dc41da14a10b11e295ce955L105-R115) [[2]](diffhunk://#diff-d0f6b1371188cc74436f93d1595836ca5a3ea053521861fef69ef6b45e0a04d6L166-R189) [[3]](diffhunk://#diff-fc5217a5f043771633c90b733d1afe9d53e8b4b061faf0cfb22c49445503a8e5L76-R85)

### UI Enhancements:

* **Dynamic Styling for Groups**: Updated UI elements to dynamically style group names differently, using the `text-primary-emphasis` class for groups. (`resources/js/components/forms/album/AlbumCreateShareDialog.vue`, `resources/js/components/forms/sharing/ShareLine.vue`) [[1]](diffhunk://#diff-d8c27c2d8de238f554d68590bd1e779892ab080a8dc41da14a10b11e295ce955L20-R24) [[2]](diffhunk://#diff-f1d3c83755c67d518ed969f0e2711472f11b0b7b0795222063a5dda69b948630L9-R11)
* **Improved Select Components**: Updated `SearchTargetUser` and other components to display both users and groups in dropdowns and lists, with clear visual differentiation. (`resources/js/components/forms/album/SearchTargetUser.vue`, `resources/js/components/forms/sharing/BulkSharingModal.vue`) [[1]](diffhunk://#diff-081954bc9ab1cab267aecb4187f075c12e689b2659e13da9f07d9a157eca5528L11-R54) [[2]](diffhunk://#diff-d0f6b1371188cc74436f93d1595836ca5a3ea053521861fef69ef6b45e0a04d6L43-R64)

### Refactoring for Consistency:

* **Unified Props and Data Types**: Replaced `LightUserResource` with the new `UserOrGroup` type across multiple components for consistency and to support groups. (`resources/js/components/forms/album/AlbumCreateShareDialog.vue`, `resources/js/components/forms/sharing/CreateSharing.vue`) [[1]](diffhunk://#diff-d8c27c2d8de238f554d68590bd1e779892ab080a8dc41da14a10b11e295ce955L78-R82) [[2]](diffhunk://#diff-fc5217a5f043771633c90b733d1afe9d53e8b4b061faf0cfb22c49445503a8e5R31-R52)
* **Removed Legacy Code**: Refactored and removed redundant logic for filtering and loading users, replacing it with the new composable. (`resources/js/components/forms/album/SearchTargetUser.vue`, `resources/js/components/forms/sharing/BulkSharingModal.vue`) [[1]](diffhunk://#diff-081954bc9ab1cab267aecb4187f075c12e689b2659e13da9f07d9a157eca5528L11-R54) [[2]](diffhunk://#diff-d0f6b1371188cc74436f93d1595836ca5a3ea053521861fef69ef6b45e0a04d6L166-R189)

These changes enhance the flexibility of the sharing functionality while maintaining a clean and consistent codebase.