### PR TITLE
Add import from server via Web UI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,8 @@
 - Use Typescript in composition API for Vue3. Use PrimeVue for UI components.
 - Do not use await async calls in Vue3, use .then() instead.
 - Do not use const function = () => {}, use function functionName() {} instead.
+- the <template> comes first, then <script lang="ts">, then <style>.
+- axios requests should be in the services/ directory and make use of `${Constants.getApiUrl()}` to specify the base URL.
 
 # Documentation Conventions
 

--- a/app/Exceptions/InvalidOptionsException.php
+++ b/app/Exceptions/InvalidOptionsException.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Exceptions;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Indicates that the front-end provided an input that is not valid.
+ * Returns status code 422 (Unprocessable entity) to an HTTP client.
+ */
+class InvalidOptionsException extends BaseLycheeException
+{
+	public function __construct(string $msg, ?\Throwable $previous = null)
+	{
+		parent::__construct(Response::HTTP_UNPROCESSABLE_ENTITY, $msg, $previous);
+	}
+}

--- a/app/Http/Controllers/Admin/ImportFromServerController.php
+++ b/app/Http/Controllers/Admin/ImportFromServerController.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Controllers\Admin;
+
+use App\Actions\Import\Exec;
+use App\Contracts\Exceptions\ExternalLycheeException;
+use App\DTO\ImportMode;
+use App\Exceptions\EmptyFolderException;
+use App\Exceptions\InvalidDirectoryException;
+use App\Exceptions\UnexpectedException;
+use App\Http\Requests\Admin\ImportFromServerRequest;
+use App\Http\Resources\Admin\ImportDirectoryResource;
+use App\Http\Resources\Admin\ImportFromServerOptionsResource;
+use App\Http\Resources\Admin\ImportFromServerResource;
+use App\Models\Configs;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Log;
+
+class ImportFromServerController extends Controller
+{
+	public function options(): ImportFromServerOptionsResource
+	{
+		return new ImportFromServerOptionsResource();
+	}
+
+	/**
+	 * Import photos from server directory into Lychee.
+	 *
+	 * @param ImportFromServerRequest $request Request containing import parameters
+	 *
+	 * @return ImportFromServerResource
+	 *
+	 * @throws ExternalLycheeException
+	 */
+	public function __invoke(ImportFromServerRequest $request): ImportFromServerResource
+	{
+		// Configure import settings
+		$import_mode = new ImportMode(
+			delete_imported: $request->delete_imported,
+			skip_duplicates: $request->skip_duplicates,
+			import_via_symlink: $request->import_via_symlink,
+			resync_metadata: $request->resync_metadata,
+			shall_rename_photo_title: Configs::getValueAsBool('renamer_photo_title_enabled'),
+			shall_rename_album_title: Configs::getValueAsBool('renamer_album_title_enabled'),
+		);
+
+		// Create the executor with should_execute_jobs set to false to collect jobs instead of executing them directly
+		$exec = new Exec(
+			import_mode: $import_mode,
+			intended_owner_id: Configs::getValueAsInt('owner_id'),
+			delete_missing_photos: $request->delete_missing_photos,
+			delete_missing_albums: $request->delete_missing_albums,
+			is_dry_run: false,
+			should_execute_jobs: false,
+		);
+
+		$directory_results = [];
+		$all_jobs = [];
+
+		// Execute import for each directory and collect jobs
+		foreach ($request->directories as $directory) {
+			try {
+				$jobs = $exec->do($directory, $request->album());
+				$all_jobs = array_merge($all_jobs, $jobs);
+				$directory_results[] = new ImportDirectoryResource(
+					directory: $directory,
+					status: true,
+					jobs_count: count($jobs)
+				);
+			} catch (EmptyFolderException $e) {
+				$directory_results[] = new ImportDirectoryResource(
+					directory: $directory,
+					status: false,
+					message: 'Empty folder: ' . $e->getMessage()
+				);
+			} catch (InvalidDirectoryException $e) {
+				$directory_results[] = new ImportDirectoryResource(
+					directory: $directory,
+					status: false,
+					message: 'Invalid directory: ' . $e->getMessage()
+				);
+			} catch (\Exception $e) {
+				$directory_results[] = new ImportDirectoryResource(
+					directory: $directory,
+					status: false,
+					message: $e->getMessage()
+				);
+				throw new UnexpectedException($e);
+			}
+		}
+
+		// Dispatch all collected jobs at once
+		foreach ($all_jobs as $job) {
+			try {
+				dispatch($job);
+			} catch (\Throwable $e) {
+				// Fail silently if dispatched sync.
+				Log::error(__LINE__ . ':' . __FILE__ . ' ' . $e->getMessage(), $e->getTrace());
+			}
+		}
+
+		// Create the overall result resource
+		$result = new ImportFromServerResource(
+			status: true,
+			message: 'Import process completed',
+			results: $directory_results,
+			job_count: count($all_jobs)
+		);
+
+		return $result;
+	}
+}

--- a/app/Http/Controllers/Admin/ImportFromServerController.php
+++ b/app/Http/Controllers/Admin/ImportFromServerController.php
@@ -14,6 +14,7 @@ use App\DTO\ImportMode;
 use App\Exceptions\EmptyFolderException;
 use App\Exceptions\InvalidDirectoryException;
 use App\Exceptions\UnexpectedException;
+use App\Http\Requests\Admin\ImportFromServerOptionsRequest;
 use App\Http\Requests\Admin\ImportFromServerRequest;
 use App\Http\Resources\Admin\ImportDirectoryResource;
 use App\Http\Resources\Admin\ImportFromServerOptionsResource;
@@ -24,7 +25,7 @@ use Illuminate\Support\Facades\Log;
 
 class ImportFromServerController extends Controller
 {
-	public function options(): ImportFromServerOptionsResource
+	public function options(ImportFromServerOptionsRequest $request): ImportFromServerOptionsResource
 	{
 		return new ImportFromServerOptionsResource();
 	}

--- a/app/Http/Controllers/Admin/ImportFromServerController.php
+++ b/app/Http/Controllers/Admin/ImportFromServerController.php
@@ -86,7 +86,7 @@ class ImportFromServerController extends Controller
 					status: false,
 					message: 'Invalid directory: ' . $e->getMessage()
 				);
-			} catch (\Exception $e) {
+			} catch (\Throwable $e) {
 				$directory_results[] = new ImportDirectoryResource(
 					directory: $directory,
 					status: false,

--- a/app/Http/Requests/Admin/ImportFromServerBrowseRequest.php
+++ b/app/Http/Requests/Admin/ImportFromServerBrowseRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Admin;
+
+use App\Http\Requests\BaseApiRequest;
+use App\Models\Configs;
+use Illuminate\Support\Facades\Auth;
+
+class ImportFromServerBrowseRequest extends BaseApiRequest
+{
+	public string $directory;
+
+	public function authorize(): bool
+	{
+		// Only the owner of Lychee can use this functionality
+		return Auth::user() !== null && Auth::user()->id === Configs::getValueAsInt('owner_id');
+	}
+
+	/**
+	 * Get the validation rules that apply to the request.
+	 */
+	public function rules(): array
+	{
+		return [
+			'directory' => ['present', 'string'],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		$this->directory = $values['directory'] ?? '';
+	}
+}

--- a/app/Http/Requests/Admin/ImportFromServerOptionsRequest.php
+++ b/app/Http/Requests/Admin/ImportFromServerOptionsRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Admin;
+
+use App\Http\Requests\AbstractEmptyRequest;
+use App\Models\Configs;
+use Illuminate\Support\Facades\Auth;
+
+class ImportFromServerOptionsRequest extends AbstractEmptyRequest
+{
+	public function authorize(): bool
+	{
+		// Only the owner of Lychee can use this functionality
+		return Auth::user() !== null && Auth::user()->id === Configs::getValueAsInt('owner_id');
+	}
+}

--- a/app/Http/Requests/Admin/ImportFromServerRequest.php
+++ b/app/Http/Requests/Admin/ImportFromServerRequest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Admin;
+
+use App\Contracts\Http\Requests\HasAbstractAlbum;
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Http\Requests\BaseApiRequest;
+use App\Http\Requests\Traits\HasAbstractAlbumTrait;
+use App\Models\Album;
+use App\Models\Configs;
+use App\Rules\RandomIDRule;
+use Illuminate\Support\Facades\Auth;
+
+class ImportFromServerRequest extends BaseApiRequest implements HasAbstractAlbum
+{
+	use HasAbstractAlbumTrait;
+	/**
+	 * The directories to import from.
+	 *
+	 * @var string[]
+	 */
+	public array $directories;
+	public bool $delete_imported;
+	public bool $import_via_symlink;
+	public bool $skip_duplicates;
+	public bool $resync_metadata;
+	public bool $delete_missing_photos;
+	public bool $delete_missing_albums;
+
+	public function authorize(): bool
+	{
+		// Only the owner of Lychee can use this functionality
+		return Auth::user() !== null && Auth::user()->id === Configs::getValueAsInt('owner_id');
+	}
+
+	/**
+	 * Get the validation rules that apply to the request.
+	 */
+	public function rules(): array
+	{
+		return [
+			'directories' => ['required', 'array', 'min:1'],
+			'directories.*' => ['required', 'string'],
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['present', new RandomIDRule(true)],
+			'delete_imported' => ['required', 'boolean'],
+			'import_via_symlink' => ['required', 'boolean'],
+			'skip_duplicates' => ['required', 'boolean'],
+			'resync_metadata' => ['required', 'boolean'],
+			'delete_missing_photos' => ['required', 'boolean'],
+			'delete_missing_albums' => ['required', 'boolean'],
+		];
+	}
+
+	/**
+	 * Configure the validator instance.
+	 *
+	 * @param \Illuminate\Validation\Validator $validator
+	 *
+	 * @return void
+	 */
+	public function withValidator($validator): void
+	{
+		$validator->after(function ($validator): void {
+			// Check for conflicting settings
+			if ($this->import_via_symlink && $this->delete_imported) {
+				$validator->errors()->add(
+					'import_via_symlink',
+					'The settings for import via symbolic links and deletion of imported files are conflicting'
+				);
+			}
+		});
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		$this->directories = $values['directories'];
+
+		// Set the album property
+		$album_id = $values[RequestAttribute::ALBUM_ID_ATTRIBUTE] ?? null;
+		if ($album_id !== null) {
+			$this->album = Album::query()->find($album_id);
+		}
+
+		$this->delete_imported = static::toBoolean($values['delete_imported']);
+		$this->import_via_symlink = static::toBoolean($values['import_via_symlink']);
+		$this->skip_duplicates = static::toBoolean($values['skip_duplicates']);
+		$this->resync_metadata = static::toBoolean($values['resync_metadata']);
+		$this->delete_missing_photos = static::toBoolean($values['delete_missing_photos']);
+		$this->delete_missing_albums = static::toBoolean($values['delete_missing_albums']);
+	}
+}

--- a/app/Http/Requests/Admin/ImportFromServerRequest.php
+++ b/app/Http/Requests/Admin/ImportFromServerRequest.php
@@ -81,11 +81,5 @@ class ImportFromServerRequest extends BaseApiRequest implements HasAbstractAlbum
 		if ($this->import_via_symlink && $this->delete_imported) {
 			throw new InvalidOptionsException('The settings for import via symbolic links and deletion of imported files are conflicting');
 		}
-
-		foreach ($this->directories as $directory) {
-			if (!is_dir($directory)) {
-				throw new InvalidOptionsException('directory does not exists: ' . $directory);
-			}
-		}
 	}
 }

--- a/app/Http/Resources/Admin/ImportDirectoryResource.php
+++ b/app/Http/Resources/Admin/ImportDirectoryResource.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Admin;
+
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class ImportDirectoryResource extends Data
+{
+	/**
+	 * @param string      $directory  The directory path
+	 * @param bool        $status     Status of the import operation
+	 * @param string|null $message    Optional error message
+	 * @param int|null    $jobs_count Number of jobs created for this directory
+	 */
+	public function __construct(
+		public string $directory,
+		public bool $status,
+		public ?string $message = null,
+		public ?int $jobs_count = null,
+	) {
+	}
+}

--- a/app/Http/Resources/Admin/ImportFromServerOptionsResource.php
+++ b/app/Http/Resources/Admin/ImportFromServerOptionsResource.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Admin;
+
+use App\Models\Configs;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class ImportFromServerOptionsResource extends Data
+{
+	public bool $delete_imported;
+	public bool $import_via_symlink;
+	public bool $skip_duplicates;
+	public bool $resync_metadata;
+	public bool $delete_missing_photos;
+	public bool $delete_missing_albums;
+
+	/**
+	 * Creates a new resource instance.
+	 * Initializes properties with values from the configuration.
+	 */
+	public function __construct()
+	{
+		$this->delete_imported = Configs::getValueAsBool('delete_imported');
+		$this->import_via_symlink = Configs::getValueAsBool('import_via_symlink');
+		$this->skip_duplicates = Configs::getValueAsBool('skip_duplicates');
+		$this->resync_metadata = false; // Default value as this is not in config
+		$this->delete_missing_photos = Configs::getValueAsBool('sync_delete_missing_photos');
+		$this->delete_missing_albums = Configs::getValueAsBool('sync_delete_missing_albums');
+	}
+}

--- a/app/Http/Resources/Admin/ImportFromServerOptionsResource.php
+++ b/app/Http/Resources/Admin/ImportFromServerOptionsResource.php
@@ -21,6 +21,7 @@ class ImportFromServerOptionsResource extends Data
 	public bool $resync_metadata;
 	public bool $delete_missing_photos;
 	public bool $delete_missing_albums;
+	public string $directory;
 
 	/**
 	 * Creates a new resource instance.
@@ -34,5 +35,6 @@ class ImportFromServerOptionsResource extends Data
 		$this->resync_metadata = false; // Default value as this is not in config
 		$this->delete_missing_photos = Configs::getValueAsBool('sync_delete_missing_photos');
 		$this->delete_missing_albums = Configs::getValueAsBool('sync_delete_missing_albums');
+		$this->directory = base_path('');
 	}
 }

--- a/app/Http/Resources/Admin/ImportFromServerResource.php
+++ b/app/Http/Resources/Admin/ImportFromServerResource.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Admin;
+
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class ImportFromServerResource extends Data
+{
+	/**
+	 * @param bool                      $status    Overall status of the import operation
+	 * @param string                    $message   Result message
+	 * @param ImportDirectoryResource[] $results   Collection of directory import results
+	 * @param int                       $job_count Total number of jobs dispatched
+	 */
+	public function __construct(
+		public bool $status,
+		public string $message,
+		#[LiteralTypeScriptType('App.Http.Resources.Admin.ImportDirectoryResource[]')]
+		public array $results,
+		public int $job_count,
+	) {
+	}
+}

--- a/app/Http/Resources/Rights/AlbumRightsResource.php
+++ b/app/Http/Resources/Rights/AlbumRightsResource.php
@@ -12,6 +12,7 @@ use App\Contracts\Models\AbstractAlbum;
 use App\Models\Album;
 use App\Models\Configs;
 use App\Policies\AlbumPolicy;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
@@ -29,6 +30,7 @@ class AlbumRightsResource extends Data
 	public bool $can_transfer = false;
 	public bool $can_access_original = false;
 	public bool $can_pasword_protect = false;
+	public bool $can_import_from_server = false;
 
 	/**
 	 * Given an album, returns the access rights associated to it.
@@ -45,5 +47,6 @@ class AlbumRightsResource extends Data
 		$this->can_transfer = Gate::check(AlbumPolicy::CAN_TRANSFER, [AbstractAlbum::class, $abstract_album]);
 		$this->can_access_original = Gate::check(AlbumPolicy::CAN_ACCESS_FULL_PHOTO, [AbstractAlbum::class, $abstract_album]);
 		$this->can_pasword_protect = !Configs::getValueAsBool('cache_enabled');
+		$this->can_import_from_server = Auth::check() && Auth::id() === Configs::getValueAsInt('owner_id');
 	}
 }

--- a/app/Http/Resources/Rights/RootAlbumRightsResource.php
+++ b/app/Http/Resources/Rights/RootAlbumRightsResource.php
@@ -9,9 +9,11 @@
 namespace App\Http\Resources\Rights;
 
 use App\Contracts\Models\AbstractAlbum;
+use App\Models\Configs;
 use App\Models\LiveMetrics;
 use App\Policies\AlbumPolicy;
 use App\Policies\MetricsPolicy;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
@@ -22,11 +24,13 @@ class RootAlbumRightsResource extends Data
 	public bool $can_edit;
 	public bool $can_upload;
 	public bool $can_see_live_metrics;
+	public bool $can_import_from_server;
 
 	public function __construct()
 	{
 		$this->can_edit = Gate::check(AlbumPolicy::CAN_EDIT, [AbstractAlbum::class, null]);
 		$this->can_upload = Gate::check(AlbumPolicy::CAN_UPLOAD, [AbstractAlbum::class, null]);
 		$this->can_see_live_metrics = Gate::check(MetricsPolicy::CAN_SEE_LIVE, LiveMetrics::class);
+		$this->can_import_from_server = Auth::check() && Auth::id() === Configs::getValueAsInt('owner_id');
 	}
 }

--- a/app/Metadata/Cache/RouteCacheManager.php
+++ b/app/Metadata/Cache/RouteCacheManager.php
@@ -113,6 +113,7 @@ final readonly class RouteCacheManager
 			'api/v2/ChangeLogs' => false,
 
 			'api/v2/Import' => new RouteCacheConfig(tag: CacheTag::SETTINGS, user_dependant: true),
+			'api/v2/Import::browse' => false, // This will return a different result each time depending on the directory requested.
 
 			'api/v2/UserGroups' => false,
 			'api/v2/UserGroups/Users' => false,

--- a/app/Metadata/Cache/RouteCacheManager.php
+++ b/app/Metadata/Cache/RouteCacheManager.php
@@ -112,6 +112,8 @@ final readonly class RouteCacheManager
 			'api/v2/Version' => false,
 			'api/v2/ChangeLogs' => false,
 
+			'api/v2/Import' => new RouteCacheConfig(tag: CacheTag::SETTINGS, user_dependant: true),
+
 			'api/v2/UserGroups' => false,
 			'api/v2/UserGroups/Users' => false,
 

--- a/lang/ar/gallery.php
+++ b/lang/ar/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'دمج المحدد',
         'upload_photo' => 'رفع صورة',
         'import_link' => 'استيراد من الرابط',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'استيراد من Dropbox',
         'new_album' => 'ألبوم جديد',
         'new_tag_album' => 'ألبوم علامة جديدة',

--- a/lang/ar/import_from_server.php
+++ b/lang/ar/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/ar/import_from_server.php
+++ b/lang/ar/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/cz/gallery.php
+++ b/lang/cz/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Merge Selected',
         'upload_photo' => 'Upload Photo',
         'import_link' => 'Import from Link',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Import from Dropbox',
         'new_album' => 'New Album',
         'new_tag_album' => 'New Tag Album',

--- a/lang/cz/import_from_server.php
+++ b/lang/cz/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/cz/import_from_server.php
+++ b/lang/cz/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/de/gallery.php
+++ b/lang/de/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Ausgewähltes zusammenführen',
         'upload_photo' => 'Foto hochladen',
         'import_link' => 'Von Link importieren',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Importieren aus der Dropbox',
         'new_album' => 'Neues Album',
         'new_tag_album' => 'Neues Tag Album',

--- a/lang/de/import_from_server.php
+++ b/lang/de/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/de/import_from_server.php
+++ b/lang/de/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/el/gallery.php
+++ b/lang/el/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Merge Selected',
         'upload_photo' => 'Upload Photo',
         'import_link' => 'Import from Link',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Import from Dropbox',
         'new_album' => 'New Album',
         'new_tag_album' => 'New Tag Album',

--- a/lang/el/import_from_server.php
+++ b/lang/el/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/el/import_from_server.php
+++ b/lang/el/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/en/gallery.php
+++ b/lang/en/gallery.php
@@ -228,6 +228,7 @@ return [
 
 		'upload_photo' => 'Upload Photo',
 		'import_link' => 'Import from Link',
+		'import_server' => 'Import from Server',
 		'import_dropbox' => 'Import from Dropbox',
 		'new_album' => 'New Album',
 		'new_tag_album' => 'New Tag Album',

--- a/lang/en/import_from_server.php
+++ b/lang/en/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/en/import_from_server.php
+++ b/lang/en/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/es/gallery.php
+++ b/lang/es/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Fusionar seleccionados',
         'upload_photo' => 'Subir foto',
         'import_link' => 'Importar desde el enlace',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Importar desde Dropbox',
         'new_album' => 'Nuevo álbum',
         'new_tag_album' => 'Nuevo álbum de Tag',

--- a/lang/es/import_from_server.php
+++ b/lang/es/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/es/import_from_server.php
+++ b/lang/es/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/fa/gallery.php
+++ b/lang/fa/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'ادغام انتخاب شده‌ها',
         'upload_photo' => 'بارگذاری عکس',
         'import_link' => 'وارد کردن از لینک',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'وارد کردن از Dropbox',
         'new_album' => 'آلبوم جدید',
         'new_tag_album' => 'آلبوم برچسب جدید',

--- a/lang/fa/import_from_server.php
+++ b/lang/fa/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/fa/import_from_server.php
+++ b/lang/fa/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/fr/gallery.php
+++ b/lang/fr/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Fusionner la sélection',
         'upload_photo' => 'Téléverser une photo',
         'import_link' => 'Importer via un lien',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Importer depuis Dropbox',
         'new_album' => 'Nouvel album',
         'new_tag_album' => 'Nouvel album par étiquette',

--- a/lang/fr/import_from_server.php
+++ b/lang/fr/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/fr/import_from_server.php
+++ b/lang/fr/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/hu/gallery.php
+++ b/lang/hu/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Merge Selected',
         'upload_photo' => 'Upload Photo',
         'import_link' => 'Import from Link',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Import from Dropbox',
         'new_album' => 'New Album',
         'new_tag_album' => 'New Tag Album',

--- a/lang/hu/import_from_server.php
+++ b/lang/hu/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/hu/import_from_server.php
+++ b/lang/hu/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/it/gallery.php
+++ b/lang/it/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Merge Selected',
         'upload_photo' => 'Upload Photo',
         'import_link' => 'Import from Link',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Import from Dropbox',
         'new_album' => 'New Album',
         'new_tag_album' => 'New Tag Album',

--- a/lang/it/import_from_server.php
+++ b/lang/it/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/it/import_from_server.php
+++ b/lang/it/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/ja/gallery.php
+++ b/lang/ja/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Merge Selected',
         'upload_photo' => 'Upload Photo',
         'import_link' => 'Import from Link',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Import from Dropbox',
         'new_album' => 'New Album',
         'new_tag_album' => 'New Tag Album',

--- a/lang/ja/import_from_server.php
+++ b/lang/ja/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/ja/import_from_server.php
+++ b/lang/ja/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/nl/gallery.php
+++ b/lang/nl/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Alles samenvoegen',
         'upload_photo' => 'Foto uploaden',
         'import_link' => 'Importeer van link',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Importeer van Dropbox',
         'new_album' => 'Nieuw album',
         'new_tag_album' => 'Nieuw tag-album',

--- a/lang/nl/import_from_server.php
+++ b/lang/nl/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/nl/import_from_server.php
+++ b/lang/nl/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/no/gallery.php
+++ b/lang/no/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Merge Selected',
         'upload_photo' => 'Upload Photo',
         'import_link' => 'Import from Link',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Import from Dropbox',
         'new_album' => 'New Album',
         'new_tag_album' => 'New Tag Album',

--- a/lang/no/import_from_server.php
+++ b/lang/no/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/no/import_from_server.php
+++ b/lang/no/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/pl/gallery.php
+++ b/lang/pl/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Scal wybrane',
         'upload_photo' => 'Prześlij zdjęcie',
         'import_link' => 'Import z łącza',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Import z Dropbox',
         'new_album' => 'Nowy album',
         'new_tag_album' => 'Nowy album z tagami',

--- a/lang/pl/import_from_server.php
+++ b/lang/pl/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/pl/import_from_server.php
+++ b/lang/pl/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/pt/gallery.php
+++ b/lang/pt/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Merge Selected',
         'upload_photo' => 'Upload Photo',
         'import_link' => 'Import from Link',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Import from Dropbox',
         'new_album' => 'New Album',
         'new_tag_album' => 'New Tag Album',

--- a/lang/pt/import_from_server.php
+++ b/lang/pt/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/pt/import_from_server.php
+++ b/lang/pt/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/ru/gallery.php
+++ b/lang/ru/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Объединить выбранные',
         'upload_photo' => 'Загрузить фото',
         'import_link' => 'Импортировать по ссылке',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Импортировать из Dropbox',
         'new_album' => 'Новый альбом',
         'new_tag_album' => 'Новый альбом с тегами',

--- a/lang/ru/import_from_server.php
+++ b/lang/ru/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/ru/import_from_server.php
+++ b/lang/ru/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/sk/gallery.php
+++ b/lang/sk/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Merge Selected',
         'upload_photo' => 'Upload Photo',
         'import_link' => 'Import from Link',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Import from Dropbox',
         'new_album' => 'New Album',
         'new_tag_album' => 'New Tag Album',

--- a/lang/sk/import_from_server.php
+++ b/lang/sk/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/sk/import_from_server.php
+++ b/lang/sk/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/sv/gallery.php
+++ b/lang/sv/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Merge Selected',
         'upload_photo' => 'Upload Photo',
         'import_link' => 'Import from Link',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Import from Dropbox',
         'new_album' => 'New Album',
         'new_tag_album' => 'New Tag Album',

--- a/lang/sv/import_from_server.php
+++ b/lang/sv/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/sv/import_from_server.php
+++ b/lang/sv/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/vi/gallery.php
+++ b/lang/vi/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Merge Selected',
         'upload_photo' => 'Upload Photo',
         'import_link' => 'Import from Link',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Import from Dropbox',
         'new_album' => 'New Album',
         'new_tag_album' => 'New Tag Album',

--- a/lang/vi/import_from_server.php
+++ b/lang/vi/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/vi/import_from_server.php
+++ b/lang/vi/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/zh_CN/gallery.php
+++ b/lang/zh_CN/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => '合并所选',
         'upload_photo' => '上传照片',
         'import_link' => '从链接导入',
+		'import_server' => 'Import from Server',
         'import_dropbox' => '从 Dropbox 导入',
         'new_album' => '新建相册',
         'new_tag_album' => '新建标签相册',

--- a/lang/zh_CN/import_from_server.php
+++ b/lang/zh_CN/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/zh_CN/import_from_server.php
+++ b/lang/zh_CN/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/lang/zh_TW/gallery.php
+++ b/lang/zh_TW/gallery.php
@@ -207,6 +207,7 @@ return [
         'merge_all' => 'Merge Selected',
         'upload_photo' => 'Upload Photo',
         'import_link' => 'Import from Link',
+		'import_server' => 'Import from Server',
         'import_dropbox' => 'Import from Dropbox',
         'new_album' => 'New Album',
         'new_tag_album' => 'New Tag Album',

--- a/lang/zh_TW/import_from_server.php
+++ b/lang/zh_TW/import_from_server.php
@@ -17,5 +17,6 @@ return [
 	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
 	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
 	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+	'importing_please_be_patient' => 'Importing, please be patient...',
 ];
 

--- a/lang/zh_TW/import_from_server.php
+++ b/lang/zh_TW/import_from_server.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Import from Server
+	|--------------------------------------------------------------------------
+	*/
+	'title' => 'Synchronize your server files',
+	'description' => 'Synchronize your server files with Lychee. This will import photos from a directory and all children directories. This process is very slow and we recommend using workers and queues in order to avoid timeout.',
+	'sync' => 'Synchronize',
+	'loading' => 'Loading...',
+	'selected_directory' => 'Current selected directory:',
+	'resync_metadata' => "Re-sync metadata of existing files.",
+	'delete_imported' => "Delete the original files.",
+	'import_via_symlink' => "Import photos via symlink instead of copying the files.",
+	'skip_duplicates' => "Skip photos and albums if they already exist in the gallery.",
+	'delete_missing_photos' => "Delete photos in the album that are not present in the synced directory.",
+	'delete_missing_albums' => "Delete albums in the parent album that are not present in the synced directory.",
+];
+

--- a/resources/js/components/headers/AlbumHeader.vue
+++ b/resources/js/components/headers/AlbumHeader.vue
@@ -1,6 +1,4 @@
 <template>
-	<ImportFromLink v-if="canUpload" v-model:visible="is_import_from_link_open" @refresh="emits('refresh')" />
-	<DropBox v-if="canUpload" v-model:visible="is_import_from_dropbox_open" :album-id="props.album.id" />
 	<Toolbar
 		v-if="album"
 		class="w-full border-0 transition-all duration-100 ease-in-out"
@@ -63,19 +61,17 @@
 <script setup lang="ts">
 import Button from "primevue/button";
 import Toolbar from "primevue/toolbar";
-import { computed } from "vue";
 import ContextMenu from "primevue/contextmenu";
-import ImportFromLink from "@/components/modals/ImportFromLink.vue";
 import { useContextMenuAlbumAdd } from "@/composables/contextMenus/contextMenuAlbumAdd";
 import Divider from "primevue/divider";
 import { useGalleryModals } from "@/composables/modalsTriggers/galleryModals";
 import { useLycheeStateStore } from "@/stores/LycheeState";
 import { storeToRefs } from "pinia";
 import AlbumService from "@/services/album-service";
-import DropBox from "@/components/modals/DropBox.vue";
 import { useTogglablesStateStore } from "@/stores/ModalsState";
 import { useFavouriteStore } from "@/stores/FavouriteState";
 import GoBack from "./GoBack.vue";
+import { computed } from "vue";
 
 const props = defineProps<{
 	config: App.Http.Resources.GalleryConfigs.AlbumConfig;
@@ -91,8 +87,7 @@ const favourites = useFavouriteStore();
 const { dropbox_api_key, is_favourite_enabled } = storeToRefs(lycheeStore);
 const { is_album_edit_open, is_full_screen } = storeToRefs(togglableStore);
 
-const { toggleCreateAlbum, is_import_from_link_open, toggleImportFromLink, is_import_from_dropbox_open, toggleImportFromDropbox, toggleUpload } =
-	useGalleryModals(togglableStore);
+const { toggleCreateAlbum, toggleImportFromLink, toggleImportFromDropbox, toggleUpload, toggleImportFromServer } = useGalleryModals(togglableStore);
 
 const emits = defineEmits<{
 	refresh: [];
@@ -117,6 +112,8 @@ function deleteTrack() {
 	AlbumService.deleteTrack(props.album.id);
 }
 
+const is_owner = computed(() => props.album.rights.can_import_from_server);
+
 const { addmenu, addMenu, openAddMenu } = useContextMenuAlbumAdd(
 	props.album,
 	props.config,
@@ -127,9 +124,9 @@ const { addmenu, addMenu, openAddMenu } = useContextMenuAlbumAdd(
 		toggleUploadTrack,
 		deleteTrack,
 		toggleImportFromDropbox,
+		toggleImportFromServer,
 	},
 	dropbox_api_key,
+	is_owner,
 );
-
-const canUpload = computed(() => props.user.id !== null && props.album.rights.can_upload === true);
 </script>

--- a/resources/js/components/headers/AlbumsHeader.vue
+++ b/resources/js/components/headers/AlbumsHeader.vue
@@ -1,6 +1,4 @@
 <template>
-	<ImportFromLink v-if="canUpload" v-model:visible="is_import_from_link_open" />
-	<DropBox v-if="canUpload" v-model:visible="is_import_from_dropbox_open" :album-id="null" />
 	<Toolbar
 		:class="{
 			'bg-transparent': props.config.is_header_bar_transparent,
@@ -120,7 +118,6 @@ import SpeedDial from "primevue/speeddial";
 import Toolbar from "primevue/toolbar";
 import ContextMenu from "primevue/contextmenu";
 import Divider from "primevue/divider";
-import ImportFromLink from "@/components/modals/ImportFromLink.vue";
 import { computed, ComputedRef } from "vue";
 import { onKeyStroke } from "@vueuse/core";
 import { useLycheeStateStore } from "@/stores/LycheeState";
@@ -130,7 +127,6 @@ import { useRouter } from "vue-router";
 import { useTogglablesStateStore } from "@/stores/ModalsState";
 import { useContextMenuAlbumsAdd } from "@/composables/contextMenus/contextMenuAlbumsAdd";
 import { useGalleryModals } from "@/composables/modalsTriggers/galleryModals";
-import DropBox from "@/components/modals/DropBox.vue";
 import BackLinkButton from "./BackLinkButton.vue";
 import OpenLeftMenu from "./OpenLeftMenu.vue";
 import { useFavouriteStore } from "@/stores/FavouriteState";
@@ -168,15 +164,10 @@ const { is_login_open, is_upload_visible, is_create_album_visible, is_create_tag
 
 const router = useRouter();
 
-const {
-	toggleCreateAlbum,
-	toggleCreateTagAlbum,
-	is_import_from_link_open,
-	toggleImportFromLink,
-	is_import_from_dropbox_open,
-	toggleImportFromDropbox,
-	toggleUpload,
-} = useGalleryModals(togglableStore);
+const { toggleCreateAlbum, toggleCreateTagAlbum, toggleImportFromLink, toggleImportFromDropbox, toggleUpload, toggleImportFromServer } =
+	useGalleryModals(togglableStore);
+
+const is_owner = computed(() => props.rights.can_import_from_server);
 
 const { addmenu, addMenu } = useContextMenuAlbumsAdd(
 	{
@@ -185,11 +176,11 @@ const { addmenu, addMenu } = useContextMenuAlbumsAdd(
 		toggleImportFromLink: toggleImportFromLink,
 		toggleImportFromDropbox: toggleImportFromDropbox,
 		toggleCreateTagAlbum: toggleCreateTagAlbum,
+		toggleImportFromServer: toggleImportFromServer,
 	},
 	dropbox_api_key,
+	is_owner,
 );
-
-const canUpload = computed(() => props.user.id !== null);
 
 function openAddMenu(event: Event) {
 	addmenu.value.show(event);
@@ -211,7 +202,7 @@ onKeyStroke("/", () => !shouldIgnoreKeystroke() && props.config.is_search_access
 // 1. lose focus
 // 2. close modals
 // 3. go back
-onKeyStroke("escape", () => {
+onKeyStroke("Escape", () => {
 	// 1. lose focus
 	if (document.activeElement instanceof HTMLElement) {
 		document.activeElement.blur();

--- a/resources/js/components/headers/TimelineHeader.vue
+++ b/resources/js/components/headers/TimelineHeader.vue
@@ -1,6 +1,7 @@
 <template>
-	<ImportFromLink v-if="canUpload" v-model:visible="is_import_from_link_open" :parent-id="null" />
-	<DropBox v-if="canUpload" v-model:visible="is_import_from_dropbox_open" :album-id="null" />
+	<ImportFromLink v-if="props.rights.can_upload" v-model:visible="is_import_from_link_open" />
+	<ImportFromServer v-if="props.rights.can_import_from_server" v-model:visible="is_import_from_server_open" />
+	<DropBox v-if="props.rights.can_upload" v-model:visible="is_import_from_dropbox_open" />
 	<Toolbar
 		class="w-full border-0 h-14 z-10 rounded-none"
 		:pt:root:class="'flex-nowrap relative'"
@@ -117,6 +118,7 @@ import BackLinkButton from "./BackLinkButton.vue";
 import OpenLeftMenu from "./OpenLeftMenu.vue";
 import { useFavouriteStore } from "@/stores/FavouriteState";
 import { useLeftMenuStateStore } from "@/stores/LeftMenuState";
+import ImportFromServer from "@/components/modals/ImportFromServer.vue";
 
 const props = defineProps<{
 	user: App.Http.Resources.Models.UserResource;
@@ -153,10 +155,13 @@ const {
 	is_import_from_link_open,
 	toggleImportFromLink,
 	is_import_from_dropbox_open,
+	toggleImportFromServer,
+	is_import_from_server_open,
 	toggleImportFromDropbox,
 	toggleUpload,
 } = useGalleryModals(togglableStore);
 
+const is_owner = computed(() => props.rights.can_import_from_server);
 const { addmenu, addMenu } = useContextMenuAlbumsAdd(
 	{
 		toggleUpload: toggleUpload,
@@ -164,11 +169,11 @@ const { addmenu, addMenu } = useContextMenuAlbumsAdd(
 		toggleImportFromLink: toggleImportFromLink,
 		toggleImportFromDropbox: toggleImportFromDropbox,
 		toggleCreateTagAlbum: toggleCreateTagAlbum,
+		toggleImportFromServer: toggleImportFromServer,
 	},
 	dropbox_api_key,
+	is_owner,
 );
-
-const canUpload = computed(() => props.user.id !== null);
 
 function openAddMenu(event: Event) {
 	addmenu.value.show(event);

--- a/resources/js/components/modals/DropBox.vue
+++ b/resources/js/components/modals/DropBox.vue
@@ -23,12 +23,16 @@ import PhotoService from "@/services/photo-service";
 import DropBoxChooser from "@/components/forms/upload/DropBoxChooser.vue";
 import { useLycheeStateStore } from "@/stores/LycheeState";
 import { storeToRefs } from "pinia";
+import { useRouter } from "vue-router";
+import { usePhotoRoute } from "@/composables/photo/photoRoute";
 
 const visible = defineModel("visible", { default: false }) as Ref<boolean>;
-const props = defineProps<{ albumId: string | null }>();
 const emits = defineEmits<{
 	refresh: [];
 }>();
+
+const router = useRouter();
+const { getParentId } = usePhotoRoute(router);
 
 const lycheeStore = useLycheeStateStore();
 const { dropbox_api_key } = storeToRefs(lycheeStore);
@@ -36,7 +40,7 @@ const { dropbox_api_key } = storeToRefs(lycheeStore);
 function action(files: Dropbox.ChooserFile[]) {
 	PhotoService.importFromUrl(
 		files.map((file) => file.link),
-		props.albumId,
+		getParentId() ?? null,
 	).then(() => {
 		visible.value = false;
 		emits("refresh");

--- a/resources/js/components/modals/ImportFromServer.vue
+++ b/resources/js/components/modals/ImportFromServer.vue
@@ -1,0 +1,208 @@
+<template>
+	<Dialog v-model:visible="visible" modal :dismissable-mask="true" pt:root:class="border-none" @hide="closeCallback">
+		<template #container="{ closeCallback }">
+			<div class="flex flex-col gap-4 bg-gradient-to-b from-bg-300 to-bg-400 relative max-w-2xl w-full rounded-md text-muted-color">
+				<div class="p-9 flex flex-col" v-if="options">
+					<h2 class="text-muted-color-emphasis font-bold text-lg mb-2">{{ $t("import_from_server.title") }}</h2>
+					<p class="mb-5 text-base">
+						{{ $t("import_from_server.description") }}
+					</p>
+					<div class="mb-2">
+						<span class="text-muted-color-emphasis">{{ $t("import_from_server.selected_directory") }}</span>
+						<pre class="text-sm font-mono w-full overflow-clip">{{ directory }}</pre>
+					</div>
+					<div class="flex flex-col text-xs max-h-48 overflow-y-scroll">
+						<div
+							v-for="dir in directories"
+							@click="onBrowse(dir)"
+							:key="`${directory}/${dir}`"
+							class="cursor-pointer hover:bg-primary-500/10 p-0.5 bg-surface-900/25 dark:border-t-surface-700/50 border-t first:border-none font-mono"
+						>
+							{{ dir }}
+						</div>
+					</div>
+					<div class="flex flex-col gap-2 mt-4">
+						<form>
+							<div class="flex items-center gap-2">
+								<ToggleSwitch
+									inputId="delete_imported"
+									v-model="options.delete_imported"
+									class="cursor-pointer"
+									:style="danger_style"
+								/>
+								<span v-if="options.delete_imported" class="pi pi-exclamation-triangle text-danger-600 text-xs"></span>
+								<label for="delete_imported" class="cursor-pointer text-sm">{{ $t("import_from_server.delete_imported") }}</label>
+							</div>
+							<div class="flex items-center gap-2">
+								<ToggleSwitch inputId="import_via_symlink" v-model="options.import_via_symlink" class="cursor-pointer" />
+								<label for="import_via_symlink" class="cursor-pointer text-sm">{{
+									$t("import_from_server.import_via_symlink")
+								}}</label>
+							</div>
+							<div class="flex items-center gap-2">
+								<ToggleSwitch inputId="skip_duplicates" v-model="options.skip_duplicates" class="cursor-pointer" />
+								<label for="skip_duplicates" class="cursor-pointer text-sm">{{ $t("import_from_server.skip_duplicates") }}</label>
+							</div>
+							<div class="flex items-center gap-2">
+								<ToggleSwitch inputId="resync_metadata" v-model="options.resync_metadata" class="cursor-pointer" />
+								<label for="resync_metadata" class="cursor-pointer text-sm">{{ $t("import_from_server.resync_metadata") }}</label>
+							</div>
+							<div class="flex items-center gap-2">
+								<ToggleSwitch
+									inputId="delete_missing_photos"
+									v-model="options.delete_missing_photos"
+									class="cursor-pointer"
+									:style="warning_style"
+								/>
+								<span v-if="options.delete_missing_photos" class="pi pi-exclamation-triangle text-orange-600 text-xs"></span>
+								<label for="delete_missing_photos" class="cursor-pointer text-sm">{{
+									$t("import_from_server.delete_missing_photos")
+								}}</label>
+							</div>
+							<div class="flex items-center gap-2">
+								<ToggleSwitch
+									inputId="delete_missing_albums"
+									v-model="options.delete_missing_albums"
+									class="cursor-pointer"
+									:style="warning_style"
+								/>
+								<span v-if="options.delete_missing_albums" class="pi pi-exclamation-triangle text-orange-600 text-xs"></span>
+								<label for="delete_missing_albums" class="cursor-pointer text-sm">{{
+									$t("import_from_server.delete_missing_albums")
+								}}</label>
+							</div>
+						</form>
+					</div>
+				</div>
+				<div v-else class="p-9">
+					{{ $t("import_from_server.loading") }}
+				</div>
+				<div class="flex justify-center">
+					<Button
+						severity="secondary"
+						class="w-full font-bold border-none rounded-none ltr:rounded-bl-xl rtl:rounded-br-xl"
+						@click="closeCallback"
+					>
+						{{ $t("dialogs.button.cancel") }}
+					</Button>
+					<Button severity="contrast" class="w-full font-bold border-none rounded-none ltr:rounded-br-xl rtl:rounded-bl-xl" @click="submit">
+						{{ $t("import_from_server.sync") }}
+					</Button>
+				</div>
+			</div>
+		</template>
+	</Dialog>
+</template>
+<script setup lang="ts">
+import { useRouter } from "vue-router";
+import { usePhotoRoute } from "@/composables/photo/photoRoute";
+import { onMounted, Ref, ref } from "vue";
+import ImportService, { ImportFromServerRequest } from "@/services/import-service";
+import AlbumService from "@/services/album-service";
+import Dialog from "primevue/dialog";
+import Button from "primevue/button";
+import { useToast } from "primevue/usetoast";
+import ToggleSwitch from "primevue/toggleswitch";
+
+const visible = defineModel("visible", { default: false }) as Ref<boolean>;
+const emits = defineEmits<{ refresh: [] }>();
+const toast = useToast();
+
+const router = useRouter();
+const { getParentId } = usePhotoRoute(router);
+
+const options = ref<App.Http.Resources.Admin.ImportFromServerOptionsResource | undefined>(undefined);
+const directory = ref<string>("");
+
+const directories = ref<string[]>([]);
+
+// We saved previously browsed directories to avoid reloading them
+const browsed = ref<Map<string, string[]>>(new Map<string, string[]>());
+
+function load() {
+	return ImportService.getOptions().then((response) => {
+		options.value = response.data;
+		directory.value = response.data.directory;
+	});
+}
+
+function browse(dir: string) {
+	if (browsed.value.has(dir)) {
+		// We have validated that the key exists, so the cast as is safe
+		directories.value = browsed.value.get(dir) as string[];
+		console.log("Using cached browse for", dir, directories.value);
+		return;
+	}
+
+	ImportService.browse(dir).then((response) => {
+		directories.value = response.data;
+		browsed.value.set(dir, response.data);
+	});
+}
+
+function onBrowse(dir: string) {
+	// Clear current directories immediately to avoid confusion
+	if (dir === "..") {
+		const parts = directory.value.split("/");
+		parts.pop();
+		directory.value = parts.join("/");
+		directory.value = normalize(directory.value);
+		console.log("cd .. to", directory.value);
+	} else {
+		directory.value = normalize(directory.value);
+		directory.value = directory.value + "/" + dir;
+	}
+	browse(directory.value);
+}
+
+function normalize(path: string): string {
+	if (path === "") {
+		return "/";
+	}
+	if (path === "/") {
+		return "";
+	}
+	return path;
+}
+
+function submit() {
+	if (!options.value) {
+		return;
+	}
+
+	const payload: ImportFromServerRequest = {
+		album_id: getParentId() ?? null,
+		directories: [directory.value],
+		delete_imported: options.value.delete_imported,
+		import_via_symlink: options.value.import_via_symlink,
+		skip_duplicates: options.value.skip_duplicates,
+		resync_metadata: options.value.resync_metadata,
+		delete_missing_photos: options.value.delete_missing_photos,
+		delete_missing_albums: options.value.delete_missing_albums,
+	};
+
+	ImportService.importFromServer(payload).then(() => {
+		directory.value = "";
+		visible.value = false;
+		toast.add({ severity: "success", summary: "Success", detail: "Import started successfully", life: 3000 });
+		// Clear cache for the parent album to ensure the new photos are displayed
+		AlbumService.clearCache();
+		emits("refresh");
+	});
+}
+
+function closeCallback() {
+	visible.value = false;
+}
+
+onMounted(() => {
+	load().then(() => {
+		browse(directory.value);
+	});
+});
+
+const danger_style =
+	"--p-toggleswitch-checked-background: var(--p-red-800);--p-toggleswitch-checked-hover-background: var(--p-red-900);--p-toggleswitch-hover-background: var(--p-red-900);";
+const warning_style =
+	"--p-toggleswitch-checked-background: var(--p-orange-700);--p-toggleswitch-checked-hover-background: var(--p-orange-800);--p-toggleswitch-hover-background: var(--p-orange-800);";
+</script>

--- a/resources/js/composables/contextMenus/contextMenuAlbumAdd.ts
+++ b/resources/js/composables/contextMenus/contextMenuAlbumAdd.ts
@@ -19,6 +19,7 @@ type Callbacks = {
 	toggleUploadTrack: () => void;
 	deleteTrack: () => void;
 	toggleImportFromDropbox: () => void;
+	toggleImportFromServer: () => void;
 };
 
 export function useContextMenuAlbumAdd(
@@ -29,6 +30,7 @@ export function useContextMenuAlbumAdd(
 	config: App.Http.Resources.GalleryConfigs.AlbumConfig,
 	callbacks: Callbacks,
 	dropbox_api_key: Ref<string>,
+	is_owner: Ref<boolean>,
 ) {
 	const addmenu = ref(); // ! Reference to the context menu
 	const addMenu = computed(function () {
@@ -51,6 +53,12 @@ export function useContextMenuAlbumAdd(
 				icon: "pi pi-box",
 				callback: callbacks.toggleImportFromDropbox,
 				if: dropbox_api_key.value !== "disabled",
+			},
+			{
+				label: "gallery.menus.import_server",
+				icon: "pi pi-server",
+				callback: callbacks.toggleImportFromServer,
+				if: is_owner.value === true && config.is_model_album,
 			},
 			{
 				is_divider: true,

--- a/resources/js/composables/contextMenus/contextMenuAlbumsAdd.ts
+++ b/resources/js/composables/contextMenus/contextMenuAlbumsAdd.ts
@@ -6,9 +6,10 @@ type Callbacks = {
 	toggleCreateAlbum: () => void;
 	toggleCreateTagAlbum: () => void;
 	toggleImportFromDropbox: () => void;
+	toggleImportFromServer: () => void;
 };
 
-export function useContextMenuAlbumsAdd(callbacks: Callbacks, dropbox_api_key: Ref<string>) {
+export function useContextMenuAlbumsAdd(callbacks: Callbacks, dropbox_api_key: Ref<string>, is_owner: Ref<boolean>) {
 	const addmenu = ref(); // ! Reference to the context menu
 	const addMenu = ref(
 		[
@@ -30,6 +31,12 @@ export function useContextMenuAlbumsAdd(callbacks: Callbacks, dropbox_api_key: R
 				icon: "pi pi-box",
 				callback: callbacks.toggleImportFromDropbox,
 				if: dropbox_api_key.value !== "disabled",
+			},
+			{
+				label: "gallery.menus.import_server",
+				icon: "pi pi-server",
+				callback: callbacks.toggleImportFromServer,
+				if: is_owner.value === true,
 			},
 			{
 				is_divider: true,

--- a/resources/js/composables/modalsTriggers/galleryModals.ts
+++ b/resources/js/composables/modalsTriggers/galleryModals.ts
@@ -1,9 +1,10 @@
 import { TogglablesStateStore } from "@/stores/ModalsState";
 import { storeToRefs } from "pinia";
-import { ref } from "vue";
 
 export function useGalleryModals(togglableStore: TogglablesStateStore) {
 	const {
+		is_create_album_visible,
+		is_create_tag_album_visible,
 		is_upload_visible,
 		is_rename_visible,
 		is_move_visible,
@@ -13,14 +14,16 @@ export function useGalleryModals(togglableStore: TogglablesStateStore) {
 		is_import_from_link_open,
 		is_tag_visible,
 		is_copy_visible,
+		is_import_from_dropbox_open,
+		is_import_from_server_open,
 	} = storeToRefs(togglableStore);
 
 	function toggleCreateAlbum() {
-		togglableStore.is_create_album_visible = !togglableStore.is_create_album_visible;
+		is_create_album_visible.value = !is_create_album_visible.value;
 	}
 
 	function toggleCreateTagAlbum() {
-		togglableStore.is_create_tag_album_visible = !togglableStore.is_create_tag_album_visible;
+		is_create_tag_album_visible.value = !is_create_tag_album_visible.value;
 	}
 
 	function toggleRename() {
@@ -47,10 +50,12 @@ export function useGalleryModals(togglableStore: TogglablesStateStore) {
 		is_import_from_link_open.value = !is_import_from_link_open.value;
 	}
 
-	const is_import_from_dropbox_open = ref(false);
-
 	function toggleImportFromDropbox() {
 		is_import_from_dropbox_open.value = !is_import_from_dropbox_open.value;
+	}
+
+	function toggleImportFromServer() {
+		is_import_from_server_open.value = !is_import_from_server_open.value;
 	}
 
 	function toggleUpload() {
@@ -66,7 +71,9 @@ export function useGalleryModals(togglableStore: TogglablesStateStore) {
 	}
 
 	return {
+		is_create_album_visible,
 		toggleCreateAlbum,
+		is_create_tag_album_visible,
 		toggleCreateTagAlbum,
 		is_delete_visible,
 		toggleDelete,
@@ -82,6 +89,9 @@ export function useGalleryModals(togglableStore: TogglablesStateStore) {
 		toggleImportFromLink,
 		is_import_from_dropbox_open,
 		toggleImportFromDropbox,
+		is_import_from_server_open,
+		toggleImportFromServer,
+		is_upload_visible,
 		toggleUpload,
 		is_tag_visible,
 		toggleTag,

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -113,6 +113,20 @@ declare namespace App.Enum {
 	export type VersionChannelType = "release" | "git" | "tag";
 	export type WatermarkPosition = "top-left" | "top" | "top-right" | "left" | "center" | "right" | "bottom-left" | "bottom" | "bottom-right";
 }
+declare namespace App.Http.Resources.Admin {
+	export type ImportDirectoryResource = {
+		directory: string;
+		status: boolean;
+		message: string | null;
+		jobs_count: number | null;
+	};
+	export type ImportFromServerResource = {
+		status: boolean;
+		message: string;
+		results: any;
+		job_count: number;
+	};
+}
 declare namespace App.Http.Resources.Collections {
 	export type PositionDataResource = {
 		id: string | null;

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -120,10 +120,18 @@ declare namespace App.Http.Resources.Admin {
 		message: string | null;
 		jobs_count: number | null;
 	};
+	export type ImportFromServerOptionsResource = {
+		delete_imported: boolean;
+		import_via_symlink: boolean;
+		skip_duplicates: boolean;
+		resync_metadata: boolean;
+		delete_missing_photos: boolean;
+		delete_missing_albums: boolean;
+	};
 	export type ImportFromServerResource = {
 		status: boolean;
 		message: string;
-		results: any;
+		results: App.Http.Resources.Admin.ImportDirectoryResource[];
 		job_count: number;
 	};
 }
@@ -750,6 +758,7 @@ declare namespace App.Http.Resources.Rights {
 		can_transfer: boolean;
 		can_access_original: boolean;
 		can_pasword_protect: boolean;
+		can_import_from_server: boolean;
 	};
 	export type GlobalRightsResource = {
 		root_album: App.Http.Resources.Rights.RootAlbumRightsResource;
@@ -775,6 +784,7 @@ declare namespace App.Http.Resources.Rights {
 		can_edit: boolean;
 		can_upload: boolean;
 		can_see_live_metrics: boolean;
+		can_import_from_server: boolean;
 	};
 	export type SettingsRightsResource = {
 		can_edit: boolean;

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -127,6 +127,7 @@ declare namespace App.Http.Resources.Admin {
 		resync_metadata: boolean;
 		delete_missing_photos: boolean;
 		delete_missing_albums: boolean;
+		directory: string;
 	};
 	export type ImportFromServerResource = {
 		status: boolean;

--- a/resources/js/services/import-service.ts
+++ b/resources/js/services/import-service.ts
@@ -1,0 +1,41 @@
+import axios, { AxiosResponse } from "axios";
+import Constants from "./constants";
+
+export type ImportFromServerRequest = {
+	directories: string[];
+	album_id: string | null;
+	delete_imported: boolean;
+	import_via_symlink: boolean;
+	skip_duplicates: boolean;
+	resync_metadata: boolean;
+	delete_missing_photos: boolean;
+	delete_missing_albums: boolean;
+};
+
+/**
+ * Service for handling server import related operations
+ */
+const ImportService = {
+	/**
+	 * Get import from server options
+	 * @returns Promise with import options
+	 */
+	getOptions(): Promise<AxiosResponse<App.Http.Resources.Admin.ImportFromServerOptionsResource>> {
+		return axios.get(`${Constants.getApiUrl()}Import`, { data: {} });
+	},
+
+	/**
+	 * Import files from server directories
+	 * @param request Import request data
+	 * @returns Promise with the import result
+	 */
+	importFromServer(request: ImportFromServerRequest): Promise<AxiosResponse<App.Http.Resources.Admin.ImportFromServerResource>> {
+		return axios.post(`${Constants.getApiUrl()}Import`, request);
+	},
+
+	browse(directory: string): Promise<AxiosResponse<string[]>> {
+		return axios.get(`${Constants.getApiUrl()}Import::browse`, { params: { directory }, data: {} });
+	},
+};
+
+export default ImportService;

--- a/resources/js/stores/ModalsState.ts
+++ b/resources/js/stores/ModalsState.ts
@@ -40,6 +40,8 @@ export const useTogglablesStateStore = defineStore("togglables-store", {
 		is_import_from_link_open: false,
 		is_tag_visible: false,
 		is_copy_visible: false,
+		is_import_from_dropbox_open: false,
+		is_import_from_server_open: false,
 
 		// Selections Ids
 		selectedPhotosIdx: [] as number[],

--- a/resources/js/views/gallery-panels/Album.vue
+++ b/resources/js/views/gallery-panels/Album.vue
@@ -6,6 +6,9 @@
 	<LoginModal v-if="user?.id === null" @logged-in="refresh" />
 	<WebauthnModal v-if="user?.id === null" @logged-in="refresh" />
 	<AlbumCreateDialog v-if="album?.rights.can_upload && config?.is_model_album" key="create_album_modal" />
+	<ImportFromLink v-if="album?.rights.can_upload" v-model:visible="is_import_from_link_open" @refresh="refresh" />
+	<ImportFromServer v-if="album?.rights.can_import_from_server" v-model:visible="is_import_from_server_open" />
+	<DropBox v-if="album?.rights.can_upload" v-model:visible="is_import_from_dropbox_open" />
 
 	<!-- Warnings & Locks -->
 	<SensitiveWarning v-if="config?.is_nsfw_warning_visible" :album-id="albumId" />
@@ -173,6 +176,9 @@ import MetricsService from "@/services/metrics-service";
 import { usePhotoRoute } from "@/composables/photo/photoRoute";
 import { useAlbumRoute } from "@/composables/photo/albumRoute";
 import { useLtRorRtL } from "@/utils/Helpers";
+import ImportFromLink from "@/components/modals/ImportFromLink.vue";
+import DropBox from "@/components/modals/DropBox.vue";
+import ImportFromServer from "@/components/modals/ImportFromServer.vue";
 
 const { isLTR } = useLtRorRtL();
 
@@ -210,12 +216,23 @@ const {
 	list_upload_files,
 	is_create_album_visible,
 	is_album_edit_open,
+	is_import_from_link_open,
 } = storeToRefs(togglableStore);
 
 const { scrollToTop, setScroll } = useScrollable(togglableStore, albumId);
 
-const { is_delete_visible, toggleDelete, is_merge_album_visible, is_move_visible, toggleMove, is_rename_visible, is_tag_visible, is_copy_visible } =
-	useGalleryModals(togglableStore);
+const {
+	is_delete_visible,
+	toggleDelete,
+	is_merge_album_visible,
+	is_move_visible,
+	toggleMove,
+	is_rename_visible,
+	is_tag_visible,
+	is_copy_visible,
+	is_import_from_dropbox_open,
+	is_import_from_server_open,
+} = useGalleryModals(togglableStore);
 
 // Set up Album ID reference. This one is updated at each page change.
 const { isPasswordProtected, isLoading, user, modelAlbum, album, photo, transition, photosTimeline, rights, photos, config, refresh, setTransition } =

--- a/resources/js/views/gallery-panels/Album.vue
+++ b/resources/js/views/gallery-panels/Album.vue
@@ -7,8 +7,8 @@
 	<WebauthnModal v-if="user?.id === null" @logged-in="refresh" />
 	<AlbumCreateDialog v-if="album?.rights.can_upload && config?.is_model_album" key="create_album_modal" />
 	<ImportFromLink v-if="album?.rights.can_upload" v-model:visible="is_import_from_link_open" @refresh="refresh" />
-	<ImportFromServer v-if="album?.rights.can_import_from_server" v-model:visible="is_import_from_server_open" />
-	<DropBox v-if="album?.rights.can_upload" v-model:visible="is_import_from_dropbox_open" />
+	<ImportFromServer v-if="album?.rights.can_import_from_server" v-model:visible="is_import_from_server_open" @refresh="refresh" />
+	<DropBox v-if="album?.rights.can_upload" v-model:visible="is_import_from_dropbox_open" @refresh="refresh" />
 
 	<!-- Warnings & Locks -->
 	<SensitiveWarning v-if="config?.is_nsfw_warning_visible" :album-id="albumId" />

--- a/resources/js/views/gallery-panels/Albums.vue
+++ b/resources/js/views/gallery-panels/Albums.vue
@@ -7,9 +7,9 @@
 	<LoginModal v-if="user?.id === null" @logged-in="refresh" />
 	<WebauthnModal v-if="user?.id === null" @logged-in="refresh" />
 	<LiveMetrics v-if="user?.id" />
-	<ImportFromLink v-if="rootRights?.can_upload" v-model:visible="is_import_from_link_open" />
-	<ImportFromServer v-if="rootRights?.can_import_from_server" v-model:visible="is_import_from_server_open" />
-	<DropBox v-if="rootRights?.can_upload" v-model:visible="is_import_from_dropbox_open" />
+	<ImportFromLink v-if="rootRights?.can_upload" v-model:visible="is_import_from_link_open" @refresh="refresh" />
+	<ImportFromServer v-if="rootRights?.can_import_from_server" v-model:visible="is_import_from_server_open" @refresh="refresh" />
+	<DropBox v-if="rootRights?.can_upload" v-model:visible="is_import_from_dropbox_open" @refresh="refresh" />
 
 	<div v-if="rootConfig && rootRights" id="galleryView" class="relative w-full h-full select-none" @scroll="onScroll">
 		<SelectDrag :albums="selectableAlbums" :with-scroll="false" />

--- a/resources/js/views/gallery-panels/Albums.vue
+++ b/resources/js/views/gallery-panels/Albums.vue
@@ -7,6 +7,9 @@
 	<LoginModal v-if="user?.id === null" @logged-in="refresh" />
 	<WebauthnModal v-if="user?.id === null" @logged-in="refresh" />
 	<LiveMetrics v-if="user?.id" />
+	<ImportFromLink v-if="rootRights?.can_upload" v-model:visible="is_import_from_link_open" />
+	<ImportFromServer v-if="rootRights?.can_import_from_server" v-model:visible="is_import_from_server_open" />
+	<DropBox v-if="rootRights?.can_upload" v-model:visible="is_import_from_dropbox_open" />
 
 	<div v-if="rootConfig && rootRights" id="galleryView" class="relative w-full h-full select-none" @scroll="onScroll">
 		<SelectDrag :albums="selectableAlbums" :with-scroll="false" />
@@ -179,6 +182,9 @@ import LiveMetrics from "@/components/drawers/LiveMetrics.vue";
 import { useLeftMenuStateStore } from "@/stores/LeftMenuState";
 import { useRouter } from "vue-router";
 import SelectDrag from "@/components/forms/album/SelectDrag.vue";
+import ImportFromLink from "@/components/modals/ImportFromLink.vue";
+import DropBox from "@/components/modals/DropBox.vue";
+import ImportFromServer from "@/components/modals/ImportFromServer.vue";
 
 const auth = useAuthStore();
 const lycheeStore = useLycheeStateStore();
@@ -190,7 +196,8 @@ lycheeStore.init();
 const albumId = ref("gallery");
 
 const { onScroll, setScroll } = useScrollable(togglableStore, albumId);
-const { is_full_screen, is_login_open, is_upload_visible, list_upload_files, is_webauthn_open } = storeToRefs(togglableStore);
+const { is_full_screen, is_login_open, is_upload_visible, list_upload_files, is_webauthn_open, is_import_from_server_open } =
+	storeToRefs(togglableStore);
 const { are_nsfw_visible, title } = storeToRefs(lycheeStore);
 
 const {
@@ -216,8 +223,18 @@ const { selectedAlbum, selectedAlbumsIdx, selectedAlbums, selectedAlbumsIds, alb
 );
 
 // Modals for Albums
-const { is_delete_visible, toggleDelete, is_merge_album_visible, toggleMergeAlbum, is_move_visible, toggleMove, is_rename_visible, toggleRename } =
-	useGalleryModals(togglableStore);
+const {
+	is_delete_visible,
+	toggleDelete,
+	is_merge_album_visible,
+	toggleMergeAlbum,
+	is_move_visible,
+	toggleMove,
+	is_rename_visible,
+	toggleRename,
+	is_import_from_link_open,
+	is_import_from_dropbox_open,
+} = useGalleryModals(togglableStore);
 
 function togglePin() {
 	if (!selectedAlbum.value) return;

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -97,6 +97,7 @@ Route::get('/Sharing::albums', [Gallery\SharingController::class, 'listAlbums'])
  */
 Route::post('/Import', Admin\ImportFromServerController::class);
 Route::get('/Import', [Admin\ImportFromServerController::class, 'options']);
+Route::get('/Import::browse', [Admin\ImportFromServerController::class, 'browse']);
 
 /**
  * PHOTO.

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -95,13 +95,8 @@ Route::get('/Sharing::albums', [Gallery\SharingController::class, 'listAlbums'])
 /**
  * IMPORT.
  */
-// Route::post('/Import::server', [ImportController::class, 'server']);
-// Route::post('/Import::serverCancel', [ImportController::class, 'serverCancel']);
-
-/**
- * LEGACY.
- */
-// Route::post('/Legacy::translateLegacyModelIDs', [LegacyController::class, 'translateLegacyModelIDs']);
+Route::post('/Import', Admin\ImportFromServerController::class);
+Route::post('/Import::options', [Admin\ImportFromServerController::class, 'options']);
 
 /**
  * PHOTO.

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -96,7 +96,7 @@ Route::get('/Sharing::albums', [Gallery\SharingController::class, 'listAlbums'])
  * IMPORT.
  */
 Route::post('/Import', Admin\ImportFromServerController::class);
-Route::post('/Import::options', [Admin\ImportFromServerController::class, 'options']);
+Route::get('/Import', [Admin\ImportFromServerController::class, 'options']);
 
 /**
  * PHOTO.

--- a/tests/Feature_v2/Import/ImportFromServerBrowseTest.php
+++ b/tests/Feature_v2/Import/ImportFromServerBrowseTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace Tests\Feature_v2\Import;
+
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+
+class ImportFromServerBrowseTest extends BaseApiWithDataTest
+{
+	public function testBrowseEndpointAsGuest(): void
+	{
+		$response = $this->getJsonWithData('/Import::browse', ['directory' => 'tests']);
+		$this->assertUnauthorized($response);
+	}
+
+	public function testBrowseEndpointLoggedIn(): void
+	{
+		$response = $this->actingAs($this->userLocked)->getJsonWithData('/Import::browse', ['directory' => 'tests']);
+		$this->assertForbidden($response);
+	}
+
+	public function testBrowseEndpointAsOwnerWrongDir(): void
+	{
+		$response = $this->actingAs($this->admin)->getJsonWithData('/Import::browse', ['directory' => 'wrong-dir']);
+		$this->assertUnprocessable($response);
+	}
+
+	public function testBrowseEndpointAsOwner(): void
+	{
+		$response = $this->actingAs($this->admin)->getJsonWithData('/Import::browse', ['directory' => 'tests']);
+		$this->assertOk($response);
+		$content = $response->json();
+		// We have to sort in order to have a predictable order for the test.
+		// The order returned by the filesystem is not predictable.
+		sort($content);
+		self::assertEquals($content, ['..', 'Constants', 'Feature_v2', 'Samples', 'Traits', 'Unit']);
+	}
+}

--- a/tests/Feature_v2/Import/ImportFromServerOptionsTest.php
+++ b/tests/Feature_v2/Import/ImportFromServerOptionsTest.php
@@ -14,19 +14,19 @@ class ImportFromServerOptionsTest extends BaseApiWithDataTest
 {
 	public function testOptionsEndpointAsGuest(): void
 	{
-		$response = $this->postJson('/Import::options');
+		$response = $this->getJson('/Import');
 		$this->assertUnauthorized($response);
 	}
 
 	public function testOptionsEndpointLoggedIn(): void
 	{
-		$response = $this->actingAs($this->userLocked)->postJson('/Import::options');
+		$response = $this->actingAs($this->userLocked)->getJson('/Import');
 		$this->assertForbidden($response);
 	}
 
 	public function testOptionsEndpointAsOwner(): void
 	{
-		$response = $this->actingAs($this->admin)->postJson('/Import::options');
-		$response->assertCreated();
+		$response = $this->actingAs($this->admin)->getJson('/Import');
+		$response->assertOk();
 	}
 }

--- a/tests/Feature_v2/Import/ImportFromServerOptionsTest.php
+++ b/tests/Feature_v2/Import/ImportFromServerOptionsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace Tests\Feature_v2\Import;
+
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+
+class ImportFromServerOptionsTest extends BaseApiWithDataTest
+{
+	public function testOptionsEndpointAsGuest(): void
+	{
+		$response = $this->postJson('/Import::options');
+		$this->assertUnauthorized($response);
+	}
+
+	public function testOptionsEndpointLoggedIn(): void
+	{
+		$response = $this->actingAs($this->userLocked)->postJson('/Import::options');
+		$this->assertForbidden($response);
+	}
+
+	public function testOptionsEndpointAsOwner(): void
+	{
+		$response = $this->actingAs($this->admin)->postJson('/Import::options');
+		$response->assertCreated();
+	}
+}

--- a/tests/Feature_v2/Import/ImportFromServerOptionsTest.php
+++ b/tests/Feature_v2/Import/ImportFromServerOptionsTest.php
@@ -27,6 +27,6 @@ class ImportFromServerOptionsTest extends BaseApiWithDataTest
 	public function testOptionsEndpointAsOwner(): void
 	{
 		$response = $this->actingAs($this->admin)->getJson('/Import');
-		$response->assertOk();
+		$this->assertOk($response);
 	}
 }

--- a/tests/Feature_v2/Import/ImportFromServerTest.php
+++ b/tests/Feature_v2/Import/ImportFromServerTest.php
@@ -39,11 +39,11 @@ class ImportFromServerTest extends BaseApiWithDataTest
 		$this->assertForbidden($response);
 	}
 
-	public function testImportFromServertWrongDir(): void
+	public function testImportFromServertWrongDirNotAuthorized(): void
 	{
 		$payload = $this->getDefaultPayload('wrong-dir');
 		$response = $this->actingAs($this->userLocked)->postJson('/Import', $payload);
-		$this->assertUnprocessable($response);
+		$this->assertForbidden($response);
 	}
 
 	public function testImportFromServertConflictingOptions(): void
@@ -55,6 +55,13 @@ class ImportFromServerTest extends BaseApiWithDataTest
 		$this->assertUnprocessable($response);
 	}
 
+	public function testImportFromServertWrongDir(): void
+	{
+		$payload = $this->getDefaultPayload('wrong-dir');
+		$response = $this->actingAs($this->admin)->postJson('/Import', $payload);
+		$this->assertUnprocessable($response);
+	}
+
 	public function testImportFromServerSuccess(): void
 	{
 		// No need to dispatch. :)
@@ -63,7 +70,7 @@ class ImportFromServerTest extends BaseApiWithDataTest
 		$directory = 'tests/Samples/sync';
 
 		$response = $this->actingAs($this->admin)->postJson('/Import', $this->getDefaultPayload($directory, $this->album5->id));
-		$response->assertCreated();
+		$this->assertCreated($response);
 		$response->assertJsonStructure([
 			'status',
 			'message',

--- a/tests/Feature_v2/Import/ImportFromServerTest.php
+++ b/tests/Feature_v2/Import/ImportFromServerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace Tests\Feature_v2\Import;
+
+use Illuminate\Support\Facades\Queue;
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+
+class ImportFromServerTest extends BaseApiWithDataTest
+{
+	private function getDefaultPayload(string $directory, ?string $album_id = null): array
+	{
+		return [
+			'directories' => [$directory],
+			'delete_imported' => false,
+			'import_via_symlink' => false,
+			'skip_duplicates' => false,
+			'resync_metadata' => false,
+			'delete_missing_photos' => false,
+			'delete_missing_albums' => false,
+			'album_id' => $album_id,
+		];
+	}
+
+	public function testImportFromServertAsGuest(): void
+	{
+		$response = $this->postJson('/Import', $this->getDefaultPayload('tests'));
+		$this->assertUnauthorized($response);
+	}
+
+	public function testImportFromServertLoggedIn(): void
+	{
+		$response = $this->actingAs($this->userLocked)->postJson('/Import', $this->getDefaultPayload('tests'));
+		$this->assertForbidden($response);
+	}
+
+	public function testImportFromServertWrongDir(): void
+	{
+		$payload = $this->getDefaultPayload('wrong-dir');
+		$response = $this->actingAs($this->userLocked)->postJson('/Import', $payload);
+		$this->assertUnprocessable($response);
+	}
+
+	public function testImportFromServertConflictingOptions(): void
+	{
+		$payload = $this->getDefaultPayload('tests');
+		$payload['delete_imported'] = true;
+		$payload['import_via_symlink'] = true;
+		$response = $this->actingAs($this->userLocked)->postJson('/Import', $payload);
+		$this->assertUnprocessable($response);
+	}
+
+	public function testImportFromServerSuccess(): void
+	{
+		// No need to dispatch. :)
+		Queue::fake();
+
+		$directory = 'tests/Samples/sync';
+
+		$response = $this->actingAs($this->admin)->postJson('/Import', $this->getDefaultPayload($directory, $this->album5->id));
+		$response->assertCreated();
+		$response->assertJsonStructure([
+			'status',
+			'message',
+			'results' => [
+				['directory', 'status', 'jobs_count'],
+			],
+			'job_count',
+		]);
+		$response->assertJson(['status' => true]);
+
+		// Check that jobs were created
+		$this->assertGreaterThan(0, $response->json('job_count'));
+		Queue::assertCount($response->json('job_count'));
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Server-side "Import from Server": endpoints to fetch options, browse directories, start imports with per-directory results and job counts; frontend modal and service to drive it.

- **Permissions**
  - New can_import_from_server flag exposed; access limited to configured owner.

- **API Changes**
  - Added GET /Import, GET /Import::browse and POST /Import; removed legacy import/translation routes.

- **Frontend**
  - New modals, context-menu item, composables, types and service for import flow.

- **Translations**
  - Added locale strings and menu entry for "Import from Server" across many languages.

- **Tests**
  - Added authorization, validation, conflict and success-path tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->