### PR TITLE
fix: photo edit

### DIFF
--- a/app/Http/Requests/Photo/EditPhotoRequest.php
+++ b/app/Http/Requests/Photo/EditPhotoRequest.php
@@ -29,6 +29,7 @@ use App\Http\Requests\Traits\HasTitleTrait;
 use App\Http\Requests\Traits\HasUploadDateTrait;
 use App\Models\Photo;
 use App\Policies\PhotoPolicy;
+use App\Rules\AlbumIDRule;
 use App\Rules\DescriptionRule;
 use App\Rules\RandomIDRule;
 use App\Rules\TitleRule;
@@ -69,7 +70,7 @@ class EditPhotoRequest extends BaseApiRequest implements HasPhoto, HasTags, HasU
 			RequestAttribute::LICENSE_ATTRIBUTE => ['required', new Enum(LicenseType::class)],
 			RequestAttribute::UPLOAD_DATE_ATTRIBUTE => ['required', 'date'],
 			RequestAttribute::TAKEN_DATE_ATTRIBUTE => ['nullable', 'date'],
-			RequestAttribute::FROM_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
+			RequestAttribute::FROM_ID_ATTRIBUTE => ['present', new AlbumIDRule(true)],
 		];
 	}
 

--- a/resources/js/components/drawers/PhotoEdit.vue
+++ b/resources/js/components/drawers/PhotoEdit.vue
@@ -120,12 +120,16 @@ import InputGroupAddon from "primevue/inputgroupaddon";
 import { useToast } from "primevue/usetoast";
 import Checkbox from "primevue/checkbox";
 import { sprintf } from "sprintf-js";
+import { useRouter } from "vue-router";
+import { usePhotoRoute } from "@/composables/photo/photoRoute";
 
 const props = defineProps<{
 	photo: App.Http.Resources.Models.PhotoResource;
 }>();
 
 const toast = useToast();
+const router = useRouter();
+const { getParentId } = usePhotoRoute(router);
 const isEditOpen = defineModel("isEditOpen", { default: false }) as Ref<boolean>;
 
 const photo_id = ref<string | undefined>(undefined);
@@ -172,7 +176,7 @@ function save() {
 		takenDate = takenAtDate.value.toISOString().slice(0, 19) + (takenAtTz.value ?? "");
 	}
 
-	PhotoService.update(photo_id.value, {
+	PhotoService.update(photo_id.value, getParentId() ?? null, {
 		title: title.value,
 		description: description.value ?? "",
 		tags: tags.value ?? [],

--- a/resources/js/services/photo-service.ts
+++ b/resources/js/services/photo-service.ts
@@ -25,8 +25,8 @@ const PhotoService = {
 		return axios.post(`${Constants.getApiUrl()}Photo::fromUrl`, { urls: urls.filter(Boolean), album_id: album_id });
 	},
 
-	update(photo_id: string, data: PhotoUpdateRequest): Promise<AxiosResponse<App.Http.Resources.Models.PhotoResource>> {
-		return axios.patch(`${Constants.getApiUrl()}Photo?photo_id=${photo_id}`, data);
+	update(photo_id: string, album_id: string | null, data: PhotoUpdateRequest): Promise<AxiosResponse<App.Http.Resources.Models.PhotoResource>> {
+		return axios.patch(`${Constants.getApiUrl()}Photo?photo_id=${photo_id}&from_id=${album_id}`, data);
 	},
 
 	rename(photo_id: string, title: string): Promise<AxiosResponse> {


### PR DESCRIPTION
Version 6.6.6 introduced `from_id` on some end-points. We forgot to add it to the Service querying the API.