### PR TITLE
Fix duplicates when group and public hidden while admin was used

### DIFF
--- a/app/Policies/AlbumQueryPolicy.php
+++ b/app/Policies/AlbumQueryPolicy.php
@@ -544,7 +544,7 @@ class AlbumQueryPolicy
 						APC::COMPUTED_ACCESS_PERMISSIONS . '.' . APC::BASE_ALBUM_ID,
 						fn ($q3) => $q3->select('acc_per.' . APC::BASE_ALBUM_ID)
 							->from('access_permissions', 'acc_per')
-							->where(APC::USER_ID, '=', $user->id)
+							->where('acc_per.' . APC::USER_ID, '=', $user->id)
 					)
 			)
 			// Then select the public permissions.
@@ -553,11 +553,11 @@ class AlbumQueryPolicy
 					->whereNotIn(
 						APC::COMPUTED_ACCESS_PERMISSIONS . '.' . APC::BASE_ALBUM_ID,
 						// Ensure that we already have not selected the user or group permissions.
-						fn ($q3) => $q3->select('acc_per.' . APC::BASE_ALBUM_ID)
-							->from('access_permissions', 'acc_per')
-							->where(APC::USER_ID, '=', $user->id)
+						fn ($q3) => $q3->select('acc_per_group.' . APC::BASE_ALBUM_ID)
+							->from('access_permissions', 'acc_per_group')
+							->where('acc_per_group.' . APC::USER_ID, '=', $user->id)
 							->orWhereIn(
-								APC::COMPUTED_ACCESS_PERMISSIONS . '.' . APC::USER_GROUP_ID,
+								'acc_per_group.' . APC::USER_GROUP_ID,
 								$user_groups
 							)
 					)

--- a/tests/Feature_v2/Album/AlbumSharingTest.php
+++ b/tests/Feature_v2/Album/AlbumSharingTest.php
@@ -263,7 +263,7 @@ class AlbumSharingTest extends BaseApiWithDataTest
 
 		$response = $this->actingAs($this->userWithGroup1)->getJson('Albums');
 
-		$ids = array_map(fn($a) => $a['id'], $response->json()['shared_albums']);
+		$ids = array_map(fn ($a) => $a['id'], $response->json()['shared_albums']);
 		$this->assertCount(5, $ids);
 		$this->assertContains($this->album1->id, $ids);
 		$this->assertContains($this->album2->id, $ids);

--- a/tests/Feature_v2/Album/AlbumSharingTest.php
+++ b/tests/Feature_v2/Album/AlbumSharingTest.php
@@ -255,4 +255,20 @@ class AlbumSharingTest extends BaseApiWithDataTest
 		$response->assertJsonCount(1, 'shared_albums');
 		$response->assertJsonPath('shared_albums.0.id', $this->album1->id);
 	}
+
+	public function testSharedViewAsAdmin(): void
+	{
+		$this->userWithGroup1->may_administrate = true;
+		$this->userWithGroup1->save();
+
+		$response = $this->actingAs($this->userWithGroup1)->getJson('Albums');
+
+		$ids = array_map(fn($a) => $a['id'], $response->json()['shared_albums']);
+		$this->assertCount(5, $ids);
+		$this->assertContains($this->album1->id, $ids);
+		$this->assertContains($this->album2->id, $ids);
+		$this->assertContains($this->album3->id, $ids);
+		$this->assertContains($this->album4->id, $ids);
+		$this->assertContains($this->album5->id, $ids);
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected permission filtering in nested queries to eliminate ambiguous references, ensuring album access is accurately computed for users and groups.
  * Fixes cases where shared albums might not appear or be incorrectly filtered, especially for users with administrative rights.

* **Tests**
  * Added coverage for viewing shared albums as an administrator, verifying that all expected shared albums are returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->