### PR TITLE
Adds public but hidden album option

### DIFF
--- a/app/Actions/Album/Create.php
+++ b/app/Actions/Album/Create.php
@@ -87,6 +87,10 @@ class Create
 			$album->access_permissions()->saveMany([AccessPermission::ofPublic()]);
 		}
 
+		if ($default_protection_type === DefaultAlbumProtectionType::PUBLIC_HIDDEN) {
+			$album->access_permissions()->saveMany([AccessPermission::ofPublicHidden()]);
+		}
+
 		if ($default_protection_type === DefaultAlbumProtectionType::INHERIT && $parent_album !== null) {
 			$album->access_permissions()->saveMany($this->copyPermission($parent_album));
 		}

--- a/app/Enum/DefaultAlbumProtectionType.php
+++ b/app/Enum/DefaultAlbumProtectionType.php
@@ -16,4 +16,5 @@ enum DefaultAlbumProtectionType: int
 	case PRIVATE = 1;
 	case PUBLIC = 2;
 	case INHERIT = 3;
+	case PUBLIC_HIDDEN = 4;
 }

--- a/app/Models/AccessPermission.php
+++ b/app/Models/AccessPermission.php
@@ -162,6 +162,24 @@ class AccessPermission extends Model
 	}
 
 	/**
+	 * Return a new Public hidden sharing permission with defaults.
+	 *
+	 * @throws ConfigurationKeyMissingException
+	 */
+	public static function ofPublicHidden(): self
+	{
+		return new AccessPermission([
+			APC::IS_LINK_REQUIRED => true,
+			APC::GRANTS_FULL_PHOTO_ACCESS => Configs::getValueAsBool('grants_full_photo_access'),
+			APC::GRANTS_DOWNLOAD => Configs::getValueAsBool('grants_download'),
+			APC::GRANTS_UPLOAD => false,
+			APC::GRANTS_EDIT => false,
+			APC::GRANTS_DELETE => false,
+			APC::PASSWORD => null,
+		]);
+	}
+
+	/**
 	 * Return a new permission set associated to a specific userId.
 	 */
 	public static function withGrantFullPermissionsToUser(int $user_id): self

--- a/app/SmartAlbums/BaseSmartAlbum.php
+++ b/app/SmartAlbums/BaseSmartAlbum.php
@@ -198,6 +198,17 @@ abstract class BaseSmartAlbum implements AbstractAlbum
 		$this->public_permissions->save();
 	}
 
+	public function setPublicHidden(): void
+	{
+		if ($this->public_permissions !== null) {
+			return;
+		}
+
+		$this->public_permissions = AccessPermission::ofPublicHidden();
+		$this->public_permissions->base_album_id = $this->id;
+		$this->public_permissions->save();
+	}
+
 	public function setPrivate(): void
 	{
 		if ($this->public_permissions === null) {

--- a/lang/ar/gallery.php
+++ b/lang/ar/gallery.php
@@ -234,5 +234,6 @@ return [
         'private' => 'خاص',
         'public' => 'عام',
         'inherit_from_parent' => 'وراثة من الوالد',
+        'public_but_hidden' => 'عام لكن مخفي',
     ],
 ];

--- a/lang/cz/gallery.php
+++ b/lang/cz/gallery.php
@@ -235,5 +235,6 @@ return [
         'private' => 'private',
         'public' => 'public',
         'inherit_from_parent' => 'inherit from parent',
+        'public_but_hidden' => 'veřejné ale skryté',
     ],
 ];

--- a/lang/de/gallery.php
+++ b/lang/de/gallery.php
@@ -234,5 +234,6 @@ return [
         'private' => 'Privat',
         'public' => 'Öffentlich',
         'inherit_from_parent' => 'vom Übergeordneten erben',
+        'public_but_hidden' => 'öffentlich aber versteckt',
     ],
 ];

--- a/lang/el/gallery.php
+++ b/lang/el/gallery.php
@@ -235,5 +235,6 @@ return [
         'private' => 'private',
         'public' => 'public',
         'inherit_from_parent' => 'inherit from parent',
+        'public_but_hidden' => 'δημόσιο αλλά κρυμμένο',
     ],
 ];

--- a/lang/en/gallery.php
+++ b/lang/en/gallery.php
@@ -257,5 +257,6 @@ return [
 		'private' => 'private',
 		'public' => 'public',
 		'inherit_from_parent' => 'inherit from parent',
+		'public_but_hidden' => 'public but hidden',
 	],
 ];

--- a/lang/es/gallery.php
+++ b/lang/es/gallery.php
@@ -234,5 +234,6 @@ return [
         'private' => 'privado',
         'public' => 'público',
         'inherit_from_parent' => 'Heredar del padre',
+        'public_but_hidden' => 'público pero oculto',
     ],
 ];

--- a/lang/fa/gallery.php
+++ b/lang/fa/gallery.php
@@ -234,5 +234,6 @@ return [
         'private' => 'خصوصی',
         'public' => 'عمومی',
         'inherit_from_parent' => 'ارث بری از والد',
+        'public_but_hidden' => 'عمومی اما مخفی',
     ],
 ];

--- a/lang/fr/gallery.php
+++ b/lang/fr/gallery.php
@@ -234,5 +234,6 @@ return [
         'private' => 'privé',
         'public' => 'public',
         'inherit_from_parent' => 'hériter du parent',
+		'public_but_hidden' => 'public mais caché',
     ],
 ];

--- a/lang/hu/gallery.php
+++ b/lang/hu/gallery.php
@@ -235,5 +235,6 @@ return [
         'private' => 'private',
         'public' => 'public',
         'inherit_from_parent' => 'inherit from parent',
+        'public_but_hidden' => 'nyilvános de rejtett',
     ],
 ];

--- a/lang/it/gallery.php
+++ b/lang/it/gallery.php
@@ -235,5 +235,6 @@ return [
         'private' => 'private',
         'public' => 'public',
         'inherit_from_parent' => 'inherit from parent',
+        'public_but_hidden' => 'pubblico ma nascosto',
     ],
 ];

--- a/lang/ja/gallery.php
+++ b/lang/ja/gallery.php
@@ -235,5 +235,6 @@ return [
         'private' => 'private',
         'public' => 'public',
         'inherit_from_parent' => 'inherit from parent',
+        'public_but_hidden' => '公開だが非表示',
     ],
 ];

--- a/lang/nl/gallery.php
+++ b/lang/nl/gallery.php
@@ -234,5 +234,6 @@ return [
         'private' => 'Privé',
         'public' => 'Openbaar',
         'inherit_from_parent' => 'Overnemen van ouder',
+        'public_but_hidden' => 'openbaar maar verborgen',
     ],
 ];

--- a/lang/no/gallery.php
+++ b/lang/no/gallery.php
@@ -234,5 +234,6 @@ return [
         'private' => 'private',
         'public' => 'public',
         'inherit_from_parent' => 'inherit from parent',
+        'public_but_hidden' => 'offentlig men skjult',
     ],
 ];

--- a/lang/pl/gallery.php
+++ b/lang/pl/gallery.php
@@ -234,5 +234,6 @@ return [
         'private' => 'prywatny',
         'public' => 'publiczny',
         'inherit_from_parent' => 'dziedziczą po rodzicu',
+        'public_but_hidden' => 'publiczny ale ukryty',
     ],
 ];

--- a/lang/pt/gallery.php
+++ b/lang/pt/gallery.php
@@ -235,5 +235,6 @@ return [
         'private' => 'private',
         'public' => 'public',
         'inherit_from_parent' => 'inherit from parent',
+        'public_but_hidden' => 'público mas oculto',
     ],
 ];

--- a/lang/ru/gallery.php
+++ b/lang/ru/gallery.php
@@ -234,5 +234,6 @@ return [
         'private' => 'частный',
         'public' => 'публичный',
         'inherit_from_parent' => 'унаследовать от родителя',
+        'public_but_hidden' => 'публичный но скрытый',
     ],
 ];

--- a/lang/sk/gallery.php
+++ b/lang/sk/gallery.php
@@ -235,5 +235,6 @@ return [
         'private' => 'private',
         'public' => 'public',
         'inherit_from_parent' => 'inherit from parent',
+        'public_but_hidden' => 'verejné ale skryté',
     ],
 ];

--- a/lang/sv/gallery.php
+++ b/lang/sv/gallery.php
@@ -235,5 +235,6 @@ return [
         'private' => 'private',
         'public' => 'public',
         'inherit_from_parent' => 'inherit from parent',
+        'public_but_hidden' => 'offentlig men dold',
     ],
 ];

--- a/lang/vi/gallery.php
+++ b/lang/vi/gallery.php
@@ -235,5 +235,6 @@ return [
         'private' => 'private',
         'public' => 'public',
         'inherit_from_parent' => 'inherit from parent',
+        'public_but_hidden' => 'công khai nhưng ẩn',
     ],
 ];

--- a/lang/zh_CN/gallery.php
+++ b/lang/zh_CN/gallery.php
@@ -234,5 +234,6 @@ return [
         'private' => '私密',
         'public' => '公开',
         'inherit_from_parent' => '继承自父级',
+        'public_but_hidden' => '公开但隐藏',
     ],
 ];

--- a/lang/zh_TW/gallery.php
+++ b/lang/zh_TW/gallery.php
@@ -235,5 +235,6 @@ return [
         'private' => 'private',
         'public' => 'public',
         'inherit_from_parent' => 'inherit from parent',
+        'public_but_hidden' => '公開但隱藏',
     ],
 ];


### PR DESCRIPTION
Adds a new album default protection type: "public but hidden".

This feature allows users to create albums that are publicly accessible via a link but are not visible in the main gallery view by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new album visibility option: “Public but hidden” (unlisted). Albums can be accessed via link without appearing in public listings. View/download capabilities respect existing settings. Supported for regular and smart albums.

- Localization
  - Added translations for “Public but hidden” across multiple languages, including English, German, French, Spanish, Italian, Dutch, Swedish, Norwegian, Czech, Slovak, Polish, Russian, Greek, Arabic, Farsi, Hungarian, Portuguese, Japanese, Vietnamese, Chinese (Simplified/Traditional).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->