### PR TITLE
Add throttling to login api: 10 tentative per hour

### DIFF
--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -128,7 +128,7 @@ Route::get('/Search', [SearchController::class, 'search'])->middleware(['cache_c
 /**
  * SESSION.
  */
-Route::post('/Auth::login', [AuthController::class, 'login']);
+Route::post('/Auth::login', [AuthController::class, 'login'])->middleware('throttle:10,60,login');
 Route::post('/Auth::logout', [AuthController::class, 'logout']);
 Route::get('/Auth::user', [AuthController::class, 'getCurrentUser']);
 Route::get('/Auth::rights', [AuthController::class, 'getGlobalRights']);

--- a/tests/Feature_v2/User/LoginTest.php
+++ b/tests/Feature_v2/User/LoginTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\User;
+
+use Illuminate\Support\Facades\Cache;
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+
+class LoginTest extends BaseApiWithDataTest
+{
+	public function testLoginRateMiddleware(): void
+	{
+        Cache::flush();
+        for ($i = 0; $i < 10; $i++) {
+            $response = $this->postJson('Auth::login', [
+                'username' => 'username',
+                'password' => 'wrong_password',
+            ]);
+            $response->assertStatus(401);
+        }
+
+		$response = $this->postJson('Auth::login', [
+			'username' => 'username',
+			'password' => 'wrong_password',
+		]);
+        $response->assertStatus(429);
+        Cache::flush();
+	}
+}

--- a/tests/Feature_v2/User/LoginTest.php
+++ b/tests/Feature_v2/User/LoginTest.php
@@ -25,20 +25,20 @@ class LoginTest extends BaseApiWithDataTest
 {
 	public function testLoginRateMiddleware(): void
 	{
-        Cache::flush();
-        for ($i = 0; $i < 10; $i++) {
-            $response = $this->postJson('Auth::login', [
-                'username' => 'username',
-                'password' => 'wrong_password',
-            ]);
-            $response->assertStatus(401);
-        }
+		Cache::flush();
+		for ($i = 0; $i < 10; $i++) {
+			$response = $this->postJson('Auth::login', [
+				'username' => 'username',
+				'password' => 'wrong_password',
+			]);
+			$response->assertStatus(401);
+		}
 
 		$response = $this->postJson('Auth::login', [
 			'username' => 'username',
 			'password' => 'wrong_password',
 		]);
-        $response->assertStatus(429);
-        Cache::flush();
+		$response->assertStatus(429);
+		Cache::flush();
 	}
 }


### PR DESCRIPTION
This pull request introduces a rate-limiting middleware to the login route in the API and adds a corresponding test to ensure the middleware functions as expected. The changes enhance security by mitigating brute-force login attempts.

### Security Enhancements:
* [`routes/api_v2.php`](diffhunk://#diff-dba9a30b214808bd1ac63349d1e384b6cbd8d80ef675e4bd7cf0d0ee31c961e8L131-R131): Added a `throttle:10,60,login` middleware to the `/Auth::login` route to limit login attempts to 10 requests per minute.

### Testing Additions:
* [`tests/Feature_v2/User/LoginTest.php`](diffhunk://#diff-7b6eb13b64d60f594a428eb309722f02d93c76e4a780cdaec2e7bff68d70c34aR1-R44): Created a new `LoginTest` class to verify the rate-limiting middleware. The test simulates 10 failed login attempts, ensuring the 11th attempt returns a `429 Too Many Requests` status.