### PR TITLE
Change Rename, Move, and Merge icons

### DIFF
--- a/resources/js/components/gallery/photoModule/Dock.vue
+++ b/resources/js/components/gallery/photoModule/Dock.vue
@@ -29,8 +29,8 @@
 			</template>
 			<DockButton
 				v-tooltip.bottom="$t('gallery.photo.actions.move')"
-				icon="transfer"
-				class="fill-white lg:hover:fill-primary-500"
+				pi="folder"
+				class="lg:hover:text-primary-500 text-white"
 				@click="emits('toggleMove')"
 			/>
 			<DockButton

--- a/resources/js/composables/contextMenus/contextMenu.ts
+++ b/resources/js/composables/contextMenus/contextMenu.ts
@@ -159,7 +159,7 @@ export function useContextMenu(selectors: Selectors, photoCallbacks: PhotoCallba
 				},
 				{
 					label: "gallery.menus.move",
-					icon: "pi pi-arrows-alt",
+					icon: "pi pi-folder",
 					callback: photoCallbacks.toggleMove,
 					access: selectedPhoto.rights.can_edit,
 				},
@@ -224,7 +224,7 @@ export function useContextMenu(selectors: Selectors, photoCallbacks: PhotoCallba
 				},
 				{
 					label: "gallery.menus.move_all",
-					icon: "pi pi-arrows-alt",
+					icon: "pi pi-folder",
 					callback: photoCallbacks.toggleMove,
 					access: selectors.selectedPhotos.value.reduce(canEdit, true),
 				},
@@ -279,7 +279,7 @@ export function useContextMenu(selectors: Selectors, photoCallbacks: PhotoCallba
 				},
 				{
 					label: "gallery.menus.move",
-					icon: "pi pi-arrows-alt",
+					icon: "pi pi-folder",
 					callback: albumCallbacks.toggleMove,
 					access: selectedAlbum.rights.can_move ?? false,
 				},
@@ -317,7 +317,7 @@ export function useContextMenu(selectors: Selectors, photoCallbacks: PhotoCallba
 			},
 			{
 				label: "gallery.menus.move_all",
-				icon: "pi pi-arrows-alt",
+				icon: "pi pi-folder",
 				callback: albumCallbacks.toggleMove,
 				access: selectors.selectedAlbums?.value.reduce(canMove, true),
 			},

--- a/resources/js/composables/contextMenus/contextMenu.ts
+++ b/resources/js/composables/contextMenus/contextMenu.ts
@@ -147,7 +147,7 @@ export function useContextMenu(selectors: Selectors, photoCallbacks: PhotoCallba
 				},
 				{
 					label: "gallery.menus.rename",
-					icon: "pi pi-pencil",
+					icon: "pi pi-pen-to-square",
 					callback: photoCallbacks.toggleRename,
 					access: selectedPhoto.rights.can_edit,
 				},
@@ -159,7 +159,7 @@ export function useContextMenu(selectors: Selectors, photoCallbacks: PhotoCallba
 				},
 				{
 					label: "gallery.menus.move",
-					icon: "pi pi-arrow-right-arrow-left",
+					icon: "pi pi-arrows-alt",
 					callback: photoCallbacks.toggleMove,
 					access: selectedPhoto.rights.can_edit,
 				},
@@ -224,7 +224,7 @@ export function useContextMenu(selectors: Selectors, photoCallbacks: PhotoCallba
 				},
 				{
 					label: "gallery.menus.move_all",
-					icon: "pi pi-arrow-right-arrow-left",
+					icon: "pi pi-arrows-alt",
 					callback: photoCallbacks.toggleMove,
 					access: selectors.selectedPhotos.value.reduce(canEdit, true),
 				},
@@ -267,19 +267,19 @@ export function useContextMenu(selectors: Selectors, photoCallbacks: PhotoCallba
 			...[
 				{
 					label: "gallery.menus.rename",
-					icon: "pi pi-pencil",
+					icon: "pi pi-pen-to-square",
 					callback: albumCallbacks.toggleRename,
 					access: selectedAlbum.rights.can_edit ?? false,
 				},
 				{
 					label: "gallery.menus.merge",
-					icon: "pi pi-paperclip",
+					icon: "pi pi-arrow-down-left-and-arrow-up-right-to-center",
 					callback: albumCallbacks.toggleMerge,
 					access: selectedAlbum.rights.can_move ?? false,
 				},
 				{
 					label: "gallery.menus.move",
-					icon: "pi pi-arrow-right-arrow-left",
+					icon: "pi pi-arrows-alt",
 					callback: albumCallbacks.toggleMove,
 					access: selectedAlbum.rights.can_move ?? false,
 				},
@@ -311,13 +311,13 @@ export function useContextMenu(selectors: Selectors, photoCallbacks: PhotoCallba
 		return [
 			{
 				label: "gallery.menus.merge_all",
-				icon: "pi pi-paperclip",
+				icon: "pi pi-arrow-down-left-and-arrow-up-right-to-center",
 				callback: albumCallbacks.toggleMerge,
 				access: selectors.selectedAlbums?.value.reduce(canMove, true),
 			},
 			{
 				label: "gallery.menus.move_all",
-				icon: "pi pi-arrow-right-arrow-left",
+				icon: "pi pi-arrows-alt",
 				callback: albumCallbacks.toggleMove,
 				access: selectors.selectedAlbums?.value.reduce(canMove, true),
 			},

--- a/resources/js/views/TagsManagement.vue
+++ b/resources/js/views/TagsManagement.vue
@@ -50,7 +50,7 @@
 					{{ $t("tags.rename") }}
 				</Button>
 				<Button :text="!isMerging" severity="primary" size="small" class="border-none" @click="toggleMerging">
-					<i class="pi pi-paperclip"></i>
+					<i class="pi pi-arrow-down-left-and-arrow-up-right-to-center"></i>
 					{{ $t("tags.merge") }}
 				</Button>
 				<Button :text="!isDeleting" severity="danger" size="small" class="border-none" @click="toggleDeleting">


### PR DESCRIPTION
I found the icons in the context menu unintuitive, so this PR changes them to something that I think makes more sense. I also changed the Rename icon in the Tags UI to match.

This is definitely a matter of opinion; feel free to reject.

## Screenshots

### Before

<img width="243" height="260" alt="before" src="https://github.com/user-attachments/assets/560082a0-d144-41dd-86b5-4eaf33c2e817" />

### After

<img width="232" height="257" alt="Screenshot 2025-08-19 at 12 39 16 PM" src="https://github.com/user-attachments/assets/98fda72d-2e15-476e-ba6e-69b29921ff1c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated context menu icons for photos and albums: Rename uses pen-to-square, Move uses folder, Merge uses diagonal arrows icon.
  * Applied icon updates consistently across single- and multi-item menus and the Tags Management Merge button.
  * Dock move button icon and hover style refreshed to match new visuals.
  * Visual-only changes; no behavior or permission impacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->