### PR TITLE
fix access rights so it does not leak

### DIFF
--- a/app/Actions/Tag/DeleteTag.php
+++ b/app/Actions/Tag/DeleteTag.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Tag;
+
+use App\Models\User;
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * We cannot delete tags directly due to foreign keys.
+ * We must first delete the tag-photo relationship then the tag.
+ *
+ * However if User A has tagged photos with `car` and User B has also tagged photos with `car`
+ * We should only delete the links of photos to tag for user A.
+ *
+ * Then we delete the tag only if there are no links remaining.
+ *
+ * Of course this does not apply if the user is an administrator.
+ * In that case we delete the links and the tag regardless of the user.
+ */
+class DeleteTag
+{
+	use TagCleanupTrait;
+
+	/**
+	 * @param int[] $tag_ids
+	 *
+	 * @return void
+	 */
+	public function do(array $tag_ids): void
+	{
+		/** @var User $user */
+		$user = Auth::user();
+
+		DB::table('photos_tags')
+			->whereIn('tag_id', $tag_ids)
+			->when(
+				$user->may_administrate === false,
+				fn ($q) => $q
+					->whereExists(fn (Builder $query) => $query->select(DB::raw(1))
+							->from('photos')
+							->whereColumn('photos.id', 'photo_id')
+							->where('photos.owner_id', $user->id))
+			)
+			->delete();
+
+		$this->cleanupUnusedTags();
+	}
+}

--- a/app/Actions/Tag/EditTag.php
+++ b/app/Actions/Tag/EditTag.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Tag;
+
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * The dummy approach would be to rename the tag directly in the database.
+ * However this does not work if we are working in a multi user setting.
+ *
+ * If User A has photos with tag `car` and User B has photos with tag `car`,
+ * the renaming from User A should not impact User B.
+ *
+ * First we check if there is a tag that already exists with that name.
+ * If there is one found, we just need to migrate the photos.
+ * If there are no tag found, we can create a new one and migrate the photos to that one.
+ *
+ * Once the migration is done, we can check if there are any tags with no link and clean up.
+ */
+class EditTag
+{
+	use TagCleanupTrait;
+
+	public function do(Tag $old_tag, string $name): void
+	{
+		/** @var Tag $new_tag */
+		$new_tag = Tag::where('name', $name)->first() ?? Tag::create(['name' => $name]);
+
+		/** @var User $user */
+		$user = Auth::user();
+
+		DB::table('photos_tags')
+			->where('tag_id', $old_tag->id)
+			->when(
+				$user->may_administrate === false,
+				fn ($q) => $q
+					->whereExists(fn (Builder $query) => $query->select(DB::raw(1))
+							->from('photos')
+							->whereColumn('photos.id', 'photo_id')
+							->where('photos.owner_id', $user->id)
+					)
+			)
+			->update(['tag_id' => $new_tag->id]);
+
+		$this->cleanupUnusedTags();
+	}
+}

--- a/app/Actions/Tag/GetTagWithPhotos.php
+++ b/app/Actions/Tag/GetTagWithPhotos.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Tag;
+
+use App\Http\Resources\Models\PhotoResource;
+use App\Http\Resources\Tags\TagWithPhotosResource;
+use App\Models\Configs;
+use App\Models\Photo;
+use App\Models\Tag;
+use App\Models\User;
+use App\Policies\PhotoQueryPolicy;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * GetTagWithPhotos retrieves a tag along with its associated photos.
+ *
+ * Note that if this actions is called from a non admin user,
+ * the photos returned will be limited to those owned by the user.
+ * This is to ensure that users only see their own photos
+ * associated with the tag, maintaining privacy and security.
+ */
+class GetTagWithPhotos
+{
+	public function __construct(
+		private PhotoQueryPolicy $photo_query_policy,
+	) {
+	}
+
+	/**
+	 * Returns a tag with its associated photos.
+	 *
+	 * @return TagWithPhotosResource
+	 */
+	public function do(Tag $tag): TagWithPhotosResource
+	{
+		/** @var User $user */
+		$user = Auth::user();
+
+		$base_query = Photo::query()
+			->with(['size_variants', 'statistics', 'palette', 'tags'])
+			->when(
+				$user->may_administrate === false,
+				fn ($q) => $q->where('photos.owner_id', Auth::id())
+			)
+			->whereHas('tags', fn ($q) => $q->where('tags.id', $tag->id));
+
+		$photos_query = $this->photo_query_policy->applySearchabilityFilter(
+			query: $base_query,
+			origin: null,
+			include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums')
+		);
+
+		/** @var Collection<int,Photo> $photos */
+		$photos = $photos_query->get();
+		$photo_resources = $photos->map(fn ($photo) => new PhotoResource($photo, null));
+
+		return new TagWithPhotosResource(
+			id: $tag->id,
+			name: $tag->name,
+			photos: $photo_resources,
+		);
+	}
+}

--- a/app/Actions/Tag/ListTags.php
+++ b/app/Actions/Tag/ListTags.php
@@ -49,7 +49,8 @@ class ListTags
 			)
 			->groupBy(['tags.id', 'tags.name'])
 			->orderBy('tags.name')
-			->having('num', '>', 0) // Exclude tags with no photos => this makes sure we do not leak tags from other users.
+			->havingRaw('COUNT(photos_tags.photo_id) > 0') // Exclude tags with no photos => this makes sure we do not leak tags from other users.
+			// Here we can not use `->having('num', '>', 0)` because the aliasing in Postgresql is done AFTER the `HAVING` clause... 
 			->get();
 
 		return new TagsResource($tags->map(fn ($tag) => new TagResource(

--- a/app/Actions/Tag/ListTags.php
+++ b/app/Actions/Tag/ListTags.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Tag;
+
+use App\Http\Resources\Tags\TagResource;
+use App\Http\Resources\Tags\TagsResource;
+use App\Models\User;
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * We list all the tags with their photo counts.
+ *
+ * We also make sure to only return the taags which are associated with photos of the current user (unless it's the admin).
+ */
+class ListTags
+{
+	/**
+	 * Returns the list of all tags with their photo counts.
+	 *
+	 * @return TagsResource
+	 */
+	public function do(): TagsResource
+	{
+		/** @var User $user */
+		$user = Auth::user();
+
+		/** @var Collection<int,object{id:int,name:string,num:int}> $tags */
+		$tags = DB::table('tags')
+			->select(['tags.id', 'tags.name', DB::raw('COUNT(photos_tags.photo_id) AS num')])
+			->leftJoin('photos_tags', 'tags.id', '=', 'photos_tags.tag_id')
+			->when(
+				$user->may_administrate === false,
+				fn ($q) => $q
+					->whereExists(function (Builder $query): void {
+						$query->select(DB::raw(1))
+							->from('photos')
+							->whereColumn('photos.id', 'photos_tags.photo_id')
+							->where('photos.owner_id', Auth::id());
+					})
+			)
+			->groupBy(['tags.id', 'tags.name'])
+			->orderBy('tags.name')
+			->having('num', '>', 0) // Exclude tags with no photos => this makes sure we do not leak tags from other users.
+			->get();
+
+		return new TagsResource($tags->map(fn ($tag) => new TagResource(
+			id: $tag->id,
+			name: $tag->name,
+			num: $tag->num
+		)));
+	}
+}

--- a/app/Actions/Tag/ListTags.php
+++ b/app/Actions/Tag/ListTags.php
@@ -50,7 +50,7 @@ class ListTags
 			->groupBy(['tags.id', 'tags.name'])
 			->orderBy('tags.name')
 			->havingRaw('COUNT(photos_tags.photo_id) > 0') // Exclude tags with no photos => this makes sure we do not leak tags from other users.
-			// Here we can not use `->having('num', '>', 0)` because the aliasing in Postgresql is done AFTER the `HAVING` clause... 
+			// Here we can not use `->having('num', '>', 0)` because the aliasing in Postgresql is done AFTER the `HAVING` clause...
 			->get();
 
 		return new TagsResource($tags->map(fn ($tag) => new TagResource(

--- a/app/Actions/Tag/MergeTag.php
+++ b/app/Actions/Tag/MergeTag.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Tag;
+
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * A dummy implementation would just tranfer all the pictures from one tag to another,
+ * and then delete the source tag.
+ *
+ * This is unfortunately not that simple: if User A has tagged photos with `car` and User B has also tagged photos with `car`,
+ * we should not touch the tag `car` if user B wants to merge it with another tag.
+ *
+ * For this we first figure out which are the photos which belongs to current user and the source tag.
+ * We check if those pictures also have the destination tag also attached (avoid duplication).
+ * Then we insert the missing tag-photo relationships.
+ *
+ * Finally we delete relationships between the source tag and the photos from the current user.
+ *
+ * If the source tag has no more relationships, we delete it.
+ */
+class MergeTag
+{
+	use TagCleanupTrait;
+
+	public function do(Tag $source, Tag $into): void
+	{
+		/** @var User $user */
+		$user = Auth::user();
+
+		// We filter here the photos owned by the user.
+		$source_photo_ids = DB::table('photos_tags')
+			->where('tag_id', $source->id)
+			->when(
+				$user->may_administrate === false,
+				fn ($q) => $q
+					->whereExists(fn (Builder $query) => $query->select(DB::raw(1))
+							->from('photos')
+							->whereColumn('photos.id', 'photos_tags.photo_id')
+							->where('photos.owner_id', $user->id)
+					)
+			)
+			->select('photo_id')
+			->pluck('photo_id')
+			->toArray();
+
+		$existing_photo_ids = DB::table('photos_tags')
+			->where('tag_id', $into->id)
+			->whereIn('photo_id', $source_photo_ids)
+			->select('photo_id')
+			->pluck('photo_id')
+			->toArray();
+
+		// Those are the photos we need to add to the destination tag.
+		$photo_ids_to_add = array_diff($source_photo_ids, $existing_photo_ids);
+
+		DB::beginTransaction();
+		try {
+			if (count($photo_ids_to_add) > 0) {
+				$insert_data = array_map(function ($photo_id) use ($into) {
+					return [
+						'photo_id' => $photo_id,
+						'tag_id' => $into->id,
+					];
+				}, $photo_ids_to_add);
+				DB::table('photos_tags')->insert($insert_data);
+			}
+
+			DB::table('photos_tags')
+				->where('tag_id', $source->id)
+				->whereIn('photo_id', $source_photo_ids) // Only the photos associated with the source tag and owned by the user
+				->delete();
+
+			DB::commit();
+		} catch (\Exception $e) {
+			DB::rollBack();
+			throw $e;
+		}
+
+		// Cleanup unused tags after merging
+		// This will remove the source tag if it has no more relationships.
+		$this->cleanupUnusedTags();
+	}
+}

--- a/app/Actions/Tag/TagCleanupTrait.php
+++ b/app/Actions/Tag/TagCleanupTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Actions\Tag;
+
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
+trait TagCleanupTrait
+{
+	/**
+	 * Cleans up tags that are not linked to any photos.
+	 */
+	protected function cleanupUnusedTags(): void
+	{
+		DB::table('tags')
+			->whereNotExists(function (Builder $query): void {
+				$query->select(DB::raw(1))
+					->from('photos_tags')
+					->whereColumn('photos_tags.tag_id', 'tags.id');
+			})
+			->delete();
+	}
+}

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -8,98 +8,43 @@
 
 namespace App\Http\Controllers;
 
-use App\Exceptions\TagAlreadyExistException;
+use App\Actions\Tag\DeleteTag;
+use App\Actions\Tag\EditTag;
+use App\Actions\Tag\GetTagWithPhotos;
+use App\Actions\Tag\ListTags;
+use App\Actions\Tag\MergeTag;
 use App\Http\Requests\Tags\DeleteTagRequest;
 use App\Http\Requests\Tags\EditTagRequest;
 use App\Http\Requests\Tags\GetTagRequest;
 use App\Http\Requests\Tags\ListTagRequest;
 use App\Http\Requests\Tags\MergeTagRequest;
-use App\Http\Resources\Models\PhotoResource;
-use App\Http\Resources\Tags\TagResource;
 use App\Http\Resources\Tags\TagsResource;
 use App\Http\Resources\Tags\TagWithPhotosResource;
-use App\Models\Configs;
-use App\Models\Photo;
-use App\Models\Tag;
-use App\Policies\PhotoQueryPolicy;
 use Illuminate\Routing\Controller;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 
 class TagController extends Controller
 {
-	/**
-	 * Returns the list of all tags with their photo counts.
-	 *
-	 * @return TagsResource
-	 */
-	public function list(ListTagRequest $request): TagsResource
+	public function list(ListTagRequest $request, ListTags $list_tags): TagsResource
 	{
-		/** @var Collection<int,object{name:string,num:int}> $tags */
-		$tags = DB::table('tags')
-			->select(['tags.id', 'tags.name', DB::raw('COUNT(photos_tags.photo_id) AS num')])
-			->leftJoin('photos_tags', 'tags.id', '=', 'photos_tags.tag_id')
-			->groupBy(['tags.id', 'tags.name'])
-			->orderBy('tags.name')
-			->get();
-
-		return new TagsResource($tags->map(fn ($tag) => new TagResource(
-			id: $tag->id,
-			name: $tag->name,
-			num: $tag->num
-		)));
+		return $list_tags->do();
 	}
 
-	/**
-	 * Returns a tag with its associated photos.
-	 *
-	 * @return TagWithPhotosResource
-	 */
-	public function get(GetTagRequest $request, PhotoQueryPolicy $photo_query_policy): TagWithPhotosResource
+	public function get(GetTagRequest $request, GetTagWithPhotos $get_tag_with_photos): TagWithPhotosResource
 	{
 		$tag = $request->tag();
 
-		// Start with a base Photo query and include the tag join
-		$base_query = Photo::query()
-			->with(['size_variants', 'statistics', 'palette', 'tags'])
-			->whereHas('tags', function ($query) use ($tag): void {
-				$query->where('tags.id', $tag->id);
-			});
-
-		// Apply searchability filter
-		$photos_query = $photo_query_policy->applySearchabilityFilter(
-			query: $base_query,
-			origin: null,
-			include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums')
-		);
-
-		/** @var \Illuminate\Support\Collection<int,Photo> $photos */
-		$photos = $photos_query->get();
-
-		$photo_resources = $photos->map(fn (Photo $photo) => new PhotoResource($photo, null));
-
-		return new TagWithPhotosResource(
-			id: $tag->id,
-			name: $tag->name,
-			photos: $photo_resources,
-		);
+		return $get_tag_with_photos->do($tag);
 	}
 
-	public function edit(EditTagRequest $request): void
+	public function edit(EditTagRequest $request, EditTag $edit_tag): void
 	{
 		$tag = $request->tag();
+		$name = $request->name();
 
-		if (Tag::where('name', $request->name())->exists()) {
-			throw new TagAlreadyExistException();
-		}
-
-		// Update the tag name
-		DB::table('tags')
-			->where('id', $tag->id)
-			->update(['name' => $request->name()]);
+		$edit_tag->do($tag, $name);
 	}
 
-	public function delete(DeleteTagRequest $request): void
+	public function delete(DeleteTagRequest $request, DeleteTag $delete_tag): void
 	{
 		$tags = $request->tags;
 
@@ -107,85 +52,11 @@ class TagController extends Controller
 			return;
 		}
 
-		// First delete all the relations between the selected tags and the photos
-		DB::table('photos_tags')
-			->whereIn('tag_id', $tags)
-			->delete();
-
-		// Then delete the tags themselves
-		DB::table('tags')
-			->whereIn('id', $tags)
-			->delete();
+		$delete_tag->do($tags);
 	}
 
-	/**
-	 * Merge one tag into another.
-	 *
-	 * This transfers all photo associations from the source tag to the destination tag
-	 * and then deletes the source tag.
-	 */
-	public function merge(MergeTagRequest $request): void
+	public function merge(MergeTagRequest $request, MergeTag $merge_tag): void
 	{
-		$source_tag = $request->tag();
-		$destination_tag = $request->destinationTag();
-
-		// Get all photos related to the source tag
-		$source_photo_ids = DB::table('photos_tags')
-			->where('tag_id', $source_tag->id)
-			->select('photo_id')
-			->pluck('photo_id')
-			->toArray();
-
-		if (count($source_photo_ids) === 0) {
-			// If source tag has no photos, just delete it
-			DB::table('tags')
-				->where('id', $source_tag->id)
-				->delete();
-
-			return;
-		}
-
-		// Get existing photo associations for the destination tag to avoid duplicates
-		$existing_photo_ids = DB::table('photos_tags')
-			->where('tag_id', $destination_tag->id)
-			->whereIn('photo_id', $source_photo_ids)
-			->select('photo_id')
-			->pluck('photo_id')
-			->toArray();
-
-		// Filter out photos that are already associated with the destination tag
-		$photo_ids_to_add = array_diff($source_photo_ids, $existing_photo_ids);
-
-		// Begin a transaction to ensure data integrity
-		DB::beginTransaction();
-
-		try {
-			// Add new photo associations to the destination tag
-			if (count($photo_ids_to_add) > 0) {
-				$insert_data = array_map(function ($photo_id) use ($destination_tag) {
-					return [
-						'photo_id' => $photo_id,
-						'tag_id' => $destination_tag->id,
-					];
-				}, $photo_ids_to_add);
-
-				DB::table('photos_tags')->insert($insert_data);
-			}
-
-			// Delete the source tag's photo associations
-			DB::table('photos_tags')
-				->where('tag_id', $source_tag->id)
-				->delete();
-
-			// Delete the source tag
-			DB::table('tags')
-				->where('id', $source_tag->id)
-				->delete();
-
-			DB::commit();
-		} catch (\Exception $e) {
-			DB::rollBack();
-			throw $e;
-		}
+		$merge_tag->do($request->tag(), $request->destinationTag());
 	}
 }

--- a/tests/Feature_v2/Tags/GetTagsTest.php
+++ b/tests/Feature_v2/Tags/GetTagsTest.php
@@ -79,7 +79,7 @@ class GetTagsTest extends BaseApiWithDataTest
 		$this->assertArrayHasKey('photos', $data);
 		$this->assertEquals($this->tag_test->name, $data['name']);
 		$this->assertIsArray($data['photos']);
-		$this->assertEquals($data['photos'][0]['id'], $this->photo1->id);
+		$this->assertCount(0, $data['photos']);
 	}
 
 	public function testGetTagWithMissingTagId(): void

--- a/tests/Feature_v2/Tags/MergeTagsTest.php
+++ b/tests/Feature_v2/Tags/MergeTagsTest.php
@@ -78,12 +78,10 @@ class MergeTagsTest extends BaseApiWithDataTest
 		$this->assertNull(Tag::find($this->source_tag->id));
 
 		// Check that destination tag now has the photo
-		$this->assertTrue(
-			DB::table('photos_tags')
-				->where('photo_id', $this->photo1->id)
-				->where('tag_id', $this->destination_tag->id)
-				->exists()
-		);
+		$this->assertDatabaseHas('photos_tags', [
+			'photo_id' => $this->photo1->id,
+			'tag_id' => $this->destination_tag->id,
+		]);
 	}
 
 	public function testMergeTagsWithMissingSourceTagId(): void
@@ -127,5 +125,70 @@ class MergeTagsTest extends BaseApiWithDataTest
 			'destination_id' => 999999,
 		]);
 		$this->assertNotFound($response);
+	}
+
+	public function testEditTagAdvanced(): void
+	{
+		// Tag photo2 by User2 for `test`
+		$response = $this->actingAs($this->userMayUpload2)->patchJson('Photo::tags', [
+			'photo_ids' => [$this->photo2->id],
+			'tags' => [$this->source_tag->name],
+			'shall_override' => false,
+		]);
+		$this->assertNoContent($response);
+
+		// Validate that `test` has 2 photos associated.
+		$this->assertDatabaseCount('photos_tags', 3);
+		// test -> photo1
+		// source_tag_to_merge -> photo1
+		// source_tag_to_merge -> photo2
+
+		$response = $this->actingAs($this->userMayUpload1)->putJson('Tag', [
+			'tag_id' => $this->source_tag->id,
+			'destination_id' => $this->destination_tag->id,
+		]);
+		$this->assertNoContent($response);
+
+		// With this we validate the photo2 remains under tag `source_tag_to_merge`.
+		$this->assertDatabaseCount('photos_tags', 3);
+		$this->assertDatabaseMissing('photos_tags', [
+			'tag_id' => $this->source_tag->id,
+			'photo_id' => $this->photo1->id,
+		]);
+		$this->assertDatabaseHas('photos_tags', [
+			'tag_id' => $this->tag_test->id,
+			'photo_id' => $this->photo1->id,
+		]);
+		$this->assertDatabaseHas('photos_tags', [
+			'tag_id' => $this->destination_tag->id,
+			'photo_id' => $this->photo1->id,
+		]);
+		$this->assertDatabaseHas('photos_tags', [
+			'tag_id' => $this->source_tag->id,
+			'photo_id' => $this->photo2->id,
+		]);
+
+		$response = $this->actingAs($this->userMayUpload1)->putJson('Tag', [
+			'tag_id' => $this->tag_test->id,
+			'destination_id' => $this->destination_tag->id,
+		]);
+		$this->assertNoContent($response);
+
+		// With this we validate the photo2 remains under tag `source_tag_to_merge`.
+		$this->assertDatabaseCount('photos_tags', 2);
+		$this->assertDatabaseMissing('photos_tags', [
+			'tag_id' => $this->tag_test->id,
+			'photo_id' => $this->photo1->id,
+		]);
+		$this->assertDatabaseHas('photos_tags', [
+			'tag_id' => $this->destination_tag->id,
+			'photo_id' => $this->photo1->id,
+		]);
+		$this->assertDatabaseHas('photos_tags', [
+			'tag_id' => $this->source_tag->id,
+			'photo_id' => $this->photo2->id,
+		]);
+		$this->assertDatabaseCount('photos_tags', 2);
+		$this->assertDatabaseCount('tags', 2);
 	}
 }


### PR DESCRIPTION
This refactors the logic to avoid leaking tags between users.

While the logic is slightly more complex, I do hope the comments helps understanding the reasoning and the code. :)
Tests have been expanded to really lock down the expected behaviour.