### PR TITLE
Explicitly set phpstan memory limit to 512MB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ rector:
 	 vendor/bin/rector process
 
 phpstan:
-	vendor/bin/phpstan analyze
+	vendor/bin/phpstan analyze --memory-limit 512M
 
 # Generating new versions
 gen_patch:
@@ -157,5 +157,5 @@ docker-build-dev: docker-build-base-image docker-build-dev-image
 
 test_pgsql_v2:
 	docker compose -f docker-compose-pgsql.yaml up -d
-	vendor/bin/phpunit --testsuite Feature_v2 --stop-on-failure --stop-on-error --no-coverage --log-junit report_v2.xml --configuration phpunit.pgsql.xml 
+	vendor/bin/phpunit --testsuite Feature_v2 --stop-on-failure --stop-on-error --no-coverage --log-junit report_v2.xml --configuration phpunit.pgsql.xml
 	docker compose down


### PR DESCRIPTION
On my machine, the PHP memory limit defaulted to 128MB. This caused PHPStan to run out of memory:

<img width="1359" height="411" alt="Screenshot 2025-07-24 at 1 32 59 PM" src="https://github.com/user-attachments/assets/a60c7643-bffa-455e-8da9-f2745b891c89" />

This PR sets a 512MB limit for PHPStan. See: https://github.com/LycheeOrg/Lychee/pull/3545#discussion_r2228998010