### PR TITLE
[SE] Renamer now supports empty replacement string

### DIFF
--- a/app/Http/Requests/Renamer/UpdateRenamerRuleRequest.php
+++ b/app/Http/Requests/Renamer/UpdateRenamerRuleRequest.php
@@ -59,7 +59,7 @@ class UpdateRenamerRuleRequest extends BaseApiRequest implements HasDescription
 			RequestAttribute::RULE_ATTRIBUTE => ['required', new StringRule(false, 100)],
 			RequestAttribute::DESCRIPTION_ATTRIBUTE => ['present', 'nullable', new DescriptionRule()],
 			RequestAttribute::NEEDLE_ATTRIBUTE => ['present', new StringRule(false, 255)],
-			RequestAttribute::REPLACEMENT_ATTRIBUTE => ['present', new StringRule(false, 255)],
+			RequestAttribute::REPLACEMENT_ATTRIBUTE => ['present', new StringRule(true, 255)],
 			RequestAttribute::MODE_ATTRIBUTE => ['required', new Enum(RenamerModeType::class)],
 			RequestAttribute::ORDER_ATTRIBUTE => ['required', 'integer', 'min:1'],
 			RequestAttribute::IS_ENABLED_ATTRIBUTE => ['required', 'boolean'],

--- a/app/Http/Requests/Renamer/UpdateRenamerRuleRequest.php
+++ b/app/Http/Requests/Renamer/UpdateRenamerRuleRequest.php
@@ -59,7 +59,7 @@ class UpdateRenamerRuleRequest extends BaseApiRequest implements HasDescription
 			RequestAttribute::RULE_ATTRIBUTE => ['required', new StringRule(false, 100)],
 			RequestAttribute::DESCRIPTION_ATTRIBUTE => ['present', 'nullable', new DescriptionRule()],
 			RequestAttribute::NEEDLE_ATTRIBUTE => ['present', new StringRule(false, 255)],
-			RequestAttribute::REPLACEMENT_ATTRIBUTE => ['present', new StringRule(true, 255)],
+			RequestAttribute::REPLACEMENT_ATTRIBUTE => ['present', 'string', 'max:255'],
 			RequestAttribute::MODE_ATTRIBUTE => ['required', new Enum(RenamerModeType::class)],
 			RequestAttribute::ORDER_ATTRIBUTE => ['required', 'integer', 'min:1'],
 			RequestAttribute::IS_ENABLED_ATTRIBUTE => ['required', 'boolean'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating Renamer rules now accepts an empty Replacement field without validation errors.
  * The Replacement field must still be present and is limited to 255 characters, but can be blank.
  * This resolves failed saves when intentionally leaving the Replacement value empty and ensures smoother rule updates in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->