### PR TITLE
Fix some situations where clicks were ignored

### DIFF
--- a/resources/js/composables/album/dragAndSelect.ts
+++ b/resources/js/composables/album/dragAndSelect.ts
@@ -119,8 +119,16 @@ export function useDragAndSelect(
 		return true;
 	}
 
+	function isInteractiveTarget(target: EventTarget | null): boolean {
+		if (!(target instanceof HTMLElement)) return false;
+		if (target.closest("[data-stop-drag-select='true']")) return true;
+		const interactiveSelectors =
+			"a,button,input,textarea,select,summary,[role='button'],[role='menuitem'],[role='link'],.p-drawer-mask,.p-speeddial,.p-contextmenu,.p-dialog";
+		return target.closest(interactiveSelectors) !== null;
+	}
+
 	function show(e: MouseEvent) {
-		if (!canStart(e)) {
+		if (!canStart(e) || isInteractiveTarget(e.target)) {
 			return;
 		}
 

--- a/resources/js/composables/selections/selections.ts
+++ b/resources/js/composables/selections/selections.ts
@@ -1,5 +1,5 @@
 import { TogglablesStateStore } from "@/stores/ModalsState";
-import { modKey, shiftKeyState } from "@/utils/keybindings-utils";
+import { getModKey } from "@/utils/keybindings-utils";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 import { useAlbumActions } from "@/composables/album/albumActions";
@@ -60,12 +60,19 @@ export function useSelection(photosStore: PhotosStore, albumsStore: AlbumsStore,
 		selectedAlbumsIdx.value = selectedAlbumsIdx.value.filter((i) => i !== idx);
 	}
 
-	function photoSelect(idx: number, e: Event): void {
+	function getMouseModifiers(e: MouseEvent): { isMod: boolean; isShift: boolean } {
+		const modKey = getModKey();
+		const isMod = modKey === "Meta" ? e.metaKey : e.ctrlKey;
+		return { isMod, isShift: e.shiftKey };
+	}
+
+	function photoSelect(idx: number, e: MouseEvent): void {
 		// clear the Album selection.
 		selectedAlbumsIdx.value = [];
 
 		// we do not support CTRL + SHIFT
-		if (!modKey().value && !shiftKeyState.value) {
+		const { isMod, isShift } = getMouseModifiers(e);
+		if (!isMod && !isShift) {
 			return;
 		}
 
@@ -77,12 +84,12 @@ export function useSelection(photosStore: PhotosStore, albumsStore: AlbumsStore,
 			return;
 		}
 
-		if (modKey().value) {
+		if (isMod) {
 			handlePhotoCtrl(idx, e);
 			return;
 		}
 
-		if (shiftKeyState.value) {
+		if (isShift) {
 			handlePhotoShift(idx, e);
 			return;
 		}
@@ -126,12 +133,13 @@ export function useSelection(photosStore: PhotosStore, albumsStore: AlbumsStore,
 		lastPhotoClicked.value = idx;
 	}
 
-	function albumClick(idx: number, e: Event): void {
+	function albumClick(idx: number, e: MouseEvent): void {
 		// clear the Photo selection.
 		selectedPhotosIdx.value = [];
 
 		// we do not support CTRL + SHIFT
-		if (!modKey().value && !shiftKeyState.value) {
+		const { isMod, isShift } = getMouseModifiers(e);
+		if (!isMod && !isShift) {
 			return;
 		}
 
@@ -143,12 +151,12 @@ export function useSelection(photosStore: PhotosStore, albumsStore: AlbumsStore,
 			return;
 		}
 
-		if (modKey().value) {
+		if (isMod) {
 			handleAlbumCtrl(idx, e);
 			return;
 		}
 
-		if (shiftKeyState.value) {
+		if (isShift) {
 			handleAlbumShift(idx, e);
 			return;
 		}

--- a/resources/sass/app.css
+++ b/resources/sass/app.css
@@ -194,6 +194,12 @@ html {
 	outline-offset: 0px;
 }
 
+/* PrimeVue overlays linger briefly during exit animations; disable pointer events
+   so the fading mask no longer swallows the user's next click. */
+.p-component-overlay-leave-active {
+	pointer-events: none;
+}
+
 .filter-shadow {
 	filter: drop-shadow(0 0 0.5rem black);
 }


### PR DESCRIPTION
This code was generated by OpenAI Codex, though I have reviewed and tested it.

I had noticed that sometimes the Lychee UI appeared to ignore clicks, and this has meant the UI feels glitchy and reliable to me.

**This PR includes these fixes:**

- `resources/js/composables/album/dragAndSelect.ts:119` now bails out when the mousedown originates from links, buttons, dialogs, drawers, etc., preventing the marquee-selection logic from hijacking clicks meant
    for UI chrome.
- `resources/js/composables/selections/selections.ts:8` derives modifier state directly from each MouseEvent, so stale global key refs can’t force preventDefault()/stopPropagation() on album or photo clicks.
- `resources/sass/app.css:121` disables pointer events on PrimeVue overlay masks as soon as their leave animation starts, so fading masks no longer swallow the next click after closing a drawer or dialog.

**Suggested verification steps:**

- Drag-select guard (resources/js/composables/album/dragAndSelect.ts:119):
    - Click toolbar buttons (e.g., OpenLeftMenu, header SpeedDial actions) and confirm they trigger on the first click even when the gallery grid is loaded.
    - Open context menus or modals, close them, then immediately click an album card to ensure navigation fires without needing a second click.
    - Attempt marquee selection inside the grid to confirm drag-to-select still works when starting over album/photo thumbs.
- Selection modifiers (resources/js/composables/selections/selections.ts:8):
    - On both macOS (Cmd) and Windows/Linux (Ctrl), single-click, Ctrl/Cmd-click, and Shift-click albums/photos to confirm selection toggles and ranges behave correctly.
    - After using an OS-level shortcut (Cmd+Tab, Win key, etc.), return to the app and single-click an album to ensure it navigates instead of being treated as a multi-select.
    - Verify Shift-select ranges begin/end at the expected items and that mixing Shift/Ctrl still clears photo vs. album selections as before.
- Overlay mask pointer-events (resources/sass/app.css:121):
    - Open the left drawer (LeftMenu.vue), close it, and immediately click an album/menu icon—ensure the click is processed.
    - Repeat for PrimeVue dialogs such as Upload, Delete, or context menus: close the overlay and instantly click underlying content to confirm no mask blocks input.
    - Observe overlays while they fade out to confirm no visual regressions (opacity/animation unaffected).
- Smoke-test primary album navigation: open several albums, navigate back, ensure router-links still resolve (resources/js/components/gallery/albumModule/AlbumThumb.vue workflow
  unchanged).
- Run basic keyboard shortcuts (e.g., a, n, u in resources/js/views/gallery-panels/Albums.vue:208) to confirm keybinding behavior is untouched by modifier changes.
- Scroll and drag-select large galleries to ensure performance remains acceptable and that throttle logic in dragAndSelect still updates selections.

**Note that this is running on** https://pictures.dzombak.com, should you wish to verify the changes there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Selection drag-and-select no longer activates when clicking interactive elements like buttons, links, and input fields.
  * Fixed overlays blocking user interactions during animation exit transitions.

* **Improvements**
  * Enhanced mouse modifier key detection for consistent selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->