### PR TITLE
Fix cleanup action not working on directories

### DIFF
--- a/app/Assets/Helpers.php
+++ b/app/Assets/Helpers.php
@@ -11,8 +11,11 @@ namespace App\Assets;
 use App\Exceptions\Internal\ZeroModuloException;
 use Exception;
 use Illuminate\Http\Request;
+use Safe\Exceptions\FilesystemException;
 use Safe\Exceptions\InfoException;
 use function Safe\ini_get;
+use function Safe\rmdir;
+use function Safe\unlink;
 
 class Helpers
 {
@@ -262,5 +265,28 @@ class Helpers
 		}
 
 		return $request->path() . '?' . http_build_query($query);
+	}
+
+	/**
+	 * Actually remove the directory recursively.
+	 *
+	 * @param string $dir
+	 *
+	 * @return void
+	 *
+	 * @throws FilesystemException
+	 */
+	public function remove_dir(string $dir): void
+	{
+		$it = new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS);
+		$files = new \RecursiveIteratorIterator($it, \RecursiveIteratorIterator::CHILD_FIRST);
+		foreach ($files as $file) {
+			if ($file->isDir()) {
+				rmdir($file->getPathname());
+			} else {
+				unlink($file->getPathname());
+			}
+		}
+		rmdir($dir);
 	}
 }

--- a/app/Assets/Helpers.php
+++ b/app/Assets/Helpers.php
@@ -281,10 +281,14 @@ class Helpers
 		$it = new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS);
 		$files = new \RecursiveIteratorIterator($it, \RecursiveIteratorIterator::CHILD_FIRST);
 		foreach ($files as $file) {
+			/** @var \SplFileInfo $file */
+			if ($file->isLink() || $file->isFile()) {
+				// Remove files and symlinks without following them
+				unlink($file->getPathname());
+				continue;
+			}
 			if ($file->isDir()) {
 				rmdir($file->getPathname());
-			} else {
-				unlink($file->getPathname());
 			}
 		}
 		rmdir($dir);

--- a/app/Facades/Helpers.php
+++ b/app/Facades/Helpers.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string decimalToDegreeMinutesSeconds(float $decimal, bool $type)
  * @method static string censor(string $string, float  $percentOfClear = 0.5)
  * @method static string getUriWithQueryString(\Illuminate\Http\Request $request): string
+ * @method static void    remove_dir(string $dir): void
  */
 class Helpers extends Facade
 {

--- a/app/Http/Controllers/Admin/Maintenance/Cleaning.php
+++ b/app/Http/Controllers/Admin/Maintenance/Cleaning.php
@@ -8,11 +8,11 @@
 
 namespace App\Http\Controllers\Admin\Maintenance;
 
+use App\Facades\Helpers;
 use App\Http\Requests\Maintenance\CleaningRequest;
 use App\Http\Resources\Diagnostics\CleaningState;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Log;
-use function Safe\rmdir;
 use function Safe\unlink;
 
 /**
@@ -46,7 +46,7 @@ class Cleaning extends Controller
 			$results[] = sprintf(__('maintenance.cleaning.result'), $file_info->getFilename());
 
 			if ($file_info->isDir()) {
-				rmdir($file_info->getRealPath());
+				Helpers::remove_dir($file_info->getRealPath());
 				continue;
 			}
 			unlink($file_info->getRealPath());

--- a/app/Jobs/CleanUpExtraction.php
+++ b/app/Jobs/CleanUpExtraction.php
@@ -9,6 +9,7 @@
 namespace App\Jobs;
 
 use App\Enum\JobStatus;
+use App\Facades\Helpers;
 use App\Models\JobHistory;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -16,9 +17,6 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Str;
-use Safe\Exceptions\FilesystemException;
-use function Safe\rmdir;
-use function Safe\unlink;
 
 class CleanUpExtraction implements ShouldQueue
 {
@@ -57,7 +55,7 @@ class CleanUpExtraction implements ShouldQueue
 		// Check if all the sub directories are empty.
 		if ($this->is_empty($this->folder_path)) {
 			// Only clear the directory if it is empty.
-			$this->remove_dir($this->folder_path);
+			Helpers::remove_dir($this->folder_path);
 			$this->history->status = JobStatus::SUCCESS;
 			$this->history->save();
 
@@ -81,28 +79,5 @@ class CleanUpExtraction implements ShouldQueue
 		}
 
 		return true;
-	}
-
-	/**
-	 * Actually remove the directory recursively.
-	 *
-	 * @param string $dir
-	 *
-	 * @return void
-	 *
-	 * @throws FilesystemException
-	 */
-	private function remove_dir(string $dir): void
-	{
-		$it = new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS);
-		$files = new \RecursiveIteratorIterator($it, \RecursiveIteratorIterator::CHILD_FIRST);
-		foreach ($files as $file) {
-			if ($file->isDir()) {
-				rmdir($file->getPathname());
-			} else {
-				unlink($file->getPathname());
-			}
-		}
-		rmdir($dir);
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents false failure status after successful cleanup in background extraction tasks.
  - Improves reliability of directory deletion during maintenance and cleanup.

- Refactor
  - Centralizes recursive directory removal via a shared helper for consistent behavior across the app.

- Documentation
  - Updates facade documentation to expose the new directory removal method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->