### PR TITLE
Translations update from LycheeOrg - Weblate

### DIFF
--- a/lang/de/dialogs.php
+++ b/lang/de/dialogs.php
@@ -61,7 +61,7 @@ return [
         'button_hidden' => 'Schaltfläche im Header wird ausgeblendet.',
     ],
     'login' => [
-        'auth_with' => 'Authenticate with %s',
+        'auth_with' => 'Authentifizierung mit %s',
         'username' => 'Benutzername',
         'password' => 'Passwort',
         'unknown_invalid' => 'Unbekannter Benutzer oder ungültiges Passwort.',

--- a/lang/de/gallery.php
+++ b/lang/de/gallery.php
@@ -162,8 +162,8 @@ return [
             ],
             'links' => [
                 'header' => 'Links',
-                'copy' => 'Copy',
-                'copy_success' => 'Link copied to clipboard.',
+                'copy' => 'Kopieren',
+                'copy_success' => 'Link in die Zwischenablage kopiert.',
             ],
         ],
         'edit' => [

--- a/lang/no/gallery.php
+++ b/lang/no/gallery.php
@@ -9,7 +9,7 @@ return [
     'smart_albums' => 'Smarte album',
     'pinned_albums' => 'Festede album',
     'albums' => 'Album',
-    'root' => 'Albums',
+    'root' => 'Album',
     'favourites' => 'Favoritter',
     'original' => 'Original',
     'medium' => 'Medium',

--- a/lang/no/maintenance.php
+++ b/lang/no/maintenance.php
@@ -49,7 +49,7 @@ return [
     'optimize' => [
         'title' => 'Optimaliser databasen',
         'description' => 'Hvis du merker at installasjonen er treg, kan det skyldes at databasen din ikke har all den nødvendige indeksen.',
-        'button' => 'Optimize Database',
+        'button' => 'Optimaliser databasen',
     ],
     'update' => [
         'title' => 'Oppdateringer',
@@ -70,7 +70,7 @@ return [
     ],
     'flush-cache' => [
         'title' => 'Flush Cache',
-        'description' => 'Flush the cache of every user to solve invalidation problems.',
-        'button' => 'Flush',
+        'description' => 'Tøm hurtigbufferen til alle brukere for å løse ugyldighetsproblemer.',
+        'button' => 'Tøm',
     ],
 ];

--- a/lang/no/statistics.php
+++ b/lang/no/statistics.php
@@ -38,7 +38,7 @@ return [
     ],
     'metrics' => [
         'header' => 'Live metrics',
-        'preview_text' => 'Dette er en forhåndsvisning av live-målingene som er tilgjengelige i Lychee <span class="text-primary-emphasis font-bold">SE</span>. Dataene som vises her er tilfeldig generert og gjenspeiler ikke serveren din.<span class="text-primary-emphasis font-bold">',
+        'preview_text' => 'Dette er en forhåndsvisning av live-målingene som er tilgjengelige i Lychee <span class="text-primary-emphasis font-bold">SE</span>. Dataene som vises her er tilfeldig generert og gjenspeiler ikke serveren din.',
         'a_visitor' => 'A visitor',
         'visitors' => '%d visitors',
         'visit_singular' => '%1$s viewed %2$s',

--- a/lang/no/statistics.php
+++ b/lang/no/statistics.php
@@ -38,7 +38,7 @@ return [
     ],
     'metrics' => [
         'header' => 'Live metrics',
-        'preview_text' => 'This is a preview of the live metrics available in Lychee <span class="text-primary-emphasis font-bold">SE</span>. The data shown here are randomly generated and do not reflect your server.',
+        'preview_text' => 'Dette er en forhåndsvisning av live-målingene som er tilgjengelige i Lychee <span class="text-primary-emphasis font-bold">SE</span>. Dataene som vises her er tilfeldig generert og gjenspeiler ikke serveren din.<span class="text-primary-emphasis font-bold">',
         'a_visitor' => 'A visitor',
         'visitors' => '%d visitors',
         'visit_singular' => '%1$s viewed %2$s',


### PR DESCRIPTION
Translations update from [LycheeOrg - Weblate](http://weblate.lycheeorg.dev) for [Lychee/aspect_ratio](http://weblate.lycheeorg.dev/projects/lycheeorg/aspect_ratio/).



Current translation status:

![Weblate translation status](http://weblate.lycheeorg.dev/widget/lycheeorg/aspect_ratio/horizontal-auto.svg)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Localization updates:
    - German: refined login authentication text; translated gallery link actions and confirmation message.
    - Norwegian: changed gallery root label to singular; translated maintenance actions and descriptions (optimize DB, flush cache); removed the “Live metrics” header and translated the statistics preview text.
  - Improves consistency and clarity of UI text in German and Norwegian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->