### PR TITLE
Add move to S3 command

### DIFF
--- a/app/Actions/Photo/Pipes/Shared/UploadSizeVariantsToS3.php
+++ b/app/Actions/Photo/Pipes/Shared/UploadSizeVariantsToS3.php
@@ -28,7 +28,7 @@ class UploadSizeVariantsToS3 implements PhotoPipe
 			// @codeCoverageIgnoreStart
 			$state->getPhoto()->size_variants->toCollection()
 				->filter(fn ($v) => $v !== null && $v->type !== SizeVariantType::PLACEHOLDER)
-				->map(fn (SizeVariant $variant) => new UploadSizeVariantToS3Job($variant))
+				->map(fn (SizeVariant $variant) => new UploadSizeVariantToS3Job($variant, $state->getPhoto()->owner_id))
 				->each(fn ($job) => dispatch($job));
 			// @codeCoverageIgnoreEnd
 		}

--- a/app/Console/Commands/ImageProcessing/MoveToS3.php
+++ b/app/Console/Commands/ImageProcessing/MoveToS3.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Console\Commands\ImageProcessing;
+
+use App\Assets\Features;
+use App\Enum\StorageDiskType;
+use App\Exceptions\UnexpectedException;
+use App\Jobs\UploadSizeVariantToS3Job;
+use App\Models\Configs;
+use App\Models\SizeVariant;
+use Illuminate\Console\Command;
+use Safe\Exceptions\InfoException;
+use function Safe\set_time_limit;
+
+class MoveToS3 extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'lychee:s3_migrate {limit=5 : number of photos to move to s3} {tm=600 : timeout time requirement}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Migrate existing photos to the configured S3 bucket';
+
+	/**
+	 * Execute the console command.
+	 */
+	public function handle(): int
+	{
+		if (Features::inactive('use-s3')) {
+			$this->error('S3 support is not activated.');
+
+			return 0;
+		}
+		// @codeCoverageIgnoreStart
+		try {
+			$limit = (int) $this->argument('limit');
+			$timeout = (int) $this->argument('tm');
+
+			try {
+				set_time_limit($timeout);
+			} catch (InfoException) {
+				// Silently do nothing, if `set_time_limit` is denied.
+			}
+
+			$sive_variants = SizeVariant::query()
+				->whereNot('short_path', 'LIKE', '%placeholder/%')
+				->where('storage_disk', '=', StorageDiskType::LOCAL->value)
+				->limit($limit)
+				->get();
+			if (count($sive_variants) === 0) {
+				$this->line('No files require migrations.');
+
+				return 0;
+			}
+			$owner_id = Configs::getValueAsInt('owner_id');
+			foreach ($sive_variants as $size_variant) {
+				$this->line('Moving ' . $size_variant->short_path . ' to S3.');
+				UploadSizeVariantToS3Job::dispatch($size_variant, $owner_id);
+			}
+
+			return 0;
+		} catch (\Throwable $e) {
+			throw new UnexpectedException($e);
+		}
+		// @codeCoverageIgnoreEnd
+	}
+}

--- a/app/Console/Commands/ImageProcessing/MoveToS3.php
+++ b/app/Console/Commands/ImageProcessing/MoveToS3.php
@@ -9,6 +9,7 @@
 namespace App\Console\Commands\ImageProcessing;
 
 use App\Assets\Features;
+use App\Enum\SizeVariantType;
 use App\Enum\StorageDiskType;
 use App\Exceptions\UnexpectedException;
 use App\Jobs\UploadSizeVariantToS3Job;
@@ -56,7 +57,7 @@ class MoveToS3 extends Command
 			}
 
 			$sive_variants = SizeVariant::query()
-				->whereNot('short_path', 'LIKE', '%placeholder/%')
+				->whereNot('type', '=', SizeVariantType::PLACEHOLDER->value)
 				->where('storage_disk', '=', StorageDiskType::LOCAL->value)
 				->limit($limit)
 				->get();

--- a/app/Jobs/UploadSizeVariantToS3Job.php
+++ b/app/Jobs/UploadSizeVariantToS3Job.php
@@ -33,15 +33,16 @@ class UploadSizeVariantToS3Job implements ShouldQueue
 
 	protected JobHistory $history;
 
-	protected SizeVariant $variant;
-
-	public function __construct(SizeVariant $variant)
+	public function __construct(
+		protected SizeVariant $variant,
+		int $owner_id,
+	)
 	{
 		$this->variant = $variant;
 
 		// Set up our new history record.
 		$this->history = new JobHistory();
-		$this->history->owner_id = Auth::user()->id;
+		$this->history->owner_id = $owner_id;
 		$this->history->job = Str::limit(sprintf('Upload sizeVariant to S3: %s.', $this->variant->short_path), 200);
 		$this->history->status = JobStatus::READY;
 		$this->history->save();

--- a/app/Jobs/UploadSizeVariantToS3Job.php
+++ b/app/Jobs/UploadSizeVariantToS3Job.php
@@ -19,7 +19,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -36,8 +35,7 @@ class UploadSizeVariantToS3Job implements ShouldQueue
 	public function __construct(
 		protected SizeVariant $variant,
 		int $owner_id,
-	)
-	{
+	) {
 		$this->variant = $variant;
 
 		// Set up our new history record.

--- a/tests/Feature_v2/Commands/MoveToS3Test.php
+++ b/tests/Feature_v2/Commands/MoveToS3Test.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\Commands;
+
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+
+class MoveToS3Test extends BaseApiWithDataTest
+{
+	public const COMMAND = 'lychee:s3_migrate';
+
+	public function testSuccess(): void
+	{
+		$this->artisan(self::COMMAND, [])
+			->assertSuccessful();
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a command to migrate existing local photos to S3, with options to limit items processed and set a timeout. Provides clear messaging when no files require migration and runs uploads in the background.

- Bug Fixes
  - Ensures S3 upload jobs correctly attribute actions to the proper photo owner, improving accuracy of ownership tracking.

- Tests
  - Added a feature test to verify the new S3 migration command executes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->