### PR TITLE
Allow customizing copyright text in footer

### DIFF
--- a/app/Http/Resources/GalleryConfigs/FooterConfig.php
+++ b/app/Http/Resources/GalleryConfigs/FooterConfig.php
@@ -53,6 +53,7 @@ class FooterConfig extends Data
 		}
 
 		$site_owner = Configs::getValueAsString('site_owner');
+
 		return $copyright_year !== '' ? sprintf(__('landing.copyright'), $site_owner, $copyright_year) : '';
 	}
 }

--- a/app/Http/Resources/GalleryConfigs/FooterConfig.php
+++ b/app/Http/Resources/GalleryConfigs/FooterConfig.php
@@ -19,7 +19,6 @@ class FooterConfig extends Data
 	public bool $footer_show_copyright;
 	public bool $footer_show_social_media;
 	public string $copyright;
-	public string $copyright_text;
 	public string $sm_facebook_url;
 	public string $sm_flickr_url;
 	public string $sm_instagram_url;
@@ -31,26 +30,29 @@ class FooterConfig extends Data
 		$this->footer_additional_text = Configs::getValueAsString('footer_additional_text');
 		$this->footer_show_copyright = Configs::getValueAsBool('footer_show_copyright');
 		$this->footer_show_social_media = Configs::getValueAsBool('footer_show_social_media');
-		$this->copyright_text = Configs::getValueAsString('copyright_text');
-		$site_copyright_begin = Configs::getValueAsString('site_copyright_begin');
-		$site_copyright_end = Configs::getValueAsString('site_copyright_end');
-		$site_owner = Configs::getValueAsString('site_owner');
+		$this->copyright = $this->get_copyright();
 		$this->sm_facebook_url = Configs::getValueAsString('sm_facebook_url');
 		$this->sm_flickr_url = Configs::getValueAsString('sm_flickr_url');
 		$this->sm_instagram_url = Configs::getValueAsString('sm_instagram_url');
 		$this->sm_twitter_url = Configs::getValueAsString('sm_twitter_url');
 		$this->sm_youtube_url = Configs::getValueAsString('sm_youtube_url');
+	}
 
-		$copy_right_year = $site_copyright_begin;
+	private function get_copyright(): string
+	{
+		$copyright_text = Configs::getValueAsString('copyright_text');
+		if ($copyright_text !== '') {
+			return $copyright_text;
+		}
+
+		$site_copyright_begin = Configs::getValueAsString('site_copyright_begin');
+		$site_copyright_end = Configs::getValueAsString('site_copyright_end');
+		$copyright_year = $site_copyright_begin;
 		if ($site_copyright_begin !== $site_copyright_end) {
-			$copy_right_year = $copy_right_year . '-' . $site_copyright_end;
+			$copyright_year = $copyright_year . '-' . $site_copyright_end;
 		}
 
-		// Use custom copyright text if provided, otherwise use default format
-		if ($this->copyright_text !== '') {
-			$this->copyright = $this->copyright_text;
-		} else {
-			$this->copyright = $copy_right_year !== '' ? sprintf(__('landing.copyright'), $site_owner, $copy_right_year) : '';
-		}
+		$site_owner = Configs::getValueAsString('site_owner');
+		return $copyright_year !== '' ? sprintf(__('landing.copyright'), $site_owner, $copyright_year) : '';
 	}
 }

--- a/app/Http/Resources/GalleryConfigs/FooterConfig.php
+++ b/app/Http/Resources/GalleryConfigs/FooterConfig.php
@@ -19,6 +19,7 @@ class FooterConfig extends Data
 	public bool $footer_show_copyright;
 	public bool $footer_show_social_media;
 	public string $copyright;
+	public string $copyright_text;
 	public string $sm_facebook_url;
 	public string $sm_flickr_url;
 	public string $sm_instagram_url;
@@ -30,6 +31,7 @@ class FooterConfig extends Data
 		$this->footer_additional_text = Configs::getValueAsString('footer_additional_text');
 		$this->footer_show_copyright = Configs::getValueAsBool('footer_show_copyright');
 		$this->footer_show_social_media = Configs::getValueAsBool('footer_show_social_media');
+		$this->copyright_text = Configs::getValueAsString('copyright_text');
 		$site_copyright_begin = Configs::getValueAsString('site_copyright_begin');
 		$site_copyright_end = Configs::getValueAsString('site_copyright_end');
 		$site_owner = Configs::getValueAsString('site_owner');
@@ -44,6 +46,11 @@ class FooterConfig extends Data
 			$copy_right_year = $copy_right_year . '-' . $site_copyright_end;
 		}
 
-		$this->copyright = $copy_right_year !== '' ? sprintf(__('landing.copyright'), $site_owner, $copy_right_year) : '';
+		// Use custom copyright text if provided, otherwise use default format
+		if ($this->copyright_text !== '') {
+			$this->copyright = $this->copyright_text;
+		} else {
+			$this->copyright = $copy_right_year !== '' ? sprintf(__('landing.copyright'), $site_owner, $copy_right_year) : '';
+		}
 	}
 }

--- a/database/migrations/2025_08_12_114738_add_copyright_text_setting.php
+++ b/database/migrations/2025_08_12_114738_add_copyright_text_setting.php
@@ -2,6 +2,7 @@
 
 /**
  * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 

--- a/database/migrations/2025_08_12_114738_add_copyright_text_setting.php
+++ b/database/migrations/2025_08_12_114738_add_copyright_text_setting.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class() extends Migration {
+	public function up(): void
+	{
+		DB::table('configs')->insert([
+			[
+				'key' => 'copyright_text',
+				'value' => '',
+				'cat' => 'Footer',
+				'type_range' => 'string',
+				'is_secret' => false,
+				'description' => 'Copyright text (replaces default copyright notice)',
+				'details' => '',
+				'level' => 0,
+				'not_on_docker' => false,
+				'order' => 5,
+				'is_expert' => false,
+			],
+		]);
+	}
+
+	public function down(): void
+	{
+		DB::table('configs')->where('key', 'copyright_text')->delete();
+	}
+};

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -276,7 +276,6 @@ declare namespace App.Http.Resources.GalleryConfigs {
 		footer_show_copyright: boolean;
 		footer_show_social_media: boolean;
 		copyright: string;
-		copyright_text: string;
 		sm_facebook_url: string;
 		sm_flickr_url: string;
 		sm_instagram_url: string;

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -276,6 +276,7 @@ declare namespace App.Http.Resources.GalleryConfigs {
 		footer_show_copyright: boolean;
 		footer_show_social_media: boolean;
 		copyright: string;
+		copyright_text: string;
 		sm_facebook_url: string;
 		sm_flickr_url: string;
 		sm_instagram_url: string;


### PR DESCRIPTION
This PR allows the user to customize the copyright text displayed in the site's footer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "Copyright text" setting to customize the footer. When set, it replaces the default translated notice.
  * Migration adds the new setting with an empty default so there are no visual changes until configured by admins.

* **Refactor**
  * Footer copyright generation moved to a dedicated helper to preserve existing display and translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->