### PR TITLE
Resolve vite build warning in embed folder

### DIFF
--- a/vite.embed.config.ts
+++ b/vite.embed.config.ts
@@ -15,6 +15,7 @@ import { resolve } from 'path';
  */
 export default defineConfig({
 	plugins: [vue()],
+	publicDir: false,
 	resolve: {
 		alias: {
 			'@': fileURLToPath(new URL('./resources/js/', import.meta.url)),


### PR DESCRIPTION
This PR resolves the following warning:

```
▶ npm run build:embed       

> build:embed
> vite build --config vite.embed.config.ts

vite v7.1.11 building for production...
✓ 29 modules transformed.

(!) The public directory feature may not work correctly. outDir /home/biv/Documents/Projects/Lychee/public/embed and publicDir /home/biv/Documents/Projects/Lychee/public are not separate folders.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for embedded deployments to optimize public file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->