### PR TITLE
Translations update from LycheeOrg - Weblate

### DIFF
--- a/lang/no/landing.php
+++ b/lang/no/landing.php
@@ -6,7 +6,7 @@ return [
 	|--------------------------------------------------------------------------
 	*/
     'gallery' => 'Galleri',
-    'access_gallery' => 'Access the gallery',
-    'Powered_by_Lychee' => 'Powered by Lychee',
-    'copyright' => 'All images on this website are subject to copyright by %1$s © %2$s',
+    'access_gallery' => 'Få tilgang til galleriet',
+    'Powered_by_Lychee' => 'Drevet av Lychee',
+    'copyright' => 'Alle bilder på denne nettsiden er opphavsrettslig beskyttet av %1$s © %2$s',
 ];

--- a/lang/no/left-menu.php
+++ b/lang/no/left-menu.php
@@ -7,9 +7,9 @@ return [
 	*/
     'back_to_gallery' => 'Tilbake til galleriet',
     'login' => 'Login',
-    'frame' => 'Frame',
-    'map' => 'Map',
-    'admin' => 'Admin',
+    'frame' => 'Ramme',
+    'map' => 'Kart',
+    'admin' => 'Administrator',
     'clockwork' => 'Clockwork App',
     'logs' => 'Show Logs',
     'jobs' => 'Show Job History',


### PR DESCRIPTION
Translations update from [LycheeOrg - Weblate](http://weblate.lycheeorg.dev) for [Lychee/aspect_ratio](http://weblate.lycheeorg.dev/projects/lycheeorg/aspect_ratio/).



Current translation status:

![Weblate translation status](http://weblate.lycheeorg.dev/widget/lycheeorg/aspect_ratio/horizontal-auto.svg)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Improved Norwegian translations on the landing page: “Access the gallery,” “Powered by Lychee,” and copyright notice updated to native phrasing.
  * Updated left menu labels to Norwegian: “Frame” → “Ramme,” “Map” → “Kart,” “Admin” → “Administrator.”
  * No changes to keys or structure; only text updated for clearer, more consistent Norwegian user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->