### PR TITLE
Add video support to embedded galleries; fix gallery limit bug

### DIFF
--- a/app/Http/Requests/Embed/EmbededRequest.php
+++ b/app/Http/Requests/Embed/EmbededRequest.php
@@ -66,7 +66,7 @@ class EmbededRequest extends BaseApiRequest implements HasBaseAlbum
 
 		// Validate and cap limit to 500 max
 		if ($limit !== null) {
-			$this->limit = max(1, min((int) $this->limit, 500));
+			$this->limit = max(1, min((int) $limit, 500));
 		}
 		$this->offset = max(0, (int) $offset);
 

--- a/app/Http/Resources/Embed/EmbedPhotoResource.php
+++ b/app/Http/Resources/Embed/EmbedPhotoResource.php
@@ -8,6 +8,7 @@
 
 namespace App\Http\Resources\Embed;
 
+use App\Assets\Helpers;
 use App\Http\Resources\Models\SizeVariantsResouce;
 use App\Models\Photo;
 use Spatie\LaravelData\Data;
@@ -25,6 +26,8 @@ class EmbedPhotoResource extends Data
 	public string $id;
 	public ?string $title;
 	public ?string $description;
+	public bool $is_video;
+	public ?string $duration;
 	public SizeVariantsResouce $size_variants;
 	/** @var array<string, string|null> */
 	public array $exif;
@@ -34,6 +37,12 @@ class EmbedPhotoResource extends Data
 		$this->id = $photo->id;
 		$this->title = $photo->title;
 		$this->description = $photo->description;
+		$this->is_video = $photo->isVideo();
+
+		// For videos, aperture field stores duration in seconds
+		$this->duration = $this->is_video && $photo->aperture !== null
+			? app(Helpers::class)->secondsToHMS(intval($photo->aperture))
+			: null;
 
 		// Reuse existing SizeVariantsResouce instead of duplicating logic
 		// Pass null for album since embeds are always public

--- a/resources/js/embed/components/EmbedWidget.vue
+++ b/resources/js/embed/components/EmbedWidget.vue
@@ -57,6 +57,13 @@
 						@keydown.enter="openLightbox(albumData.photos[filmstripActiveIndex].id)"
 						@keydown.space.prevent="openLightbox(albumData.photos[filmstripActiveIndex].id)"
 					/>
+					<!-- Video play icon overlay for filmstrip main viewer -->
+					<div v-if="albumData && albumData.photos[filmstripActiveIndex]?.is_video" class="lychee-embed__video-overlay">
+						<svg class="lychee-embed__play-icon" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+							<circle cx="50" cy="50" r="45" fill="rgba(0, 0, 0, 0.6)" />
+							<polygon points="37,30 37,70 70,50" fill="white" />
+						</svg>
+					</div>
 
 					<!-- Navigation arrows -->
 					<button
@@ -117,6 +124,13 @@
 							loading="lazy"
 							class="lychee-embed__photo-img"
 						/>
+						<!-- Video play icon overlay -->
+						<div v-if="thumb.photo.is_video" class="lychee-embed__video-overlay">
+							<svg class="lychee-embed__play-icon" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+								<circle cx="50" cy="50" r="45" fill="rgba(0, 0, 0, 0.6)" />
+								<polygon points="37,30 37,70 70,50" fill="white" />
+							</svg>
+						</div>
 					</div>
 				</div>
 			</div>
@@ -148,6 +162,13 @@
 						loading="lazy"
 						class="lychee-embed__photo-img"
 					/>
+					<!-- Video play icon overlay -->
+					<div v-if="photo.is_video" class="lychee-embed__video-overlay">
+						<svg class="lychee-embed__play-icon" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+							<circle cx="50" cy="50" r="45" fill="rgba(0, 0, 0, 0.6)" />
+							<polygon points="37,30 37,70 70,50" fill="white" />
+						</svg>
+					</div>
 				</div>
 			</div>
 
@@ -610,5 +631,35 @@ watch(
 	height: 100%;
 	object-fit: cover;
 	display: block;
+}
+
+/* Video play icon overlay */
+.lychee-embed__video-overlay {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	pointer-events: none;
+	transition: opacity 0.3s ease;
+}
+
+.lychee-embed__photo:hover .lychee-embed__video-overlay,
+.lychee-embed__filmstrip-thumb:hover .lychee-embed__video-overlay,
+.lychee-embed__filmstrip-main:hover .lychee-embed__video-overlay {
+	opacity: 0.7;
+}
+
+.lychee-embed__play-icon {
+	width: 20%;
+	height: 20%;
+	min-width: 40px;
+	min-height: 40px;
+	max-width: 80px;
+	max-height: 80px;
+	filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.3));
 }
 </style>

--- a/resources/js/embed/types.ts
+++ b/resources/js/embed/types.ts
@@ -96,6 +96,8 @@ export interface Photo {
 	id: string;
 	title: string | null;
 	description: string | null;
+	is_video: boolean;
+	duration: string | null;
 	size_variants: {
 		placeholder: SizeVariantData | null;
 		thumb: SizeVariantData | null;
@@ -104,10 +106,7 @@ export interface Photo {
 		small2x: SizeVariantData | null;
 		medium: SizeVariantData | null;
 		medium2x: SizeVariantData | null;
-		original: {
-			width: number;
-			height: number;
-		};
+		original: SizeVariantData | null;
 	};
 	exif: PhotoExif;
 }

--- a/resources/js/embed/utils/columns.ts
+++ b/resources/js/embed/utils/columns.ts
@@ -172,7 +172,7 @@ export function getAspectRatio(width: number, height: number): number {
  * @returns Object with width and height, defaults to { width: 1, height: 1 } if all variants are null
  */
 export function getSafeDimensions(sizeVariants: {
-	original: { width: number; height: number };
+	original: { width?: number; height?: number } | null;
 	medium: { width?: number; height?: number } | null;
 	small: { width?: number; height?: number } | null;
 	thumb: { width?: number; height?: number } | null;


### PR DESCRIPTION
This PR:

- Fixes a bug wherein any embedded gallery `limit` parameter other than "no limit" resulted in only one photo being returned
- Adds video support to embedded galleries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added video playback support to embedded photo galleries with play indicator overlays
  * Video items now display duration and metadata (frame rate, ISO) in full-screen view
  * Video controls (play, pause, volume) available when viewing videos

<!-- end of auto-generated comment: release notes by coderabbit.ai -->