### PR TITLE
Fix broken Back button when viewing photo in lightbox

### DIFF
--- a/resources/js/composables/album/albumRefresher.ts
+++ b/resources/js/composables/album/albumRefresher.ts
@@ -102,6 +102,8 @@ export function useAlbumRefresher(albumId: Ref<string>, photoId: Ref<string | un
 		return Promise.all([loadUser(), loadAlbum()]).then(() => {
 			if (photoId.value) {
 				photo.value = photos.value.find((photo: App.Http.Resources.Models.PhotoResource) => photo.id === photoId.value);
+			} else {
+				photo.value = undefined;
 			}
 		});
 	}


### PR DESCRIPTION
Prior to this PR, using the browser Back button when viewing a photo changed the page's URL, but the photo remained on screen and the browser did not navigate back to the gallery.

This PR fixes this bug, so the Back button works properly to go from a photo back to an album.