### PR TITLE
While processing in CLI, do not crash on large photos

### DIFF
--- a/app/Console/Commands/ImageProcessing/ExtractColourPalette.php
+++ b/app/Console/Commands/ImageProcessing/ExtractColourPalette.php
@@ -59,8 +59,14 @@ class ExtractColourPalette extends Command
 			}
 
 			foreach ($photos as $photo) {
-				$this->line(sprintf('Extracting Color Palette for %s [%s].', $photo->title, $photo->id));
-				ExtractColoursJob::dispatchSync($photo);
+				try {
+					$this->line(sprintf('Extracting Color Palette for %s [%s].', $photo->title, $photo->id));
+					ExtractColoursJob::dispatchSync($photo);
+					// @codeCoverageIgnoreStart
+				} catch (\Throwable $e) {
+					$this->error(sprintf('Error extracting color palette for %s [%s]: %s', $photo->title, $photo->id, $e->getMessage()));
+				}
+				// @codeCoverageIgnoreEnd
 			}
 
 			return 0;

--- a/app/Console/Commands/ImageProcessing/ExtractColourPalette.php
+++ b/app/Console/Commands/ImageProcessing/ExtractColourPalette.php
@@ -50,7 +50,8 @@ class ExtractColourPalette extends Command
 				->whereDoesntHave('palette')
 				->where('type', 'like', 'image/%')
 				->orderBy('id')
-				->lazyById($limit);
+				->limit($limit)
+				->lazyById();
 
 			if (count($photos) === 0) {
 				$this->line('No photos require palette extraction.');

--- a/app/Console/Commands/ImageProcessing/VariantFilesize.php
+++ b/app/Console/Commands/ImageProcessing/VariantFilesize.php
@@ -49,7 +49,7 @@ class VariantFilesize extends Command
 			}
 
 			// Internally, only holds $limit entries at once
-			$variants = $variants_query->lazyById($limit);
+			$variants = $variants_query->limit($limit)->lazyById(100);
 
 			$this->withProgressBar($variants, function (SizeVariant $variant) use (&$exit_code): void {
 				$variant_file = $variant->getFile();

--- a/app/Exceptions/ColourPaletteExtractionException.php
+++ b/app/Exceptions/ColourPaletteExtractionException.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Exceptions;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * ColourPaletteExtractionException.
+ *
+ * This exception is thrown, if the colour palette extraction fails.
+ * It returns status code 500 (Internal Server Error) to the HTTP client.
+ */
+class ColourPaletteExtractionException extends BaseLycheeException
+{
+	public const DEFAULT_MESSAGE = 'Colour palette extraction failed.';
+
+	public function __construct(string $msg = self::DEFAULT_MESSAGE, ?\Throwable $previous = null)
+	{
+		parent::__construct(Response::HTTP_INTERNAL_SERVER_ERROR, $msg, $previous);
+	}
+}

--- a/app/Http/Controllers/Admin/Maintenance/GenSizeVariants.php
+++ b/app/Http/Controllers/Admin/Maintenance/GenSizeVariants.php
@@ -42,7 +42,7 @@ class GenSizeVariants extends Controller
 			->whereDoesntHave('size_variants', function (Builder $query) use ($request): void {
 				$query->where('type', '=', $request->kind());
 			});
-		$photos = $photos_query->lazyById(Configs::getValueAsInt('maintenance_processing_limit'));
+		$photos = $photos_query->limit(Configs::getValueAsInt('maintenance_processing_limit'))->lazyById(100);
 
 		$generated = 0;
 		/** @var Photo $photo */

--- a/app/Http/Controllers/Admin/Maintenance/MissingFileSizes.php
+++ b/app/Http/Controllers/Admin/Maintenance/MissingFileSizes.php
@@ -37,7 +37,7 @@ class MissingFileSizes extends Controller
 			->where('filesize', '=', 0)
 			->orderBy('id');
 		// Internally, only holds $limit entries at once
-		$variants = $variants_query->lazyById(Configs::getValueAsInt('maintenance_processing_limit'));
+		$variants = $variants_query->limit(Configs::getValueAsInt('maintenance_processing_limit'))->lazyById(100);
 
 		$generated = 0;
 

--- a/app/Http/Controllers/Admin/Maintenance/MissingPalettes.php
+++ b/app/Http/Controllers/Admin/Maintenance/MissingPalettes.php
@@ -54,7 +54,8 @@ class MissingPalettes extends Controller
 			->whereDoesntHave('palette')
 			->where('type', 'like', 'image/%')
 			->orderBy('id')
-			->lazyById($limit);
+			->limit($limit)
+			->lazyById(100);
 
 		foreach ($photos as $photo) {
 			try {

--- a/app/Http/Controllers/Admin/Maintenance/MissingPalettes.php
+++ b/app/Http/Controllers/Admin/Maintenance/MissingPalettes.php
@@ -13,6 +13,7 @@ use App\Jobs\ExtractColoursJob;
 use App\Models\Configs;
 use App\Models\Photo;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Log;
 use LycheeVerify\Verify;
 
 /**
@@ -56,7 +57,13 @@ class MissingPalettes extends Controller
 			->lazyById($limit);
 
 		foreach ($photos as $photo) {
-			ExtractColoursJob::dispatchSync($photo);
+			try {
+				ExtractColoursJob::dispatch($photo);
+				// @codeCoverageIgnoreStart
+			} catch (\Exception $e) {
+				Log::error('Error extracting colour palette for photo ID ' . $photo->id . ': ' . $e->getMessage());
+			}
+			// @codeCoverageIgnoreEnd
 		}
 	}
 }

--- a/app/Jobs/ExtractColoursJob.php
+++ b/app/Jobs/ExtractColoursJob.php
@@ -9,6 +9,7 @@
 namespace App\Jobs;
 
 use App\Enum\JobStatus;
+use App\Exceptions\ColourPaletteExtractionException;
 use App\Exceptions\Internal\LycheeLogicException;
 use App\Image\ColourExtractor\FarzaiExtractor;
 use App\Image\ColourExtractor\LeagueExtractor;
@@ -81,6 +82,11 @@ class ExtractColoursJob implements ShouldQueue
 			default => throw new LycheeLogicException('Unsupported colour extraction driver.'),
 		};
 		$colours = $extractor->extract($file);
+
+		if (count($colours) < 5) {
+			// If we don't have enough colours, we can't create a palette.
+			throw new ColourPaletteExtractionException('Not enough colours extracted to create a palette.');
+		}
 
 		// Creates the colours if they don't exists yet.
 		$colour_1 = Colour::fromHex($colours[0]);

--- a/app/Models/Colour.php
+++ b/app/Models/Colour.php
@@ -21,6 +21,13 @@ use Illuminate\Support\Facades\DB;
  */
 class Colour extends Model
 {
+	/**
+	 * Indicates if the model's ID is auto-incrementing.
+	 *
+	 * @var bool
+	 */
+	public $incrementing = false;
+
 	public $timestamps = false;
 
 	protected $fillable = [
@@ -60,7 +67,7 @@ class Colour extends Model
 
 		$id = hexdec($hex); // Use the hex value as the ID
 
-		$c = Colour::find($id);
+		$c = Colour::where('id', '=', $id)->first();
 		if ($c !== null) {
 			return $c; // Return existing colour if found
 		}

--- a/app/Models/Colour.php
+++ b/app/Models/Colour.php
@@ -60,10 +60,12 @@ class Colour extends Model
 
 		$id = hexdec($hex); // Use the hex value as the ID
 
-		$colour = Colour::updateOrCreate(
-			[
-				'id' => $id,
-			],
+		$c = Colour::find($id);
+		if ($c !== null) {
+			return $c; // Return existing colour if found
+		}
+
+		$colour = Colour::create(
 			[
 				'id' => $id,
 				'R' => hexdec(substr($hex, 0, 2)),


### PR DESCRIPTION
Avoid the following (which could be resolved by checking if the image size is small enough for Imagick.
See more here:
https://stackoverflow.com/questions/77578848/imagemagick-throws-width-or-height-exceeds-when-converting-svg-to-png-with-ver

Let's just not fail for now. We later can consider a fix or a warning in the settings.
```
▶ docker exec -it 394cec php artisan lychee:extract_colour_palette       
Extracting Color Palette for IMG_1363-Pano [0VmiYZJs-xGaFypAGiddDcOe].

In ExtractColourPalette.php line 68:
                                                     
  Unknown Lychee exception (this is probably a bug)  
                                                     

In ImageFactoryForColourExtraction.php line 119:
                        
  Failed to load image  
                        

In ImageFactoryForColourExtraction.php line 107:
                                                                                                                    
  width or height exceeds limit `/tmp/magick-xfA9Pq9r7doI2aNcxSwY9sYPDRh85scS' @ error/cache.c/OpenPixelCache/3909  
```
