### PR TITLE
refactor: remove Auth facade dependencies from AlbumQueryPolicy

### DIFF
--- a/app/Actions/Albums/PositionData.php
+++ b/app/Actions/Albums/PositionData.php
@@ -12,8 +12,10 @@ use App\Contracts\Exceptions\InternalLycheeException;
 use App\Enum\SizeVariantType;
 use App\Http\Resources\Collections\PositionDataResource;
 use App\Models\Photo;
+use App\Policies\AlbumPolicy;
 use App\Policies\PhotoQueryPolicy;
 use App\Repositories\ConfigManager;
+use Illuminate\Support\Facades\Auth;
 
 class PositionData
 {
@@ -32,6 +34,9 @@ class PositionData
 	 */
 	public function do(): PositionDataResource
 	{
+		$user = Auth::user();
+		$unlocked_album_ids = AlbumPolicy::getUnlockedAlbumIDs();
+
 		$photo_query = $this->photo_query_policy->applySearchabilityFilter(
 			query: Photo::query()
 				->with([
@@ -51,6 +56,8 @@ class PositionData
 				])
 				->whereNotNull('latitude')
 				->whereNotNull('longitude'),
+			user: $user,
+			unlocked_album_ids: $unlocked_album_ids,
 			origin: null,
 			include_nsfw: !$this->config_manager->getValueAsBool('hide_nsfw_in_map')
 		);

--- a/app/Actions/Search/AlbumSearch.php
+++ b/app/Actions/Search/AlbumSearch.php
@@ -17,8 +17,10 @@ use App\Models\Builders\AlbumBuilder;
 use App\Models\Builders\TagAlbumBuilder;
 use App\Models\Extensions\SortingDecorator;
 use App\Models\TagAlbum;
+use App\Policies\AlbumPolicy;
 use App\Policies\AlbumQueryPolicy;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
 
 class AlbumSearch
 {
@@ -36,10 +38,13 @@ class AlbumSearch
 	 */
 	public function queryTagAlbums(array $terms): Collection
 	{
+		$user = Auth::user();
+
 		// Note: `applyVisibilityFilter` already adds a JOIN clause with `base_albums`.
 		// No need to add a second JOIN clause.
 		$album_query = $this->album_query_policy->applyVisibilityFilter(
-			TagAlbum::query()
+			TagAlbum::query(),
+			$user
 		);
 		$this->addSearchCondition($terms, $album_query);
 
@@ -60,13 +65,16 @@ class AlbumSearch
 	 */
 	public function queryAlbums(array $terms, ?Album $album = null): Collection
 	{
+		$user = Auth::user();
+		$unlocked_album_ids = AlbumPolicy::getUnlockedAlbumIDs();
+
 		$album_query = Album::query()
 			->select(['albums.*'])
 			->join('base_albums', 'base_albums.id', '=', 'albums.id')
 			->when($album !== null, fn ($q) => $q->where('albums._lft', '>=', $album->_lft)
 				->where('albums._rgt', '<=', $album->_rgt));
 		$this->addSearchCondition($terms, $album_query);
-		$this->album_query_policy->applyBrowsabilityFilter($album_query);
+		$this->album_query_policy->applyBrowsabilityFilter($album_query, $user, $unlocked_album_ids);
 
 		$sorting = AlbumSortingCriterion::createDefault();
 

--- a/app/Actions/Search/PhotoSearch.php
+++ b/app/Actions/Search/PhotoSearch.php
@@ -14,10 +14,12 @@ use App\Eloquent\FixedQueryBuilder;
 use App\Models\Album;
 use App\Models\Extensions\SortingDecorator;
 use App\Models\Photo;
+use App\Policies\AlbumPolicy;
 use App\Policies\PhotoQueryPolicy;
 use App\Repositories\ConfigManager;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
 
 class PhotoSearch
 {
@@ -55,8 +57,13 @@ class PhotoSearch
 	 */
 	public function sqlQuery(array $terms, ?Album $album = null): Builder
 	{
+		$user = Auth::user();
+		$unlocked_album_ids = AlbumPolicy::getUnlockedAlbumIDs();
+
 		$query = $this->photo_query_policy->applySearchabilityFilter(
 			query: Photo::query()->with(['albums', 'statistics', 'size_variants', 'palette', 'tags', 'rating']),
+			user: $user,
+			unlocked_album_ids: $unlocked_album_ids,
 			origin: $album,
 			include_nsfw: !$this->config_manager->getValueAsBool('hide_nsfw_in_search')
 		);

--- a/app/Actions/Shop/BasketService.php
+++ b/app/Actions/Shop/BasketService.php
@@ -17,7 +17,9 @@ use App\Models\Album;
 use App\Models\Order;
 use App\Models\Photo;
 use App\Models\User;
+use App\Policies\AlbumPolicy;
 use App\Policies\AlbumQueryPolicy;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -139,7 +141,12 @@ class BasketService
 		// up with photos that are purchasable but in albums that the user cannot see.
 		// This would lead to inconsistencies in the OrderItems.
 		if ($include_subalbums) {
-			$albums_ids = $this->album_query_policy->applyBrowsabilityFilter(Album::query()->select('id'), $album->_lft, $album->_rgt)->pluck('id')->toArray();
+			$albums_ids = $this->album_query_policy->applyBrowsabilityFilter(
+				query: Album::query()->select('id'),
+				user: Auth::user(),
+				unlocked_album_ids: AlbumPolicy::getUnlockedAlbumIDs(),
+				origin_left: $album->_lft,
+				origin_right: $album->_rgt)->pluck('id')->toArray();
 		} else {
 			$albums_ids = [$album->id];
 		}

--- a/app/Actions/Tag/GetTagWithPhotos.php
+++ b/app/Actions/Tag/GetTagWithPhotos.php
@@ -54,6 +54,7 @@ class GetTagWithPhotos
 
 		$photos_query = $this->photo_query_policy->applySensitivityFilter(
 			query: $base_query,
+			user: $user,
 			origin: null,
 			include_nsfw: !$this->config_manager->getValueAsBool('hide_nsfw_in_tag_listing')
 		);

--- a/app/Http/Controllers/Gallery/EmbedController.php
+++ b/app/Http/Controllers/Gallery/EmbedController.php
@@ -18,8 +18,10 @@ use App\Models\Album;
 use App\Models\Extensions\BaseAlbum;
 use App\Models\Extensions\SortingDecorator;
 use App\Models\Photo;
+use App\Policies\AlbumPolicy;
 use App\Policies\PhotoQueryPolicy;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -104,6 +106,9 @@ class EmbedController extends Controller
 	 */
 	private function findPublicPhotos(int $limit, int $offset, string $sort): \Illuminate\Support\Collection
 	{
+		$user = Auth::user();
+		$unlocked_album_ids = AlbumPolicy::getUnlockedAlbumIDs();
+
 		// Start with base photo query
 		$photos_query = Photo::query();
 
@@ -112,6 +117,8 @@ class EmbedController extends Controller
 		// No origin album context (null) means search across all albums
 		$this->photo_query_policy->applySearchabilityFilter(
 			query: $photos_query,
+			user: $user,
+			unlocked_album_ids: $unlocked_album_ids,
 			origin: null,
 			include_nsfw: !request()->configs()->getValueAsBool('hide_nsfw_in_rss')
 		);

--- a/app/Http/Controllers/Gallery/FrameController.php
+++ b/app/Http/Controllers/Gallery/FrameController.php
@@ -14,8 +14,10 @@ use App\Http\Requests\Frame\FrameRequest;
 use App\Http\Resources\Frame\FrameData;
 use App\Http\Resources\Models\PhotoResource;
 use App\Models\Photo;
+use App\Policies\AlbumPolicy;
 use App\Policies\PhotoQueryPolicy;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
 
 class FrameController extends Controller
 {
@@ -84,8 +86,13 @@ class FrameController extends Controller
 
 		// default query
 		if ($album === null) {
+			$user = Auth::user();
+			$unlocked_album_ids = AlbumPolicy::getUnlockedAlbumIDs();
+
 			$query = $this->photo_query_policy->applySearchabilityFilter(
 				query: Photo::query()->with(['albums', 'size_variants', 'palette', 'tags', 'rating']),
+				user: $user,
+				unlocked_album_ids: $unlocked_album_ids,
 				origin: null,
 				include_nsfw: !request()->configs()->getValueAsBool('hide_nsfw_in_frame')
 			);

--- a/app/Http/Controllers/Shop/CatalogController.php
+++ b/app/Http/Controllers/Shop/CatalogController.php
@@ -12,6 +12,7 @@ use App\Http\Requests\Catalog\GetCatalogRequest;
 use App\Http\Resources\Shop\CatalogResource;
 use App\Models\Album;
 use App\Models\Purchasable;
+use App\Policies\AlbumPolicy;
 use App\Policies\AlbumQueryPolicy;
 use Illuminate\Routing\Controller;
 
@@ -43,9 +44,15 @@ class CatalogController extends Controller
 			->where('is_active', true)
 			->get();
 
+		$unlocked_album_ids = AlbumPolicy::getUnlockedAlbumIDs();
 		$children_purchasables = Purchasable::query()
 			->whereNull('photo_id')
-			->whereIn('album_id', $this->album_query_policy->applyBrowsabilityFilter(Album::query()->where('parent_id', $album->id)->select('id'), $album->_lft, $album->_rgt))
+			->whereIn('album_id', $this->album_query_policy->applyBrowsabilityFilter(
+				query: Album::query()->where('parent_id', $album->id)->select('id'),
+				user: $request->user(),
+				unlocked_album_ids: $unlocked_album_ids,
+				origin_left: $album->_lft,
+				origin_right: $album->_rgt))
 			->where('is_active', true)
 			->get();
 

--- a/app/Relations/HasManyChildAlbums.php
+++ b/app/Relations/HasManyChildAlbums.php
@@ -16,6 +16,7 @@ use App\Models\Builders\AlbumBuilder;
 use App\Models\Extensions\SortingDecorator;
 use App\Policies\AlbumQueryPolicy;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @extends HasManyBidirectionally<Album,Album>
@@ -61,7 +62,8 @@ class HasManyChildAlbums extends HasManyBidirectionally
 	{
 		if (static::$constraints) {
 			parent::addConstraints();
-			$this->album_query_policy->applyVisibilityFilter($this->getRelationQuery());
+			$user = Auth::user();
+			$this->album_query_policy->applyVisibilityFilter($this->getRelationQuery(), $user);
 		}
 	}
 
@@ -73,7 +75,8 @@ class HasManyChildAlbums extends HasManyBidirectionally
 	public function addEagerConstraints(array $models)
 	{
 		parent::addEagerConstraints($models);
-		$this->album_query_policy->applyVisibilityFilter($this->getRelationQuery());
+		$user = Auth::user();
+		$this->album_query_policy->applyVisibilityFilter($this->getRelationQuery(), $user);
 	}
 
 	/**

--- a/app/Relations/HasManyChildPhotos.php
+++ b/app/Relations/HasManyChildPhotos.php
@@ -16,10 +16,12 @@ use App\Exceptions\Internal\InvalidOrderDirectionException;
 use App\Models\Album;
 use App\Models\Extensions\SortingDecorator;
 use App\Models\Photo;
+use App\Policies\AlbumPolicy;
 use App\Policies\PhotoQueryPolicy;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\InvalidCastException;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @extends BelongsToMany<Photo,Album>
@@ -81,7 +83,9 @@ class HasManyChildPhotos extends BelongsToMany
 
 		if (static::$constraints) {
 			$this->addWhereConstraints();
-			$this->photo_query_policy->applyVisibilityFilter($this->getRelationQuery());
+			$user = Auth::user();
+			$unlocked_album_ids = AlbumPolicy::getUnlockedAlbumIDs();
+			$this->photo_query_policy->applyVisibilityFilter($this->getRelationQuery(), $user, $unlocked_album_ids);
 		}
 	}
 
@@ -93,7 +97,9 @@ class HasManyChildPhotos extends BelongsToMany
 	public function addEagerConstraints(array $models)
 	{
 		parent::addEagerConstraints($models);
-		$this->photo_query_policy->applyVisibilityFilter($this->getRelationQuery());
+		$user = Auth::user();
+		$unlocked_album_ids = AlbumPolicy::getUnlockedAlbumIDs();
+		$this->photo_query_policy->applyVisibilityFilter($this->getRelationQuery(), $user, $unlocked_album_ids);
 	}
 
 	/**

--- a/app/Relations/HasManyPhotosByTag.php
+++ b/app/Relations/HasManyPhotosByTag.php
@@ -82,11 +82,15 @@ class HasManyPhotosByTag extends BaseHasManyPhotos
 			->all();
 		$tag_ids = array_values(array_unique($tag_ids));
 
+		$user = \Illuminate\Support\Facades\Auth::user();
+		$unlocked_album_ids = \App\Policies\AlbumPolicy::getUnlockedAlbumIDs();
+
 		$config_manager = app(ConfigManager::class);
 		if ($config_manager->getValueAsBool('TA_override_visibility')) {
 			$this->photo_query_policy
 				->applySensitivityFilter(
-					$this->getRelationQuery(),
+					query: $this->getRelationQuery(),
+					user: $user,
 					origin: null,
 					include_nsfw: !$config_manager->getValueAsBool('hide_nsfw_in_tag_albums')
 				)
@@ -94,7 +98,9 @@ class HasManyPhotosByTag extends BaseHasManyPhotos
 		} else {
 			$this->photo_query_policy
 				->applySearchabilityFilter(
-					$this->getRelationQuery(),
+					query: $this->getRelationQuery(),
+					user: $user,
+					unlocked_album_ids: $unlocked_album_ids,
 					origin: null,
 					include_nsfw: !$config_manager->getValueAsBool('hide_nsfw_in_tag_albums')
 				)

--- a/app/Relations/HasManyPhotosRecursively.php
+++ b/app/Relations/HasManyPhotosRecursively.php
@@ -16,6 +16,7 @@ use App\Models\Extensions\SortingDecorator;
 use App\Policies\AlbumPolicy;
 use App\Policies\AlbumQueryPolicy;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 
 /**
@@ -83,7 +84,7 @@ class HasManyPhotosRecursively extends BaseHasManyPhotos
 			throw new NotImplementedException('eagerly fetching all photos of an album is not implemented for multiple albums');
 		}
 
-		$user = \Illuminate\Support\Facades\Auth::user();
+		$user = Auth::user();
 		$unlocked_album_ids = AlbumPolicy::getUnlockedAlbumIDs();
 
 		$this->photo_query_policy

--- a/app/Relations/HasManyPhotosRecursively.php
+++ b/app/Relations/HasManyPhotosRecursively.php
@@ -83,9 +83,14 @@ class HasManyPhotosRecursively extends BaseHasManyPhotos
 			throw new NotImplementedException('eagerly fetching all photos of an album is not implemented for multiple albums');
 		}
 
+		$user = \Illuminate\Support\Facades\Auth::user();
+		$unlocked_album_ids = AlbumPolicy::getUnlockedAlbumIDs();
+
 		$this->photo_query_policy
 			->applySearchabilityFilter(
 				query: $this->getRelationQuery(),
+				user: $user,
+				unlocked_album_ids: $unlocked_album_ids,
 				origin: $albums[0],
 				include_nsfw: true
 			);

--- a/app/SmartAlbums/BaseSmartAlbum.php
+++ b/app/SmartAlbums/BaseSmartAlbum.php
@@ -24,6 +24,7 @@ use App\Models\Extensions\Thumb;
 use App\Models\Extensions\ToArrayThrowsNotImplemented;
 use App\Models\Extensions\UTCBasedTimes;
 use App\Models\Photo;
+use App\Policies\AlbumPolicy;
 use App\Policies\PhotoQueryPolicy;
 use App\Repositories\ConfigManager;
 use App\SmartAlbums\Utils\MimicModel;
@@ -108,7 +109,7 @@ abstract class BaseSmartAlbum implements AbstractAlbum
 	public function photos(): Builder
 	{
 		$user = Auth::user();
-		$unlocked_album_ids = \App\Policies\AlbumPolicy::getUnlockedAlbumIDs();
+		$unlocked_album_ids = AlbumPolicy::getUnlockedAlbumIDs();
 
 		$base_query = Photo::query()->leftJoin(PA::PHOTO_ALBUM, 'photos.id', '=', PA::PHOTO_ID)->with(['size_variants', 'statistics', 'palette', 'tags', 'rating']);
 

--- a/app/SmartAlbums/BaseSmartAlbum.php
+++ b/app/SmartAlbums/BaseSmartAlbum.php
@@ -107,11 +107,14 @@ abstract class BaseSmartAlbum implements AbstractAlbum
 	 */
 	public function photos(): Builder
 	{
+		$user = Auth::user();
+		$unlocked_album_ids = \App\Policies\AlbumPolicy::getUnlockedAlbumIDs();
+
 		$base_query = Photo::query()->leftJoin(PA::PHOTO_ALBUM, 'photos.id', '=', PA::PHOTO_ID)->with(['size_variants', 'statistics', 'palette', 'tags', 'rating']);
 
 		if (!$this->config_manager->getValueAsBool('SA_override_visibility')) {
 			return $this->photo_query_policy
-				->applySearchabilityFilter(query: $base_query, origin: null, include_nsfw: !$this->config_manager->getValueAsBool('hide_nsfw_in_smart_albums'))
+				->applySearchabilityFilter(query: $base_query, user: $user, unlocked_album_ids: $unlocked_album_ids, origin: null, include_nsfw: !$this->config_manager->getValueAsBool('hide_nsfw_in_smart_albums'))
 				->when(
 					$this->config_manager->getValueAsBool('enable_smart_album_per_owner') && Auth::check(),
 					fn (Builder $query) => $query->where('photos.owner_id', '=', Auth::id())
@@ -121,7 +124,7 @@ abstract class BaseSmartAlbum implements AbstractAlbum
 
 		// If the smart album visibility override is enabled, we do not need to apply any security filter, as all photos are visible
 		// in this smart album. We still need to apply the smart album condition, though.
-		return $this->photo_query_policy->applySensitivityFilter(query: $base_query, origin: null, include_nsfw: !$this->config_manager->getValueAsBool('hide_nsfw_in_smart_albums'))
+		return $this->photo_query_policy->applySensitivityFilter(query: $base_query, user: $user, origin: null, include_nsfw: !$this->config_manager->getValueAsBool('hide_nsfw_in_smart_albums'))
 			->where($this->smart_photo_condition);
 	}
 


### PR DESCRIPTION
Remove implicit dependencies on Auth facade state from policy classes by accepting explicit user and unlocked album IDs as parameters instead of fetching them internally. This makes the code more testable and follows dependency injection principles.

Changes:
- AlbumQueryPolicy: All methods now accept ?User $user and array $unlocked_album_ids
- PhotoQueryPolicy: All methods now accept ?User $user and array $unlocked_album_ids
- Updated all callers (19 files) to pass Auth::user() and AlbumPolicy::getUnlockedAlbumIDs()
- Updated relations, actions, controllers, and smart albums to follow new signatures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consistent, user-aware access control applied across albums, photos, search, timelines, RSS, embeds, frames, smart albums and shop listings.
  * Filtering now respects authenticated user context and unlocked-album status so visible content more accurately reflects each user’s permissions.
  * Policy and query filtering paths unified for more predictable, testable visibility and search results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->