### PR TITLE
fix: On small screen, remove padding on left & right padding

### DIFF
--- a/resources/js/components/gallery/photoModule/PhotoBox.vue
+++ b/resources/js/components/gallery/photoModule/PhotoBox.vue
@@ -17,7 +17,7 @@
 			ref="videoElement"
 			controls
 			class="absolute m-auto w-auto h-auto"
-			:class="is_full_screen || is_slideshow_active ? 'max-w-full max-h-full' : 'max-wh-full-56'"
+			:class="is_full_screen || is_slideshow_active ? 'max-w-full max-h-full' : 'max-w-full md:max-w-[calc(100%-56px)] max-h-[calc(100%-56px)]'"
 			autobuffer
 			:autoplay="lycheeStore.can_autoplay"
 		>
@@ -52,7 +52,7 @@
 			alt="medium"
 			class="absolute m-auto w-auto h-auto bg-contain bg-center bg-no-repeat"
 			:src="props.photo.size_variants.medium?.url ?? ''"
-			:class="is_full_screen || is_slideshow_active ? 'max-w-full max-h-full' : 'max-wh-full-56'"
+			:class="is_full_screen || is_slideshow_active ? 'max-w-full max-h-full' : 'max-w-full md:max-w-[calc(100%-56px)] max-h-[calc(100%-56px)]'"
 			:srcset="srcSetMedium"
 		/>
 		<img
@@ -60,7 +60,7 @@
 			id="image"
 			alt="big"
 			class="absolute m-auto w-auto h-auto bg-contain bg-center bg-no-repeat"
-			:class="is_full_screen || is_slideshow_active ? 'max-w-full max-h-full' : 'max-wh-full-56'"
+			:class="is_full_screen || is_slideshow_active ? 'max-w-full max-h-full' : 'max-w-full md:max-w-[calc(100%-56px)] max-h-[calc(100%-56px)]'"
 			:style="style"
 			:src="props.photo.size_variants.original?.url ?? ''"
 		/>
@@ -73,7 +73,7 @@
 			:data-photo-src="photo?.size_variants.medium?.url"
 			:data-video-src="photo?.live_photo_url"
 			class="absolute m-auto w-auto h-auto"
-			:class="is_full_screen || is_slideshow_active ? 'max-w-full max-h-full' : 'max-wh-full-56'"
+			:class="is_full_screen || is_slideshow_active ? 'max-w-full max-h-full' : 'max-w-full md:max-w-[calc(100%-56px)] max-h-[calc(100%-56px)]'"
 			:style="style"
 		></div>
 		<!-- This is a livephoto : full -->
@@ -85,7 +85,7 @@
 			:data-photo-src="photo?.size_variants.original?.url"
 			:data-video-src="photo?.live_photo_url"
 			class="absolute m-auto w-auto h-auto"
-			:class="is_full_screen || is_slideshow_active ? 'max-w-full max-h-full' : 'max-wh-full-56'"
+			:class="is_full_screen || is_slideshow_active ? 'max-w-full max-h-full' : 'max-w-full md:max-w-[calc(100%-56px)] max-h-[calc(100%-56px)]'"
 			:style="style"
 		></div>
 	</div>

--- a/resources/js/views/Settings.vue
+++ b/resources/js/views/Settings.vue
@@ -67,7 +67,7 @@ import ConfigGroup from "@/components/settings/ConfigGroup.vue";
 import ConfirmSave from "@/components/settings/ConfirmSave.vue";
 import General from "@/components/settings/General.vue";
 import AllSettings from "@/components/settings/AllSettings.vue";
-import { MenuItem } from "primevue/menuitem";
+import { type MenuItem } from "primevue/menuitem";
 import CssJs from "@/components/settings/CssJs.vue";
 import { useRoute, useRouter } from "vue-router";
 import { watch } from "vue";

--- a/resources/sass/app.css
+++ b/resources/sass/app.css
@@ -207,11 +207,6 @@ html {
 	text-shadow: 0 1px 3px #00000066;
 }
 
-.max-wh-full-56 {
-	max-width: calc(100% - 56px);
-	max-height: calc(100% - 56px);
-}
-
 input:checked + .slider:before {
 	transform: translateX(20px);
 	background-color: #fff;


### PR DESCRIPTION
This pull request includes updates to improve the layout and styling of the `PhotoBox` component, as well as minor code cleanup in the settings and CSS files.

### Layout and Styling Improvements:
* In `resources/js/components/gallery/photoModule/PhotoBox.vue`, updated the `:class` bindings for various elements to replace the `max-wh-full-56` class with inline calculations (`max-w-full md:max-w-[calc(100%-56px)] max-h-[calc(100%-56px)]`) for more precise control over layout in fullscreen and slideshow modes. [[1]](diffhunk://#diff-7cc6ef43457fa61afed0b62b8ad53df1380504933faf6b32aa6f781da33866cbL20-R20) [[2]](diffhunk://#diff-7cc6ef43457fa61afed0b62b8ad53df1380504933faf6b32aa6f781da33866cbL55-R63) [[3]](diffhunk://#diff-7cc6ef43457fa61afed0b62b8ad53df1380504933faf6b32aa6f781da33866cbL76-R76) [[4]](diffhunk://#diff-7cc6ef43457fa61afed0b62b8ad53df1380504933faf6b32aa6f781da33866cbL88-R88)

### Code Cleanup:
* Removed the unused `.max-wh-full-56` CSS class from `resources/sass/app.css`, as its functionality has been replaced by inline styles.
* Updated the import statement in `resources/js/views/Settings.vue` to use a type import for `MenuItem` from `primevue/menuitem`, ensuring better type safety.