### PR TITLE
Handle negative (= unlimited) `memory_limit` during computation of upload chunk size

### DIFF
--- a/app/Http/Resources/GalleryConfigs/UploadConfig.php
+++ b/app/Http/Resources/GalleryConfigs/UploadConfig.php
@@ -32,10 +32,14 @@ class UploadConfig extends Data
 		$size = Configs::getValueAsInt('upload_chunk_size');
 		if ($size === 0) {
 			try {
+				$memory_size = Helpers::convertSize(ini_get('memory_limit')) / 10;
+				if ($memory_size < 0) {
+					$memory_size = INF;
+				}
 				$size = (int) min(
 					Helpers::convertSize(ini_get('upload_max_filesize')),
 					Helpers::convertSize(ini_get('post_max_size')),
-					Helpers::convertSize(ini_get('memory_limit')) / 10
+					$memory_size
 				);
 			} catch (InfoException $e) {
 				return 1024 * 1024;


### PR DESCRIPTION
This fixes the error "The total chunks must be an integer." as described in [this discussion](https://github.com/LycheeOrg/Lychee/discussions/2961).

It is caused by `ini_get('memory_limit')` returning `-1`, which will then be divided by `10` and converted to an integer. The final chunk size is the minimum of this value and the other inputs, thus `0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of upload size limits when no custom chunk size is set, deriving a safe value from server memory settings with safeguards against invalid values.
  * Prevents stalls or failures during large uploads and improves stability across varied server configurations.
  * Retains a safe 1 MB fallback on configuration/info errors to ensure uploads continue to work reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->