### PR TITLE
Fix 500 on search

### DIFF
--- a/app/Http/Controllers/Gallery/SearchController.php
+++ b/app/Http/Controllers/Gallery/SearchController.php
@@ -53,6 +53,6 @@ class SearchController extends Controller
 
 		$album_results = $album_search->queryAlbums($terms, $album);
 
-		return ResultsResource::fromData($album_results, $photo_results);
+		return ResultsResource::fromData($album_results, $photo_results, $album);
 	}
 }

--- a/app/Http/Resources/Search/ResultsResource.php
+++ b/app/Http/Resources/Search/ResultsResource.php
@@ -8,6 +8,7 @@
 
 namespace App\Http\Resources\Search;
 
+use App\Contracts\Models\AbstractAlbum;
 use App\Http\Resources\Models\PhotoResource;
 use App\Http\Resources\Models\ThumbAlbumResource;
 use App\Http\Resources\Traits\HasPrepPhotoCollection;
@@ -68,14 +69,16 @@ class ResultsResource extends Data
 	/**
 	 * @param Collection<int,Album>           $albums
 	 * @param LengthAwarePaginator<int,Photo> $photos
+	 * @param AbstractAlbum|null              $album
 	 *
 	 * @return ResultsResource
 	 */
-	public static function fromData(Collection $albums, LengthAwarePaginator $photos): self
+	public static function fromData(Collection $albums, LengthAwarePaginator $photos, AbstractAlbum|null $album): self
 	{
-		return new self(
+		/** @disregard Undefined method through() (stupid intelephense) */ return new self(
 			albums: ThumbAlbumResource::collect($albums),
-			photos: PhotoResource::collect($photos),
+			/** @phpstan-ignore method.notFound (this methods exists, it's in the doc...) */
+			photos: $photos->through(fn ($p) => new PhotoResource($p, $album)),
 		);
 	}
 }

--- a/resources/js/services/metrics-service.ts
+++ b/resources/js/services/metrics-service.ts
@@ -1,5 +1,6 @@
 import axios, { type AxiosResponse } from "axios";
 import Constants from "./constants";
+import { ALL } from "@/config/constants";
 
 const MetricsService = {
 	get(): Promise<AxiosResponse<App.Http.Resources.Models.LiveMetricsResource[]>> {
@@ -13,7 +14,7 @@ const MetricsService = {
 			return Promise.resolve(null);
 		}
 		// This is the case if we are in global search mode.
-		if (album_id === undefined || album_id === "all") {
+		if (album_id === undefined || album_id === ALL) {
 			return Promise.resolve(null);
 		}
 
@@ -22,7 +23,7 @@ const MetricsService = {
 
 	favourite(photo_id: string, album_id: string | undefined): Promise<AxiosResponse<null> | null> {
 		// This is the case if we are in global search mode.
-		if (album_id === undefined || album_id === "all") {
+		if (album_id === undefined || album_id === ALL) {
 			return Promise.resolve(null);
 		}
 

--- a/resources/js/services/metrics-service.ts
+++ b/resources/js/services/metrics-service.ts
@@ -13,7 +13,7 @@ const MetricsService = {
 			return Promise.resolve(null);
 		}
 		// This is the case if we are in global search mode.
-		if (album_id === undefined) {
+		if (album_id === undefined || album_id === "all") {
 			return Promise.resolve(null);
 		}
 
@@ -22,7 +22,7 @@ const MetricsService = {
 
 	favourite(photo_id: string, album_id: string | undefined): Promise<AxiosResponse<null> | null> {
 		// This is the case if we are in global search mode.
-		if (album_id === undefined) {
+		if (album_id === undefined || album_id === "all") {
 			return Promise.resolve(null);
 		}
 


### PR DESCRIPTION
Consequence of the album requirement on PhotoResource... 

### Backend Changes:

* **Enhanced `ResultsResource` to support album context:**
  - Updated the `fromData` method in `ResultsResource` to accept an optional `AbstractAlbum` parameter. This allows the resource to include album-specific context when constructing photo resources.
  - Modified the `SearchController` to pass the album parameter to `ResultsResource` when constructing the response.

* **Dependency inclusion:**
  - Added the `AbstractAlbum` contract import in `ResultsResource` to support the new parameter.

### Frontend Changes:

* **Improved global search handling in `MetricsService`:**
  - Updated the logic to treat "all" as a valid album ID for global search mode in two methods (`photo` and `favourite`). This ensures consistent behavior when no specific album is targeted. [[1]](diffhunk://#diff-e081103bbf5b4a618c2510746556b2a0d3f16d3eb95f48d1066d9f8847590b9eL16-R16) [[2]](diffhunk://#diff-e081103bbf5b4a618c2510746556b2a0d3f16d3eb95f48d1066d9f8847590b9eL25-R25)