### PR TITLE
Include <img> tag in RSS item descriptions

### DIFF
--- a/resources/views/vendor/feed/rss.blade.php
+++ b/resources/views/vendor/feed/rss.blade.php
@@ -21,7 +21,7 @@
             <item>
                 <title><![CDATA[{{ $item->title }}]]></title>
                 <link>{{ url($item->link) }}</link>
-                <description><![CDATA[{!! $item->summary !!}]]></description>
+                <description><![CDATA[@if($item->__isset('enclosure'))<img src="{{ url($item->enclosure) }}" /><br/><br/>@endif{!! $item->summary !!}]]></description>
                 <author><![CDATA[{{ $item->authorName }}@if(!empty($item->authorEmail)) <{{ $item->authorEmail }}>@endif]]></author>
                 <guid>{{ url($item->id) }}</guid>
                 <pubDate>{{ $item->timestamp() }}</pubDate>


### PR DESCRIPTION
This change allows most RSS readers to display the full photo as expected. The following examples are from [the NetNewsWire RSS reader](https://netnewswire.com) on macOS, showing a Lychee RSS feed.

## Before this PR

<img width="1652" height="1250" alt="Screenshot 2025-07-19 at 7 57 52 PM" src="https://github.com/user-attachments/assets/9ca93b75-2d7b-49e1-b2da-a8ba502e7149" />

## After this PR

<img width="1652" height="1250" alt="Screenshot 2025-07-19 at 7 58 14 PM" src="https://github.com/user-attachments/assets/30b9785d-c363-4442-98e5-b69c3fb88639" />
