### PR TITLE
Add ability to manage admin users.

### DIFF
--- a/app/Actions/User/Create.php
+++ b/app/Actions/User/Create.php
@@ -27,6 +27,7 @@ class Create
 		?string $email = null,
 		bool $may_upload = false,
 		bool $may_edit_own_settings = false,
+		bool $may_administrate = false,
 		?int $quota_kb = null,
 		?string $note = null,
 	): User {
@@ -40,7 +41,7 @@ class Create
 		$user = new User();
 		$user->may_upload = $may_upload;
 		$user->may_edit_own_settings = $may_edit_own_settings;
-		$user->may_administrate = false;
+		$user->may_administrate = $may_administrate;
 		$user->username = $username;
 		$user->email = $email;
 		$user->password = Hash::make($password);

--- a/app/Actions/User/Save.php
+++ b/app/Actions/User/Save.php
@@ -33,6 +33,7 @@ class Save
 		?string $password,
 		bool $may_upload,
 		bool $may_edit_own_settings,
+		bool $may_administrate = false,
 		?int $quota_kb = null,
 		?string $note = null,
 	): void {
@@ -52,6 +53,7 @@ class Save
 		$user->username = $username;
 		$user->may_upload = $may_upload;
 		$user->may_edit_own_settings = $may_edit_own_settings;
+		$user->may_administrate = $may_administrate;
 		$user->note = $note;
 		$user->quota_kb = $quota_kb;
 		if ($password !== null && $password !== '') {

--- a/app/Contracts/Http/Requests/RequestAttribute.php
+++ b/app/Contracts/Http/Requests/RequestAttribute.php
@@ -84,6 +84,7 @@ class RequestAttribute
 	public const TAGS_ATTRIBUTE = 'tags';
 	public const MAY_UPLOAD_ATTRIBUTE = 'may_upload';
 	public const MAY_EDIT_OWN_SETTINGS_ATTRIBUTE = 'may_edit_own_settings';
+	public const MAY_ADMINISTRATE = 'may_administrate';
 
 	/**
 	 * Import from server attributes.

--- a/app/Enum/ConfigType.php
+++ b/app/Enum/ConfigType.php
@@ -22,6 +22,7 @@ enum ConfigType: string
 	case BOOL = '0|1';
 	case TERNARY = '0|1|2';
 	case DISABLED = '';
+	case ADMIN_USER = 'admin_user';
 	case LICENSE = 'license';
 	case MAP_PROVIDER = 'map_provider';
 }

--- a/app/Http/Controllers/Admin/UserManagementController.php
+++ b/app/Http/Controllers/Admin/UserManagementController.php
@@ -60,6 +60,7 @@ class UserManagementController extends Controller
 			password: $request->password(),
 			may_upload: $request->mayUpload(),
 			may_edit_own_settings: $request->mayEditOwnSettings(),
+			may_administrate: $request->mayAdministrate(),
 			quota_kb: $request->quota_kb(),
 			note: $request->note()
 		);
@@ -93,6 +94,7 @@ class UserManagementController extends Controller
 			password: $request->password(),
 			may_upload: $request->mayUpload(),
 			may_edit_own_settings: $request->mayEditOwnSettings(),
+			may_administrate: $request->mayAdministrate(),
 			quota_kb: $request->quota_kb(),
 			note: $request->note()
 		);

--- a/app/Http/Controllers/Install/SetUpAdminController.php
+++ b/app/Http/Controllers/Install/SetUpAdminController.php
@@ -9,6 +9,7 @@
 namespace App\Http\Controllers\Install;
 
 use App\Http\Requests\Install\SetUpAdminRequest;
+use App\Models\Configs;
 use App\Models\User;
 use Illuminate\Contracts\View\View;
 use Illuminate\Routing\Controller;
@@ -50,6 +51,8 @@ class SetUpAdminController extends Controller
 			$user->username = $request->username();
 			$user->password = Hash::make($request->password());
 			$user->save();
+
+			Configs::set('owner_id', $user->id);
 		} catch (\Throwable $e) {
 			$error = $e->getMessage();
 			$error .= '<br>' . $e->getPrevious()->getMessage();

--- a/app/Http/Requests/Settings/SetConfigsRequest.php
+++ b/app/Http/Requests/Settings/SetConfigsRequest.php
@@ -15,6 +15,7 @@ use App\Http\Resources\Editable\EditableConfigResource;
 use App\Rules\ConfigKeyRequireSupportRule;
 use App\Rules\ConfigKeyRule;
 use App\Rules\ConfigValueRule;
+use App\Rules\OwnerConfigRule;
 
 class SetConfigsRequest extends GetAllConfigsRequest implements HasConfigs
 {
@@ -36,7 +37,7 @@ class SetConfigsRequest extends GetAllConfigsRequest implements HasConfigs
 	{
 		return [
 			RequestAttribute::CONFIGS_ATTRIBUTE => ['required'],
-			RequestAttribute::CONFIGS_ARRAY_KEY_ATTRIBUTE => ['required', new ConfigKeyRule(), new ConfigKeyRequireSupportRule($this->verify)],
+			RequestAttribute::CONFIGS_ARRAY_KEY_ATTRIBUTE => ['required', new ConfigKeyRule(), new ConfigKeyRequireSupportRule($this->verify), new OwnerConfigRule()],
 			RequestAttribute::CONFIGS_ARRAY_VALUE_ATTRIBUTE => ['present', new ConfigValueRule()],
 		];
 	}

--- a/app/Http/Requests/UserManagement/AddUserRequest.php
+++ b/app/Http/Requests/UserManagement/AddUserRequest.php
@@ -39,6 +39,7 @@ class AddUserRequest extends BaseApiRequest implements HasUsername, HasPassword,
 
 	protected bool $may_upload = false;
 	protected bool $may_edit_own_settings = false;
+	protected bool $may_administrate = false;
 
 	/**
 	 * {@inheritDoc}
@@ -58,6 +59,7 @@ class AddUserRequest extends BaseApiRequest implements HasUsername, HasPassword,
 			RequestAttribute::PASSWORD_ATTRIBUTE => ['required', new PasswordRule(false)],
 			RequestAttribute::MAY_UPLOAD_ATTRIBUTE => 'present|boolean',
 			RequestAttribute::MAY_EDIT_OWN_SETTINGS_ATTRIBUTE => 'present|boolean',
+			RequestAttribute::MAY_ADMINISTRATE => ['sometimes', 'boolean', new BooleanRequireSupportRule(false, $this->verify)],
 			RequestAttribute::HAS_QUOTA_ATTRIBUTE => ['sometimes', 'boolean', new BooleanRequireSupportRule(false, $this->verify)],
 			RequestAttribute::QUOTA_ATTRIBUTE => ['sometimes', 'int', new IntegerRequireSupportRule(0, $this->verify)],
 			RequestAttribute::NOTE_ATTRIBUTE => ['sometimes', 'string', new StringRequireSupportRule('', $this->verify)],
@@ -73,6 +75,7 @@ class AddUserRequest extends BaseApiRequest implements HasUsername, HasPassword,
 		$this->password = $values[RequestAttribute::PASSWORD_ATTRIBUTE];
 		$this->may_upload = static::toBoolean($values[RequestAttribute::MAY_UPLOAD_ATTRIBUTE]);
 		$this->may_edit_own_settings = static::toBoolean($values[RequestAttribute::MAY_EDIT_OWN_SETTINGS_ATTRIBUTE]);
+		$this->may_administrate = static::toBoolean($values[RequestAttribute::MAY_ADMINISTRATE] ?? false);
 		$has_quota = static::toBoolean($values[RequestAttribute::HAS_QUOTA_ATTRIBUTE] ?? false);
 		$this->quota_kb = $has_quota ? intval($values[RequestAttribute::QUOTA_ATTRIBUTE]) : null;
 		$this->note = $values[RequestAttribute::NOTE_ATTRIBUTE] ?? '';
@@ -86,5 +89,10 @@ class AddUserRequest extends BaseApiRequest implements HasUsername, HasPassword,
 	public function mayEditOwnSettings(): bool
 	{
 		return $this->may_edit_own_settings;
+	}
+
+	public function mayAdministrate(): bool
+	{
+		return $this->may_administrate;
 	}
 }

--- a/app/Http/Requests/UserManagement/DeleteUserRequest.php
+++ b/app/Http/Requests/UserManagement/DeleteUserRequest.php
@@ -15,6 +15,7 @@ use App\Http\Requests\Traits\HasUserTrait;
 use App\Models\User;
 use App\Policies\UserPolicy;
 use App\Rules\IntegerIDRule;
+use App\Rules\OwnerIdRule;
 use Illuminate\Support\Facades\Gate;
 
 class DeleteUserRequest extends BaseApiRequest implements HasUser
@@ -35,7 +36,7 @@ class DeleteUserRequest extends BaseApiRequest implements HasUser
 	public function rules(): array
 	{
 		return [
-			RequestAttribute::ID_ATTRIBUTE => ['required', new IntegerIDRule(false)],
+			RequestAttribute::ID_ATTRIBUTE => ['required', new IntegerIDRule(false), new OwnerIdRule()],
 		];
 	}
 

--- a/app/Http/Resources/Models/UserManagementResource.php
+++ b/app/Http/Resources/Models/UserManagementResource.php
@@ -8,6 +8,7 @@
 
 namespace App\Http\Resources\Models;
 
+use App\Models\Configs;
 use App\Models\User;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
@@ -20,6 +21,7 @@ class UserManagementResource extends Data
 	public bool $may_administrate;
 	public bool $may_upload;
 	public bool $may_edit_own_settings;
+	public bool $is_owner;
 
 	public ?int $quota_kb = null;
 	public ?string $description = null;
@@ -37,6 +39,7 @@ class UserManagementResource extends Data
 	{
 		$this->id = $user->id;
 		$this->username = $user->username;
+		$this->is_owner = $user->may_administrate && $user->id === Configs::getValueAsInt('owner_id');
 		$this->may_administrate = $user->may_administrate;
 		$this->may_upload = $user->may_upload || $user->may_administrate;
 		$this->may_edit_own_settings = $user->may_edit_own_settings || $user->may_administrate;

--- a/app/Models/Configs.php
+++ b/app/Models/Configs.php
@@ -139,6 +139,14 @@ class Configs extends Model
 					$message = sprintf($message_template, implode(' or ', $val_range[$this->type_range]));
 				}
 				break;
+			case ConfigType::ADMIN_USER->value:
+				$admin_candidate = User::where('may_administrate', true)
+					->where('id', '=', $candidate_value)
+					->first();
+				if ($admin_candidate === null) {
+					$message = sprintf($message_template, 'a valid admin user ID');
+				}
+				break;
 			case ConfigType::LICENSE->value:
 				if (LicenseType::tryFrom($candidate_value) === null) {
 					$message = sprintf($message_template, 'a valid license');

--- a/app/Rules/OwnerConfigRule.php
+++ b/app/Rules/OwnerConfigRule.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Rules;
+
+use App\Exceptions\UnauthorizedException;
+use App\Models\Configs;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Auth;
+
+final class OwnerConfigRule implements ValidationRule
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function validate(string $attribute, mixed $value, \Closure $fail): void
+	{
+		if ($value !== 'owner_id') {
+			return;
+		}
+
+		if (Configs::getValueAsInt('owner_id') !== Auth::id()) {
+			throw new UnauthorizedException('Only the owner can change the owner_id configuration.');
+		}
+	}
+}

--- a/app/Rules/OwnerIdRule.php
+++ b/app/Rules/OwnerIdRule.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Rules;
+
+use App\Exceptions\UnauthorizedException;
+use App\Models\Configs;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Auth;
+
+final class OwnerIdRule implements ValidationRule
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function validate(string $attribute, mixed $value, \Closure $fail): void
+	{
+		if (Configs::getValueAsInt('owner_id') !== intval($value)) {
+			return;
+		}
+
+		if (Auth::id() === Configs::getValueAsInt('owner_id')) {
+			return;
+		}
+
+		throw new UnauthorizedException('Only the owner can do this.');
+	}
+}

--- a/database/migrations/2025_06_29_080951_create_owner.php
+++ b/database/migrations/2025_06_29_080951_create_owner.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class() extends Migration {
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		DB::table('configs')->insert([
+			[
+				'key' => 'owner_id',
+				'value' => '',
+				'cat' => 'Admin',
+				'type_range' => 'admin_user',
+				'description' => 'Owner of the installation',
+				'details' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> Changing this value will allow another admin to take over the server.',
+				'is_secret' => true,
+				'is_expert' => true,
+				'level' => 0,
+				'order' => 11,
+			],
+		]);
+
+		// Set the owner_id to the first user with may_administrate set to true
+		// If no such user exists (installation phase), set it to 0
+		$owner = DB::table('users')->select('id')->where('may_administrate', true)->orderBy('id', 'asc')->first();
+		if ($owner !== null) {
+			DB::table('configs')->where('key', 'owner_id')->update(['value' => $owner->id]);
+		} else {
+			DB::table('configs')->where('key', 'owner_id')->update(['value' => 0]);
+		}
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		DB::table('configs')->where('key', 'owner_id')->delete();
+	}
+};

--- a/resources/js/components/forms/users/CreateEditUser.vue
+++ b/resources/js/components/forms/users/CreateEditUser.vue
@@ -19,6 +19,21 @@
 					<label for="mayEdit" class="ltr:ml-2 rtl:mr-2 cursor-pointer">{{ $t("users.create_edit.edit_rights") }}</label>
 				</div>
 				<div class="w-full items-center text-muted-color" v-if="is_se_enabled || is_se_preview_enabled">
+					<Checkbox
+						inputId="mayAdministrate"
+						v-model="may_administrate"
+						:binary="true"
+						:pt:box:class="'data-[p=checked]:bg-warning-700 data-[p=checked]:border-warning-700'"
+					>
+						<template #icon="{ checked }">
+							<i v-if="checked" class="pi pi-exclamation-triangle text-xs text-white" />
+						</template>
+					</Checkbox>
+					<label for="mayAdministrate" class="ltr:ml-2 rtl:mr-2 cursor-pointer">
+						{{ $t("users.create_edit.admin_rights") }} <SETag />
+					</label>
+				</div>
+				<div class="w-full items-center text-muted-color" v-if="is_se_enabled || is_se_preview_enabled">
 					<Checkbox inputId="hasQuota" v-model="has_quota" :binary="true" />
 					<label for="hasQuota" class="ltr:ml-2 rtl:mr-2 cursor-pointer">{{ $t("users.create_edit.quota") }} <SETag /></label>
 				</div>
@@ -93,6 +108,7 @@ const username = ref<string | undefined>(props.user?.username);
 const note = ref<string | undefined>(props.user?.note ?? undefined);
 const password = ref<string | undefined>(undefined);
 const may_edit_own_settings = ref(props.user?.may_edit_own_settings ?? false);
+const may_administrate = ref(props.user?.may_administrate ?? false);
 const may_upload = ref(props.user?.may_upload ?? false);
 const has_quota = ref(props.user?.quota_kb !== undefined && props.user?.quota_kb !== null);
 const quota_kb = ref(props.user?.quota_kb?.toString() ?? "0");
@@ -111,6 +127,7 @@ function createUser() {
 		username: username.value,
 		password: password.value,
 		may_edit_own_settings: may_edit_own_settings.value,
+		may_administrate: may_administrate.value,
 		may_upload: may_upload.value,
 		has_quota: is_se_enabled ? has_quota.value : undefined,
 		quota_kb: is_se_enabled ? parseInt(quota_kb.value) : undefined,
@@ -120,6 +137,7 @@ function createUser() {
 			visible.value = false;
 			password.value = undefined;
 			may_upload.value = false;
+			may_administrate.value = false;
 			may_edit_own_settings.value = false;
 			username.value = undefined;
 			has_quota.value = false;
@@ -145,6 +163,7 @@ function editUser() {
 		username: username.value,
 		password: password.value,
 		may_edit_own_settings: may_edit_own_settings.value,
+		may_administrate: may_administrate.value,
 		may_upload: may_upload.value,
 		has_quota: is_se_enabled ? has_quota.value : undefined,
 		quota_kb: is_se_enabled ? parseInt(quota_kb.value) : undefined,
@@ -154,6 +173,7 @@ function editUser() {
 			visible.value = false;
 			password.value = undefined;
 			may_upload.value = false;
+			may_administrate.value = false;
 			may_edit_own_settings.value = false;
 			username.value = undefined;
 			has_quota.value = false;
@@ -172,6 +192,7 @@ watch(
 		id.value = newUser?.id;
 		username.value = newUser?.username;
 		may_edit_own_settings.value = newUser?.may_edit_own_settings ?? false;
+		may_administrate.value = newUser?.may_administrate ?? false;
 		may_upload.value = newUser?.may_upload ?? false;
 		has_quota.value = newUser?.quota_kb !== undefined && newUser?.quota_kb !== null;
 		quota_kb.value = newUser?.quota_kb?.toString() ?? "0";

--- a/resources/js/components/forms/users/ListUser.vue
+++ b/resources/js/components/forms/users/ListUser.vue
@@ -3,7 +3,12 @@
 		<div class="w-9/12 lg:w-8/12 flex flex-wrap">
 			<div class="w-2/3">
 				{{ props.user.username }}
-				<i class="pi pi-crown text-orange-400" v-if="props.user.may_administrate" v-tooltip.top="$t('users.line.admin')"></i>
+				<i
+					class="pi pi-crown text-red-600"
+					v-if="props.user.may_administrate && props.user.is_owner"
+					v-tooltip.top="$t('users.line.owner')"
+				></i>
+				<i class="pi pi-crown text-orange-400" v-else-if="props.user.may_administrate" v-tooltip.top="$t('users.line.admin')"></i>
 			</div>
 			<div class="w-1/3 flex items-center justify-evenly">
 				<div class="w-full text-center">
@@ -29,13 +34,13 @@
 				/>
 			</template>
 		</div>
-		<Button @click="editUser" severity="contrast" class="border-none w-1/12 lg:w-2/12" :disabled="props.user.may_administrate">
+		<Button @click="editUser" severity="contrast" class="border-none w-1/12 lg:w-2/12" :disabled="props.user.is_owner">
 			<i class="pi pi-user-edit" /><span class="hidden md:inline">{{ $t("users.line.edit") }}</span>
 		</Button>
 		<Button
 			@click="deleteUser"
 			class="border-none bg-transparent text-danger-600 hover:bg-danger-700 hover:text-white w-1/12 lg:w-2/12"
-			:disabled="props.user.may_administrate"
+			:disabled="props.user.is_owner"
 		>
 			<i class="pi pi-user-minus" /><span class="hidden md:inline">{{ $t("users.line.delete") }}</span>
 		</Button>

--- a/resources/js/components/settings/ConfigGroup.vue
+++ b/resources/js/components/settings/ConfigGroup.vue
@@ -111,6 +111,7 @@
 					<SelectField v-else-if="config.key === 'album_decoration'" :config @filled="filled" @reset="reset" />
 					<SelectField v-else-if="config.key === 'album_decoration_orientation'" :config @filled="filled" @reset="reset" />
 					<StringField v-else-if="config.key === 'raw_formats'" :config="config" @filled="filled" @reset="reset" />
+					<StringField v-else-if="config.key === 'owner_id'" :config="config" @filled="filled" @reset="reset" />
 					<StringField v-else-if="config.key === 'local_takestamp_video_formats'" :config="config" @filled="filled" @reset="reset" />
 					<!-- Generic -->
 					<StringField v-else-if="config.type.startsWith('string')" :config="config" @filled="filled" @reset="reset" />

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -30,7 +30,7 @@ declare namespace App.Enum {
 		| "taken_at"
 		| "is_starred"
 		| "type";
-	export type ConfigType = "int" | "positive" | "string" | "string_required" | "0|1" | "0|1|2" | "" | "license" | "map_provider";
+	export type ConfigType = "int" | "positive" | "string" | "string_required" | "0|1" | "0|1|2" | "" | "admin_user" | "license" | "map_provider";
 	export type CountType = "taken_at" | "created_at";
 	export type DateOrderingType = "older_younger" | "younger_older";
 	export type DbDriverType = "mysql" | "pgsql" | "sqlite";
@@ -550,6 +550,7 @@ declare namespace App.Http.Resources.Models {
 		may_administrate: boolean;
 		may_upload: boolean;
 		may_edit_own_settings: boolean;
+		is_owner: boolean;
 		quota_kb: number | null;
 		description: string | null;
 		note: string | null;

--- a/resources/js/services/user-management-service.ts
+++ b/resources/js/services/user-management-service.ts
@@ -5,6 +5,7 @@ type UserManagementCreateRequest = {
 	username: string;
 	password: string | null | undefined;
 	may_upload: boolean;
+	may_administrate: boolean;
 	may_edit_own_settings: boolean;
 	has_quota?: boolean;
 	quota_kb?: number;

--- a/tests/Feature_v2/Base/BaseApiWithDataTest.php
+++ b/tests/Feature_v2/Base/BaseApiWithDataTest.php
@@ -21,6 +21,7 @@ namespace Tests\Feature_v2\Base;
 use App\Enum\UserGroupRole;
 use App\Models\AccessPermission;
 use App\Models\Album;
+use App\Models\Configs;
 use App\Models\Palette;
 use App\Models\Photo;
 use App\Models\TagAlbum;
@@ -152,6 +153,8 @@ abstract class BaseApiWithDataTest extends BaseApiTest
 			->create();
 
 		$this->album5 = Album::factory()->as_root()->owned_by($this->admin)->create();
+
+		Configs::set('owner_id', $this->admin->id);
 
 		$this->withoutVite();
 		$this->clearCachedSmartAlbums();

--- a/tests/Unit/CoverageTest.php
+++ b/tests/Unit/CoverageTest.php
@@ -176,6 +176,7 @@ class CoverageTest extends AbstractTestCase
 			'email',
 			true,
 			true,
+			false,
 			0,
 			'note'
 		);


### PR DESCRIPTION
This pull request introduces a new "owner" concept to the system, allowing for the designation of a specific administrative user as the owner of the installation. It adds support for managing ownership, including validation rules, configuration changes, and UI updates. Additionally, it enhances user management by introducing a `may_administrate` permission for more granular control over administrative rights.

### Ownership Management

* Added a new configuration key `owner_id` in the `configs` table to track the owner of the installation, along with a migration to initialize this value based on existing administrators (`database/migrations/2025_06_29_080951_create_owner.php`).
* Introduced `OwnerConfigRule` to restrict changes to the `owner_id` configuration to the current owner only (`app/Rules/OwnerConfigRule.php`).
* Added `OwnerIdRule` to enforce that only the owner can perform specific actions, such as deleting or modifying the owner account (`app/Rules/OwnerIdRule.php`).

### Administrative Permissions

* Introduced a new `may_administrate` permission for users, allowing fine-grained control over administrative capabilities in user creation and update workflows (`app/Actions/User/Create.php`, `app/Actions/User/Save.php`). [[1]](diffhunk://#diff-5f0206eb6f691068a54a00524b3fc3f6f45816fb4b61050bfd52eb4b751c9a3cR30) [[2]](diffhunk://#diff-b1003dcbf19e6eb21d9b6cd59cf15f873ce0a0779b876f093fa929dff657b196R36)
* Updated user-related request classes (`AddUserRequest`, `SetUserSettingsRequest`) to handle the `may_administrate` attribute, including validation and processing (`app/Http/Requests/UserManagement/AddUserRequest.php`, `app/Http/Requests/UserManagement/SetUserSettingsRequest.php`). [[1]](diffhunk://#diff-d70c1e24c1c1e86e68b5d9b72652a30d5447ff3d0d357a5f1ea8f5c42cbd790cR42) [[2]](diffhunk://#diff-11dd9235cf3518d1b70efdf432ea7f7b8b1631ed7f2117a5477427a712933ea5L58-R65)

### Frontend Updates

* Added a checkbox in the user creation/edit form to toggle the `may_administrate` permission, with a warning icon and special styling to indicate the significance of this permission (`resources/js/components/forms/users/CreateEditUser.vue`).

### Additional Enhancements

* Extended the `UserManagementResource` to include an `is_owner` field, which identifies if a user is the owner of the installation (`app/Http/Resources/Models/UserManagementResource.php`).
* Updated the `Configs` model to validate the `owner_id` value against existing administrative users (`app/Models/Configs.php`).