### PR TITLE
Add photo / album dependant rules

### DIFF
--- a/app/Actions/Import/Pipes/CreateNonExistingAlbums.php
+++ b/app/Actions/Import/Pipes/CreateNonExistingAlbums.php
@@ -76,7 +76,7 @@ class CreateNonExistingAlbums implements ImportPipe
 
 		// We do this to keep backward compatibility with previously imported albums.
 		if ($this->state->import_mode->shall_rename_album_title) {
-			$renamer = $this->state->getRenamer();
+			$renamer = $this->state->getAlbumRenamer();
 			$title = $renamer->handle($title);
 		}
 

--- a/app/Actions/Import/Pipes/DeleteMissingAlbums.php
+++ b/app/Actions/Import/Pipes/DeleteMissingAlbums.php
@@ -106,7 +106,7 @@ class DeleteMissingAlbums implements ImportPipe
 
 		// get renamed albums
 		if ($this->state->import_mode->shall_rename_album_title) {
-			$renamed_existing_folders = $this->state->getRenamer()->handleMany($existing_folders);
+			$renamed_existing_folders = $this->state->getAlbumRenamer()->handleMany($existing_folders);
 			$existing_folders = array_merge($existing_folders, $renamed_existing_folders);
 		}
 

--- a/app/Actions/Import/Pipes/DeleteMissingPhotos.php
+++ b/app/Actions/Import/Pipes/DeleteMissingPhotos.php
@@ -115,7 +115,7 @@ class DeleteMissingPhotos implements ImportPipe
 
 		if ($this->state->import_mode->shall_rename_photo_title) {
 			// Apply renamer rules to the existing filenames
-			$renamed_existing_files = $this->state->getRenamer()->handleMany($existing_files);
+			$renamed_existing_files = $this->state->getPhotoRenamer()->handleMany($existing_files);
 			$existing_files = array_merge($existing_files, $renamed_existing_files);
 		}
 

--- a/app/Actions/Import/Pipes/ImportPhotos.php
+++ b/app/Actions/Import/Pipes/ImportPhotos.php
@@ -97,8 +97,8 @@ class ImportPhotos implements ImportPipe
 		foreach ($image_paths as $key => $image_path) {
 			$basename = basename($image_path);
 			$filename = pathinfo($image_path, PATHINFO_FILENAME);
-			$renamed_basename = $this->state->getRenamer()->handle($basename);
-			$renamed_filename = $this->state->getRenamer()->handle($filename);
+			$renamed_basename = $this->state->getPhotoRenamer()->handle($basename);
+			$renamed_filename = $this->state->getPhotoRenamer()->handle($filename);
 
 			if (in_array($basename, $already_existing, true) ||
 				in_array($filename, $already_existing, true) ||
@@ -144,7 +144,7 @@ class ImportPhotos implements ImportPipe
 		$candidates = array_merge($base_names, $file_names);
 
 		if ($this->state->import_mode->shall_rename_photo_title) {
-			$candidates_renamed = $this->state->getRenamer()->handleMany($candidates);
+			$candidates_renamed = $this->state->getPhotoRenamer()->handleMany($candidates);
 			$candidates = array_merge($candidates, $candidates_renamed);
 		}
 

--- a/app/Actions/Photo/Pipes/Standalone/AutoRenamer.php
+++ b/app/Actions/Photo/Pipes/Standalone/AutoRenamer.php
@@ -10,7 +10,7 @@ namespace App\Actions\Photo\Pipes\Standalone;
 
 use App\Contracts\PhotoCreate\StandalonePipe;
 use App\DTO\PhotoCreate\StandaloneDTO;
-use App\Metadata\Renamer;
+use App\Metadata\Renamer\PhotoRenamer;
 
 /**
  * Apply renaming rules to the photo title.
@@ -29,7 +29,7 @@ class AutoRenamer implements StandalonePipe
 			return $next($state);
 		}
 
-		$renamer = new Renamer($state->intended_owner_id);
+		$renamer = new PhotoRenamer($state->intended_owner_id);
 		$state->photo->title = $renamer->handle($state->photo->title);
 
 		return $next($state);

--- a/app/Contracts/Http/Requests/RequestAttribute.php
+++ b/app/Contracts/Http/Requests/RequestAttribute.php
@@ -121,6 +121,8 @@ class RequestAttribute
 	public const MODE_ATTRIBUTE = 'mode';
 	public const ORDER_ATTRIBUTE = 'order';
 	public const IS_ENABLED_ATTRIBUTE = 'is_enabled';
+	public const IS_PHOTO_RULE_ATTRIBUTE = 'is_photo_rule';
+	public const IS_ALBUM_RULE_ATTRIBUTE = 'is_album_rule';
 
 	/**
 	 * Shop management attributes.

--- a/app/DTO/ImportDTO.php
+++ b/app/DTO/ImportDTO.php
@@ -11,7 +11,8 @@ namespace App\DTO;
 use App\Actions\Album\Create as AlbumCreate;
 use App\Actions\Photo\Create as PhotoCreate;
 use App\Jobs\ImportImageJob;
-use App\Metadata\Renamer;
+use App\Metadata\Renamer\AlbumRenamer;
+use App\Metadata\Renamer\PhotoRenamer;
 use App\Models\Album;
 
 class ImportDTO
@@ -19,7 +20,8 @@ class ImportDTO
 	protected AlbumCreate $album_create;
 	protected PhotoCreate $photo_create;
 	public FolderNode $root_folder;
-	protected Renamer $renamer;
+	protected AlbumRenamer $album_renamer;
+	protected PhotoRenamer $photo_renamer;
 
 	/** @var ImportImageJob[] */
 	public array $job_bus = [];
@@ -36,7 +38,8 @@ class ImportDTO
 	) {
 		$this->album_create = new AlbumCreate($intended_owner_id);
 		$this->photo_create = new PhotoCreate($import_mode, $intended_owner_id);
-		$this->renamer = new Renamer($intended_owner_id);
+		$this->album_renamer = new AlbumRenamer($intended_owner_id);
+		$this->photo_renamer = new PhotoRenamer($intended_owner_id);
 	}
 
 	public function getAlbumCreate(): AlbumCreate
@@ -49,8 +52,13 @@ class ImportDTO
 		return $this->photo_create;
 	}
 
-	public function getRenamer(): Renamer
+	public function getPhotoRenamer(): PhotoRenamer
 	{
-		return $this->renamer;
+		return $this->photo_renamer;
+	}
+
+	public function getAlbumRenamer(): AlbumRenamer
+	{
+		return $this->album_renamer;
 	}
 }

--- a/app/Http/Requests/Renamer/CreateRenamerRuleRequest.php
+++ b/app/Http/Requests/Renamer/CreateRenamerRuleRequest.php
@@ -31,6 +31,8 @@ class CreateRenamerRuleRequest extends BaseApiRequest implements HasDescription
 	public RenamerModeType $mode;
 	public int $order;
 	public bool $is_enabled;
+	public bool $is_photo_rule;
+	public bool $is_album_rule;
 
 	/**
 	 * {@inheritDoc}
@@ -55,6 +57,8 @@ class CreateRenamerRuleRequest extends BaseApiRequest implements HasDescription
 			RequestAttribute::MODE_ATTRIBUTE => ['required', new Enum(RenamerModeType::class)],
 			RequestAttribute::ORDER_ATTRIBUTE => ['required', 'integer', 'min:1'],
 			RequestAttribute::IS_ENABLED_ATTRIBUTE => ['required', 'boolean'],
+			RequestAttribute::IS_PHOTO_RULE_ATTRIBUTE => ['required', 'boolean'],
+			RequestAttribute::IS_ALBUM_RULE_ATTRIBUTE => ['required', 'boolean'],
 		];
 	}
 
@@ -70,5 +74,7 @@ class CreateRenamerRuleRequest extends BaseApiRequest implements HasDescription
 		$this->mode = RenamerModeType::from($values[RequestAttribute::MODE_ATTRIBUTE]);
 		$this->order = $values[RequestAttribute::ORDER_ATTRIBUTE];
 		$this->is_enabled = self::toBoolean($values[RequestAttribute::IS_ENABLED_ATTRIBUTE]);
+		$this->is_photo_rule = self::toBoolean($values[RequestAttribute::IS_PHOTO_RULE_ATTRIBUTE]);
+		$this->is_album_rule = self::toBoolean($values[RequestAttribute::IS_ALBUM_RULE_ATTRIBUTE]);
 	}
 }

--- a/app/Http/Requests/Renamer/RenameRequest.php
+++ b/app/Http/Requests/Renamer/RenameRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Renamer;
+
+use App\Contracts\Http\Requests\HasAlbumIds;
+use App\Contracts\Http\Requests\HasPhotoIds;
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Contracts\Models\AbstractAlbum;
+use App\Http\Requests\BaseApiRequest;
+use App\Http\Requests\Traits\HasAlbumIdsTrait;
+use App\Http\Requests\Traits\HasPhotoIdsTrait;
+use App\Models\Photo;
+use App\Policies\AlbumPolicy;
+use App\Policies\PhotoPolicy;
+use App\Rules\RandomIDRule;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Request for renaming already existing photos/albums given their Id.
+ */
+class RenameRequest extends BaseApiRequest implements HasPhotoIds, HasAlbumIds
+{
+	use HasPhotoIdsTrait;
+	use HasAlbumIdsTrait;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::check(PhotoPolicy::CAN_EDIT_ID, [Photo::class, $this->photoIds()]) &&
+			Gate::check(AlbumPolicy::CAN_EDIT_ID, [AbstractAlbum::class, $this->albumIds()]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function rules(): array
+	{
+		return [
+			RequestAttribute::ALBUM_IDS_ATTRIBUTE => ['sometimes', 'array'],
+			RequestAttribute::ALBUM_IDS_ATTRIBUTE . '.*' => ['string', new RandomIDRule(false)],
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE => ['sometimes', 'array'],
+			RequestAttribute::PHOTO_IDS_ATTRIBUTE . '.*' => ['string', new RandomIDRule(false)],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		$this->photo_ids = $values[RequestAttribute::PHOTO_IDS_ATTRIBUTE] ?? [];
+		$this->album_ids = $values[RequestAttribute::ALBUM_IDS_ATTRIBUTE] ?? [];
+	}
+}

--- a/app/Http/Requests/Renamer/TestRenamerRequest.php
+++ b/app/Http/Requests/Renamer/TestRenamerRequest.php
@@ -19,6 +19,9 @@ class TestRenamerRequest extends BaseApiRequest
 {
 	public string $candidate;
 
+	public bool $is_photo;
+	public bool $is_album;
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -36,6 +39,8 @@ class TestRenamerRequest extends BaseApiRequest
 	{
 		return [
 			'candidate' => ['required', new StringRule(false, 1000)],
+			'is_photo' => ['required', 'boolean'],
+			'is_album' => ['required', 'boolean'],
 		];
 	}
 
@@ -45,5 +50,7 @@ class TestRenamerRequest extends BaseApiRequest
 	protected function processValidatedValues(array $values, array $files): void
 	{
 		$this->candidate = $values['candidate'];
+		$this->is_photo = self::toBoolean($values['is_photo']);
+		$this->is_album = self::toBoolean($values['is_album']);
 	}
 }

--- a/app/Http/Requests/Renamer/UpdateRenamerRuleRequest.php
+++ b/app/Http/Requests/Renamer/UpdateRenamerRuleRequest.php
@@ -33,6 +33,8 @@ class UpdateRenamerRuleRequest extends BaseApiRequest implements HasDescription
 	public RenamerModeType $mode;
 	public int $order;
 	public bool $is_enabled;
+	public bool $is_photo_rule;
+	public bool $is_album_rule;
 
 	/**
 	 * {@inheritDoc}
@@ -63,6 +65,8 @@ class UpdateRenamerRuleRequest extends BaseApiRequest implements HasDescription
 			RequestAttribute::MODE_ATTRIBUTE => ['required', new Enum(RenamerModeType::class)],
 			RequestAttribute::ORDER_ATTRIBUTE => ['required', 'integer', 'min:1'],
 			RequestAttribute::IS_ENABLED_ATTRIBUTE => ['required', 'boolean'],
+			RequestAttribute::IS_PHOTO_RULE_ATTRIBUTE => ['required', 'boolean'],
+			RequestAttribute::IS_ALBUM_RULE_ATTRIBUTE => ['required', 'boolean'],
 		];
 	}
 
@@ -79,5 +83,7 @@ class UpdateRenamerRuleRequest extends BaseApiRequest implements HasDescription
 		$this->mode = RenamerModeType::from($values[RequestAttribute::MODE_ATTRIBUTE]);
 		$this->order = $values[RequestAttribute::ORDER_ATTRIBUTE];
 		$this->is_enabled = self::toBoolean($values[RequestAttribute::IS_ENABLED_ATTRIBUTE]);
+		$this->is_photo_rule = self::toBoolean($values[RequestAttribute::IS_PHOTO_RULE_ATTRIBUTE]);
+		$this->is_album_rule = self::toBoolean($values[RequestAttribute::IS_ALBUM_RULE_ATTRIBUTE]);
 	}
 }

--- a/app/Http/Resources/Models/RenamerRuleResource.php
+++ b/app/Http/Resources/Models/RenamerRuleResource.php
@@ -25,6 +25,8 @@ class RenamerRuleResource extends Data
 	public string $replacement;
 	public RenamerModeType $mode;
 	public bool $is_enabled;
+	public bool $is_photo_rule;
+	public bool $is_album_rule;
 
 	public function __construct(RenamerRule $renamer_rule)
 	{
@@ -37,6 +39,8 @@ class RenamerRuleResource extends Data
 		$this->replacement = $renamer_rule->replacement;
 		$this->mode = $renamer_rule->mode;
 		$this->is_enabled = $renamer_rule->is_enabled;
+		$this->is_photo_rule = $renamer_rule->is_photo_rule;
+		$this->is_album_rule = $renamer_rule->is_album_rule;
 	}
 
 	public static function fromModel(RenamerRule $renamer_rule): RenamerRuleResource

--- a/app/Metadata/Renamer/AlbumRenamer.php
+++ b/app/Metadata/Renamer/AlbumRenamer.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Metadata\Renamer;
+
+final class AlbumRenamer extends Renamer
+{
+	public function __construct(int $user_id)
+	{
+		parent::__construct(
+			user_id: $user_id,
+			is_album: true,
+		);
+	}
+}

--- a/app/Metadata/Renamer/PhotoRenamer.php
+++ b/app/Metadata/Renamer/PhotoRenamer.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+namespace App\Metadata\Renamer;
+
+final class PhotoRenamer extends Renamer
+{
+	public function __construct(int $user_id)
+	{
+		parent::__construct(
+			user_id: $user_id,
+			is_photo: true,
+		);
+	}
+}

--- a/app/Metadata/Renamer/Renamer.php
+++ b/app/Metadata/Renamer/Renamer.php
@@ -80,7 +80,6 @@ class Renamer
 			->when($is_photo !== null, fn ($query) => $query->where('is_photo_rule', $is_photo))
 			->when($is_album !== null, fn ($query) => $query->where('is_album_rule', $is_album))
 			->where('is_enabled', true)
-			->where('is_enabled', true)
 			->orderBy('order', 'asc')
 			->get();
 

--- a/app/Models/RenamerRule.php
+++ b/app/Models/RenamerRule.php
@@ -32,6 +32,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string          $replacement
  * @property RenamerModeType $mode
  * @property bool            $is_enabled
+ * @property bool            $is_photo_rule
+ * @property bool            $is_album_rule
  * @property User            $owner
  */
 class RenamerRule extends Model
@@ -55,6 +57,8 @@ class RenamerRule extends Model
 		'replacement',
 		'mode',
 		'is_enabled',
+		'is_photo_rule',
+		'is_album_rule',
 	];
 
 	/**
@@ -67,6 +71,8 @@ class RenamerRule extends Model
 		'owner_id' => 'integer',
 		'mode' => RenamerModeType::class,
 		'is_enabled' => 'boolean',
+		'is_photo_rule' => 'boolean',
+		'is_album_rule' => 'boolean',
 	];
 
 	/**

--- a/database/factories/RenamerRuleFactory.php
+++ b/database/factories/RenamerRuleFactory.php
@@ -40,6 +40,8 @@ class RenamerRuleFactory extends Factory
 			'replacement' => null,
 			'mode' => null,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		];
 	}
 
@@ -57,6 +59,24 @@ class RenamerRuleFactory extends Factory
 		return $this->state(function (array $attributes) use ($owner_id) {
 			return [
 				'owner_id' => $owner_id,
+			];
+		});
+	}
+
+	public function is_photo_rule(bool $is_photo_rule): self
+	{
+		return $this->state(function (array $attributes) use ($is_photo_rule) {
+			return [
+				'is_photo_rule' => $is_photo_rule,
+			];
+		});
+	}
+
+	public function is_album_rule(bool $is_album_rule): self
+	{
+		return $this->state(function (array $attributes) use ($is_album_rule) {
+			return [
+				'is_album_rule' => $is_album_rule,
 			];
 		});
 	}

--- a/database/migrations/2025_10_05_071052_add_album_photo_renamer.php
+++ b/database/migrations/2025_10_05_071052_add_album_photo_renamer.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2025_10_05_071052_add_album_photo_renamer.php
+++ b/database/migrations/2025_10_05_071052_add_album_photo_renamer.php
@@ -18,7 +18,7 @@ return new class() extends Migration {
 	 */
 	public function down(): void
 	{
-		Schema::table('base_albums', function (Blueprint $table) {
+		Schema::table('renamer_rules', function (Blueprint $table) {
 			$table->dropColumn('is_photo_rule');
 			$table->dropColumn('is_album_rule');
 		});

--- a/database/migrations/2025_10_05_071052_add_album_photo_renamer.php
+++ b/database/migrations/2025_10_05_071052_add_album_photo_renamer.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+	public function up(): void
+	{
+		Schema::table('renamer_rules', function (Blueprint $table) {
+			$table->boolean('is_photo_rule')->nullable(false)->default(true)->after('is_enabled');
+			$table->boolean('is_album_rule')->nullable(false)->default(true)->after('is_photo_rule');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		Schema::table('base_albums', function (Blueprint $table) {
+			$table->dropColumn('is_photo_rule');
+			$table->dropColumn('is_album_rule');
+		});
+	}
+};

--- a/lang/ar/renamer.php
+++ b/lang/ar/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/cz/renamer.php
+++ b/lang/cz/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/de/renamer.php
+++ b/lang/de/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/el/renamer.php
+++ b/lang/el/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/en/renamer.php
+++ b/lang/en/renamer.php
@@ -85,8 +85,6 @@ return [
 	'replace_with_label' => 'Replace with',
 	'photo' => 'Photo',
 	'album' => 'Album',
-	'photo' => 'Photo',
-	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/en/renamer.php
+++ b/lang/en/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,10 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/es/renamer.php
+++ b/lang/es/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/fa/renamer.php
+++ b/lang/fa/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'حالت',
 	'order' => 'ترتیب',
 	'enabled' => 'فعال',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'توضیحات اختیاری در مورد عملکرد این قانون',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'در حال بارگیری قوانین تغییر نام...',
 	'pattern_label' => 'الگو',
 	'replace_with_label' => 'جایگزین با',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'تایید حذف',

--- a/lang/fr/renamer.php
+++ b/lang/fr/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/hu/renamer.php
+++ b/lang/hu/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/it/renamer.php
+++ b/lang/it/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/ja/renamer.php
+++ b/lang/ja/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/nl/renamer.php
+++ b/lang/nl/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/no/renamer.php
+++ b/lang/no/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/pl/renamer.php
+++ b/lang/pl/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/pt/renamer.php
+++ b/lang/pt/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/ru/renamer.php
+++ b/lang/ru/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/sk/renamer.php
+++ b/lang/sk/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/sv/renamer.php
+++ b/lang/sv/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/vi/renamer.php
+++ b/lang/vi/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/zh_CN/renamer.php
+++ b/lang/zh_CN/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/lang/zh_TW/renamer.php
+++ b/lang/zh_TW/renamer.php
@@ -22,6 +22,8 @@ return [
 	'mode' => 'Mode',
 	'order' => 'Order',
 	'enabled' => 'Enabled',
+	'photo_rule' => 'Rule applied to Photos',
+	'album_rule' => 'Rule applied to Albums',
 
 	// Form placeholders and help text
 	'description_placeholder' => 'Optional description of what this rule does',
@@ -81,6 +83,8 @@ return [
 	'loading' => 'Loading renamer rules...',
 	'pattern_label' => 'Pattern',
 	'replace_with_label' => 'Replace with',
+	'photo' => 'Photo',
+	'album' => 'Album',
 
 	// Delete confirmation
 	'confirm_delete_header' => 'Confirm Deletion',

--- a/resources/js/components/renamer/RenamerRuleLine.vue
+++ b/resources/js/components/renamer/RenamerRuleLine.vue
@@ -7,18 +7,28 @@
 				<div class="flex items-center">
 					<div :class="{ 'w-2 h-2 rounded-full': true, 'bg-green-500': rule.is_enabled, 'bg-red-500': !rule.is_enabled }"></div>
 				</div>
+				<div class="flex flex-col gap-2">
+					<Tag
+						:value="$t('renamer.photo')"
+						v-if="rule.is_photo_rule"
+						severity="success"
+						rounded
+						class="px-2 py-0.25 text-2xs ltr:mr-2 rtl:ml-2"
+					/>
+					<Tag :value="$t('renamer.album')" v-if="rule.is_album_rule" severity="warn" rounded class="px-2 py-0.25 text-2xs" />
+				</div>
 			</div>
 
 			<!-- Rule info -->
 			<div class="flex-grow flex-col justify-start">
 				<div class="flex items-center gap-4">
 					<h4 class="text-sm font-bold">{{ rule.rule }}</h4>
-					<Tag :value="rule.mode" severity="primary" size="small" rounded class="px-4 py-0.5" />
+					<Tag :value="rule.mode" severity="primary" rounded class="px-4 py-0.5" />
 				</div>
 				<p v-if="rule.description" class="text-xs text-muted-color mt-1">{{ rule.description }}</p>
 			</div>
 			<!-- This part might change later with more complex rules... -->
-			<div class="text-xs text-muted-color mt-1 text-center flex-grow">
+			<div class="text-xs text-muted-color mt-1 text-center flex-grow" v-show="hasNeddle">
 				<span class="font-medium mx-2">{{ $t("renamer.pattern_label") }}:</span>
 				<pre class="inline font-mono before:content-['`'] after:content-['`']">{{ rule.needle }}</pre>
 				<span class="mx-2 rtl:hidden">&xrarr;</span><span class="mx-2 ltr:hidden">&xlarr;</span
@@ -38,8 +48,9 @@
 <script setup lang="ts">
 import Button from "primevue/button";
 import Tag from "primevue/tag";
+import { computed } from "vue";
 
-defineProps<{
+const props = defineProps<{
 	rule: App.Http.Resources.Models.RenamerRuleResource;
 	canEdit: boolean;
 	canDelete: boolean;
@@ -49,4 +60,8 @@ defineEmits<{
 	edit: [];
 	delete: [];
 }>();
+
+const hasNeddle = computed(() => {
+	return ["first", "all", "regex"].includes(props.rule.mode);
+});
 </script>

--- a/resources/js/components/renamer/RenamerRuleModal.vue
+++ b/resources/js/components/renamer/RenamerRuleModal.vue
@@ -259,7 +259,7 @@ function resetForm() {
 			order: 1,
 			is_enabled: true,
 			is_photo_rule: true,
-			is_album_rule: false,
+			is_album_rule: true,
 		};
 	}
 	errors.value = {};

--- a/resources/js/components/renamer/RenamerRuleModal.vue
+++ b/resources/js/components/renamer/RenamerRuleModal.vue
@@ -124,14 +124,30 @@
 						</div>
 
 						<!-- Enabled -->
-						<div class="flex flex-col">
-							<div class="flex items-center">
-								<ToggleSwitch id="is_enabled" v-model="form.is_enabled" :binary="true" input-id="is_enabled" />
-								<label for="is_enabled" class="ltr:ml-2 rtl:mr-2"
-									><span class="font-semibold">{{ $t("renamer.enabled") }}</span>
-								</label>
+						<div class="grid grid-cols-2">
+							<div class="flex flex-col">
+								<div class="flex items-center">
+									<ToggleSwitch id="is_enabled" v-model="form.is_enabled" :binary="true" input-id="is_enabled" />
+									<label for="is_enabled" class="ltr:ml-2 rtl:mr-2"
+										><span class="font-semibold">{{ $t("renamer.enabled") }}</span>
+									</label>
+								</div>
+								<small class="text-muted-color ltr:text-left rtl:text-right">{{ $t("renamer.enabled_help") }}</small>
 							</div>
-							<small class="text-muted-color ltr:text-left rtl:text-right">{{ $t("renamer.enabled_help") }}</small>
+							<div class="flex flex-col">
+								<div class="flex items-center">
+									<ToggleSwitch id="is_photo_rule" v-model="form.is_photo_rule" :binary="true" input-id="is_photo_rule" />
+									<label for="is_photo_rule" class="ltr:ml-2 rtl:mr-2"
+										><span class="font-semibold">{{ $t("renamer.photo_rule") }}</span>
+									</label>
+								</div>
+								<div class="flex items-center">
+									<ToggleSwitch id="is_album_rule" v-model="form.is_album_rule" :binary="true" input-id="is_album_rule" />
+									<label for="is_album_rule" class="ltr:ml-2 rtl:mr-2"
+										><span class="font-semibold">{{ $t("renamer.album_rule") }}</span>
+									</label>
+								</div>
+							</div>
 						</div>
 					</div>
 				</form>
@@ -212,6 +228,8 @@ const form = ref<CreateRenamerRuleRequest>({
 	mode: "all" as App.Enum.RenamerModeType,
 	order: 1,
 	is_enabled: true,
+	is_photo_rule: true,
+	is_album_rule: true,
 });
 
 const errors = ref<Record<string, string>>({});
@@ -227,6 +245,8 @@ function resetForm() {
 			mode: props.rule.mode,
 			order: props.rule.order,
 			is_enabled: props.rule.is_enabled,
+			is_photo_rule: props.rule.is_photo_rule,
+			is_album_rule: props.rule.is_album_rule,
 		};
 	} else {
 		// Create mode - reset to defaults
@@ -238,6 +258,8 @@ function resetForm() {
 			mode: "all" as App.Enum.RenamerModeType,
 			order: 1,
 			is_enabled: true,
+			is_photo_rule: true,
+			is_album_rule: false,
 		};
 	}
 	errors.value = {};

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -103,9 +103,13 @@ declare namespace App.Enum {
 		| "microsoft"
 		| "nextcloud"
 		| "keycloak";
+	export type OmnipayProviderType = "Dummy" | "Mollie" | "PayPal_Express" | "PayPal_ExpressInContext" | "PayPal_Pro" | "PayPal_Rest" | "Stripe";
 	export type OrderSortingType = "ASC" | "DESC";
+	export type PaymentStatusType = "pending" | "cancelled" | "failed" | "refunded" | "processing" | "completed";
 	export type PhotoLayoutType = "square" | "justified" | "masonry" | "grid";
 	export type PhotoThumbInfoType = "title" | "description";
+	export type PurchasableLicenseType = "personal" | "commercial" | "extended";
+	export type PurchasableSizeVariantType = "medium" | "medium2x" | "original" | "full";
 	export type RenamerModeType = "first" | "all" | "regex" | "trim" | "strtolower" | "strtoupper" | "ucwords" | "ucfirst";
 	export type SeverityType = "emergency" | "alert" | "critical" | "error" | "warning" | "notice" | "info" | "debug";
 	export type ShiftType = "relative" | "absolute";
@@ -564,6 +568,8 @@ declare namespace App.Http.Resources.Models {
 		replacement: string;
 		mode: App.Enum.RenamerModeType;
 		is_enabled: boolean;
+		is_photo_rule: boolean;
+		is_album_rule: boolean;
 	};
 	export type SizeVariantResource = {
 		type: App.Enum.SizeVariantType;
@@ -771,6 +777,7 @@ declare namespace App.Http.Resources.Rights {
 		can_access_original: boolean;
 		can_pasword_protect: boolean;
 		can_import_from_server: boolean;
+		can_make_purchasable: boolean;
 	};
 	export type GlobalRightsResource = {
 		root_album: App.Http.Resources.Rights.RootAlbumRightsResource;
@@ -786,6 +793,7 @@ declare namespace App.Http.Resources.Rights {
 		is_watermarker_enabled: boolean;
 		is_photo_timeline_enabled: boolean;
 		is_mod_renamer_enabled: boolean;
+		is_mod_webshop_enabled: boolean;
 	};
 	export type PhotoRightsResource = {
 		can_edit: boolean;
@@ -845,6 +853,85 @@ declare namespace App.Http.Resources.Search {
 		per_page: number;
 		to: number;
 		total: number;
+	};
+}
+declare namespace App.Http.Resources.Shop {
+	export type CatalogResource = {
+		album_purchasable: App.Http.Resources.Shop.PurchasableResource | null;
+		children_purchasables: App.Http.Resources.Shop.PurchasableResource[];
+		photo_purchasables: App.Http.Resources.Shop.PurchasableResource[];
+	};
+	export type CheckoutOptionResource = {
+		currency: string;
+		allow_guest_checkout: boolean;
+		terms_url: string;
+		privacy_url: string;
+		payment_providers: App.Enum.OmnipayProviderType[];
+	};
+	export type CheckoutResource = {
+		is_success: boolean;
+		is_redirect: boolean;
+		redirect_url: string | null;
+		message: string;
+		order: App.Http.Resources.Shop.OrderResource | null;
+	};
+	export type ConfigOptionResource = {
+		currency: string;
+		default_price_cents: number;
+		default_license: App.Enum.PurchasableLicenseType;
+		default_size: App.Enum.PurchasableSizeVariantType;
+	};
+	export type EditablePurchasableResource = {
+		purchasable_id: number;
+		album_id: string | null;
+		album_title: string | null;
+		photo_id: string | null;
+		photo_title: string | null;
+		photo_url: string | null;
+		prices: App.Http.Resources.Shop.PriceResource[] | null;
+		owner_notes: string | null;
+		description: string | null;
+		is_active: boolean;
+	};
+	export type OrderItemResource = {
+		id: number;
+		order_id: number;
+		purchasable_id: number | null;
+		album_id: string | null;
+		photo_id: string | null;
+		title: string;
+		license_type: App.Enum.PurchasableLicenseType;
+		price: string;
+		size_variant_type: App.Enum.PurchasableSizeVariantType;
+		item_notes: string | null;
+	};
+	export type OrderResource = {
+		id: number;
+		provider: App.Enum.OmnipayProviderType | null;
+		transaction_id: string;
+		username: string | null;
+		email: string | null;
+		status: App.Enum.PaymentStatusType;
+		amount: string;
+		paid_at: string | null;
+		created_at: string | null;
+		comment: string | null;
+		items: App.Http.Resources.Shop.OrderItemResource[] | null;
+		can_process_payment: boolean;
+	};
+	export type PriceResource = {
+		size_variant: App.Enum.PurchasableSizeVariantType;
+		license_type: App.Enum.PurchasableLicenseType;
+		price: string;
+		price_cents: number;
+	};
+	export type PurchasableResource = {
+		purchasable_id: number;
+		album_id: string | null;
+		photo_id: string | null;
+		prices: App.Http.Resources.Shop.PriceResource[] | null;
+		description: string;
+		is_active: boolean;
 	};
 }
 declare namespace App.Http.Resources.Statistics {

--- a/resources/js/services/renamer-service.ts
+++ b/resources/js/services/renamer-service.ts
@@ -15,6 +15,8 @@ export type CreateRenamerRuleRequest = {
 	mode: App.Enum.RenamerModeType;
 	order: number;
 	is_enabled: boolean;
+	is_photo_rule: boolean;
+	is_album_rule: boolean;
 };
 
 export type UpdateRenamerRuleRequest = CreateRenamerRuleRequest & {

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -286,6 +286,7 @@ Route::delete('/Tag', [TagController::class, 'delete']);
  * RENAMER RULES.
  */
 Route::get('/Renamer', [RenamerController::class, 'index'])->middleware(['support:se']);
+Route::patch('/Renamer', [RenamerController::class, 'rename'])->middleware(['support:se']);
 Route::post('/Renamer', [RenamerController::class, 'store'])->middleware(['support:se']);
 Route::put('/Renamer', [RenamerController::class, 'update'])->middleware(['support:se']);
 Route::delete('/Renamer', [RenamerController::class, 'destroy'])->middleware(['support:se']);

--- a/tests/Feature_v2/RenamerRules/RenameTest.php
+++ b/tests/Feature_v2/RenamerRules/RenameTest.php
@@ -1,0 +1,469 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\RenamerRules;
+
+use App\Enum\RenamerModeType;
+use App\Models\Album;
+use App\Models\Photo;
+use App\Models\RenamerRule;
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+
+class RenameTest extends BaseApiWithDataTest
+{
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->requireSe();
+		\Configs::set('renamer_enabled', true);
+	}
+
+	public function tearDown(): void
+	{
+		\Configs::set('renamer_enabled', false);
+		$this->resetSe();
+		parent::tearDown();
+	}
+
+	public function testRenameUnauthorized(): void
+	{
+		$response = $this->patchJson('Renamer', [
+			'photo_ids' => [$this->photo1->id],
+		]);
+		$this->assertUnauthorized($response);
+	}
+
+	public function testRenameForbidden(): void
+	{
+		// userNoUpload tries to rename a photo they don't own
+		$response = $this->actingAs($this->userNoUpload)->patchJson('Renamer', [
+			'photo_ids' => [$this->photo1->id],
+		]);
+		$this->assertForbidden($response);
+
+		// userNoUpload tries to rename an album they don't own
+		$response = $this->actingAs($this->userNoUpload)->patchJson('Renamer', [
+			'album_ids' => [$this->album1->id],
+		]);
+		$this->assertForbidden($response);
+	}
+
+	public function testRenamePhotosWithPhotoOnlyRule(): void
+	{
+		// Create a photo-only rule
+		RenamerRule::factory()
+			->owner_id($this->userMayUpload1->id)
+			->order(1)
+			->rule('photo_only_rule')
+			->description('Photo only rule')
+			->needle('CR_')
+			->replacement('Photo_')
+			->mode(RenamerModeType::FIRST)
+			->state([
+				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => false,
+			])
+			->create();
+
+		// Create test photos with titles starting with 'CR_'
+		$photo1 = Photo::factory()
+			->owned_by($this->userMayUpload1)
+			->with_title('CR_1234')
+			->in($this->album1)
+			->create();
+
+		$photo2 = Photo::factory()
+			->owned_by($this->userMayUpload1)
+			->with_title('CR_5678')
+			->in($this->album1)
+			->create();
+
+		// Rename the photos
+		$response = $this->actingAs($this->userMayUpload1)->patchJson('Renamer', [
+			'photo_ids' => [$photo1->id, $photo2->id],
+		]);
+		$this->assertNoContent($response);
+
+		// Verify the photos were renamed
+		$photo1->refresh();
+		$photo2->refresh();
+		$this->assertSame('Photo_1234', $photo1->title);
+		$this->assertSame('Photo_5678', $photo2->title);
+	}
+
+	public function testRenameAlbumsWithAlbumOnlyRule(): void
+	{
+		// Create an album-only rule
+		RenamerRule::factory()
+			->owner_id($this->userMayUpload1->id)
+			->order(1)
+			->rule('album_only_rule')
+			->description('Album only rule')
+			->needle('Album_')
+			->replacement('MyAlbum_')
+			->mode(RenamerModeType::FIRST)
+			->state([
+				'is_enabled' => true,
+				'is_photo_rule' => false,
+				'is_album_rule' => true,
+			])
+			->create();
+
+		// Create test albums with titles starting with 'Album_'
+		$album1 = Album::factory()
+			->owned_by($this->userMayUpload1)
+			->as_root()
+			->with_title('Album_Test1')
+			->create();
+
+		$album2 = Album::factory()
+			->owned_by($this->userMayUpload1)
+			->as_root()
+			->with_title('Album_Test2')
+			->create();
+
+		// Rename the albums
+		$response = $this->actingAs($this->userMayUpload1)->patchJson('Renamer', [
+			'album_ids' => [$album1->id, $album2->id],
+		]);
+		$this->assertNoContent($response);
+
+		// Verify the albums were renamed
+		$album1->refresh();
+		$album2->refresh();
+		$this->assertSame('MyAlbum_Test1', $album1->title);
+		$this->assertSame('MyAlbum_Test2', $album2->title);
+	}
+
+	public function testRenameWithBothRule(): void
+	{
+		// Create a rule that applies to both photos and albums
+		RenamerRule::factory()
+			->owner_id($this->userMayUpload1->id)
+			->order(1)
+			->rule('both_rule')
+			->description('Both rule')
+			->needle('Test_')
+			->replacement('Renamed_')
+			->mode(RenamerModeType::FIRST)
+			->state([
+				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
+			])
+			->create();
+
+		// Create test photo and album with titles starting with 'Test_'
+		$photo = Photo::factory()
+			->owned_by($this->userMayUpload1)
+			->with_title('Test_Photo123')
+			->in($this->album1)
+			->create();
+
+		$album = Album::factory()
+			->owned_by($this->userMayUpload1)
+			->as_root()
+			->with_title('Test_Album456')
+			->create();
+
+		// Rename both photo and album
+		$response = $this->actingAs($this->userMayUpload1)->patchJson('Renamer', [
+			'photo_ids' => [$photo->id],
+			'album_ids' => [$album->id],
+		]);
+		$this->assertNoContent($response);
+
+		// Verify both were renamed
+		$photo->refresh();
+		$album->refresh();
+		$this->assertSame('Renamed_Photo123', $photo->title);
+		$this->assertSame('Renamed_Album456', $album->title);
+	}
+
+	public function testRenameWithAllThreeRules(): void
+	{
+		// Create a photo-only rule
+		RenamerRule::factory()
+			->owner_id($this->userMayUpload1->id)
+			->order(1)
+			->rule('photo_only_rule')
+			->description('Photo only rule')
+			->needle('TEST_')
+			->replacement('Photo_')
+			->mode(RenamerModeType::FIRST)
+			->state([
+				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => false,
+			])
+			->create();
+
+		// Create an album-only rule
+		RenamerRule::factory()
+			->owner_id($this->userMayUpload1->id)
+			->order(2)
+			->rule('album_only_rule')
+			->description('Album only rule')
+			->needle('TEST_')
+			->replacement('Album_')
+			->mode(RenamerModeType::FIRST)
+			->state([
+				'is_enabled' => true,
+				'is_photo_rule' => false,
+				'is_album_rule' => true,
+			])
+			->create();
+
+		// Create a rule that applies to both
+		RenamerRule::factory()
+			->owner_id($this->userMayUpload1->id)
+			->order(3)
+			->rule('both_rule')
+			->description('Both rule')
+			->needle('_old')
+			->replacement('_new')
+			->mode(RenamerModeType::ALL)
+			->state([
+				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
+			])
+			->create();
+
+		// Create test photos and albums
+		$photo1 = Photo::factory()
+			->owned_by($this->userMayUpload1)
+			->with_title('TEST_1234_old')
+			->in($this->album1)
+			->create();
+
+		$photo2 = Photo::factory()
+			->owned_by($this->userMayUpload1)
+			->with_title('TEST_5678')
+			->in($this->album1)
+			->create();
+
+		$album1 = Album::factory()
+			->owned_by($this->userMayUpload1)
+			->as_root()
+			->with_title('TEST_vacation_old')
+			->create();
+
+		$album2 = Album::factory()
+			->owned_by($this->userMayUpload1)
+			->as_root()
+			->with_title('TEST_work')
+			->create();
+
+		// Rename all photos and albums
+		$response = $this->actingAs($this->userMayUpload1)->patchJson('Renamer', [
+			'photo_ids' => [$photo1->id, $photo2->id],
+			'album_ids' => [$album1->id, $album2->id],
+		]);
+		$this->assertNoContent($response);
+
+		// Verify the renaming results
+		$photo1->refresh();
+		$photo2->refresh();
+		$album1->refresh();
+		$album2->refresh();
+
+		// photo1: IMG_ -> Photo_, then _old -> _new
+		$this->assertSame('Photo_1234_new', $photo1->title);
+		// photo2: IMG_ -> Photo_ (no _old to replace)
+		$this->assertSame('Photo_5678', $photo2->title);
+		// album1: Folder_ -> Album_, then _old -> _new
+		$this->assertSame('Album_vacation_new', $album1->title);
+		// album2: Folder_ -> Album_ (no _old to replace)
+		$this->assertSame('Album_work', $album2->title);
+	}
+
+	public function testRenameMultiplePhotosInBatch(): void
+	{
+		// Create a rule
+		RenamerRule::factory()
+			->owner_id($this->userMayUpload1->id)
+			->order(1)
+			->rule('batch_rule')
+			->description('Batch rule')
+			->needle('OLD_')
+			->replacement('NEW_')
+			->mode(RenamerModeType::FIRST)
+			->state([
+				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => false,
+			])
+			->create();
+
+		// Create 150 photos to test chunking (CHUNK_SIZE is 100)
+		$photoIds = [];
+		$expectations = [];
+		for ($i = 1; $i <= 150; $i++) {
+			$photo = Photo::factory()
+				->owned_by($this->userMayUpload1)
+				->with_title('OLD_' . $i)
+				->in($this->album1)
+				->create();
+			$photoIds[] = $photo->id;
+			$expectations[$photo->id] = 'NEW_' . $i;
+		}
+
+		// Rename all photos
+		$response = $this->actingAs($this->userMayUpload1)->patchJson('Renamer', [
+			'photo_ids' => $photoIds,
+		]);
+		$this->assertNoContent($response);
+
+		// Verify all photos were renamed
+		$photos = Photo::query()->whereIn('id', $photoIds)->orderBy('title', 'ASC')->get();
+		foreach ($photos as $photo) {
+			$this->assertSame($expectations[$photo->id], $photo->title);
+		}
+	}
+
+	public function testRenameWithUserIsolation(): void
+	{
+		// Create rule for userMayUpload1
+		RenamerRule::factory()
+			->owner_id($this->userMayUpload1->id)
+			->order(1)
+			->rule('user1_rule')
+			->description('User 1 rule')
+			->needle('TEST_')
+			->replacement('USER1_')
+			->mode(RenamerModeType::FIRST)
+			->state([
+				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
+			])
+			->create();
+
+		// Create rule for userMayUpload2
+		RenamerRule::factory()
+			->owner_id($this->userMayUpload2->id)
+			->order(1)
+			->rule('user2_rule')
+			->description('User 2 rule')
+			->needle('TEST_')
+			->replacement('USER2_')
+			->mode(RenamerModeType::FIRST)
+			->state([
+				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
+			])
+			->create();
+
+		// Create photos for both users
+		$photo1 = Photo::factory()
+			->owned_by($this->userMayUpload1)
+			->with_title('TEST_photo1')
+			->in($this->album1)
+			->create();
+
+		$photo2 = Photo::factory()
+			->owned_by($this->userMayUpload2)
+			->with_title('TEST_photo2')
+			->in($this->album2)
+			->create();
+
+		// User 1 renames their photo
+		$response = $this->actingAs($this->userMayUpload1)->patchJson('Renamer', [
+			'photo_ids' => [$photo1->id],
+		]);
+		$this->assertNoContent($response);
+
+		// User 2 renames their photo
+		$response = $this->actingAs($this->userMayUpload2)->patchJson('Renamer', [
+			'photo_ids' => [$photo2->id],
+		]);
+		$this->assertNoContent($response);
+
+		// Verify each user's rules were applied correctly
+		$photo1->refresh();
+		$photo2->refresh();
+		$this->assertSame('USER1_photo1', $photo1->title);
+		$this->assertSame('USER2_photo2', $photo2->title);
+	}
+
+	public function testRenameEmptyPhotoAndAlbumIds(): void
+	{
+		// Create a rule
+		RenamerRule::factory()
+			->owner_id($this->userMayUpload1->id)
+			->order(1)
+			->rule('test_rule')
+			->description('Test rule')
+			->needle('TEST_')
+			->replacement('NEW_')
+			->mode(RenamerModeType::FIRST)
+			->state([
+				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
+			])
+			->create();
+
+		// Call rename with empty arrays
+		$response = $this->actingAs($this->userMayUpload1)->patchJson('Renamer', [
+			'photo_ids' => [],
+			'album_ids' => [],
+		]);
+		$this->assertNoContent($response);
+	}
+
+	public function testRenameWithSharedPermissions(): void
+	{
+		// Create a rule for userMayUpload2
+		RenamerRule::factory()
+			->owner_id($this->userMayUpload2->id)
+			->order(1)
+			->rule('shared_rule')
+			->description('Shared rule')
+			->needle('SHARED_')
+			->replacement('RENAMED_')
+			->mode(RenamerModeType::FIRST)
+			->state([
+				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => false,
+			])
+			->create();
+
+		// userMayUpload2 has permission to edit album1 (via perm1)
+		// Create a photo in album1
+		$photo = Photo::factory()
+			->owned_by($this->userMayUpload1)
+			->with_title('SHARED_photo')
+			->in($this->album1)
+			->create();
+
+		// userMayUpload2 renames the photo using their rules
+		$response = $this->actingAs($this->userMayUpload2)->patchJson('Renamer', [
+			'photo_ids' => [$photo->id],
+		]);
+		$this->assertNoContent($response);
+
+		// Verify userMayUpload2's rules were applied
+		$photo->refresh();
+		$this->assertSame('RENAMED_photo', $photo->title);
+	}
+}

--- a/tests/Feature_v2/RenamerRules/RenameTest.php
+++ b/tests/Feature_v2/RenamerRules/RenameTest.php
@@ -284,13 +284,13 @@ class RenameTest extends BaseApiWithDataTest
 		$album1->refresh();
 		$album2->refresh();
 
-		// photo1: IMG_ -> Photo_, then _old -> _new
+		// photo1: TEST_ -> Photo_, then _old -> _new
 		$this->assertSame('Photo_1234_new', $photo1->title);
-		// photo2: IMG_ -> Photo_ (no _old to replace)
+		// photo2: TEST_ -> Photo_ (no _old to replace)
 		$this->assertSame('Photo_5678', $photo2->title);
-		// album1: Folder_ -> Album_, then _old -> _new
+		// album1: TEST_ -> Album_, then _old -> _new
 		$this->assertSame('Album_vacation_new', $album1->title);
-		// album2: Folder_ -> Album_ (no _old to replace)
+		// album2: TEST_ -> Album_ (no _old to replace)
 		$this->assertSame('Album_work', $album2->title);
 	}
 

--- a/tests/Feature_v2/RenamerRules/RenamerRulesCreateTest.php
+++ b/tests/Feature_v2/RenamerRules/RenamerRulesCreateTest.php
@@ -46,6 +46,8 @@ class RenamerRulesCreateTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertUnauthorized($response);
 	}
@@ -60,6 +62,8 @@ class RenamerRulesCreateTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertForbidden($response);
 	}
@@ -79,6 +83,8 @@ class RenamerRulesCreateTest extends BaseApiWithDataTest
 			'mode' => 'invalid_mode',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertUnprocessable($response);
 
@@ -91,6 +97,8 @@ class RenamerRulesCreateTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 0,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertUnprocessable($response);
 
@@ -103,6 +111,36 @@ class RenamerRulesCreateTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 1,
 			'is_enabled' => 'invalid',
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
+		]);
+		$this->assertUnprocessable($response);
+
+		// Test with invalid is_photo_rule (must be boolean)
+		$response = $this->actingAs($this->userMayUpload1)->postJson('Renamer', [
+			'rule' => 'test_rule',
+			'description' => 'Test rule',
+			'needle' => 'old',
+			'replacement' => 'new',
+			'mode' => 'all',
+			'order' => 1,
+			'is_enabled' => true,
+			'is_photo_rule' => 'invalid',
+			'is_album_rule' => true,
+		]);
+		$this->assertUnprocessable($response);
+
+		// Test with invalid is_album_rule (must be boolean)
+		$response = $this->actingAs($this->userMayUpload1)->postJson('Renamer', [
+			'rule' => 'test_rule',
+			'description' => 'Test rule',
+			'needle' => 'old',
+			'replacement' => 'new',
+			'mode' => 'all',
+			'order' => 1,
+			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => 'invalid',
 		]);
 		$this->assertUnprocessable($response);
 	}
@@ -118,6 +156,8 @@ class RenamerRulesCreateTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($response, Response::HTTP_CREATED);
 		$response->assertJsonPath('rule', 'test_rule_all');
@@ -138,6 +178,8 @@ class RenamerRulesCreateTest extends BaseApiWithDataTest
 			'mode' => 'first',
 			'order' => 2,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($response, Response::HTTP_CREATED);
 		$response->assertJsonPath('rule', 'test_rule_first');
@@ -154,6 +196,8 @@ class RenamerRulesCreateTest extends BaseApiWithDataTest
 			'mode' => 'regex',
 			'order' => 3,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($response, Response::HTTP_CREATED);
 		$response->assertJsonPath('rule', 'test_rule_regex');
@@ -172,6 +216,8 @@ class RenamerRulesCreateTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($response, Response::HTTP_CREATED);
 		$response->assertJsonPath('rule', 'test_rule_no_desc');
@@ -188,6 +234,8 @@ class RenamerRulesCreateTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($response, Response::HTTP_CREATED);
 		$response->assertJsonPath('rule', 'admin_rule');
@@ -204,6 +252,8 @@ class RenamerRulesCreateTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 5,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($response, Response::HTTP_CREATED);
 
@@ -218,6 +268,8 @@ class RenamerRulesCreateTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL->value,
 			'order' => 5,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 	}
 }

--- a/tests/Feature_v2/RenamerRules/RenamerRulesDeleteTest.php
+++ b/tests/Feature_v2/RenamerRules/RenamerRulesDeleteTest.php
@@ -41,6 +41,8 @@ class RenamerRulesDeleteTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		// Create a rule for another user
@@ -53,6 +55,8 @@ class RenamerRulesDeleteTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::FIRST,
 			'order' => 1,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$this->requireSe();
@@ -138,6 +142,8 @@ class RenamerRulesDeleteTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		// Verify the rule exists
@@ -168,6 +174,8 @@ class RenamerRulesDeleteTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::FIRST,
 			'order' => 2,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		// Delete the first rule
@@ -202,6 +210,8 @@ class RenamerRulesDeleteTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$rule2 = RenamerRule::create([
@@ -213,6 +223,8 @@ class RenamerRulesDeleteTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::FIRST,
 			'order' => 2,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		// Delete first rule

--- a/tests/Feature_v2/RenamerRules/RenamerRulesIntegrationTest.php
+++ b/tests/Feature_v2/RenamerRules/RenamerRulesIntegrationTest.php
@@ -51,6 +51,8 @@ class RenamerRulesIntegrationTest extends BaseApiWithDataTest
 			'mode' => 'first',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($response, Response::HTTP_CREATED);
 		$firstRuleId = $response->json('id');
@@ -64,6 +66,8 @@ class RenamerRulesIntegrationTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 2,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($response, Response::HTTP_CREATED);
 		$secondRuleId = $response->json('id');
@@ -87,6 +91,8 @@ class RenamerRulesIntegrationTest extends BaseApiWithDataTest
 			'mode' => 'regex',
 			'order' => 3,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertOk($response);
 		$response->assertJsonPath('rule', 'updated_first_rule');
@@ -140,6 +146,8 @@ class RenamerRulesIntegrationTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($response, Response::HTTP_CREATED);
 		$user1Rule1Id = $response->json('id');
@@ -152,6 +160,8 @@ class RenamerRulesIntegrationTest extends BaseApiWithDataTest
 			'mode' => 'first',
 			'order' => 2,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($response, Response::HTTP_CREATED);
 		$user1Rule2Id = $response->json('id');
@@ -165,6 +175,8 @@ class RenamerRulesIntegrationTest extends BaseApiWithDataTest
 			'mode' => 'regex',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($response, Response::HTTP_CREATED);
 		$user2Rule1Id = $response->json('id');
@@ -194,6 +206,8 @@ class RenamerRulesIntegrationTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertForbidden($response);
 
@@ -224,6 +238,8 @@ class RenamerRulesIntegrationTest extends BaseApiWithDataTest
 			'mode' => 'regex',
 			'order' => 3,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($regexRule, Response::HTTP_CREATED);
 
@@ -235,6 +251,8 @@ class RenamerRulesIntegrationTest extends BaseApiWithDataTest
 			'mode' => 'first',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($firstRule, Response::HTTP_CREATED);
 
@@ -246,6 +264,8 @@ class RenamerRulesIntegrationTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 2,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($allRule, Response::HTTP_CREATED);
 
@@ -279,6 +299,8 @@ class RenamerRulesIntegrationTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($response, Response::HTTP_CREATED);
 
@@ -291,6 +313,8 @@ class RenamerRulesIntegrationTest extends BaseApiWithDataTest
 			'mode' => 'first',
 			'order' => 1,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertStatus($response, Response::HTTP_CREATED);
 
@@ -304,6 +328,8 @@ class RenamerRulesIntegrationTest extends BaseApiWithDataTest
 				'mode' => $mode,
 				'order' => rand(1, 100),
 				'is_enabled' => rand(0, 1) === 1,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
 			]);
 			$this->assertStatus($response, Response::HTTP_CREATED);
 			$response->assertJsonPath('mode', $mode);

--- a/tests/Feature_v2/RenamerRules/RenamerRulesListTest.php
+++ b/tests/Feature_v2/RenamerRules/RenamerRulesListTest.php
@@ -67,6 +67,8 @@ class RenamerRulesListTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$rule2 = RenamerRule::create([
@@ -78,6 +80,8 @@ class RenamerRulesListTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::FIRST,
 			'order' => 2,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		// Create a rule for another user (should not be returned)
@@ -90,6 +94,8 @@ class RenamerRulesListTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::REGEX,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$response = $this->actingAs($this->userMayUpload1)->getJson('Renamer');
@@ -131,6 +137,8 @@ class RenamerRulesListTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$rule2 = RenamerRule::create([
@@ -142,6 +150,8 @@ class RenamerRulesListTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::REGEX,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		// Test as admin without 'all' parameter (should return only admin's rules)
@@ -177,6 +187,8 @@ class RenamerRulesListTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		RenamerRule::create([
@@ -188,6 +200,8 @@ class RenamerRulesListTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::REGEX,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		// Test as non-admin with 'all=true' (should still return only own rules)

--- a/tests/Feature_v2/RenamerRules/RenamerRulesOrderTest.php
+++ b/tests/Feature_v2/RenamerRules/RenamerRulesOrderTest.php
@@ -50,6 +50,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 				'mode' => RenamerModeType::ALL,
 				'order' => $i,
 				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
 			]);
 		}
 
@@ -64,6 +66,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 4,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertOk($response);
 
@@ -89,6 +93,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 				'mode' => RenamerModeType::ALL,
 				'order' => $i,
 				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
 			]);
 		}
 
@@ -103,6 +109,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 2,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertOk($response);
 
@@ -128,6 +136,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 				'mode' => RenamerModeType::ALL,
 				'order' => $i,
 				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
 			]);
 		}
 
@@ -141,6 +151,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 			'mode' => 'first',
 			'order' => 2, // Same order
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertOk($response);
 
@@ -158,6 +170,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 			'replacement' => 'updated_replacement_2',
 			'mode' => 'first',
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 	}
 
@@ -175,6 +189,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 				'mode' => RenamerModeType::ALL,
 				'order' => $i,
 				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
 			]);
 		}
 
@@ -189,6 +205,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertOk($response);
 
@@ -213,6 +231,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 				'mode' => RenamerModeType::ALL,
 				'order' => $i,
 				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
 			]);
 		}
 
@@ -227,6 +247,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 4,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertOk($response);
 
@@ -251,6 +273,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 				'mode' => RenamerModeType::ALL,
 				'order' => $i,
 				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
 			]);
 		}
 
@@ -266,6 +290,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 				'mode' => RenamerModeType::ALL,
 				'order' => $i,
 				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
 			]);
 		}
 
@@ -279,6 +305,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 3,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertOk($response);
 
@@ -307,6 +335,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 				'mode' => RenamerModeType::ALL,
 				'order' => $i,
 				'is_enabled' => true,
+				'is_photo_rule' => true,
+				'is_album_rule' => true,
 			]);
 		}
 
@@ -320,6 +350,8 @@ class RenamerRulesOrderTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		// List rules and verify they're returned in the correct order

--- a/tests/Feature_v2/RenamerRules/RenamerRulesTestTest.php
+++ b/tests/Feature_v2/RenamerRules/RenamerRulesTestTest.php
@@ -42,6 +42,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 	{
 		$response = $this->postJson('Renamer::test', [
 			'candidate' => 'test_string',
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 		$this->assertUnauthorized($response);
 	}
@@ -50,6 +52,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 	{
 		$response = $this->actingAs($this->userNoUpload)->postJson('Renamer::test', [
 			'candidate' => 'test_string',
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 		$this->assertForbidden($response);
 	}
@@ -63,6 +67,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 		// Test with empty candidate
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Renamer::test', [
 			'candidate' => '',
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 		$this->assertUnprocessable($response);
 	}
@@ -73,6 +79,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Renamer::test', [
 			'candidate' => $candidate,
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 
 		$this->assertOk($response);
@@ -92,6 +100,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$candidate = 'IMG_1234.jpg';
@@ -99,6 +109,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Renamer::test', [
 			'candidate' => $candidate,
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 
 		$this->assertOk($response);
@@ -118,6 +130,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		RenamerRule::create([
@@ -129,6 +143,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 2,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$candidate = 'IMG_1234.jpg';
@@ -136,6 +152,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Renamer::test', [
 			'candidate' => $candidate,
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 
 		$this->assertOk($response);
@@ -155,6 +173,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		RenamerRule::create([
@@ -166,6 +186,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 2,
 			'is_enabled' => false, // This rule is disabled
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$candidate = 'IMG_1234.jpg';
@@ -173,6 +195,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Renamer::test', [
 			'candidate' => $candidate,
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 
 		$this->assertOk($response);
@@ -192,6 +216,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::FIRST,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$candidate = 'banana_apple';
@@ -199,6 +225,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Renamer::test', [
 			'candidate' => $candidate,
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 
 		$this->assertOk($response);
@@ -218,6 +246,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::REGEX,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$candidate = 'IMG_1234_photo_5678.jpg';
@@ -225,6 +255,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Renamer::test', [
 			'candidate' => $candidate,
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 
 		$this->assertOk($response);
@@ -245,12 +277,16 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::REGEX,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$candidate = 'test_string';
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Renamer::test', [
 			'candidate' => $candidate,
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 
 		$this->assertOk($response);
@@ -270,6 +306,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		// Create a rule for userMayUpload2
@@ -282,6 +320,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$candidate = 'IMG_1234.jpg';
@@ -289,6 +329,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 		// Test with user1 - should use user1's rule
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Renamer::test', [
 			'candidate' => $candidate,
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 
 		$this->assertOk($response);
@@ -298,6 +340,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 		// Test with user2 - should use user2's rule
 		$response = $this->actingAs($this->userMayUpload2)->postJson('Renamer::test', [
 			'candidate' => $candidate,
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 
 		$this->assertOk($response);
@@ -317,6 +361,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		// Admin should be able to test renamer rules (using their own rules)
@@ -324,6 +370,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 
 		$response = $this->actingAs($this->admin)->postJson('Renamer::test', [
 			'candidate' => $candidate,
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 
 		$this->assertOk($response);
@@ -343,6 +391,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		// Test with a longer string (within the 1000 character limit)
@@ -351,6 +401,8 @@ class RenamerRulesTestTest extends BaseApiWithDataTest
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Renamer::test', [
 			'candidate' => $candidate,
+			'is_photo' => true,
+			'is_album' => true,
 		]);
 
 		$this->assertOk($response);

--- a/tests/Feature_v2/RenamerRules/RenamerRulesUpdateTest.php
+++ b/tests/Feature_v2/RenamerRules/RenamerRulesUpdateTest.php
@@ -41,6 +41,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		// Create a rule for another user
@@ -53,6 +55,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::FIRST,
 			'order' => 1,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$this->requireSe();
@@ -75,6 +79,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => 'first',
 			'order' => 2,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertUnauthorized($response);
 	}
@@ -90,6 +96,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => 'first',
 			'order' => 2,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertForbidden($response);
 	}
@@ -106,6 +114,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertForbidden($response);
 	}
@@ -126,6 +136,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => 'first',
 			'order' => 2,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertNotFound($response);
 
@@ -139,6 +151,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => 'invalid_mode',
 			'order' => 2,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertUnprocessable($response);
 	}
@@ -154,6 +168,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => 'first',
 			'order' => 2,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertOk($response);
 
@@ -180,6 +196,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => 'regex',
 			'order' => 3,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertOk($response);
 		$response->assertJsonPath('mode', 'regex');
@@ -195,6 +213,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => 'first',
 			'order' => 1,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertOk($response);
 		$response->assertJsonPath('mode', 'first');
@@ -212,6 +232,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => 'all',
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertOk($response);
 		$response->assertJsonPath('description', '');
@@ -228,6 +250,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => 'regex',
 			'order' => 10,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertOk($response);
 
@@ -241,6 +265,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::REGEX->value,
 			'order' => 10,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 	}
 
@@ -256,6 +282,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => RenamerModeType::ALL,
 			'order' => 1,
 			'is_enabled' => true,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 
 		$response = $this->actingAs($this->admin)->putJson('Renamer', [
@@ -267,6 +295,8 @@ class RenamerRulesUpdateTest extends BaseApiWithDataTest
 			'mode' => 'first',
 			'order' => 2,
 			'is_enabled' => false,
+			'is_photo_rule' => true,
+			'is_album_rule' => true,
 		]);
 		$this->assertOk($response);
 		$response->assertJsonPath('rule', 'updated_admin_rule');

--- a/tests/Feature_v2/RenamerTest.php
+++ b/tests/Feature_v2/RenamerTest.php
@@ -19,7 +19,7 @@
 namespace Tests\Feature_v2;
 
 use App\Enum\RenamerModeType;
-use App\Metadata\Renamer;
+use App\Metadata\Renamer\Renamer;
 use App\Models\Configs;
 use App\Models\RenamerRule;
 use Illuminate\Foundation\Testing\DatabaseTransactions;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Batch renaming endpoint for Photos and Albums; UI and API support to rename selected items.
  - Explicit photo- and album-specific renamers and rule flags enabling separate photo/album rename operations.

- **Improvements**
  - Import and maintenance flows now respect photo-/album-specific renaming for more accurate matching.
  - Rule list shows Photo/Album badges; editor layout and helper text clarified; chunked batch processing for large updates.

- **Localization**
  - Added translations for “Photo rule”, “Album rule”, “Photo”, and “Album” across locales.

- **Tests**
  - Comprehensive tests for renaming behavior, permissions, and batch processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->