### PR TITLE
Fix: sort RSS feed query reverse-chronologically

### DIFF
--- a/app/Actions/RSS/Generate.php
+++ b/app/Actions/RSS/Generate.php
@@ -106,6 +106,7 @@ class Generate
 			)
 			->where('photos.created_at', '>=', $now_minus)
 			->limit($rss_max)
+			->orderBy('photos.created_at', 'desc')
 			->toBase() // We use toBase() to avoid the use of the Eloquent casts etc.
 			->get();
 


### PR DESCRIPTION
On [my site](https://pictures.dzombak.com) I noticed that the [feed](https://pictures.dzombak.com/feed) did not include my most recently uploaded photos. If I reduced the number of days shown in the RSS feed, more recent photos appeared in the feed.

The cause of this bug is that the query for photos for the RSS feed did not specify an order. This PR sets it to `photos.created_at DESC`, so the RSS feed will always show the most recent photos regardless of the RSS days + maximum photos settings.