### PR TITLE
Split test suite in hopes to speed things up.

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -152,7 +152,6 @@ jobs:
       - php_syntax_errors
     uses: ./.github/workflows/php_tests.yml
     with:
-      test-suite: 'Unit,Feature_v2'
       env-file: '.env'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -241,7 +240,7 @@ jobs:
           # The GitHub token used to make authenticated API requests. Default is
           # ${{ github.token }}
           github-token: ${{ github.token }}
-      
+
 
   release:
     name: 5️⃣ Release
@@ -259,11 +258,11 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
 
-      - name: Download generated artifact 
+      - name: Download generated artifact
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: Lychee.zip
-      
+
       # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
       - name: Sign release with a key
         run: |
@@ -281,4 +280,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           generate_release_notes: true
           make_latest: true
-          

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -151,8 +151,6 @@ jobs:
     needs:
       - php_syntax_errors
     uses: ./.github/workflows/php_tests.yml
-    with:
-      env-file: '.env'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -3,16 +3,12 @@ name: PHP Tests
 on:
   workflow_call:
     inputs:
-      test-suite:
-        required: true
-        type: string
-        description: 'The test suite to run'
       env-file:
         required: true
         type: string
         description: 'The env files to use'
     secrets:
-      CODECOV_TOKEN: 
+      CODECOV_TOKEN:
         required: true
         description: 'codecov token secret'
 
@@ -23,8 +19,8 @@ jobs:
   tests:
     permissions:
       contents: read  # for actions/checkout to fetch code
-      pull-requests: read 
-    name: ${{ matrix.php-version }} - ${{ matrix.sql-versions }} -- ${{ inputs.test-suite }}
+      pull-requests: read
+    name: ${{ matrix.php-version }} - ${{ matrix.sql-versions }} -- ${{ matrix.test-suite }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,6 +31,9 @@ jobs:
           - mariadb
           - postgresql
           - sqlite
+        test-suite:
+          - Unit
+          - Feature_v2
     # Service containers to run with `container-job`
     services:
       # Label used to access the service container
@@ -99,7 +98,7 @@ jobs:
           php artisan migrate
 
       - name: Apply tests ${{ inputs.test-suite }}
-        run: XDEBUG_MODE=coverage vendor/bin/phpunit --configuration phpunit.ci.xml --testsuite ${{ inputs.test-suite }}
+        run: XDEBUG_MODE=coverage vendor/bin/phpunit --configuration phpunit.ci.xml --testsuite ${{ matrix.test-suite }}
 
       - name: Make sure we can go backward
         run: php artisan migrate:rollback

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -29,6 +29,7 @@ jobs:
         test-suite:
           - Unit
           - Feature_v2
+          - Install
         exclude:
           - php-version: 8.4 # We skip Feature_v2 on PHP 8.4 as it is quite slow. We rely on 8.3 to catch any issues.
             test-suite: Feature_v2

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -29,6 +29,9 @@ jobs:
         test-suite:
           - Unit
           - Feature_v2
+        exclude:
+          - php-version: 8.4 # We skip Feature_v2 on PHP 8.4 as it is quite slow. We rely on 8.3 to catch any issues.
+            test-suite: Feature_v2
     # Service containers to run with `container-job`
     services:
       # Label used to access the service container
@@ -92,7 +95,7 @@ jobs:
           php artisan optimize
           php artisan migrate
 
-      - name: Apply tests ${{ inputs.test-suite }}
+      - name: Apply tests ${{ matrix.test-suite }}
         run: XDEBUG_MODE=coverage vendor/bin/phpunit --configuration phpunit.ci.xml --testsuite ${{ matrix.test-suite }}
 
       - name: Make sure we can go backward

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -2,11 +2,6 @@ name: PHP Tests
 
 on:
   workflow_call:
-    inputs:
-      env-file:
-        required: true
-        type: string
-        description: 'The env files to use'
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -89,7 +84,7 @@ jobs:
 
       - name: copy Env
         run: |
-          cp .github/workflows/${{ inputs.env-file }}.${{ matrix.sql-versions }} .env
+          cp .github/workflows/.env.${{ matrix.sql-versions }} .env
 
       - name: Generate secure key & Optimize application & Migrate
         run: |

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,9 @@ build:
 test_unit:
 	vendor/bin/phpunit --testsuite Unit --stop-on-failure --stop-on-error --no-coverage --log-junit report_unit.xml
 
+test_install:
+	vendor/bin/phpunit --testsuite Install --stop-on-failure --stop-on-error --no-coverage --log-junit report_install.xml
+
 test_v2:
 	vendor/bin/phpunit --testsuite Feature_v2 --stop-on-failure --stop-on-error --no-coverage --log-junit report_v2.xml
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@
 codecov:
   require_ci_to_pass: true
   notify:
-    after_n_builds: 6
+    after_n_builds: 9
     wait_for_ci: true
 comment:
   behavior: default

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@
 codecov:
   require_ci_to_pass: true
   notify:
-    after_n_builds: 9
+    after_n_builds: 12
     wait_for_ci: true
 comment:
   behavior: default

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@
 codecov:
   require_ci_to_pass: true
   notify:
-    after_n_builds: 3
+    after_n_builds: 6
     wait_for_ci: true
 comment:
   behavior: default

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,6 +17,9 @@
       <exclude>./tests/Feature_v2/Base/BaseApiWithDataTest.php</exclude>
       <exclude>./tests/Feature_v2/ImageHandlers/BaseImageHandler.php</exclude>
     </testsuite>
+    <testsuite name="Install">
+      <directory suffix="Test.php">./tests/Install</directory>
+    </testsuite>
   </testsuites>
   <extensions>
     <bootstrap class="Tests\BootExtension"/>

--- a/tests/Feature_v2/Import/ImportFromServerBrowseTest.php
+++ b/tests/Feature_v2/Import/ImportFromServerBrowseTest.php
@@ -38,6 +38,6 @@ class ImportFromServerBrowseTest extends BaseApiWithDataTest
 		// We have to sort in order to have a predictable order for the test.
 		// The order returned by the filesystem is not predictable.
 		sort($content);
-		self::assertEquals($content, ['..', 'Constants', 'Feature_v2', 'Samples', 'Traits', 'Unit']);
+		self::assertEquals($content, ['..', 'Constants', 'Feature_v2', 'Install', 'Samples', 'Traits', 'Unit']);
 	}
 }

--- a/tests/Install/AdminTest.php
+++ b/tests/Install/AdminTest.php
@@ -16,16 +16,30 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Install;
+namespace Tests\Install;
 
 use App\Http\Middleware\AdminUserStatus;
 use App\Http\Middleware\InstallationStatus;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\AbstractTestCase;
+use Tests\Traits\RequiresEmptyUsers;
 
 class AdminTest extends AbstractTestCase
 {
+	use RequiresEmptyUsers;
 	use DatabaseTransactions;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->setUpRequiresEmptyUsers();
+	}
+
+	public function tearDown(): void
+	{
+		$this->tearDownRequiresEmptyUsers();
+		parent::tearDown();
+	}
 
 	public function testGet(): void
 	{

--- a/tests/Install/EnvTest.php
+++ b/tests/Install/EnvTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Install;
+namespace Tests\Install;
 
 use App\Http\Middleware\InstallationStatus;
 use Tests\AbstractTestCase;

--- a/tests/Install/MigrateTest.php
+++ b/tests/Install/MigrateTest.php
@@ -16,19 +16,22 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Install;
+namespace Tests\Install;
 
 use App\Http\Middleware\InstallationStatus;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\AbstractTestCase;
 
-class WelcomeTest extends AbstractTestCase
+class MigrateTest extends AbstractTestCase
 {
+	use DatabaseTransactions;
+
 	public function testGet(): void
 	{
-		$response = $this->get('install');
+		$response = $this->get('install/migrate');
 		$this->assertForbidden($response);
 
-		$response = $this->withoutMiddleware(InstallationStatus::class)->get('install');
+		$response = $this->withoutMiddleware(InstallationStatus::class)->get('install/migrate');
 		$this->assertOk($response);
 	}
 }

--- a/tests/Install/PermissionsTest.php
+++ b/tests/Install/PermissionsTest.php
@@ -16,19 +16,19 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Install;
+namespace Tests\Install;
 
 use App\Http\Middleware\InstallationStatus;
 use Tests\AbstractTestCase;
 
-class RequirementsTest extends AbstractTestCase
+class PermissionsTest extends AbstractTestCase
 {
 	public function testGet(): void
 	{
-		$response = $this->get('install/req');
+		$response = $this->get('install/perm');
 		$this->assertForbidden($response);
 
-		$response = $this->withoutMiddleware(InstallationStatus::class)->get('install/req');
+		$response = $this->withoutMiddleware(InstallationStatus::class)->get('install/perm');
 		$this->assertOk($response);
 	}
 }

--- a/tests/Install/RequirementsTest.php
+++ b/tests/Install/RequirementsTest.php
@@ -16,19 +16,19 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Install;
+namespace Tests\Install;
 
 use App\Http\Middleware\InstallationStatus;
 use Tests\AbstractTestCase;
 
-class PermissionsTest extends AbstractTestCase
+class RequirementsTest extends AbstractTestCase
 {
 	public function testGet(): void
 	{
-		$response = $this->get('install/perm');
+		$response = $this->get('install/req');
 		$this->assertForbidden($response);
 
-		$response = $this->withoutMiddleware(InstallationStatus::class)->get('install/perm');
+		$response = $this->withoutMiddleware(InstallationStatus::class)->get('install/req');
 		$this->assertOk($response);
 	}
 }

--- a/tests/Install/WelcomeTest.php
+++ b/tests/Install/WelcomeTest.php
@@ -16,22 +16,19 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Install;
+namespace Tests\Install;
 
 use App\Http\Middleware\InstallationStatus;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\AbstractTestCase;
 
-class MigrateTest extends AbstractTestCase
+class WelcomeTest extends AbstractTestCase
 {
-	use DatabaseTransactions;
-
 	public function testGet(): void
 	{
-		$response = $this->get('install/migrate');
+		$response = $this->get('install');
 		$this->assertForbidden($response);
 
-		$response = $this->withoutMiddleware(InstallationStatus::class)->get('install/migrate');
+		$response = $this->withoutMiddleware(InstallationStatus::class)->get('install');
 		$this->assertOk($response);
 	}
 }

--- a/tests/Traits/RequiresEmptyUsers.php
+++ b/tests/Traits/RequiresEmptyUsers.php
@@ -27,17 +27,12 @@ trait RequiresEmptyUsers
 	protected function setUpRequiresEmptyUsers(): void
 	{
 		// Assert that user table only contains the admin user
-		static::assertEquals(
-			0,
-			DB::table('users')
-				->where('id', '>', 1)
-				->count()
-		);
+		static::assertEquals(0, DB::table('users')->count());
 	}
 
 	protected function tearDownRequiresEmptyUsers(): void
 	{
 		// Clean up remaining stuff from tests
-		DB::table('users')->where('id', '>', 1)->delete();
+		DB::table('users')->where('id', '>', 0)->delete();
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * PHP tests now run via a matrix (Unit, Feature_v2, Install) with env selection per SQL version, standardized job names, and Feature_v2 excluded on PHP 8.4.
  * Added an Install testsuite and Makefile target to run it.
  * Install tests relocated to the Install namespace; one test gained lifecycle setup/teardown. One feature test expectation updated to include an additional "Install" directory item.
* **Chores**
  * Removed manual workflow inputs and applied minor CI formatting cleanup.
* **CI**
  * Codecov now requires CI passing across 12 builds before finalizing status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->