### PR TITLE
Add listing of all orders

### DIFF
--- a/app/Actions/Shop/OrderService.php
+++ b/app/Actions/Shop/OrderService.php
@@ -18,6 +18,7 @@ use App\Models\OrderItem;
 use App\Models\Photo;
 use App\Models\User;
 use App\Services\MoneyService;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 
 class OrderService
@@ -104,5 +105,22 @@ class OrderService
 		$basket->updateTotal();
 
 		return $basket;
+	}
+
+	/**
+	 * List all the orders in the DB.
+	 * Add pagination later.
+	 *
+	 * @return array<int,Order>
+	 */
+	public function getAll(): array
+	{
+		$user = Auth::user();
+
+		return Order::without(['items'])->with(['user'])
+			->when($user?->may_administrate !== true, function ($query) use ($user): void {
+				$query->where('user_id', $user?->id);
+			})
+			->orderBy('id', 'desc')->get()->all();
 	}
 }

--- a/app/Http/Controllers/Admin/ShopManagementController.php
+++ b/app/Http/Controllers/Admin/ShopManagementController.php
@@ -8,6 +8,7 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Actions\Shop\OrderService;
 use App\Actions\Shop\PurchasableService;
 use App\Http\Requests\ShopManagement\DeletePurchasablesRequest;
 use App\Http\Requests\ShopManagement\ListPurchasablesRequest;
@@ -24,8 +25,10 @@ use Illuminate\Routing\Controller;
  */
 class ShopManagementController extends Controller
 {
-	public function __construct(private PurchasableService $purchasable_service)
-	{
+	public function __construct(
+		private PurchasableService $purchasable_service,
+		private OrderService $order_service,
+	) {
 	}
 
 	/**

--- a/app/Http/Controllers/Shop/CheckoutController.php
+++ b/app/Http/Controllers/Shop/CheckoutController.php
@@ -107,7 +107,7 @@ class CheckoutController extends Controller
 	 *
 	 * @return CheckoutResource The finalization response
 	 */
-	public function finalize(FinalizeRequest $request): CheckoutResource
+	public function finalize(FinalizeRequest $request, string $provider, string $transaction_id): CheckoutResource
 	{
 		/** @disregard P1013 */
 		$order = $this->checkout_service->handlePaymentReturn($request->basket(), $request->all(), $request->provider_type());

--- a/app/Http/Controllers/Shop/OrderController.php
+++ b/app/Http/Controllers/Shop/OrderController.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Controllers\Shop;
+
+use App\Actions\Shop\OrderService;
+use App\Http\Requests\Order\GetOrderRequest;
+use App\Http\Requests\Order\ListOrderRequest;
+use App\Http\Resources\Shop\OrderResource;
+use Illuminate\Routing\Controller;
+
+/**
+ * Controller responsible for listing the orders.
+ */
+class OrderController extends Controller
+{
+	public function __construct(
+		private OrderService $order_service,
+	) {
+	}
+
+	/**
+	 * List all orders in the system.
+	 * This returns all orders in the system for management purposes.
+	 *
+	 * @return array<int,OrderResource> The list of all orders
+	 */
+	public function list(ListOrderRequest $request): array
+	{
+		return OrderResource::collect($this->order_service->getAll());
+	}
+
+	/**
+	 * Given a Order request, return the order.
+	 *
+	 * @return OrderResource
+	 */
+	public function get(GetOrderRequest $request): OrderResource
+	{
+		return OrderResource::fromModel($request->order);
+	}
+}

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -25,6 +25,7 @@ class VerifyCsrfToken extends Middleware
 		'/php/index.php',
 		'/api/Session::init',
 		'/api/v2/Zip',
+		'/api/v2/Shop/Checkout/Finalize/*',
 	];
 
 	/**

--- a/app/Http/Requests/Checkout/FinalizeRequest.php
+++ b/app/Http/Requests/Checkout/FinalizeRequest.php
@@ -54,6 +54,7 @@ class FinalizeRequest extends BaseApiRequest implements HasBasket
 
 	protected function prepareForValidation(): void
 	{
+		/** @disregard */
 		$this->merge([
 			RequestAttribute::PROVIDER_ATTRIBUTE => $this->route(RequestAttribute::PROVIDER_ATTRIBUTE),
 			RequestAttribute::TRANSACTION_ID_ATTRIBUTE => $this->route(RequestAttribute::TRANSACTION_ID_ATTRIBUTE),

--- a/app/Http/Requests/Order/GetOrderRequest.php
+++ b/app/Http/Requests/Order/GetOrderRequest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Order;
+
+use App\Http\Requests\BaseApiRequest;
+use App\Models\Order;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Retrieve an order for a given order id.
+ *
+ * The authorization check is done as follows:
+ * - If the user is logged in, we check if the order belongs to the user.
+ * - If the user is not logged in, we check if the order id matches the order's transaction id.
+ *
+ * @method merge(array $values)
+ * @method route(string $key)
+ */
+class GetOrderRequest extends BaseApiRequest
+{
+	public Order $order;
+	public string $transaction_id;
+
+	protected function prepareForValidation(): void
+	{
+		/** @disregard */
+		$this->merge([
+			'order_id' => $this->route('order_id'),
+		]);
+		/** @disregard */
+		if ($this->has('transaction_id') === false) {
+			/** @disregard */
+			$this->merge([
+				'transaction_id' => '',
+			]);
+		} else {
+			/** @disregard */
+			$this->merge([
+				'transaction_id' => strval($this->input('transaction_id')),
+			]);
+		}
+	}
+
+	public function authorize(): bool
+	{
+		/** @var User|null */
+		$user = Auth::user();
+
+		// Either we are admin or the order belongs to the user
+		if ($user?->may_administrate === true ||
+		($user !== null && $this->order->user_id === $user->id)) {
+			return true;
+		}
+
+		if ($user !== null && $this->order->user_id !== $user->id && $this->transaction_id === '') {
+			// If we are here, the user is logged in but the order does not belong to the user
+			return false;
+		}
+
+		return $this->order->transaction_id === $this->transaction_id;
+	}
+
+	public function rules(): array
+	{
+		return [
+			'order_id' => 'required|integer',
+			'transaction_id' => 'sometimes|string|max:191',
+		];
+	}
+
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		/** @var int $order_id */
+		$order_id = intval($values['order_id'] ?? null);
+		$this->order = Order::findOrFail($order_id);
+		$this->transaction_id = strval($values['transaction_id'] ?? '');
+	}
+}

--- a/app/Http/Requests/Order/ListOrderRequest.php
+++ b/app/Http/Requests/Order/ListOrderRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Order;
+
+use App\Http\Requests\AbstractEmptyRequest;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Retrieve all the Orders for a user.
+ *
+ * Only usable by logged in users.
+ */
+class ListOrderRequest extends AbstractEmptyRequest
+{
+	public function authorize(): bool
+	{
+		return Auth::check();
+	}
+}

--- a/app/Metadata/Cache/RouteCacheManager.php
+++ b/app/Metadata/Cache/RouteCacheManager.php
@@ -132,11 +132,14 @@ final readonly class RouteCacheManager
 			// Do not cache shop stuff, too much interaction with the user.
 			'api/v2/Shop' => false,
 			'api/v2/Shop/Basket' => false,
+			'api/v2/Shop/Checkout/Finalize/{provider}/{transaction_id}' => false,
 			'api/v2/Shop/Checkout/Cancel/{provider}/{transaction_id}' => false,
 
 			'api/v2/Shop/Checkout/Options' => new RouteCacheConfig(tag: CacheTag::SETTINGS, user_dependant: false),
 			'api/v2/Shop/Management/Options' => new RouteCacheConfig(tag: CacheTag::SETTINGS, user_dependant: true),
 			'api/v2/Shop/Management/List' => false,
+			'api/v2/Shop/Order/List' => false,
+			'api/v2/Shop/Order/{order_id}' => false,
 		];
 	}
 

--- a/routes/api_v2_shop.php
+++ b/routes/api_v2_shop.php
@@ -32,7 +32,7 @@ Route::middleware('support:se')->group(function (): void {
 		Route::get('/Options', [Shop\CheckoutController::class, 'options']);
 		Route::post('/Create-session', [Shop\CheckoutController::class, 'createSession']);
 		Route::post('/Process', [Shop\CheckoutController::class, 'process']);
-		Route::post('/Finalize/{provider}/{transaction_id}', [Shop\CheckoutController::class, 'finalize'])->name('shop.checkout.return');
+		Route::get('/Finalize/{provider}/{transaction_id}', [Shop\CheckoutController::class, 'finalize'])->withoutMiddleware(['content_type:json', 'accept_content_type:json'])->name('shop.checkout.return');
 		Route::get('/Cancel/{provider}/{transaction_id}', [Shop\CheckoutController::class, 'cancel'])->name('shop.checkout.cancel');
 	});
 	Route::group(['prefix' => '/Shop/Management'], function (): void {

--- a/routes/api_v2_shop.php
+++ b/routes/api_v2_shop.php
@@ -17,6 +17,10 @@ use Illuminate\Support\Facades\Route;
 // Only for SE sorry.
 Route::middleware('support:se')->group(function (): void {
 	Route::get('/Shop', [Shop\CatalogController::class, 'getAlbumCatalog']);
+	Route::group(['prefix' => '/Shop/Order'], function (): void {
+		Route::get('/List', [Shop\OrderController::class, 'list']);
+		Route::get('/{order_id}', [Shop\OrderController::class, 'get']);
+	});
 	Route::group(['prefix' => '/Shop/Basket'], function (): void {
 		Route::get('/', [Shop\BasketController::class, 'get']);
 		Route::post('/Photo', [Shop\BasketController::class, 'addPhoto']);

--- a/routes/web_v2.php
+++ b/routes/web_v2.php
@@ -70,7 +70,6 @@ Route::get('/orders', VueController::class)->middleware(['migration:complete', '
 Route::get('/basket', VueController::class)->middleware(['migration:complete']);
 Route::get('/checkout/{step?}', VueController::class)->middleware(['migration:complete']);
 
-
 Route::match(['get', 'post'], '/migrate', [Admin\UpdateController::class, 'migrate'])
 	->name('migrate')
 	->middleware(['migration:incomplete']);

--- a/routes/web_v2.php
+++ b/routes/web_v2.php
@@ -65,6 +65,11 @@ Route::get('/permissions', VueController::class)->middleware(['migration:complet
 Route::get('/fixTree', VueController::class)->middleware(['migration:complete', 'login_required:always']);
 Route::get('/duplicatesFinder', VueController::class)->middleware(['migration:complete', 'login_required:always']);
 Route::get('/renamerRules', VueController::class)->middleware(['migration:complete', 'login_required:always']);
+Route::get('/purchasables', VueController::class)->middleware(['migration:complete', 'login_required:always']);
+Route::get('/orders', VueController::class)->middleware(['migration:complete', 'login_required:always']);
+Route::get('/basket', VueController::class)->middleware(['migration:complete']);
+Route::get('/checkout/{step?}', VueController::class)->middleware(['migration:complete']);
+
 
 Route::match(['get', 'post'], '/migrate', [Admin\UpdateController::class, 'migrate'])
 	->name('migrate')

--- a/tests/Webshop/BasketControllerTest.php
+++ b/tests/Webshop/BasketControllerTest.php
@@ -84,7 +84,7 @@ class BasketControllerTest extends BaseApiWithDataTest
 		$response->assertJsonStructure([
 			'id',
 			'provider',
-			'user_id',
+			'username',
 			'email',
 			'status',
 			'amount',
@@ -96,7 +96,7 @@ class BasketControllerTest extends BaseApiWithDataTest
 
 		$response->assertJson([
 			'status' => PaymentStatusType::PENDING->value,
-			'user_id' => null,
+			'username' => null,
 			'items' => [],
 		]);
 
@@ -116,7 +116,7 @@ class BasketControllerTest extends BaseApiWithDataTest
 		$this->assertOk($response);
 		$response->assertJson([
 			'status' => PaymentStatusType::PENDING->value,
-			'user_id' => $this->userMayUpload1->id,
+			'username' => $this->userMayUpload1->name,
 			'items' => [],
 		]);
 	}
@@ -446,7 +446,7 @@ class BasketControllerTest extends BaseApiWithDataTest
 
 		$this->assertCreated($response);
 		$response->assertJson([
-			'user_id' => $this->userMayUpload1->id,
+			'username' => $this->userMayUpload1->name,
 		]);
 
 		// Verify basket is associated with the user

--- a/tests/Webshop/CheckoutCreateSessionControllerTest.php
+++ b/tests/Webshop/CheckoutCreateSessionControllerTest.php
@@ -51,7 +51,7 @@ class CheckoutCreateSessionControllerTest extends BaseCheckoutControllerTest
 		$response->assertJsonStructure([
 			'id',
 			'provider',
-			'user_id',
+			'username',
 			'email',
 			'status',
 			'amount',
@@ -94,7 +94,7 @@ class CheckoutCreateSessionControllerTest extends BaseCheckoutControllerTest
 		$this->assertCreated($response);
 		$response->assertJson([
 			'provider' => OmnipayProviderType::DUMMY->value,
-			'user_id' => $this->userMayUpload1->id,
+			'username' => $this->userMayUpload1->name,
 		]);
 	}
 
@@ -170,7 +170,7 @@ class CheckoutCreateSessionControllerTest extends BaseCheckoutControllerTest
 		$this->assertCreated($response);
 		$response->assertJson([
 			'provider' => OmnipayProviderType::DUMMY->value,
-			'user_id' => $this->userMayUpload1->id,
+			'username' => $this->userMayUpload1->name,
 			'email' => 'test@example.com',
 		]);
 	}

--- a/tests/Webshop/CheckoutFinalizeOrCancelControllerTest.php
+++ b/tests/Webshop/CheckoutFinalizeOrCancelControllerTest.php
@@ -52,7 +52,7 @@ class CheckoutFinalizeOrCancelControllerTest extends BaseCheckoutControllerTest
 
 		$this->assertDatabaseHas('orders', ['transaction_id' => $transaction_id, 'status' => PaymentStatusType::PROCESSING->value]);
 
-		$response = $this->postJson('Shop/Checkout/Finalize/' . $provider . '/' . $transaction_id, [
+		$response = $this->getJsonWithData('Shop/Checkout/Finalize/' . $provider . '/' . $transaction_id, [
 			'payment_id' => 'dummy-payment-123',
 			'status' => 'completed',
 			'transactionReference' => $this->test_order->transaction_id,
@@ -91,7 +91,7 @@ class CheckoutFinalizeOrCancelControllerTest extends BaseCheckoutControllerTest
 		$provider = OmnipayProviderType::DUMMY->value;
 		$invalidTransactionId = 'invalid-transaction-id';
 
-		$response = $this->postJson('Shop/Checkout/Finalize/' . $provider . '/' . $invalidTransactionId);
+		$response = $this->getJson('Shop/Checkout/Finalize/' . $provider . '/' . $invalidTransactionId);
 
 		$this->assertNotFound($response);
 	}
@@ -109,7 +109,7 @@ class CheckoutFinalizeOrCancelControllerTest extends BaseCheckoutControllerTest
 		$invalidProvider = 'invalid-provider';
 		$transaction_id = $this->test_order->transaction_id;
 
-		$response = $this->postJson('Shop/Checkout/Finalize/' . $invalidProvider . '/' . $transaction_id);
+		$response = $this->getJson('Shop/Checkout/Finalize/' . $invalidProvider . '/' . $transaction_id);
 
 		$this->assertUnprocessable($response);
 	}
@@ -224,7 +224,7 @@ class CheckoutFinalizeOrCancelControllerTest extends BaseCheckoutControllerTest
 		$provider = OmnipayProviderType::DUMMY->value;
 		$transaction_id = $this->test_order->transaction_id;
 
-		$response = $this->postJson('Shop/Checkout/Finalize/' . $provider . '/' . $transaction_id, [
+		$response = $this->getJsonWithData('Shop/Checkout/Finalize/' . $provider . '/' . $transaction_id, [
 			'payment_id' => 'dummy-payment-123',
 			'status' => 'completed',
 			'transactionReference' => $this->test_order->transaction_id,

--- a/tests/Webshop/OrderListingAccessTest.php
+++ b/tests/Webshop/OrderListingAccessTest.php
@@ -1,0 +1,333 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Webshop;
+
+use App\Enum\OmnipayProviderType;
+use App\Enum\PaymentStatusType;
+use App\Models\Order;
+use Illuminate\Support\Str;
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+use Tests\Traits\RequireSE;
+
+/**
+ * Test class for OrderController listing and access functionality.
+ *
+ * This class tests the order listing and retrieval functionality:
+ * - Listing orders (authentication required)
+ * - Getting specific order by ID (with proper authorization)
+ * - Access control for different user roles
+ * - Transaction ID based access for non-authenticated users
+ */
+class OrderListingAccessTest extends BaseApiWithDataTest
+{
+	use RequireSE;
+
+	private Order $order1;
+	private Order $order2;
+	private Order $order3;
+	private string $transaction_id1;
+	private string $transaction_id2;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->requireSe();
+
+		// Create orders for different scenarios
+		$this->transaction_id1 = Str::uuid()->toString();
+		$this->transaction_id2 = Str::uuid()->toString();
+
+		// Order 1: Belongs to userMayUpload1
+		$this->order1 = Order::factory()
+			->forUser($this->userMayUpload1)
+			->withTransactionId($this->transaction_id1)
+			->withProvider(OmnipayProviderType::STRIPE)
+			->withStatus(PaymentStatusType::COMPLETED)
+			->withEmail($this->userMayUpload1->email)
+			->create();
+
+		// Order 2: Belongs to userMayUpload2
+		$this->order2 = Order::factory()
+			->forUser($this->userMayUpload2)
+			->withTransactionId($this->transaction_id2)
+			->withProvider(OmnipayProviderType::PAYPAL_EXPRESS)
+			->withStatus(PaymentStatusType::PENDING)
+			->withEmail($this->userMayUpload2->email)
+			->create();
+
+		// Order 3: Anonymous order (no user)
+		$this->order3 = Order::factory()
+			->withTransactionId(Str::uuid()->toString())
+			->withProvider(OmnipayProviderType::STRIPE)
+			->withStatus(PaymentStatusType::COMPLETED)
+			->withEmail('anonymous@example.com')
+			->create();
+	}
+
+	public function tearDown(): void
+	{
+		$this->resetSe();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test listing orders when not authenticated.
+	 * Should return 401 Unauthorized.
+	 */
+	public function testListOrdersNotAuthenticated(): void
+	{
+		$response = $this->getJson('Shop/Order/List');
+
+		$this->assertUnauthorized($response);
+	}
+
+	/**
+	 * Test listing orders as regular user.
+	 * Should return orders accessible to the user.
+	 */
+	public function testListOrdersAsRegularUser(): void
+	{
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Shop/Order/List');
+
+		$this->assertOk($response);
+
+		// Should return array of orders
+		$response->assertJsonStructure([
+			'*' => [
+				'id',
+				'provider',
+				'username',
+				'email',
+				'status',
+				'amount',
+				'created_at',
+				'paid_at',
+				'comment',
+			],
+		]);
+
+		$orders = $response->json();
+		$this->assertIsArray($orders);
+
+		// Find user's order in the response
+		$userOrder = collect($orders)->firstWhere('id', $this->order1->id);
+		$this->assertNotNull($userOrder);
+		$this->assertEquals($this->order1->transaction_id, $userOrder['transaction_id']);
+		$this->assertEquals($this->userMayUpload1->name, $userOrder['username']);
+	}
+
+	/**
+	 * Test listing orders as admin user.
+	 * Should return all orders in the system.
+	 */
+	public function testListOrdersAsAdmin(): void
+	{
+		$response = $this->actingAs($this->admin)->getJson('Shop/Order/List');
+
+		$this->assertOk($response);
+
+		$orders = $response->json();
+		$this->assertIsArray($orders);
+
+		// Admin should see all orders
+		$orderIds = collect($orders)->pluck('id')->toArray();
+		$this->assertContains($this->order1->id, $orderIds);
+		$this->assertContains($this->order2->id, $orderIds);
+		$this->assertContains($this->order3->id, $orderIds);
+	}
+
+	/**
+	 * Test getting specific order when not authenticated and no transaction ID provided.
+	 * Should return 401 Unauthorized.
+	 */
+	public function testGetOrderNotAuthenticatedNoTransactionId(): void
+	{
+		$response = $this->getJson("Shop/Order/{$this->order1->id}");
+
+		$this->assertUnauthorized($response);
+	}
+
+	/**
+	 * Test getting specific order when not authenticated but with valid transaction ID.
+	 * Should return the order.
+	 */
+	public function testGetOrderNotAuthenticatedWithValidTransactionId(): void
+	{
+		$response = $this->getJson("Shop/Order/{$this->order1->id}?transaction_id={$this->transaction_id1}");
+
+		$this->assertOk($response);
+		$response->assertJson([
+			'id' => $this->order1->id,
+			'transaction_id' => $this->transaction_id1,
+			'username' => $this->userMayUpload1->name,
+			'status' => PaymentStatusType::COMPLETED->value,
+		]);
+	}
+
+	/**
+	 * Test getting specific order when not authenticated but with invalid transaction ID.
+	 * Should return 403 Forbidden.
+	 */
+	public function testGetOrderNotAuthenticatedWithInvalidTransactionId(): void
+	{
+		$invalidTransactionId = Str::uuid()->toString();
+		$response = $this->getJson("Shop/Order/{$this->order1->id}?transaction_id={$invalidTransactionId}");
+
+		$this->assertUnauthorized($response);
+	}
+
+	/**
+	 * Test getting own order as authenticated user.
+	 * Should return the order.
+	 */
+	public function testGetOwnOrderAsAuthenticatedUser(): void
+	{
+		$response = $this->actingAs($this->userMayUpload1)->getJson("Shop/Order/{$this->order1->id}");
+
+		$this->assertOk($response);
+		$response->assertJson([
+			'id' => $this->order1->id,
+			'transaction_id' => $this->transaction_id1,
+			'username' => $this->userMayUpload1->name,
+			'status' => PaymentStatusType::COMPLETED->value,
+		]);
+	}
+
+	/**
+	 * Test getting other user's order as authenticated user (non-admin).
+	 * Should return 403 Forbidden when no transaction ID provided.
+	 */
+	public function testGetOtherUserOrderAsAuthenticatedUserNoTransactionId(): void
+	{
+		$response = $this->actingAs($this->userMayUpload1)->getJson("Shop/Order/{$this->order2->id}");
+
+		$this->assertForbidden($response);
+	}
+
+	/**
+	 * Test getting other user's order as authenticated user with valid transaction ID.
+	 * Should return the order.
+	 */
+	public function testGetOtherUserOrderAsAuthenticatedUserWithValidTransactionId(): void
+	{
+		$response = $this->actingAs($this->userMayUpload1)->getJson("Shop/Order/{$this->order2->id}?transaction_id={$this->transaction_id2}");
+
+		$this->assertOk($response);
+		$response->assertJson([
+			'id' => $this->order2->id,
+			'transaction_id' => $this->transaction_id2,
+			'username' => $this->userMayUpload2->name,
+			'status' => PaymentStatusType::PENDING->value,
+		]);
+	}
+
+	/**
+	 * Test getting any order as admin user.
+	 * Should return the order regardless of ownership.
+	 */
+	public function testGetOrderAsAdmin(): void
+	{
+		$response = $this->actingAs($this->admin)->getJson("Shop/Order/{$this->order2->id}");
+
+		$this->assertOk($response);
+		$response->assertJson([
+			'id' => $this->order2->id,
+			'transaction_id' => $this->transaction_id2,
+			'username' => $this->userMayUpload2->name,
+			'status' => PaymentStatusType::PENDING->value,
+		]);
+	}
+
+	/**
+	 * Test getting anonymous order (no user_id) with valid transaction ID.
+	 * Should return the order.
+	 */
+	public function testGetAnonymousOrderWithValidTransactionId(): void
+	{
+		$response = $this->getJson("Shop/Order/{$this->order3->id}?transaction_id={$this->order3->transaction_id}");
+
+		$this->assertOk($response);
+		$response->assertJson([
+			'id' => $this->order3->id,
+			'transaction_id' => $this->order3->transaction_id,
+			'username' => null,
+			'status' => PaymentStatusType::COMPLETED->value,
+			'email' => 'anonymous@example.com',
+		]);
+	}
+
+	/**
+	 * Test getting anonymous order with invalid transaction ID.
+	 * Should return 403 Forbidden.
+	 */
+	public function testGetAnonymousOrderWithInvalidTransactionId(): void
+	{
+		$invalidTransactionId = Str::uuid()->toString();
+		$response = $this->getJson("Shop/Order/{$this->order3->id}?transaction_id={$invalidTransactionId}");
+
+		$this->assertUnauthorized($response);
+	}
+
+	/**
+	 * Test getting non-existent order.
+	 * Should return 404 Not Found.
+	 */
+	public function testGetNonExistentOrder(): void
+	{
+		$nonExistentId = 99999;
+		$response = $this->actingAs($this->admin)->getJson("Shop/Order/{$nonExistentId}");
+
+		$this->assertNotFound($response);
+	}
+
+	/**
+	 * Test getting order with invalid ID format.
+	 * Should return validation error.
+	 */
+	public function testGetOrderWithInvalidIdFormat(): void
+	{
+		$response = $this->actingAs($this->admin)->getJson('Shop/Order/invalid');
+
+		// This should return a validation error or 404, depending on routing
+		$this->assertStatus($response, [404, 422]);
+	}
+
+	/**
+	 * Test the JSON structure of order response.
+	 * Should include all expected fields.
+	 */
+	public function testOrderResponseStructure(): void
+	{
+		$response = $this->actingAs($this->admin)->getJson("Shop/Order/{$this->order1->id}");
+
+		$this->assertOk($response);
+		$response->assertJsonStructure([
+			'id',
+			'transaction_id',
+			'provider',
+			'username',
+			'email',
+			'status',
+			'amount',
+			'created_at',
+			'paid_at',
+			'comment',
+		]);
+	}
+}


### PR DESCRIPTION
This adds a listing for all orders.
The will also later allow access to already paid orders with items.

For now it serves as listing mostly from admin view of all the current orders in the system.
Pagination to be implemented later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Orders API endpoints to list orders and fetch order details; new public web routes for purchasables, orders, basket, and checkout.

* **Enhancements**
  * Responses now include transaction_id, username, can_process_payment; items returned only when available.
  * Checkout finalize is accessible via GET and bypasses CSRF for its return route.
  * Listing/getting orders enforces new authorization/validation rules.

* **Breaking Changes**
  * Replaced user_id with username across basket, checkout, and order responses.

* **Chores**
  * Updated route caching and tests to reflect new routes and GET usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->