### PR TITLE
Fix tag-pinned-shared albums not being reset

### DIFF
--- a/resources/js/stores/AlbumState.ts
+++ b/resources/js/stores/AlbumState.ts
@@ -82,19 +82,23 @@ export const useAlbumStore = defineStore("album-store", {
 					if (data.data.resource === null) {
 						return;
 					}
+					// Reset to avoid bad surprises.
+					albumsStore.albums = [];
+					albumsStore.tagAlbums = [];
+					albumsStore.pinnedAlbums = [];
+					albumsStore.sharedAlbums = [];
+					// Load data.
 					if (data.data.config.is_model_album) {
 						this.modelAlbum = data.data.resource as App.Http.Resources.Models.AlbumResource;
 						albumsStore.albums = this.modelAlbum.albums;
 					} else if (data.data.config.is_base_album) {
 						this.tagAlbum = data.data.resource as App.Http.Resources.Models.TagAlbumResource;
-						albumsStore.albums = []; // Reset to avoid bad surprises.
 					} else {
 						this.smartAlbum = data.data.resource as App.Http.Resources.Models.SmartAlbumResource;
 						this.per_page = this.smartAlbum.per_page;
 						this.total = this.smartAlbum.total;
 						this.current_page = this.smartAlbum.current_page;
 						this.last_page = this.smartAlbum.last_page;
-						albumsStore.albums = []; // Reset to avoid bad surprises.
 					}
 					photosState.setPhotos(data.data.resource.photos, data.data.config.is_photo_timeline_enabled);
 				})


### PR DESCRIPTION
Fixes #3890 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where stale data from previously loaded albums could appear when switching to a new album. The application now consistently resets all album-related information immediately upon loading, before populating fresh data from the server, preventing data inconsistencies across all album types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->