### PR TITLE
Do not log queries which are faster than 100ms by default

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -199,7 +199,7 @@ class AppServiceProvider extends ServiceProvider
 			return;
 		}
 
-		// if the query is not slow enough, we do not log it.
+		// if the query is not slow enough, we do not log it. Default is 100ms.
 		if ($query->time < config('database.log_sql_min_time', 100)) {
 			return;
 		}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -199,6 +199,11 @@ class AppServiceProvider extends ServiceProvider
 			return;
 		}
 
+		// if the query is not slow enough, we do not log it.
+		if ($query->time < config('database.log_sql_min_time', 100)) {
+			return;
+		}
+
 		// Get message with binding outside.
 		$msg = '(' . $query->time . 'ms) ' . $query->sql . ' [' . implode(', ', $query->bindings) . ']';
 
@@ -226,7 +231,7 @@ class AppServiceProvider extends ServiceProvider
 
 		$explain = DB::select('EXPLAIN ' . $query->sql, $query->bindings);
 		$renderer = new ArrayToTextTable();
-		$renderer->setIgnoredKeys(['possible_keys', 'key_len', 'ref']);
+		$renderer->setIgnoredKeys(['possible_keys', 'key_len']);
 
 		$msg .= PHP_EOL;
 		$msg .= Str::repeat('-', 20) . PHP_EOL;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -231,7 +231,7 @@ class AppServiceProvider extends ServiceProvider
 
 		$explain = DB::select('EXPLAIN ' . $query->sql, $query->bindings);
 		$renderer = new ArrayToTextTable();
-		$renderer->setIgnoredKeys(['possible_keys', 'key_len']);
+		$renderer->setIgnoredKeys(['possible_keys', 'key_len', 'ref']);
 
 		$msg .= PHP_EOL;
 		$msg .= Str::repeat('-', 20) . PHP_EOL;

--- a/config/database.php
+++ b/config/database.php
@@ -29,7 +29,32 @@ return [
 	*/
 
 	'db_log_sql' => (bool) env('DB_LOG_SQL', false),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Log SQL statements with EXPLAIN
+	|--------------------------------------------------------------------------
+	|
+	| Execute EXPLAIN on each SQL statement and log the result.
+	| This is useful to find out why a query is slow.
+	| Only use it for debugging and development purposes as it slows down
+	| the performance of the application.
+	|
+	*/
 	'explain' => (bool) env('DB_LOG_SQL_EXPLAIN', false),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Only log SQL statements with a minimum execution time
+	|--------------------------------------------------------------------------
+	|
+	| If set to a value greater than 0, only SQL statements with an execution
+	| time greater than this value will be logged.
+	| This is useful to avoid logging too many SQL statements which are
+	| executed very fast and are not relevant for debugging.
+	|
+	*/
+	'log_sql_min_time' => (int) env('DB_LOG_SQL_MIN_TIME', 100),
 
 	/*
 	|--------------------------------------------------------------------------

--- a/config/database.php
+++ b/config/database.php
@@ -53,6 +53,8 @@ return [
 	| This is useful to avoid logging too many SQL statements which are
 	| executed very fast and are not relevant for debugging.
 	|
+	| Default value is 100 milliseconds.
+	|
 	*/
 	'log_sql_min_time' => (int) env('DB_LOG_SQL_MIN_TIME', 100),
 


### PR DESCRIPTION
So we can focus on the slow queries.

This pull request introduces a feature to filter SQL query logging based on execution time, enhancing the application's debugging capabilities while reducing unnecessary log noise. The changes include adding a configuration option for a minimum query execution time and updating the logging logic accordingly.

### Enhancements to SQL query logging:

* [`app/Providers/AppServiceProvider.php`](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR202-R206): Updated the `logSQL` method to skip logging SQL queries that execute faster than the configured minimum time (`log_sql_min_time`). This prevents logging insignificant queries.

* [`config/database.php`](diffhunk://#diff-e4382b565f69d02de16eef89c8d5ca2b60a679ffca90ab8b7d85fbd78f30075bR32-R58): Added a new configuration option, `log_sql_min_time`, which allows setting a minimum execution time (in milliseconds) for SQL queries to be logged. This provides more control over the volume of logged queries.