### PR TITLE
PHP 8.3 is dead

### DIFF
--- a/.ai/embeds/IMPLEMENTATION.md
+++ b/.ai/embeds/IMPLEMENTATION.md
@@ -67,8 +67,8 @@
 ### Technology Stack
 
 **Backend**:
-- Laravel 11.x (existing)
-- PHP 8.3+
+- Laravel 12.x (existing)
+- PHP 8.4+
 - Existing Lychee models and services
 
 **Widget**:

--- a/.ai/embeds/README.md
+++ b/.ai/embeds/README.md
@@ -72,7 +72,7 @@ Allows Lychee users to embed their public photo albums on external websites usin
 ### Technology Stack
 
 **Backend**:
-- Laravel 11.x (PHP 8.3+)
+- Laravel 13.x (PHP 8.4+)
 - New API endpoint: `GET /api/v2/Embed/{albumId}`
 - CORS configuration for cross-origin access
 

--- a/.ai/embeds/README.md
+++ b/.ai/embeds/README.md
@@ -72,7 +72,7 @@ Allows Lychee users to embed their public photo albums on external websites usin
 ### Technology Stack
 
 **Backend**:
-- Laravel 13.x (PHP 8.4+)
+- Laravel 12.x (PHP 8.4+)
 - New API endpoint: `GET /api/v2/Embed/{albumId}`
 - CORS configuration for cross-origin access
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center"><a href="https://lycheeorg.dev"><img src="https://raw.githubusercontent.com/LycheeOrg/Lychee/master/Banner.png" width="400px" alt="@LycheeOrg"></a></p>
 
 [![GitHub Release][release-shield]](https://github.com/LycheeOrg/Lychee/releases)
-[![PHP 8.3 & 8.4][php-shield]](https://lycheeorg.dev/docs/#server-requirements)
+[![PHP 8.4 & 8.5][php-shield]](https://lycheeorg.dev/docs/#server-requirements)
 [![MIT License][license-shield]](https://github.com/LycheeOrg/Lychee/blob/master/LICENSE)
 [![Downloads][download-shield]](https://github.com/LycheeOrg/Lychee/releases)
 <br>
@@ -56,7 +56,7 @@ If you feel like checking the authenticity of our releases, we advise you to rea
 
 ### Build from Source deployment
 
-To run Lychee, everything you need is a web-server with PHP 8.3 or later and a database (MySQL/MariaDB, PostgreSQL or SQLite). Follow the instructions to install Lychee on your server. This version of Lychee is built on the Laravel framework. To install:
+To run Lychee, everything you need is a web-server with PHP 8.4 or later and a database (MySQL/MariaDB, PostgreSQL or SQLite). Follow the instructions to install Lychee on your server. This version of Lychee is built on the Laravel framework. To install:
 
 1. Clone this repo to your server and set the web root to `lychee/public`
 2. Run `composer install --no-dev` to install dependencies
@@ -134,7 +134,7 @@ We would like to thank Jetbrains for supporting us with their [Open Source Devel
 [build-status-shield]: https://img.shields.io/github/actions/workflow/status/LycheeOrg/Lychee/CICD.yml?branch=master
 [codecov-shield]: https://codecov.io/gh/LycheeOrg/Lychee/branch/master/graph/badge.svg
 [release-shield]: https://img.shields.io/github/release/LycheeOrg/Lychee.svg
-[php-shield]: https://img.shields.io/badge/PHP-8.3%20|%208.4-blue
+[php-shield]: https://img.shields.io/badge/PHP-8.4%20|%208.5-blue
 [license-shield]: https://img.shields.io/github/license/LycheeOrg/Lychee.svg
 [cii-shield]: https://img.shields.io/cii/summary/2855.svg
 [ossf-shield]: https://api.securityscorecards.dev/projects/github.com/LycheeOrg/Lychee/badge

--- a/app/Actions/Diagnostics/Pipes/Checks/PHPVersionCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/PHPVersionCheck.php
@@ -18,9 +18,9 @@ class PHPVersionCheck implements DiagnosticPipe
 {
 	// We only support the actively supported version of php.
 	// See here: https://www.php.net/supported-versions.php
-	public const PHP_ERROR = 8.2;
-	public const PHP_WARNING = 8.3;
-	public const PHP_LATEST = 8.4;
+	public const PHP_ERROR = 8.3;
+	public const PHP_WARNING = 8.4;
+	public const PHP_LATEST = 8.5;
 
 	/**
 	 * {@inheritDoc}

--- a/app/Actions/InstallUpdate/DefaultConfig.php
+++ b/app/Actions/InstallUpdate/DefaultConfig.php
@@ -25,7 +25,7 @@ class DefaultConfig
 			| by looping through the array and run "extension_loaded" on it.
 			|
 			*/
-		'core' => ['minPhpVersion' => '8.3.0'],
+		'core' => ['minPhpVersion' => '8.4.0'],
 
 		'requirements' => [
 			'php' => [

--- a/docs/Contribute.md
+++ b/docs/Contribute.md
@@ -24,7 +24,7 @@ This will help you navigate the codebase more effectively.
 
 ### Prerequisites
 
-- PHP 8.3 or higher
+- PHP 8.4 or higher
 - php extensions:
   - `php-curl`
   - `php-mbstring`

--- a/docs/specs/0-overview/README.md
+++ b/docs/specs/0-overview/README.md
@@ -73,7 +73,7 @@ Learn more about editions at [lycheeorg.dev/get-supporter-edition](https://lyche
 ## Technical Context
 
 **Architecture**:
-- **Backend**: PHP 8.3+ with Laravel framework
+- **Backend**: PHP 8.4+ with Laravel framework
 - **Frontend**: Vue3 Composition API with TypeScript and PrimeVue components
 - **Build**: Vite for modern frontend bundling
 - **Database**: MySQL, PostgreSQL, or SQLite
@@ -83,8 +83,8 @@ Learn more about editions at [lycheeorg.dev/get-supporter-edition](https://lyche
 2. **Manual installation**: For users comfortable managing web servers and databases
 
 **Requirements**:
-- PHP 8.3+ / Laravel framework
-- Node.js 18+ (for frontend build)
+- PHP 8.4+ / Laravel framework
+- Node.js 20+ (for frontend build)
 - Web server (Apache/Nginx)
 - Database (MySQL, PostgreSQL, SQLite)
 - Basic server administration knowledge (for manual installation)

--- a/docs/specs/4-architecture/backend-architecture.md
+++ b/docs/specs/4-architecture/backend-architecture.md
@@ -6,11 +6,11 @@ This document provides a comprehensive overview of Lychee's backend architecture
 
 ## Overview
 
-Lychee's backend is built on the **Laravel framework** (PHP 8.3+) with a clean architecture pattern that emphasizes separation of concerns, reusability, and maintainability. The architecture follows Laravel's MVC pattern enhanced with additional layers for business logic, authorization, and data transformation.
+Lychee's backend is built on the **Laravel framework** (PHP 8.4+) with a clean architecture pattern that emphasizes separation of concerns, reusability, and maintainability. The architecture follows Laravel's MVC pattern enhanced with additional layers for business logic, authorization, and data transformation.
 
 ### Technology Stack
 
-- **Backend**: PHP 8.3+, Laravel Framework
+- **Backend**: PHP 8.4+, Laravel Framework
 - **Database**: MySQL, MariaDB, PostgreSQL, or SQLite
 - **Build Tools**: Composer
 - **Image Processing**: GD, ImageMagick

--- a/docs/specs/5-operations/session-quick-reference.md
+++ b/docs/specs/5-operations/session-quick-reference.md
@@ -4,7 +4,7 @@ Use this appendix to accelerate hand-offs and new-session spin-up. Update it whe
 
 ## Session Kickoff Checklist
 - [ ] Run `git status -sb` to review branch, staged changes, and repo cleanliness.
-- [ ] Confirm environment prerequisites: PHP 8.3+, Composer installed, npm/Node.js available; log the command/output in `_current-session.md` for traceability.
+- [ ] Confirm environment prerequisites: PHP 8.4+, Composer installed, npm/Node.js available; log the command/output in `_current-session.md` for traceability.
 - [ ] Review current context: latest roadmap entry, active specification, feature plan, tasks checklist, and [docs/specs/4-architecture/open-questions.md](../4-architecture/open-questions.md).
 - [ ] Confirm that the active feature spec already encodes known decisions directly in its requirements/NFR/behaviour/telemetry sections (no per-feature `## Clarifications` appendices).
 - [ ] If new clarifications arise, record them in [docs/specs/4-architecture/open-questions.md](../4-architecture/open-questions.md), pause planning until answers are agreed, then update the spec sections and mark the questions as resolved with links to those sections; create or reference an ADR for architectural or other high‑impact decisions.
@@ -27,7 +27,7 @@ Use this appendix to accelerate hand-offs and new-session spin-up. Update it whe
 ```
 You're resuming work on Lychee photo management system. Core context:
 
-- Environment: repo at /home/biv/Documents/Projects/Lychee, PHP 8.3+, Laravel framework, Vue3/TypeScript frontend. Follow docs/specs/3-reference/coding-conventions.md and AGENTS.md.
+- Environment: repo at /home/biv/Documents/Projects/Lychee, PHP 8.4+, Laravel framework, Vue3/TypeScript frontend. Follow docs/specs/3-reference/coding-conventions.md and AGENTS.md.
 - Current status: roadmap entry #[…], spec […], plan […], tasks […]. Last green build(s): [commands + date].
 - Recent increments: [brief bullet list of the last completed increments, noting key files touched and outcomes].
 - Pending scope: [next planned increments/tasks], including failing tests to stage, implementation goals, telemetry/observability requirements, and documentation updates (keep this aligned with the `## Next suggested actions` section in `docs/specs/_current-session.md`).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP minimum requirement from 8.3+ to 8.4+
  * Updated Node.js requirement from 18+ to 20+
  * Updated backend framework versions and compatibility thresholds

* **Documentation**
  * Updated all prerequisite guides, architecture documentation, and deployment instructions to reflect new version requirements

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->