### PR TITLE
feat: Add optional gallery header image

### DIFF
--- a/app/Http/Resources/GalleryConfigs/RootConfig.php
+++ b/app/Http/Resources/GalleryConfigs/RootConfig.php
@@ -32,6 +32,10 @@ class RootConfig extends Data
 	public string $back_button_url;
 	public TimelineAlbumGranularity $timeline_album_granularity;
 
+	public string $header_image_url = '';
+	public bool $is_header_bar_transparent = false;
+	public bool $is_header_bar_gradient = false;
+
 	public function __construct()
 	{
 		$is_logged_in = Auth::check();
@@ -48,6 +52,21 @@ class RootConfig extends Data
 		$this->back_button_enabled = Configs::getValueAsBool('back_button_enabled');
 		$this->back_button_text = Configs::getValueAsString('back_button_text');
 		$this->back_button_url = Configs::getValueAsString('back_button_url');
+
+		$this->setHeaderImageUrl();
+	}
+
+	private function setHeaderImageUrl(): void
+	{
+		if (!Configs::getValueAsBool('gallery_header_enabled')) {
+			return;
+		}
+		if (Auth::check() && !Configs::getValueAsBool('gallery_header_logged_in_enabled')) {
+			return;
+		}
+		$this->header_image_url = Configs::getValueAsString('gallery_header');
+		$this->is_header_bar_transparent = Configs::getValueAsBool('gallery_header_bar_transparent');
+		$this->is_header_bar_gradient = Configs::getValueAsBool('gallery_header_bar_gradient');
 	}
 }
 

--- a/database/migrations/2025_06_24_180548_gallery_header.php
+++ b/database/migrations/2025_06_24_180548_gallery_header.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const CONFIG = 'Mod Welcome';
+	public const STRING_REQ = 'string_required';
+
+	public function getConfigs(): array
+	{
+		DB::table('configs')->where('key', 'landing_background_landscape')->update(['details' => 'This image is also used when sharing the gallery link directly.']);
+
+		return [
+			[
+				'key' => 'gallery_header_enabled',
+				'value' => '0',
+				'cat' => self::CONFIG,
+				'type_range' => self::BOOL,
+				'description' => 'Enable header image in the gallery view',
+				'details' => '',
+				'is_secret' => false,
+				'is_expert' => false,
+				'level' => 0,
+				'order' => 5,
+			],
+			[
+				'key' => 'gallery_header_logged_in_enabled',
+				'value' => '0',
+				'cat' => self::CONFIG,
+				'type_range' => self::BOOL,
+				'description' => 'Enable header image in the gallery view when logged in',
+				'details' => '',
+				'is_secret' => false,
+				'is_expert' => false,
+				'level' => 0,
+				'order' => 6,
+			],
+			[
+				'key' => 'gallery_header',
+				'value' => '',
+				'cat' => self::CONFIG,
+				'type_range' => self::STRING,
+				'description' => 'URL of header image in the gallery view',
+				'details' => '',
+				'is_secret' => false,
+				'is_expert' => false,
+				'level' => 0,
+				'order' => 7,
+			],
+			[
+				'key' => 'gallery_header_bar_transparent',
+				'value' => '1',
+				'cat' => self::CONFIG,
+				'type_range' => self::BOOL,
+				'description' => 'Make the header bar transparent.',
+				'details' => 'If enabled, the header bar will be transparent and the header image will be visible behind it.',
+				'is_secret' => false,
+				'is_expert' => true,
+				'level' => 0,
+				'order' => 8,
+			],
+			[
+				'key' => 'gallery_header_bar_gradient',
+				'value' => '1',
+				'cat' => self::CONFIG,
+				'type_range' => self::BOOL,
+				'description' => 'Add a gradient background to the header bar.',
+				'details' => 'If enabled the header bar will have a gradient background aiming to improve the readability of the text, otherwise it will be transparent.',
+				'is_secret' => false,
+				'is_expert' => true,
+				'level' => 0,
+				'order' => 8,
+			],
+		];
+	}
+};

--- a/database/migrations/2025_06_24_180548_gallery_header.php
+++ b/database/migrations/2025_06_24_180548_gallery_header.php
@@ -75,7 +75,7 @@ return new class() extends BaseConfigMigration {
 				'is_secret' => false,
 				'is_expert' => true,
 				'level' => 0,
-				'order' => 8,
+				'order' => 9,
 			],
 		];
 	}

--- a/resources/js/components/headers/AlbumsHeader.vue
+++ b/resources/js/components/headers/AlbumsHeader.vue
@@ -15,14 +15,16 @@
 		</template>
 
 		<template #center>
-			<span class="lg:hidden font-bold text-shadow-sm text-shadow-black">
-				{{ $t("gallery.albums") }}
-			</span>
-			<span
-				class="hidden lg:block font-bold text-shadow-sm text-shadow-black text-sm lg:text-base text-center w-full"
-				@click="is_metrics_open = !is_metrics_open"
-				>{{ props.title }}</span
-			>
+			<template v-if="props.config.header_image_url === ''">
+				<span class="lg:hidden font-bold text-shadow-sm text-shadow-black">
+					{{ $t("gallery.albums") }}
+				</span>
+				<span
+					class="hidden lg:block font-bold text-shadow-sm text-shadow-black text-sm lg:text-base text-center w-full"
+					@click="is_metrics_open = !is_metrics_open"
+					>{{ props.title }}</span
+				>
+			</template>
 		</template>
 
 		<template #end>
@@ -101,11 +103,16 @@
 			</a>
 		</template>
 	</ContextMenu>
-	<img
-		:src="props.config.header_image_url"
-		v-if="props.config.header_image_url !== ''"
-		class="relative w-full h-[calc(100vh/3)] object-cover -mt-14 z-0"
-	/>
+	<div class="relative w-full h-[calc(100vh/2)] -mt-14 z-0">
+		<img :src="props.config.header_image_url" v-if="props.config.header_image_url !== ''" class="object-cover h-full w-full" />
+		<div class="absolute top-0 left-0 w-full h-full flex items-center justify-center px-20">
+			<h1
+				class="text-sm font-bold sm:text-lg md:text-3xl md:font-normal text-surface-0 uppercase text-center text-shadow-md text-shadow-black/25"
+			>
+				{{ props.title }}
+			</h1>
+		</div>
+	</div>
 </template>
 <script setup lang="ts">
 import Button from "primevue/button";

--- a/resources/js/components/headers/AlbumsHeader.vue
+++ b/resources/js/components/headers/AlbumsHeader.vue
@@ -2,8 +2,12 @@
 	<ImportFromLink v-if="canUpload" v-model:visible="is_import_from_link_open" />
 	<DropBox v-if="canUpload" v-model:visible="is_import_from_dropbox_open" :album-id="null" />
 	<Toolbar
-		class="w-full border-0 h-14"
-		:pt:root:class="'flex-nowrap relative'"
+		:class="{
+			'bg-transparent': props.config.is_header_bar_transparent,
+			'bg-linear-to-b dark:from-surface-800 from-surface-50 via-75% light:via-surface-50/80 light:to-surface-50/20':
+				props.config.is_header_bar_gradient,
+		}"
+		:pt:root:class="'w-full z-10 border-0 h-14 flex-nowrap relative rounded-none'"
 		:pt:center:class="'absolute top-0 py-3 left-1/2 -translate-x-1/2 h-14'"
 	>
 		<template #start>
@@ -11,12 +15,14 @@
 		</template>
 
 		<template #center>
-			<span class="lg:hidden font-bold">
+			<span class="lg:hidden font-bold text-shadow-sm text-shadow-black">
 				{{ $t("gallery.albums") }}
 			</span>
-			<span class="hidden lg:block font-bold text-sm lg:text-base text-center w-full" @click="is_metrics_open = !is_metrics_open">{{
-				props.title
-			}}</span>
+			<span
+				class="hidden lg:block font-bold text-shadow-sm text-shadow-black text-sm lg:text-base text-center w-full"
+				@click="is_metrics_open = !is_metrics_open"
+				>{{ props.title }}</span
+			>
 		</template>
 
 		<template #end>
@@ -95,6 +101,11 @@
 			</a>
 		</template>
 	</ContextMenu>
+	<img
+		:src="props.config.header_image_url"
+		v-if="props.config.header_image_url !== ''"
+		class="relative w-full h-[calc(100vh/3)] object-cover -mt-14 z-0"
+	/>
 </template>
 <script setup lang="ts">
 import Button from "primevue/button";
@@ -128,6 +139,9 @@ const props = defineProps<{
 		back_button_enabled: boolean;
 		back_button_text: string;
 		back_button_url: string;
+		header_image_url: string;
+		is_header_bar_transparent: boolean;
+		is_header_bar_gradient: boolean;
 	};
 	hasHidden: boolean;
 }>();

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -311,6 +311,9 @@ declare namespace App.Http.Resources.GalleryConfigs {
 		back_button_text: string;
 		back_button_url: string;
 		timeline_album_granularity: App.Enum.TimelineAlbumGranularity;
+		header_image_url: string;
+		is_header_bar_transparent: boolean;
+		is_header_bar_gradient: boolean;
 	};
 	export type SettingsConfig = {
 		default_old_settings: boolean;


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/a637e496-cacd-4456-8273-236996018b69)

![image](https://github.com/user-attachments/assets/70512473-fb65-463a-a4d6-69236166ec70)

![image](https://github.com/user-attachments/assets/1dd5c677-9f23-4c1f-b7de-9938821f7986)


This pull request introduces a new feature for configurable header images in the gallery view, along with related UI and backend changes. The most important updates include adding new configuration options, updating the `RootConfig` class to handle these options, and modifying the `AlbumsHeader.vue` component to reflect the new functionality.

### Backend Changes

* **New Configuration Options**: Added new settings in the `gallery_header.php` migration file to enable or disable the header image, set its URL, and configure transparency and gradient options for the header bar. These changes allow for more customization of the gallery header.
* **Updated `RootConfig` Class**: Introduced new properties (`header_image_url`, `is_header_bar_transparent`, and `is_header_bar_gradient`) and a private method `setHeaderImageUrl()` to initialize these properties based on the new configuration settings. [[1]](diffhunk://#diff-b3e0778d77d69641424cd4665d90d589df58353f3cf78334983657e316c73659R35-R38) [[2]](diffhunk://#diff-b3e0778d77d69641424cd4665d90d589df58353f3cf78334983657e316c73659R55-R69)

### Frontend Changes

* **UI Enhancements in `AlbumsHeader.vue`**:
  - Updated the `Toolbar` component to dynamically apply styles based on the new transparency and gradient settings.
  - Added an `<img>` element to display the header image if a URL is provided in the configuration.
  - Extended the `props` definition to include the new properties for header configuration.