### PR TITLE
Translations update from LycheeOrg - Weblate

### DIFF
--- a/lang/de/gallery.php
+++ b/lang/de/gallery.php
@@ -207,7 +207,7 @@ return [
         'merge_all' => 'Ausgewähltes zusammenführen',
         'upload_photo' => 'Foto hochladen',
         'import_link' => 'Von Link importieren',
-		'import_server' => 'Import from Server',
+        'import_server' => 'Vom Server importieren',
         'import_dropbox' => 'Importieren aus der Dropbox',
         'new_album' => 'Neues Album',
         'new_tag_album' => 'Neues Tag Album',

--- a/lang/fr/gallery.php
+++ b/lang/fr/gallery.php
@@ -207,7 +207,7 @@ return [
         'merge_all' => 'Fusionner la sélection',
         'upload_photo' => 'Téléverser une photo',
         'import_link' => 'Importer via un lien',
-		'import_server' => 'Import from Server',
+        'import_server' => 'Importer à partir du serveur',
         'import_dropbox' => 'Importer depuis Dropbox',
         'new_album' => 'Nouvel album',
         'new_tag_album' => 'Nouvel album par étiquette',


### PR DESCRIPTION
Translations update from [LycheeOrg - Weblate](http://weblate.lycheeorg.dev) for [Lychee/aspect_ratio](http://weblate.lycheeorg.dev/projects/lycheeorg/aspect_ratio/).



Current translation status:

![Weblate translation status](http://weblate.lycheeorg.dev/widget/lycheeorg/aspect_ratio/horizontal-auto.svg)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Updated gallery menu label translations: French now shows “Importer à partir du serveur”; German now shows “Vom Server importieren.”
  * Improves clarity and consistency for French- and German-speaking users across the interface.
  * No functional behavior changes; text-only updates visible in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->