### PR TITLE
Add option to make the smart albums only consider photos of the user

### DIFF
--- a/app/SmartAlbums/BaseSmartAlbum.php
+++ b/app/SmartAlbums/BaseSmartAlbum.php
@@ -30,6 +30,7 @@ use App\SmartAlbums\Utils\MimicModel;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * Class BaseSmartAlbum.
@@ -113,6 +114,7 @@ abstract class BaseSmartAlbum implements AbstractAlbum
 		// If the smart album visibility override is enabled, we do not need to apply any security filter, as all photos are visible
 		// in this smart album. We still need to apply the smart album condition, though.
 		return $this->photo_query_policy->applySensitivityFilter(query: $base_query, origin: null, include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums'))
+			->when(Configs::getValueAsBool('enable_smart_album_per_owner') && Auth::check(), fn (Builder $query) => $query->where('photos.owner_id', '=', Auth::id()))
 			->where($this->smart_photo_condition);
 	}
 

--- a/app/SmartAlbums/BaseSmartAlbum.php
+++ b/app/SmartAlbums/BaseSmartAlbum.php
@@ -108,13 +108,16 @@ abstract class BaseSmartAlbum implements AbstractAlbum
 		if (!Configs::getValueAsBool('SA_override_visibility')) {
 			return $this->photo_query_policy
 				->applySearchabilityFilter(query: $base_query, origin: null, include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums'))
+				->when(
+					Configs::getValueAsBool('enable_smart_album_per_owner') && Auth::check(),
+					fn (Builder $query) => $query->where('photos.owner_id', '=', Auth::id())
+				)
 				->where($this->smart_photo_condition);
 		}
 
 		// If the smart album visibility override is enabled, we do not need to apply any security filter, as all photos are visible
 		// in this smart album. We still need to apply the smart album condition, though.
 		return $this->photo_query_policy->applySensitivityFilter(query: $base_query, origin: null, include_nsfw: !Configs::getValueAsBool('hide_nsfw_in_smart_albums'))
-			->when(Configs::getValueAsBool('enable_smart_album_per_owner') && Auth::check(), fn (Builder $query) => $query->where('photos.owner_id', '=', Auth::id()))
 			->where($this->smart_photo_condition);
 	}
 

--- a/app/SmartAlbums/UnsortedAlbum.php
+++ b/app/SmartAlbums/UnsortedAlbum.php
@@ -12,8 +12,10 @@ use App\Constants\PhotoAlbum as PA;
 use App\Enum\SmartAlbumType;
 use App\Exceptions\ConfigurationKeyMissingException;
 use App\Exceptions\Internal\FrameworkException;
+use App\Models\Configs;
 use App\Models\Photo;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 
 class UnsortedAlbum extends BaseSmartAlbum
 {
@@ -45,7 +47,7 @@ class UnsortedAlbum extends BaseSmartAlbum
 	 */
 	public function photos(): Builder
 	{
-		if ($this->public_permissions !== null) {
+		if ($this->public_permissions !== null && (!Auth::check() || !Configs::getValueAsBool('enable_smart_album_per_owner'))) {
 			return Photo::query()->leftJoin(PA::PHOTO_ALBUM, 'photos.id', '=', PA::PHOTO_ID)->with(['size_variants', 'statistics', 'palette', 'tags'])
 			->where($this->smart_photo_condition);
 		}

--- a/database/migrations/2025_12_19_161600_star_album_option.php
+++ b/database/migrations/2025_12_19_161600_star_album_option.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2025 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const MOD_GALLERY = 'Smart Albums';
+
+	/**
+	 * @return array<int,array{key:string,value:string,is_secret:bool,cat:string,type_range:string,description:string,order?:int,not_on_docker?:bool,is_expert?:bool}>
+	 */
+	public function getConfigs(): array
+	{
+		return [
+			[
+				'key' => 'enable_smart_album_per_owner',
+				'value' => '0',
+				'cat' => self::MOD_GALLERY,
+				'type_range' => self::BOOL,
+				'description' => 'Only display pictures owned by the user in smart albums.',
+				'details' => 'This setting is only applied to logged-in users.',
+				'is_secret' => false,
+				'is_expert' => false,
+				'order' => 12,
+				'not_on_docker' => false,
+				'level' => 0,
+			],
+		];
+	}
+};

--- a/lang/ar/all_settings.php
+++ b/lang/ar/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/cz/all_settings.php
+++ b/lang/cz/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/de/all_settings.php
+++ b/lang/de/all_settings.php
@@ -300,6 +300,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -596,5 +597,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/el/all_settings.php
+++ b/lang/el/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/en/all_settings.php
+++ b/lang/en/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/es/all_settings.php
+++ b/lang/es/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/fa/all_settings.php
+++ b/lang/fa/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/fr/all_settings.php
+++ b/lang/fr/all_settings.php
@@ -299,8 +299,7 @@ return [
         'webshop_offline' => 'Le traitement des paiements est ignoré. Les commandes sont marquées OFFLINE.',
         'deduplicate_pinned_albums' => 'Les albums mis en avant n’apparaissent qu’une seule fois sur la page principale.',
         'desktop_dock_full_transparency_enabled' => 'En vue photo le dock devient totalement transparent (affiché au survol).',
-        'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> Impacte l’ergonomie mobile. En vue photo le dock devient totalement transparent (affiché au tap).',
-    ],
+        'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> Impacte l’ergonomie mobile. En vue photo le dock devient totalement transparent (affiché au tap).',        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',    ],
     'documentation' => [
         'version' => 'Version actuelle de Lychee',
         'check_for_updates' => 'Vérifier automatiquement les nouvelles mises à jour',
@@ -595,6 +594,5 @@ return [
         'webshop_offline' => 'Garder la boutique hors ligne (traitement des paiements désactivé)',
         'deduplicate_pinned_albums' => 'Ne montrer les albums mis en avant qu’une seule fois sur la page principale',
         'desktop_dock_full_transparency_enabled' => 'Sur la vue photo, rendre le dock totalement transparent (apparition au survol)',
-        'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> Impacte l’ergonomie mobile. Rendre le dock totalement transparent (apparition au tap).',
-    ],
+        'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> Impacte l’ergonomie mobile. Rendre le dock totalement transparent (apparition au tap).',        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',    ],
 ];

--- a/lang/fr/all_settings.php
+++ b/lang/fr/all_settings.php
@@ -299,7 +299,8 @@ return [
         'webshop_offline' => 'Le traitement des paiements est ignoré. Les commandes sont marquées OFFLINE.',
         'deduplicate_pinned_albums' => 'Les albums mis en avant n’apparaissent qu’une seule fois sur la page principale.',
         'desktop_dock_full_transparency_enabled' => 'En vue photo le dock devient totalement transparent (affiché au survol).',
-        'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> Impacte l’ergonomie mobile. En vue photo le dock devient totalement transparent (affiché au tap).',        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',    ],
+        'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> Impacte l’ergonomie mobile. En vue photo le dock devient totalement transparent (affiché au tap).',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',    ],
     'documentation' => [
         'version' => 'Version actuelle de Lychee',
         'check_for_updates' => 'Vérifier automatiquement les nouvelles mises à jour',
@@ -594,5 +595,6 @@ return [
         'webshop_offline' => 'Garder la boutique hors ligne (traitement des paiements désactivé)',
         'deduplicate_pinned_albums' => 'Ne montrer les albums mis en avant qu’une seule fois sur la page principale',
         'desktop_dock_full_transparency_enabled' => 'Sur la vue photo, rendre le dock totalement transparent (apparition au survol)',
-        'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> Impacte l’ergonomie mobile. Rendre le dock totalement transparent (apparition au tap).',        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',    ],
+        'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> Impacte l’ergonomie mobile. Rendre le dock totalement transparent (apparition au tap).',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',    ],
 ];

--- a/lang/hu/all_settings.php
+++ b/lang/hu/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/it/all_settings.php
+++ b/lang/it/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/ja/all_settings.php
+++ b/lang/ja/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/nl/all_settings.php
+++ b/lang/nl/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/no/all_settings.php
+++ b/lang/no/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/pl/all_settings.php
+++ b/lang/pl/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/pt/all_settings.php
+++ b/lang/pt/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/ru/all_settings.php
+++ b/lang/ru/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/sk/all_settings.php
+++ b/lang/sk/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/sv/all_settings.php
+++ b/lang/sv/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/vi/all_settings.php
+++ b/lang/vi/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/zh_CN/all_settings.php
+++ b/lang/zh_CN/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];

--- a/lang/zh_TW/all_settings.php
+++ b/lang/zh_TW/all_settings.php
@@ -302,6 +302,7 @@ return [
         'deduplicate_pinned_albums' => 'Deduplicate featured albums.',
         'desktop_dock_full_transparency_enabled' => 'Enable dock full transparency for desktop.',
         'mobile_dock_full_transparency_enabled' => 'Enable dock transparency for mobile,',
+        'enable_smart_album_per_owner' => 'Only display pictures owned by the user in smart albums.',
     ],
     'details' => [
         'version' => '',
@@ -598,5 +599,6 @@ return [
         'deduplicate_pinned_albums' => 'Featured albums will only appear once on the main gallery page.',
         'desktop_dock_full_transparency_enabled' => 'On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on hover.',
         'mobile_dock_full_transparency_enabled' => '<span class="pi pi-exclamation-triangle text-orange-500"></span> This will impact usability on mobile. On the photo view, actions on top of the page are slightly transparent. Enable this to have them fully transparent and only appear on tap.',
+        'enable_smart_album_per_owner' => 'This setting is only applied to logged-in users. "Smart album visibility overrides" must be disabled for this to take effect.',
     ],
 ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration to restrict smart albums to photos owned by the signed-in user; when enabled, authenticated users see only their own photos in smart albums.
* **Documentation**
  * Added user-facing setting descriptions and help text for the new option across multiple languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->