### PR TITLE
Fix rotation

### DIFF
--- a/resources/js/composables/album/photoActions.ts
+++ b/resources/js/composables/album/photoActions.ts
@@ -28,9 +28,9 @@ export function usePhotoActions(
 			return;
 		}
 
-		PhotoService.rotate(photo.value.id, "-1").then(() => {
+		PhotoService.rotate(photo.value.id, "-1", albumId.value).then(() => {
 			AlbumService.clearCache(albumId.value);
-			// load();
+			location.reload();
 		});
 	}
 
@@ -40,9 +40,9 @@ export function usePhotoActions(
 			return;
 		}
 
-		PhotoService.rotate(photo.value.id, "1").then(() => {
+		PhotoService.rotate(photo.value.id, "1", albumId.value).then(() => {
 			AlbumService.clearCache(albumId.value);
-			// load();
+			location.reload();
 		});
 	}
 

--- a/resources/js/services/photo-service.ts
+++ b/resources/js/services/photo-service.ts
@@ -57,8 +57,8 @@ const PhotoService = {
 		return axios.post(`${Constants.getApiUrl()}Photo::duplicate`, { album_id: destination_id, photo_ids: photo_ids });
 	},
 
-	rotate(photo_id: string, direction: "1" | "-1"): Promise<AxiosResponse> {
-		return axios.post(`${Constants.getApiUrl()}Photo::rotate`, { photo_id: photo_id, direction: direction });
+	rotate(photo_id: string, direction: "1" | "-1", album_id: string | null): Promise<AxiosResponse> {
+		return axios.post(`${Constants.getApiUrl()}Photo::rotate`, { photo_id: photo_id, direction: direction, from_id: album_id });
 	},
 
 	setAsCover(photo_id: string, album_id: string): Promise<AxiosResponse> {


### PR DESCRIPTION
update of the image is done via `location.reload()` which is a bit of a work around as we can't emit an reload event easily to just reload that image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Photo rotation now correctly updates within albums, preserving album context and reflecting the change in the album view.
* Improvements
  * After rotating a photo, the page refreshes automatically so the new orientation is shown immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->