### PR TITLE
fix "command" or "a" independently selecting all items

### DIFF
--- a/resources/js/views/gallery-panels/Album.vue
+++ b/resources/js/views/gallery-panels/Album.vue
@@ -310,7 +310,12 @@ onKeyStroke("u", () => !shouldIgnoreKeystroke() && photo.value === undefined && 
 onKeyStroke("i", () => !shouldIgnoreKeystroke() && photo.value === undefined && toggleEdit());
 onKeyStroke("l", () => !shouldIgnoreKeystroke() && photo.value === undefined && user.value?.id === null && (is_login_open.value = true));
 onKeyStroke("/", () => !shouldIgnoreKeystroke() && photo.value === undefined && config.value?.is_search_accessible && openSearch());
-onKeyStroke([getModKey(), "a"], () => !shouldIgnoreKeystroke() && photo.value === undefined && selectEverything());
+onKeyStroke("a", (e) => {
+	if (!shouldIgnoreKeystroke() && photo.value === undefined && e.getModifierState(getModKey()) && !e.shiftKey && !e.altKey) {
+		e.preventDefault();
+		selectEverything();
+	}
+});
 
 // Photo operations (note that the arrow keys are flipped for RTL languages)
 onKeyStroke("ArrowLeft", () => !shouldIgnoreKeystroke() && photo.value !== undefined && isLTR() && hasPrevious() && previous(true));

--- a/resources/js/views/gallery-panels/Albums.vue
+++ b/resources/js/views/gallery-panels/Albums.vue
@@ -228,7 +228,12 @@ onKeyStroke(" ", () => !shouldIgnoreKeystroke() && unselect());
 onKeyStroke("m", () => !shouldIgnoreKeystroke() && rootRights.value?.can_edit && hasSelection() && toggleMove());
 onKeyStroke(["Delete", "Backspace"], () => !shouldIgnoreKeystroke() && rootRights.value?.can_edit && hasSelection() && toggleDelete());
 
-onKeyStroke([getModKey(), "a"], () => !shouldIgnoreKeystroke() && selectEverything());
+onKeyStroke("a", (e) => {
+	if (!shouldIgnoreKeystroke() && e.getModifierState(getModKey()) && !e.shiftKey && !e.altKey) {
+		e.preventDefault();
+		selectEverything();
+	}
+});
 onKeyStroke("l", () => !shouldIgnoreKeystroke() && user.value?.id === null && (is_login_open.value = true));
 onKeyStroke("k", () => !shouldIgnoreKeystroke() && user.value?.id === null && (is_webauthn_open.value = true));
 


### PR DESCRIPTION
Vuejs's `onKeyStroke` treats an array of keys as "or", not "and" (ref: https://vueuse.org/core/onKeyStroke/ ).

This commit PR the behavior where using the Command key, even as part of an OS-level key combination like Command+Tab, would select all items on the page.

- closes: https://github.com/LycheeOrg/Lychee/discussions/3548