### PR TITLE
Fix multiple album display when users are in multiple groups

### DIFF
--- a/app/Policies/AlbumQueryPolicy.php
+++ b/app/Policies/AlbumQueryPolicy.php
@@ -561,7 +561,7 @@ class AlbumQueryPolicy
 								$user_groups
 							)
 					)
-			);
+			)->when(!$full, fn (BaseBuilder $q) => $q->groupBy(APC::BASE_ALBUM_ID));
 	}
 
 	/**

--- a/app/Policies/AlbumQueryPolicy.php
+++ b/app/Policies/AlbumQueryPolicy.php
@@ -561,7 +561,7 @@ class AlbumQueryPolicy
 								$user_groups
 							)
 					)
-			)->when(!$full, fn (BaseBuilder $q) => $q->groupBy(APC::BASE_ALBUM_ID));
+			)->when(!$full, fn (BaseBuilder $q) => $q->groupBy(APC::BASE_ALBUM_ID, APC::IS_LINK_REQUIRED, APC::PASSWORD));
 	}
 
 	/**

--- a/tests/Feature_v2/Album/AlbumSharingTest.php
+++ b/tests/Feature_v2/Album/AlbumSharingTest.php
@@ -33,7 +33,7 @@ use Tests\Feature_v2\Base\BaseApiWithDataTest;
  * Group 1 has access to album A - with download right.
  * Group 2 has access to album A - without download rights.
  * User 1 should only see album A once and has download rights.
- * 
+ *
  * This tests ensure that:
  * - If a user is member of two groups that share the same album, it only appears once in the list of shared albums.
  * - If an album is public and shared with a user, it only appears once in the list of shared albums.
@@ -45,8 +45,8 @@ class AlbumSharingTest extends BaseApiWithDataTest
 	/**
 	 * Ensure that if a user is member of two groups that share the same album,
 	 * the album is only listed once.
-	 * 
-	 * @return void 
+	 *
+	 * @return void
 	 */
 	public function testUserInTwoGroupsWithSameSharedAlbum(): void
 	{
@@ -74,7 +74,7 @@ class AlbumSharingTest extends BaseApiWithDataTest
 			'smart_albums' => [],
 			'tag_albums' => [],
 			'albums' => [],
-			'shared_albums' => []
+			'shared_albums' => [],
 		]);
 
 		$response->assertJsonCount(1, 'shared_albums');
@@ -84,8 +84,8 @@ class AlbumSharingTest extends BaseApiWithDataTest
 	/**
 	 * Ensure that if an album is public and shared with a user,
 	 * it only appears once in the list of albums.
-	 * 
-	 * @return void 
+	 *
+	 * @return void
 	 */
 	public function testUserSharedWithPublic(): void
 	{
@@ -96,7 +96,7 @@ class AlbumSharingTest extends BaseApiWithDataTest
 			'smart_albums' => [],
 			'tag_albums' => [],
 			'albums' => [],
-			'shared_albums' => []
+			'shared_albums' => [],
 		]);
 
 		$response->assertJsonCount(1, 'shared_albums');
@@ -132,7 +132,7 @@ class AlbumSharingTest extends BaseApiWithDataTest
 			'smart_albums' => [],
 			'tag_albums' => [],
 			'albums' => [],
-			'shared_albums' => []
+			'shared_albums' => [],
 		]);
 
 		$response->assertJsonCount(1, 'shared_albums');
@@ -152,7 +152,7 @@ class AlbumSharingTest extends BaseApiWithDataTest
 			'smart_albums' => [],
 			'tag_albums' => [],
 			'albums' => [],
-			'shared_albums' => []
+			'shared_albums' => [],
 		]);
 
 		$response->assertJsonCount(1, 'shared_albums');
@@ -194,13 +194,12 @@ class AlbumSharingTest extends BaseApiWithDataTest
 			'smart_albums' => [],
 			'tag_albums' => [],
 			'albums' => [],
-			'shared_albums' => []
+			'shared_albums' => [],
 		]);
 
 		$response->assertJsonCount(1, 'shared_albums');
 		$response->assertJsonPath('shared_albums.0.id', $this->album4->id);
 	}
-
 
 	/**
 	 * Ensure that if an album is shared directly and shared with a user via group,
@@ -219,7 +218,7 @@ class AlbumSharingTest extends BaseApiWithDataTest
 			'smart_albums' => [],
 			'tag_albums' => [],
 			'albums' => [],
-			'shared_albums' => []
+			'shared_albums' => [],
 		]);
 
 		$response->assertJsonCount(1, 'shared_albums');
@@ -249,7 +248,7 @@ class AlbumSharingTest extends BaseApiWithDataTest
 			'tag_albums' => [],
 			'albums' => [],
 			'shared_albums' => [
-			]
+			],
 		]);
 
 		// Behaviour we do not want.

--- a/tests/Feature_v2/Album/AlbumSharingTest.php
+++ b/tests/Feature_v2/Album/AlbumSharingTest.php
@@ -77,10 +77,8 @@ class AlbumSharingTest extends BaseApiWithDataTest
 			'shared_albums' => []
 		]);
 
-		// ! Behaviour we do not want.
-		$response->assertJsonCount(2, 'shared_albums');
+		$response->assertJsonCount(1, 'shared_albums');
 		$response->assertJsonPath('shared_albums.0.id', $this->album1->id);
-		$response->assertJsonPath('shared_albums.1.id', $this->album1->id);
 	}
 
 	/**
@@ -258,6 +256,4 @@ class AlbumSharingTest extends BaseApiWithDataTest
 		$response->assertJsonCount(1, 'shared_albums');
 		$response->assertJsonPath('shared_albums.0.id', $this->album1->id);
 	}
-
-
 }

--- a/tests/Feature_v2/Album/AlbumSharingTest.php
+++ b/tests/Feature_v2/Album/AlbumSharingTest.php
@@ -1,0 +1,263 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\Album;
+
+use App\Models\AccessPermission;
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+
+/*
+ * Regression tests for https://github.com/LycheeOrg/Lychee/issues/3586
+ * "albums that are shared via both the new user group feature and also made public turn up twice for logged in users.
+ * When a user is member of multiple groups, more albums turn up."
+ *
+ * Expected behavior is that albums are only listed once, regardless of how they are shared.
+ * Expected behavior is that the access for that album via group are taken as max.
+ * Consiser an album A.
+ * User 1 is member of group 1 and group 2.
+ * Group 1 has access to album A - with download right.
+ * Group 2 has access to album A - without download rights.
+ * User 1 should only see album A once and has download rights.
+ * 
+ * This tests ensure that:
+ * - If a user is member of two groups that share the same album, it only appears once in the list of shared albums.
+ * - If an album is public and shared with a user, it only appears once in the list of shared albums.
+ * - If an album is public and shared with a user via group, it only appears once in the list of shared albums.
+ * - If an album is shared via member and via group, it only appears once in the list of shared albums.
+ */
+class AlbumSharingTest extends BaseApiWithDataTest
+{
+	/**
+	 * Ensure that if a user is member of two groups that share the same album,
+	 * the album is only listed once.
+	 * 
+	 * @return void 
+	 */
+	public function testUserInTwoGroupsWithSameSharedAlbum(): void
+	{
+		// Add UserLocked to group 1 and group 2.
+		$this->userLocked->user_groups()->attach($this->group1);
+		$this->userLocked->user_groups()->attach($this->group2);
+
+		// Setup group 2 to have access to album1.
+		// This is the album that is shared with group1.
+		AccessPermission::factory()
+			->for_user_group($this->group2)
+			->for_album($this->album1)
+			->visible()
+			->grants_edit()
+			->grants_delete()
+			->grants_upload()
+			->grants_download()
+			->grants_full_photo()
+			->create();
+
+		// Now userLocked should be able to see album1.
+		$response = $this->actingAs($this->userLocked)->getJson('Albums');
+		$this->assertOk($response);
+		$response->assertJson([
+			'smart_albums' => [],
+			'tag_albums' => [],
+			'albums' => [],
+			'shared_albums' => []
+		]);
+
+		// ! Behaviour we do not want.
+		$response->assertJsonCount(2, 'shared_albums');
+		$response->assertJsonPath('shared_albums.0.id', $this->album1->id);
+		$response->assertJsonPath('shared_albums.1.id', $this->album1->id);
+	}
+
+	/**
+	 * Ensure that if an album is public and shared with a user,
+	 * it only appears once in the list of albums.
+	 * 
+	 * @return void 
+	 */
+	public function testUserSharedWithPublic(): void
+	{
+		// UserMayUpload1 should be able to see album4 (it is public).
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Albums');
+		$this->assertOk($response);
+		$response->assertJson([
+			'smart_albums' => [],
+			'tag_albums' => [],
+			'albums' => [],
+			'shared_albums' => []
+		]);
+
+		$response->assertJsonCount(1, 'shared_albums');
+		$response->assertJsonPath('shared_albums.0.id', $this->album4->id);
+
+		// Give access to album4 to userMayUpload1.
+		// This is the album that is public.
+		AccessPermission::factory()
+			->for_user($this->userMayUpload1)
+			->for_album($this->album4)
+			->visible()
+			->grants_edit()
+			->grants_delete()
+			->grants_upload()
+			->grants_download()
+			->grants_full_photo()
+			->create();
+
+		$this->assertDatabaseHas('access_permissions', [
+			'base_album_id' => $this->album4->id,
+			'user_id' => $this->userMayUpload1->id,
+		]);
+		$this->assertDatabaseHas('access_permissions', [
+			'base_album_id' => $this->album4->id,
+			'user_id' => null,
+			'user_group_id' => null,
+		]);
+
+		// Now userMayUpload1 should be able to see album4.
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Albums');
+		$this->assertOk($response);
+		$response->assertJson([
+			'smart_albums' => [],
+			'tag_albums' => [],
+			'albums' => [],
+			'shared_albums' => []
+		]);
+
+		$response->assertJsonCount(1, 'shared_albums');
+		$response->assertJsonPath('shared_albums.0.id', $this->album4->id);
+	}
+
+	/**
+	 * Ensure that if an album is public and shared with a user via group,
+	 * it only appears once in the list of albums.
+	 */
+	public function testUserGroupWithPublic(): void
+	{
+		// UserMayUpload1 should be able to see album4 (it is public).
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Albums');
+		$this->assertOk($response);
+		$response->assertJson([
+			'smart_albums' => [],
+			'tag_albums' => [],
+			'albums' => [],
+			'shared_albums' => []
+		]);
+
+		$response->assertJsonCount(1, 'shared_albums');
+		$response->assertJsonPath('shared_albums.0.id', $this->album4->id);
+
+		$this->userMayUpload1->user_groups()->attach($this->group1);
+		$this->assertDatabaseHas('users_user_groups', [
+			'user_id' => $this->userMayUpload1->id,
+			'user_group_id' => $this->group1->id,
+		]);
+
+		// Give access to album4 to group1.
+		// This is the album that is public.
+		AccessPermission::factory()
+			->for_user_group($this->group1)
+			->for_album($this->album4)
+			->visible()
+			->grants_edit()
+			->grants_delete()
+			->grants_upload()
+			->grants_download()
+			->grants_full_photo()
+			->create();
+
+		$this->assertDatabaseHas('access_permissions', [
+			'base_album_id' => $this->album4->id,
+			'user_group_id' => $this->group1->id,
+		]);
+		$this->assertDatabaseHas('access_permissions', [
+			'base_album_id' => $this->album4->id,
+			'user_id' => null,
+			'user_group_id' => null,
+		]);
+
+		// Now userMayUpload1 should be able to see album4.
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Albums');
+		$this->assertOk($response);
+		$response->assertJson([
+			'smart_albums' => [],
+			'tag_albums' => [],
+			'albums' => [],
+			'shared_albums' => []
+		]);
+
+		$response->assertJsonCount(1, 'shared_albums');
+		$response->assertJsonPath('shared_albums.0.id', $this->album4->id);
+	}
+
+
+	/**
+	 * Ensure that if an album is shared directly and shared with a user via group,
+	 * it only appears once in the list of albums.
+	 */
+	public function testUserGroupWithShare(): void
+	{
+		// Remove the public permission from album4.
+		// This is to simplify the tests.
+		$this->perm4->delete();
+
+		// UserMayUpload1 should be able to see album4 (it is public).
+		$response = $this->actingAs($this->userMayUpload2)->getJson('Albums');
+		$this->assertOk($response);
+		$response->assertJson([
+			'smart_albums' => [],
+			'tag_albums' => [],
+			'albums' => [],
+			'shared_albums' => []
+		]);
+
+		$response->assertJsonCount(1, 'shared_albums');
+		$response->assertJsonPath('shared_albums.0.id', $this->album1->id);
+
+		// Add userMayUplaod2 to group1.
+		$this->userMayUpload2->user_groups()->attach($this->group1);
+		$this->assertDatabaseHas('users_user_groups', [
+			'user_id' => $this->userMayUpload2->id,
+			'user_group_id' => $this->group1->id,
+		]);
+
+		$this->assertDatabaseHas('access_permissions', [
+			'base_album_id' => $this->album1->id,
+			'user_group_id' => $this->group1->id,
+		]);
+		$this->assertDatabaseHas('access_permissions', [
+			'base_album_id' => $this->album1->id,
+			'user_id' => $this->userMayUpload2->id,
+		]);
+
+		// Now userMayUpload2 should be able to see album1 only once.
+		$response = $this->actingAs($this->userMayUpload2)->getJson('Albums');
+		$this->assertOk($response);
+		$response->assertJson([
+			'smart_albums' => [],
+			'tag_albums' => [],
+			'albums' => [],
+			'shared_albums' => [
+			]
+		]);
+
+		// Behaviour we do not want.
+		$response->assertJsonCount(1, 'shared_albums');
+		$response->assertJsonPath('shared_albums.0.id', $this->album1->id);
+	}
+
+
+}

--- a/tests/Feature_v2/Base/BaseApiWithDataTest.php
+++ b/tests/Feature_v2/Base/BaseApiWithDataTest.php
@@ -38,6 +38,55 @@ use Tests\Traits\RequiresEmptyTags;
 use Tests\Traits\RequiresEmptyUsers;
 use Tests\Traits\RequiresEmptyWebAuthnCredentials;
 
+/**
+ * BaseApiWithDataTest serves as a foundational testing class for Lychee's API features.
+ *
+ * Goal: This class provides a comprehensive test environment with pre-configured data
+ * structures to simulate various user scenarios and permissions within the Lychee photo
+ * management system.
+ *
+ * Architecture:
+ * - Extends BaseApiTest for core API testing functionality
+ * - Incorporates multiple traits for test environment setup and teardown
+ * - Creates a complete hierarchical data structure with users, albums, photos, permissions, and groups
+ *
+ * Data Structure Graph:
+ * - 👥 Users:
+ *   ├─ 👑 admin (god allmighty)
+ *   │  └─ 📁 album5 (root)
+ *   │
+ *   ├─ 👤 userMayUpload1
+ *   │  ├─ 📁 album1 (root)
+ *   │  │  ├─ 🔑 perm1 (👤 userMayUpload2)
+ *   │  │  ├─ 🔑 perm11 (👥 group1 → album1)
+ *   │  │  ├─ 🖼️ photo1 (🏷️ `test`, 🎨 palette)
+ *   │  │  ├─ 🖼️ photo1b
+ *   │  │  └─ 📁 subAlbum1
+ *   │  │     └─ 🖼️ subPhoto1
+ *   │  ├─ 🏷️ tagAlbum1 (linked to `test`)
+ *   │  └─ 🖼️ photoUnsorted
+ *   │
+ *   ├─ 👤 userMayUpload2
+ *   │  └─ 📁 album2 (root)
+ *   │     ├─ 🖼️ photo2
+ *   │     └─ 📁 subAlbum2
+ *   │        └─ 🖼️ subPhoto2
+ *   │
+ *   ├─ 👤 userNoUpload
+ *   │  └─ 📁 album3 (root)
+ *   │     └─ 🖼️ photo3
+ *   │
+ *   └─ 👤 userLocked
+ *      └─ 📁 album4 (root)
+ *         ├─ 🔑 perm4 (🌐 public visibility)
+ *         ├─ 🖼️ photo4
+ *         └─ 📁 subAlbum4 (🌐 public visibility)
+ *            ├─ 🔑 perm44 (🌐 public visibility)
+ *            └─ 🖼️ subPhoto4
+ * - 👥 Groups:
+ *   ├─ 👥 group1 (contains 👤 userWithGroup1, 👤 userWithGroupAdmin )
+ *   └─ 👥 group2
+ */
 abstract class BaseApiWithDataTest extends BaseApiTest
 {
 	use RequiresEmptyUsers;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated shared-album results so an album shared via multiple paths (public, group, user) appears only once.

* **Tests**
  * Added tests covering multiple sharing combinations to ensure de-duplication and prevent regressions.

* **Documentation**
  * Expanded test-suite documentation describing test data and fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->