### PR TITLE
Improve scrolling UX when exiting photo lightbox

### DIFF
--- a/resources/js/stores/ModalsState.ts
+++ b/resources/js/stores/ModalsState.ts
@@ -81,12 +81,11 @@ export const useTogglablesStateStore = defineStore("togglables-store", {
 			if (thumbElem) {
 				// check if thumbElem is actually out of view:
 				const rect = thumbElem.getBoundingClientRect();
-				const isVisible = (
+				const isVisible =
 					rect.top >= 40 &&
 					rect.left >= 0 &&
 					rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-					rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-				);
+					rect.right <= (window.innerWidth || document.documentElement.clientWidth);
 
 				// only scroll it into view if it's currently invisible:
 				if (!isVisible) {

--- a/resources/js/stores/ModalsState.ts
+++ b/resources/js/stores/ModalsState.ts
@@ -79,7 +79,19 @@ export const useTogglablesStateStore = defineStore("togglables-store", {
 
 		recoverAndResetScrollThumb(thumbElem: HTMLElement) {
 			if (thumbElem) {
-				thumbElem.scrollIntoView();
+				// check if thumbElem is actually out of view:
+				const rect = thumbElem.getBoundingClientRect();
+				const isVisible = (
+					rect.top >= 40 &&
+					rect.left >= 0 &&
+					rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+					rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+				);
+
+				// only scroll it into view if it's currently invisible:
+				if (!isVisible) {
+					thumbElem.scrollIntoView({ behavior: "smooth", block: "nearest" });
+				}
 			}
 
 			this.scroll_photo_id = undefined;


### PR DESCRIPTION
Prior to this PR, the album page unconditionally scrolled when exiting the photo lightbox. This scrolling was jarring — the page appeared to jump instantly — and often scrolled the page for no reason, since the photo might have been visible already.

This PR makes this scrolling logic smarter. Now:

- scrolling only happens if the photo that was viewed isn't fully visible already
- scrolling happens smoothly
- the minimum amount of scrolling necessary to make the photo visible is used