### PR TITLE
Add home redirection

### DIFF
--- a/app/Http/Resources/GalleryConfigs/InitConfig.php
+++ b/app/Http/Resources/GalleryConfigs/InitConfig.php
@@ -92,6 +92,9 @@ class InitConfig extends Data
 	// User registration enabled
 	public bool $is_registration_enabled;
 
+	// Homepage
+	public string $default_homepage;
+
 	public function __construct()
 	{
 		// Debug mode
@@ -147,6 +150,9 @@ class InitConfig extends Data
 
 		// User registration enabled
 		$this->is_registration_enabled = Configs::getValueAsBool('user_registration_enabled');
+
+		// Homepage
+		$this->default_homepage = Configs::getValueAsString('home_page_default');
 
 		$this->set_supporter_properties();
 	}

--- a/config/honeypot.php
+++ b/config/honeypot.php
@@ -48,7 +48,6 @@ return [
 		'bc',
 		'bk',
 		'blog',
-		'home',
 		'main',
 		'new',
 		'newsite',

--- a/database/migrations/2025_06_13_102340_home_page.php
+++ b/database/migrations/2025_06_13_102340_home_page.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const TIMELINE = 'Mod Timeline';
+	public const CONFIG = 'config';
+	public const STRING_REQ = 'string_required';
+
+	public function getConfigs(): array
+	{
+		return [
+			[
+				'key' => 'home_page_default',
+				'value' => 'gallery',
+				'cat' => self::CONFIG,
+				'type_range' => 'gallery', // We will change the type_range later when adding for functionalities.
+				'description' => 'Default home page after landing',
+				'details' => '',
+				'is_secret' => false,
+				'level' => 0,
+				'order' => 4,
+			],
+		];
+	}
+};

--- a/resources/js/components/settings/ConfigGroup.vue
+++ b/resources/js/components/settings/ConfigGroup.vue
@@ -118,7 +118,9 @@
 					<NumberField v-else-if="config.type === 'int'" :config="config" :min="0" @filled="filled" @reset="reset" />
 					<NumberField v-else-if="config.type === 'positive'" :config="config" :min="1" @filled="filled" @reset="reset" />
 					<SliderField v-else-if="config.type.includes('|')" :config="config" @filled="filled" @reset="reset" />
-					<p v-else class="bg-red-500">{{ config.key }} -- {{ config.value }} -- {{ config.documentation }} -- {{ config.type }}</p>
+					<p v-else-if="is_debug_enabled" class="bg-red-500">
+						{{ config.key }} -- {{ config.value }} -- {{ config.documentation }} -- {{ config.type }}
+					</p>
 				</div>
 			</div>
 		</template>
@@ -151,7 +153,7 @@ import { useLycheeStateStore } from "@/stores/LycheeState";
 import { storeToRefs } from "pinia";
 
 const lycheeStore = useLycheeStateStore();
-const { is_old_style, is_expert_mode } = storeToRefs(lycheeStore);
+const { is_old_style, is_expert_mode, is_debug_enabled } = storeToRefs(lycheeStore);
 
 const props = defineProps<{
 	configs: App.Http.Resources.Models.ConfigResource[];

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -276,6 +276,7 @@ declare namespace App.Http.Resources.GalleryConfigs {
 		is_se_info_hidden: boolean;
 		is_live_metrics_enabled: boolean;
 		is_registration_enabled: boolean;
+		default_homepage: string;
 	};
 	export type LandingPageResource = {
 		landing_page_enable: boolean;
@@ -408,8 +409,8 @@ declare namespace App.Http.Resources.Models {
 		visitor_id: string;
 		action: App.Enum.MetricsAction;
 		photo_id: string | null;
-		album_id: string | null;
-		title: string | null;
+		album_id: string;
+		title: string;
 		url: string | null;
 	};
 	export type PhotoResource = {

--- a/resources/js/menus/LeftMenu.vue
+++ b/resources/js/menus/LeftMenu.vue
@@ -112,7 +112,6 @@ import AlbumService from "@/services/album-service";
 import SETag from "@/components/icons/SETag.vue";
 import Constants from "@/services/constants";
 import { useRoute } from "vue-router";
-import { useTogglablesStateStore } from "@/stores/ModalsState";
 import Button from "primevue/button";
 import PiMiniIcon from "@/components/icons/PiMiniIcon.vue";
 import { useLeftMenuStateStore } from "@/stores/LeftMenuState";
@@ -124,7 +123,6 @@ const leftMenuState = useLeftMenuStateStore();
 const route = useRoute();
 const authStore = useAuthStore();
 const lycheeStore = useLycheeStateStore();
-const togglableStore = useTogglablesStateStore();
 const favouritesStore = useFavouriteStore();
 
 const { user, left_menu_open, initData, openLycheeAbout, canSeeAdmin, load, items, profileItems } = useLeftMenu(
@@ -140,7 +138,7 @@ function logout() {
 		initData.value = undefined;
 		authStore.setUser(null);
 		AlbumService.clearCache();
-		window.location.href = Constants.BASE_URL + "/gallery";
+		window.location.href = Constants.BASE_URL + "/home";
 	});
 }
 

--- a/resources/js/router/routes.ts
+++ b/resources/js/router/routes.ts
@@ -3,6 +3,7 @@ import Albums from "@/views/gallery-panels/Albums.vue";
 
 const Landing = () => import("@/views/Landing.vue");
 const Favourites = () => import("@/views/gallery-panels/Favourites.vue");
+const Home = () => import("@/views/Home.vue");
 const Frame = () => import("@/views/gallery-panels/Frame.vue");
 const Search = () => import("@/views/gallery-panels/Search.vue");
 const MapView = () => import("@/views/gallery-panels/Map.vue");
@@ -38,6 +39,11 @@ const routes_ = [
 		path: "/gallery/:albumId/:photoId?",
 		component: Album,
 		props: true,
+	},
+	{
+		name: "home",
+		path: "/home",
+		component: Home,
 	},
 	{
 		name: "gallery",

--- a/resources/js/stores/LycheeState.ts
+++ b/resources/js/stores/LycheeState.ts
@@ -61,6 +61,7 @@ export const useLycheeStateStore = defineStore("lychee-store", {
 		// Site title & Dropbox API key
 		title: "gallery.title",
 		dropbox_api_key: "disabled",
+		default_homepage: "gallery",
 
 		// Lychee Supporter Edition
 		is_se_enabled: false,
@@ -77,22 +78,22 @@ export const useLycheeStateStore = defineStore("lychee-store", {
 		is_registration_enabled: false,
 	}),
 	actions: {
-		init() {
+		init(): Promise<void> {
 			// Check if already initialized
 			if (this.is_init) {
-				return;
+				return Promise.resolve();
 			}
-			this.load();
+			return this.load();
 		},
 
-		load() {
+		load(): Promise<void> {
 			// semaphore to avoid multiple calls
 			if (this.is_loading) {
-				return;
+				return Promise.resolve();
 			}
 			this.is_loading = true;
 
-			InitService.fetchInitData()
+			return InitService.fetchInitData()
 				.then((response) => {
 					this.is_init = true;
 					this.is_loading = false;
@@ -146,6 +147,8 @@ export const useLycheeStateStore = defineStore("lychee-store", {
 					this.photo_previous_next_size = data.photo_previous_next_size;
 
 					this.is_registration_enabled = data.is_registration_enabled;
+
+					this.default_homepage = data.default_homepage;
 				})
 				.catch((error) => {
 					// In this specific case, even though it has been possibly disabled, we really need to see the error.

--- a/resources/js/views/Home.vue
+++ b/resources/js/views/Home.vue
@@ -1,0 +1,20 @@
+<template>
+	<!-- Nothing to see here is is more of a redirection component -->
+</template>
+<script setup lang="ts">
+import { useLycheeStateStore } from "@/stores/LycheeState";
+import { useRouter } from "vue-router";
+
+const router = useRouter();
+const lycheeStore = useLycheeStateStore();
+lycheeStore.init().then(() => {
+	// Now that we loaded the stuff, we can redirect to the correct page
+	if (lycheeStore.default_homepage === "gallery") {
+		router.push({ name: "gallery" });
+		// Insert other pages here later (feed or others...)
+	} else {
+		// Default
+		router.push({ name: "gallery" });
+	}
+});
+</script>

--- a/resources/js/views/Landing.vue
+++ b/resources/js/views/Landing.vue
@@ -15,7 +15,10 @@
 			<div id="menu" class="w-full animate-landingAnimateDown">
 				<ul class="menu list-none">
 					<li class="menu-item relative block float-right pt-6 pb-5 px-3">
-						<RouterLink to="/gallery" class="cursor-pointer block text-xs uppercase font-normal text-surface-0 hover:text-muted-color">
+						<RouterLink
+							:to="{ name: 'home' }"
+							class="cursor-pointer block text-xs uppercase font-normal text-surface-0 hover:text-muted-color"
+						>
 							{{ $t("landing.gallery") }}
 						</RouterLink>
 					</li>
@@ -62,7 +65,7 @@
 			</div>
 			<div class="flex w-full h-1/2 absolute top-1/3 md:top-1/2 left-0 items-center justify-center animate-landingEnterPopIn opacity-0">
 				<RouterLink
-					to="/gallery"
+					:to="{ name: 'home' }"
 					class="cursor-pointer block text-2xl uppercase text-surface-0 hover:scale-125 transition-all duration-300 p-10 filter-shadow text-center"
 				>
 					{{ $t("landing.access_gallery") }}<br class="md:hidden" />
@@ -88,7 +91,7 @@ const router = useRouter();
 
 InitService.fetchLandingData().then((data) => {
 	if (data.data.landing_page_enable === false) {
-		router.push("/gallery");
+		router.push({ name: "home" });
 	} else {
 		initdata.value = data.data;
 		setTimeout(() => (introVisible.value = false), 4000);

--- a/resources/js/views/Statistics.vue
+++ b/resources/js/views/Statistics.vue
@@ -64,7 +64,7 @@ authStore.getUser().then((data) => {
 
 	// Not logged in. Bye.
 	if (user.value.id === null) {
-		router.push({ name: "gallery" });
+		router.push({ name: "home" });
 	}
 
 	load.value = true;

--- a/routes/web_v2.php
+++ b/routes/web_v2.php
@@ -34,11 +34,11 @@ Route::get('/up', function () {
 });
 
 Route::get('/', VueController::class)->name('home')->middleware(['migration:complete']);
+Route::get('/home', VueController::class)->name('homepage')->middleware(['migration:complete']);
 Route::get('/gallery/{albumId?}/{photoId?}', [VueController::class, 'gallery'])->name('gallery')->middleware(['migration:complete', 'unlock_with_password']);
 Route::get('/frame/{albumId?}', [VueController::class, 'gallery'])->name('frame')->middleware(['migration:complete']);
 Route::get('/map/{albumId?}', [VueController::class, 'gallery'])->name('map')->middleware(['migration:complete']);
 Route::get('/search/{albumId?}/{photoId?}', [VueController::class, 'gallery'])->name('search')->middleware(['migration:complete']);
-
 Route::get('/profile', VueController::class)->name('profile')->middleware(['migration:complete', 'login_required:always']);
 Route::get('/users', VueController::class)->middleware(['migration:complete', 'login_required:always']);
 Route::get('/sharing', VueController::class)->middleware(['migration:complete', 'login_required:always']);


### PR DESCRIPTION
This PR is a precondition for the future timeline page, feed page (and others?)

This pull request introduces a new "Home" page feature, allowing users to configure a default homepage for the application. The changes span backend configuration, frontend routing, and state management updates. Below is a summary of the most important changes grouped by theme:

### Backend Changes:
* Added a new database migration (`2025_06_12_102340_home_page.php`) to define a configuration key `home_page_default` with a default value of "gallery" for setting the default homepage.
* Updated `InitConfig` class to include a new property `default_homepage` and fetch its value from the configuration. [[1]](diffhunk://#diff-d31771d798b76463dc8bb0c03d41ab098b9600d38beeae4bb84cbb34c118d86fR95-R97) [[2]](diffhunk://#diff-d31771d798b76463dc8bb0c03d41ab098b9600d38beeae4bb84cbb34c118d86fR154-R156)

### Frontend Routing and Components:
* Introduced a new `Home.vue` component that redirects users to the appropriate default homepage based on the configuration.
* Updated the frontend router (`routes.ts`) to add a route for the new "Home" page (`/home`). [[1]](diffhunk://#diff-f30841438b53116de31f57a100ad06f06d76a6b446d6864d38237cda97201403R6) [[2]](diffhunk://#diff-f30841438b53116de31f57a100ad06f06d76a6b446d6864d38237cda97201403R43-R47)
* Modified `Landing.vue` and `Statistics.vue` to redirect to the "Home" page instead of the "Gallery" page. [[1]](diffhunk://#diff-2b98095a7dfa60d778451af97b64df0c593fc838a7ece51b9790b979653c17d1L18-R21) [[2]](diffhunk://#diff-2b98095a7dfa60d778451af97b64df0c593fc838a7ece51b9790b979653c17d1L65-R68) [[3]](diffhunk://#diff-2b98095a7dfa60d778451af97b64df0c593fc838a7ece51b9790b979653c17d1L91-R94) [[4]](diffhunk://#diff-77b2e7d88c4b57f58de57018dc206f69376d3b22389a204eea334e6529aa624bL67-R67)

### State Management:
* Updated `LycheeStateStore` to include a new `default_homepage` property and ensure it is initialized when loading application data. [[1]](diffhunk://#diff-5585be2db0c41adcd345e27400e1476598e1979d611d3030d032d049f64f12e4R64) [[2]](diffhunk://#diff-5585be2db0c41adcd345e27400e1476598e1979d611d3030d032d049f64f12e4R150-R151)

### Miscellaneous:
* Adjusted the `web_v2.php` routes file to add a `/home` route for the new homepage.
* Removed the "home" keyword from the honeypot configuration to avoid conflicts with the new route.