### PR TITLE
Speed up pre-commit hook by running one php-cs-fixer on all PHP files

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -euo pipefail
 NO_COLOR="\033[0m"
 GREEN="\033[38;5;010m"
 YELLOW="\033[38;5;011m"
@@ -11,10 +12,15 @@ PHP_CS_FIXER_IGNORE_ENV=1
 NPM_FORMAT="node_modules/prettier"
 
 if [ -x "$PHP_CS_FIXER" ]; then
-    git status --porcelain | grep -e '^[AM]\(.*\).php$' | cut -c 3- | while read line; do
-        ${PHP_CS_FIXER} fix --config=.php-cs-fixer.php ${line};
-        git add "$line";
-    done
+    php_files=()
+    while IFS= read -r line; do
+        php_files+=("$line")
+    done < <(git status --porcelain | awk '/^[AM].*\.php$/ {print substr($0,4)}')
+    if [ "${#php_files[@]}" -gt 0 ]; then
+        printf "Running php-cs-fixer on %s PHP file(s)\n" "${#php_files[@]}"
+        "${PHP_CS_FIXER}" fix --config=.php-cs-fixer.php --path-mode=override "${php_files[@]}"
+        git add "${php_files[@]}"
+    fi
 else
     echo ""
     printf "${YELLOW}Please install php-cs-fixer, e.g.:${NO_COLOR}"


### PR DESCRIPTION
This commit runs php-cs-fixer once on all PHP files, instead of once per PHP file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pre-commit hook performance by consolidating PHP file formatting into a single batch operation rather than individual processing, reducing overhead.
  * Enhanced script reliability with stricter error handling and validation.
  * Added informative feedback displaying the count of PHP files processed during commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->