### PR TITLE
Split test suite for better parallelism

### DIFF
--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -31,6 +31,7 @@ jobs:
           - Feature_v2
           - Install
           - Webshop
+          - ImageProcessing
         exclude:
         # Some skips to reduce the number of runs
           - php-version: 8.4
@@ -39,6 +40,8 @@ jobs:
             test-suite: Feature_v2
           - php-version: 8.4
             test-suite: Webshop
+          - php-version: 8.4
+            test-suite: ImageProcessing
     # Service containers to run with `container-job`
     services:
       # Label used to access the service container

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,9 @@ test_webshop:
 test_install:
 	vendor/bin/phpunit --testsuite Install --stop-on-failure --stop-on-error --no-coverage --log-junit report_install.xml
 
+test_ImageProcessing:
+	vendor/bin/phpunit --testsuite ImageProcessing --stop-on-failure --stop-on-error --no-coverage --log-junit report_imageprocessing.xml
+
 test_v2:
 	vendor/bin/phpunit --testsuite Feature_v2 --stop-on-failure --stop-on-error --no-coverage --log-junit report_v2.xml
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ codecov:
   require_ci_to_pass: true
   notify:
     wait_for_ci: true
-    after_n_builds: 15
+    after_n_builds: 18
 comment:
   behavior: default
   require_base: false
@@ -23,7 +23,6 @@ coverage:
 ignore:
 - "^app/Console/.*"
 - "^app/Exceptions/.*"
-- "^app/Http/Middleware/VerifyCsrfToken.*"
 - "^app/Http/Middleware/VerifyCsrfToken.*"
 - "^app/Providers/BroadcastServiceProvider.*"
 - "^app/Jobs/UploadSizeVariantToS3Job.php"

--- a/phpunit.ci.xml
+++ b/phpunit.ci.xml
@@ -20,6 +20,9 @@
     <testsuite name="Install">
       <directory suffix="Test.php">./tests/Install</directory>
     </testsuite>
+    <testsuite name="ImageProcessing">
+      <directory suffix="Test.php">./tests/ImageProcessing</directory>
+    </testsuite>
     <testsuite name="Webshop">
       <directory suffix="Test.php">./tests/Webshop</directory>
       <exclude>./tests/Webshop/BaseCheckoutControllerTest.php</exclude>

--- a/phpunit.pgsql.xml
+++ b/phpunit.pgsql.xml
@@ -20,6 +20,9 @@
     <testsuite name="Install">
       <directory suffix="Test.php">./tests/Install</directory>
     </testsuite>
+    <testsuite name="ImageProcessing">
+      <directory suffix="Test.php">./tests/ImageProcessing</directory>
+    </testsuite>
     <testsuite name="Webshop">
       <directory suffix="Test.php">./tests/Webshop</directory>
       <exclude>./tests/Webshop/BaseCheckoutControllerTest.php</exclude>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,6 +20,9 @@
     <testsuite name="Install">
       <directory suffix="Test.php">./tests/Install</directory>
     </testsuite>
+    <testsuite name="ImageProcessing">
+      <directory suffix="Test.php">./tests/ImageProcessing</directory>
+    </testsuite>
     <testsuite name="Webshop">
       <directory suffix="Test.php">./tests/Webshop</directory>
       <exclude>./tests/Webshop/BaseCheckoutControllerTest.php</exclude>

--- a/tests/ImageProcessing/Album/AssertableZipArchive.php
+++ b/tests/ImageProcessing/Album/AssertableZipArchive.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Album;
+namespace Tests\ImageProcessing\Album;
 
 use App\Image\Files\InMemoryBuffer;
 use App\Image\Files\TemporaryLocalFile;

--- a/tests/ImageProcessing/Album/DownloadTest.php
+++ b/tests/ImageProcessing/Album/DownloadTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Album;
+namespace Tests\ImageProcessing\Album;
 
 use App\Enum\DownloadVariantType;
 use App\Image\Files\InMemoryBuffer;
@@ -24,9 +24,6 @@ use App\Image\Files\TemporaryLocalFile;
 use App\Image\Handlers\ImagickHandler;
 use App\Image\Handlers\VideoHandler;
 use App\Models\Album;
-use App\Models\Configs;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Session;
 use function Safe\file_get_contents;
 use function Safe\filesize;
 use function Safe\fwrite;

--- a/tests/ImageProcessing/Commands/DecodeGpsLocationsTest.php
+++ b/tests/ImageProcessing/Commands/DecodeGpsLocationsTest.php
@@ -6,11 +6,11 @@
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 
-namespace Tests\Feature_v2\Commands;
+namespace Tests\ImageProcessing\Commands;
 
 use Tests\AbstractTestCase;
 
-class ExifLensTest extends AbstractTestCase
+class DecodeGpsLocationsTest extends AbstractTestCase
 {
 	/**
 	 * Tests some console commands on a basic level.
@@ -25,8 +25,8 @@ class ExifLensTest extends AbstractTestCase
 	 */
 	public function testCommands(): void
 	{
-		$this->artisan('lychee:exif_lens')
-			->expectsOutput('No pictures requires EXIF updates.')
-			->assertExitCode(-1);
+		$this->artisan('lychee:decode_GPS_locations')
+			->expectsOutput('No photos or videos require processing.')
+			->assertExitCode(0);
 	}
 }

--- a/tests/ImageProcessing/Commands/DiagnosticsTest.php
+++ b/tests/ImageProcessing/Commands/DiagnosticsTest.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 
-namespace Tests\Feature_v2\Commands;
+namespace Tests\ImageProcessing\Commands;
 
 use Tests\AbstractTestCase;
 

--- a/tests/ImageProcessing/Commands/EncodePlaceholdersTest.php
+++ b/tests/ImageProcessing/Commands/EncodePlaceholdersTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Commands;
+namespace Tests\ImageProcessing\Commands;
 
 use App\Enum\SizeVariantType;
 use App\Models\Configs;

--- a/tests/ImageProcessing/Commands/ExifLensTest.php
+++ b/tests/ImageProcessing/Commands/ExifLensTest.php
@@ -6,11 +6,11 @@
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 
-namespace Tests\Feature_v2\Commands;
+namespace Tests\ImageProcessing\Commands;
 
 use Tests\AbstractTestCase;
 
-class DecodeGpsLocationsTest extends AbstractTestCase
+class ExifLensTest extends AbstractTestCase
 {
 	/**
 	 * Tests some console commands on a basic level.
@@ -25,8 +25,8 @@ class DecodeGpsLocationsTest extends AbstractTestCase
 	 */
 	public function testCommands(): void
 	{
-		$this->artisan('lychee:decode_GPS_locations')
-			->expectsOutput('No photos or videos require processing.')
-			->assertExitCode(0);
+		$this->artisan('lychee:exif_lens')
+			->expectsOutput('No pictures requires EXIF updates.')
+			->assertExitCode(-1);
 	}
 }

--- a/tests/ImageProcessing/Commands/FixPermissionsTest.php
+++ b/tests/ImageProcessing/Commands/FixPermissionsTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Commands;
+namespace Tests\ImageProcessing\Commands;
 
 use App\Actions\Diagnostics\Pipes\Checks\BasicPermissionCheck;
 use function Safe\chmod;

--- a/tests/ImageProcessing/Commands/GenerateThumbsTest.php
+++ b/tests/ImageProcessing/Commands/GenerateThumbsTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Commands;
+namespace Tests\ImageProcessing\Commands;
 
 use App\Enum\SizeVariantType;
 use Illuminate\Support\Facades\DB;

--- a/tests/ImageProcessing/Commands/GhostbusterTest.php
+++ b/tests/ImageProcessing/Commands/GhostbusterTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Commands;
+namespace Tests\ImageProcessing\Commands;
 
 use Illuminate\Support\Facades\DB;
 use Tests\Constants\TestConstants;

--- a/tests/ImageProcessing/Commands/MoveToS3Test.php
+++ b/tests/ImageProcessing/Commands/MoveToS3Test.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Commands;
+namespace Tests\ImageProcessing\Commands;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Commands/SyncTest.php
+++ b/tests/ImageProcessing/Commands/SyncTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Commands;
+namespace Tests\ImageProcessing\Commands;
 
 use App\Constants\PhotoAlbum as PA;
 use App\Models\Configs;

--- a/tests/ImageProcessing/Commands/TakeDateTest.php
+++ b/tests/ImageProcessing/Commands/TakeDateTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Commands;
+namespace Tests\ImageProcessing\Commands;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;

--- a/tests/ImageProcessing/Commands/VideoDataTest.php
+++ b/tests/ImageProcessing/Commands/VideoDataTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Commands;
+namespace Tests\ImageProcessing\Commands;
 
 use App\Enum\SizeVariantType;
 use Illuminate\Support\Facades\DB;

--- a/tests/ImageProcessing/Image/Handlers/BaseImageHandler.php
+++ b/tests/ImageProcessing/Image/Handlers/BaseImageHandler.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Image\Handlers;
+namespace Tests\ImageProcessing\Image\Handlers;
 
 use App\Facades\Helpers;
 use App\Models\Configs;

--- a/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerGDTest.php
+++ b/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerGDTest.php
@@ -16,16 +16,16 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Image\Handlers;
+namespace Tests\ImageProcessing\Image\Handlers;
 
 use Tests\Constants\TestConstants;
 use Tests\Traits\InteractsWithRaw;
 use Tests\Traits\RequiresImageHandler;
 
 /**
- * Runs the tests of {@link PhotosAddHandlerTestAbstract} with Imagick as image handler.
+ * Runs the tests of {@link PhotosAddHandlerTestAbstract} with GD as image handler.
  */
-class PhotosAddHandlerImagickTest extends BaseImageHandler
+class PhotosAddHandlerGDTest extends BaseImageHandler
 {
 	use InteractsWithRaw;
 	use RequiresImageHandler;
@@ -33,7 +33,7 @@ class PhotosAddHandlerImagickTest extends BaseImageHandler
 	public function setUp(): void
 	{
 		parent::setUp();
-		$this->setUpRequiresImagick();
+		$this->setUpRequiresGD();
 	}
 
 	public function tearDown(): void
@@ -45,7 +45,8 @@ class PhotosAddHandlerImagickTest extends BaseImageHandler
 	/**
 	 * Tests uploading of an accepted TIFF.
 	 *
-	 * As Imagick supports TIFFs, we also expect generated thumbnail.
+	 * As GD does not support TIFFs, no thumbnail is generated.
+	 * Nonetheless, the original file should be uploaded without error.
 	 *
 	 * @return void
 	 */
@@ -59,8 +60,7 @@ class PhotosAddHandlerImagickTest extends BaseImageHandler
 			$photo = $response->json('resource.photos.0');
 
 			self::assertStringEndsWith('.tif', $photo['size_variants']['original']['url']);
-			self::assertEquals(TestConstants::MIME_TYPE_IMG_TIFF, $photo['type']);
-			self::assertNotNull($photo['size_variants']['thumb']);
+			self::assertNull($photo['size_variants']['thumb']);
 		} finally {
 			static::setAcceptedRawFormats($acceptedRawFormats);
 		}

--- a/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerImagickTest.php
+++ b/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerImagickTest.php
@@ -16,16 +16,16 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Image\Handlers;
+namespace Tests\ImageProcessing\Image\Handlers;
 
 use Tests\Constants\TestConstants;
 use Tests\Traits\InteractsWithRaw;
 use Tests\Traits\RequiresImageHandler;
 
 /**
- * Runs the tests of {@link PhotosAddHandlerTestAbstract} with GD as image handler.
+ * Runs the tests of {@link PhotosAddHandlerTestAbstract} with Imagick as image handler.
  */
-class PhotosAddHandlerGDTest extends BaseImageHandler
+class PhotosAddHandlerImagickTest extends BaseImageHandler
 {
 	use InteractsWithRaw;
 	use RequiresImageHandler;
@@ -33,7 +33,7 @@ class PhotosAddHandlerGDTest extends BaseImageHandler
 	public function setUp(): void
 	{
 		parent::setUp();
-		$this->setUpRequiresGD();
+		$this->setUpRequiresImagick();
 	}
 
 	public function tearDown(): void
@@ -45,8 +45,7 @@ class PhotosAddHandlerGDTest extends BaseImageHandler
 	/**
 	 * Tests uploading of an accepted TIFF.
 	 *
-	 * As GD does not support TIFFs, no thumbnail is generated.
-	 * Nonetheless, the original file should be uploaded without error.
+	 * As Imagick supports TIFFs, we also expect generated thumbnail.
 	 *
 	 * @return void
 	 */
@@ -60,7 +59,8 @@ class PhotosAddHandlerGDTest extends BaseImageHandler
 			$photo = $response->json('resource.photos.0');
 
 			self::assertStringEndsWith('.tif', $photo['size_variants']['original']['url']);
-			self::assertNull($photo['size_variants']['thumb']);
+			self::assertEquals(TestConstants::MIME_TYPE_IMG_TIFF, $photo['type']);
+			self::assertNotNull($photo['size_variants']['thumb']);
 		} finally {
 			static::setAcceptedRawFormats($acceptedRawFormats);
 		}

--- a/tests/ImageProcessing/Image/WatermarkerTest.php
+++ b/tests/ImageProcessing/Image/WatermarkerTest.php
@@ -16,14 +16,14 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Image;
+namespace Tests\ImageProcessing\Image;
 
 use App\Image\Watermarker;
 use App\Models\AccessPermission;
 use App\Models\Configs;
 use Illuminate\Support\Facades\Auth;
 use Tests\Constants\TestConstants;
-use Tests\Feature_v2\Image\Handlers\BaseImageHandler;
+use Tests\ImageProcessing\Image\Handlers\BaseImageHandler;
 use Tests\Traits\InteractsWithRaw;
 use Tests\Traits\RequireSE;
 use Tests\Traits\RequiresImageHandler;

--- a/tests/ImageProcessing/Import/ImportFromServerBrowseTest.php
+++ b/tests/ImageProcessing/Import/ImportFromServerBrowseTest.php
@@ -38,6 +38,6 @@ class ImportFromServerBrowseTest extends BaseApiWithDataTest
 		// We have to sort in order to have a predictable order for the test.
 		// The order returned by the filesystem is not predictable.
 		sort($content);
-		self::assertEquals( ['..', 'Constants', 'Feature_v2',  'ImageProcessing', 'Install', 'Samples', 'Traits', 'Unit', 'Webshop'], $content);
+		self::assertEquals(['..', 'Constants', 'Feature_v2',  'ImageProcessing', 'Install', 'Samples', 'Traits', 'Unit', 'Webshop'], $content);
 	}
 }

--- a/tests/ImageProcessing/Import/ImportFromServerBrowseTest.php
+++ b/tests/ImageProcessing/Import/ImportFromServerBrowseTest.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 
-namespace Tests\Feature_v2\Import;
+namespace Tests\ImageProcessing\Import;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 
@@ -38,6 +38,6 @@ class ImportFromServerBrowseTest extends BaseApiWithDataTest
 		// We have to sort in order to have a predictable order for the test.
 		// The order returned by the filesystem is not predictable.
 		sort($content);
-		self::assertEquals($content, ['..', 'Constants', 'Feature_v2', 'Install', 'Samples', 'Traits', 'Unit', 'Webshop']);
+		self::assertEquals( ['..', 'Constants', 'Feature_v2',  'ImageProcessing', 'Install', 'Samples', 'Traits', 'Unit', 'Webshop'], $content);
 	}
 }

--- a/tests/ImageProcessing/Import/ImportFromServerOptionsTest.php
+++ b/tests/ImageProcessing/Import/ImportFromServerOptionsTest.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 
-namespace Tests\Feature_v2\Import;
+namespace Tests\ImageProcessing\Import;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Import/ImportFromServerTest.php
+++ b/tests/ImageProcessing/Import/ImportFromServerTest.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2018-2025 LycheeOrg.
  */
 
-namespace Tests\Feature_v2\Import;
+namespace Tests\ImageProcessing\Import;
 
 use Illuminate\Support\Facades\Queue;
 use Tests\Feature_v2\Base\BaseApiWithDataTest;

--- a/tests/ImageProcessing/Jobs/ExtractColoursJobTest.php
+++ b/tests/ImageProcessing/Jobs/ExtractColoursJobTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Jobs;
+namespace Tests\ImageProcessing\Jobs;
 
 use App\Exceptions\Internal\InvalidConfigOption;
 use App\Jobs\ExtractColoursJob;

--- a/tests/ImageProcessing/Photo/HasUrlGeneratorTest.php
+++ b/tests/ImageProcessing/Photo/HasUrlGeneratorTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Photo;
+namespace Test\ImageProcessing\Photo;
 
 use App\Models\Configs;
 use App\Models\Extensions\HasUrlGenerator;

--- a/tests/ImageProcessing/Photo/HasUrlGeneratorTest.php
+++ b/tests/ImageProcessing/Photo/HasUrlGeneratorTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Test\ImageProcessing\Photo;
+namespace Tests\ImageProcessing\Photo;
 
 use App\Models\Configs;
 use App\Models\Extensions\HasUrlGenerator;

--- a/tests/ImageProcessing/Photo/PhotoAddTest.php
+++ b/tests/ImageProcessing/Photo/PhotoAddTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Test\ImageProcessing\Photo;
+namespace Tests\ImageProcessing\Photo;
 
 use Tests\Constants\TestConstants;
 use Tests\Feature_v2\Base\BaseApiWithDataTest;

--- a/tests/ImageProcessing/Photo/PhotoAddTest.php
+++ b/tests/ImageProcessing/Photo/PhotoAddTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Photo;
+namespace Test\ImageProcessing\Photo;
 
 use Tests\Constants\TestConstants;
 use Tests\Feature_v2\Base\BaseApiWithDataTest;

--- a/tests/ImageProcessing/Photo/PhotoCopyTest.php
+++ b/tests/ImageProcessing/Photo/PhotoCopyTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Photo;
+namespace Test\ImageProcessing\Photo;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Photo/PhotoCopyTest.php
+++ b/tests/ImageProcessing/Photo/PhotoCopyTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Test\ImageProcessing\Photo;
+namespace Tests\ImageProcessing\Photo;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Photo/PhotoDeleteTest.php
+++ b/tests/ImageProcessing/Photo/PhotoDeleteTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Photo;
+namespace Test\ImageProcessing\Photo;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Photo/PhotoDeleteTest.php
+++ b/tests/ImageProcessing/Photo/PhotoDeleteTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Test\ImageProcessing\Photo;
+namespace Tests\ImageProcessing\Photo;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Photo/PhotoEditTest.php
+++ b/tests/ImageProcessing/Photo/PhotoEditTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Test\ImageProcessing\Photo;
+namespace Tests\ImageProcessing\Photo;
 
 use Illuminate\Support\Facades\DB;
 use Tests\Feature_v2\Base\BaseApiWithDataTest;

--- a/tests/ImageProcessing/Photo/PhotoEditTest.php
+++ b/tests/ImageProcessing/Photo/PhotoEditTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Photo;
+namespace Test\ImageProcessing\Photo;
 
 use Illuminate\Support\Facades\DB;
 use Tests\Feature_v2\Base\BaseApiWithDataTest;

--- a/tests/ImageProcessing/Photo/PhotoFromUrlTest.php
+++ b/tests/ImageProcessing/Photo/PhotoFromUrlTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Test\ImageProcessing\Photo;
+namespace Tests\ImageProcessing\Photo;
 
 use Tests\Constants\TestConstants;
 use Tests\Feature_v2\Base\BaseApiWithDataTest;

--- a/tests/ImageProcessing/Photo/PhotoFromUrlTest.php
+++ b/tests/ImageProcessing/Photo/PhotoFromUrlTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Photo;
+namespace Test\ImageProcessing\Photo;
 
 use Tests\Constants\TestConstants;
 use Tests\Feature_v2\Base\BaseApiWithDataTest;

--- a/tests/ImageProcessing/Photo/PhotoMoveTest.php
+++ b/tests/ImageProcessing/Photo/PhotoMoveTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Photo;
+namespace Test\ImageProcessing\Photo;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Photo/PhotoMoveTest.php
+++ b/tests/ImageProcessing/Photo/PhotoMoveTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Test\ImageProcessing\Photo;
+namespace Tests\ImageProcessing\Photo;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Photo/PhotoRenameTest.php
+++ b/tests/ImageProcessing/Photo/PhotoRenameTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Photo;
+namespace Test\ImageProcessing\Photo;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Photo/PhotoRenameTest.php
+++ b/tests/ImageProcessing/Photo/PhotoRenameTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Test\ImageProcessing\Photo;
+namespace Tests\ImageProcessing\Photo;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Photo/PhotoRotateTest.php
+++ b/tests/ImageProcessing/Photo/PhotoRotateTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Photo;
+namespace Test\ImageProcessing\Photo;
 
 use App\Models\Configs;
 use Tests\Constants\TestConstants;

--- a/tests/ImageProcessing/Photo/PhotoRotateTest.php
+++ b/tests/ImageProcessing/Photo/PhotoRotateTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Test\ImageProcessing\Photo;
+namespace Tests\ImageProcessing\Photo;
 
 use App\Models\Configs;
 use Tests\Constants\TestConstants;

--- a/tests/ImageProcessing/Photo/PhotoStarTest.php
+++ b/tests/ImageProcessing/Photo/PhotoStarTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Photo;
+namespace Test\ImageProcessing\Photo;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Photo/PhotoStarTest.php
+++ b/tests/ImageProcessing/Photo/PhotoStarTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Test\ImageProcessing\Photo;
+namespace Tests\ImageProcessing\Photo;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Photo/PhotoTagsTest.php
+++ b/tests/ImageProcessing/Photo/PhotoTagsTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Photo;
+namespace Test\ImageProcessing\Photo;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Photo/PhotoTagsTest.php
+++ b/tests/ImageProcessing/Photo/PhotoTagsTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Test\ImageProcessing\Photo;
+namespace Tests\ImageProcessing\Photo;
 
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 

--- a/tests/ImageProcessing/Photo/PhotoZipUploadTest.php
+++ b/tests/ImageProcessing/Photo/PhotoZipUploadTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Test\ImageProcessing\Photo;
+namespace Tests\ImageProcessing\Photo;
 
 use App\Exceptions\ZipInvalidException;
 use function Safe\unlink;

--- a/tests/ImageProcessing/Photo/PhotoZipUploadTest.php
+++ b/tests/ImageProcessing/Photo/PhotoZipUploadTest.php
@@ -16,7 +16,7 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
-namespace Tests\Feature_v2\Photo;
+namespace Test\ImageProcessing\Photo;
 
 use App\Exceptions\ZipInvalidException;
 use function Safe\unlink;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new ImageProcessing test suite and moved image-related tests into it for clearer isolation and coverage.
* **Chores**
  * Updated CI and build tooling to run and report the new suite (including a Makefile target).
  * Adjusted coverage reporting settings and test matrix exclusions to align with existing patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->