### PR TITLE
Do not load duplicates directly, it crashes the DB...

### DIFF
--- a/lang/ar/maintenance.php
+++ b/lang/ar/maintenance.php
@@ -20,6 +20,7 @@ return [
         'duplicates-title' => 'تكرارات العنوان لكل ألبوم',
         'duplicates-per-album' => 'التكرارات لكل ألبوم',
         'show' => 'عرض التكرارات',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'إصلاح سجل الوظائف',

--- a/lang/cz/maintenance.php
+++ b/lang/cz/maintenance.php
@@ -20,6 +20,7 @@ return [
         'duplicates-title' => 'Title duplicates per album',
         'duplicates-per-album' => 'Duplicates per album',
         'show' => 'Show duplicates',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Fixing Jobs History',

--- a/lang/de/maintenance.php
+++ b/lang/de/maintenance.php
@@ -20,6 +20,7 @@ return [
         'duplicates-title' => 'Titel-Duplikate pro Album',
         'duplicates-per-album' => 'Duplikate pro Album',
         'show' => 'Duplikate anzeigen',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Korrigieren des Auftragsverlaufs',

--- a/lang/el/maintenance.php
+++ b/lang/el/maintenance.php
@@ -21,6 +21,7 @@ return [
         'duplicates-title' => 'Title duplicates per album',
         'duplicates-per-album' => 'Duplicates per album',
         'show' => 'Show duplicates',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Fixing Jobs History',

--- a/lang/en/maintenance.php
+++ b/lang/en/maintenance.php
@@ -17,9 +17,10 @@ return [
         'title' => 'Duplicates',
         'description' => 'This module counts potential duplicates betwen pictures.',
         'duplicates-all' => 'Duplicates over all albums',
-        'duplicates-title' => 'Title duplicates per album',
+        'duplicates-title' => 'Title duplicates duplicate-finderper album',
         'duplicates-per-album' => 'Duplicates per album',
         'show' => 'Show duplicates',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Fixing Jobs History',

--- a/lang/es/maintenance.php
+++ b/lang/es/maintenance.php
@@ -20,6 +20,7 @@ return [
         'duplicates-title' => 'Títulos duplicados por álbum',
         'duplicates-per-album' => 'Duplicados por álbum',
         'show' => 'Mostrar duplicados',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Reparación del historial de trabajos',

--- a/lang/fa/maintenance.php
+++ b/lang/fa/maintenance.php
@@ -20,6 +20,7 @@ return [
         'duplicates-title' => 'موارد تکراری عنوان در هر آلبوم',
         'duplicates-per-album' => 'موارد تکراری در هر آلبوم',
         'show' => 'نمایش موارد تکراری',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'اصلاح تاریخچه وظایف',

--- a/lang/fr/maintenance.php
+++ b/lang/fr/maintenance.php
@@ -21,6 +21,7 @@ return [
         'duplicates-title' => 'Doublons de titre par album',
         'duplicates-per-album' => 'Doublons par album',
         'show' => 'Afficher les doublons',
+        'load' => 'Compter les doublons',
     ],
     'fix-jobs' => [
         'title' => 'Correction de l’historique des tâches',

--- a/lang/hu/maintenance.php
+++ b/lang/hu/maintenance.php
@@ -21,6 +21,7 @@ return [
         'duplicates-title' => 'Title duplicates per album',
         'duplicates-per-album' => 'Duplicates per album',
         'show' => 'Show duplicates',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Fixing Jobs History',

--- a/lang/it/maintenance.php
+++ b/lang/it/maintenance.php
@@ -21,6 +21,7 @@ return [
         'duplicates-title' => 'Title duplicates per album',
         'duplicates-per-album' => 'Duplicates per album',
         'show' => 'Show duplicates',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Fixing Jobs History',

--- a/lang/ja/maintenance.php
+++ b/lang/ja/maintenance.php
@@ -21,6 +21,7 @@ return [
         'duplicates-title' => 'Title duplicates per album',
         'duplicates-per-album' => 'Duplicates per album',
         'show' => 'Show duplicates',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'ジョブ履歴の修正',

--- a/lang/nl/maintenance.php
+++ b/lang/nl/maintenance.php
@@ -20,6 +20,7 @@ return [
         'duplicates-title' => 'Titelduplicaten per album',
         'duplicates-per-album' => 'Duplicaten per album',
         'show' => 'Toon duplicaten',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Taakgeschiedenis herstellen',

--- a/lang/no/maintenance.php
+++ b/lang/no/maintenance.php
@@ -20,6 +20,7 @@ return [
         'duplicates-title' => 'Title duplicates per album',
         'duplicates-per-album' => 'Duplicates per album',
         'show' => 'Vis duplikater',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Fixing Jobs History',

--- a/lang/pl/maintenance.php
+++ b/lang/pl/maintenance.php
@@ -21,6 +21,7 @@ return [
         'duplicates-title' => 'Duplikaty tytułów na album',
         'duplicates-per-album' => 'Duplikaty na album',
         'show' => 'Pokaż duplikaty',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Naprawianie historii zadań',

--- a/lang/pt/maintenance.php
+++ b/lang/pt/maintenance.php
@@ -21,6 +21,7 @@ return [
         'duplicates-title' => 'Title duplicates per album',
         'duplicates-per-album' => 'Duplicates per album',
         'show' => 'Show duplicates',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Fixing Jobs History',

--- a/lang/ru/maintenance.php
+++ b/lang/ru/maintenance.php
@@ -20,6 +20,7 @@ return [
         'duplicates-title' => 'Дубликаты по заголовкам альбомов',
         'duplicates-per-album' => 'Дубликаты по альбомам',
         'show' => 'Показать дубликаты',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Исправление истории задач',

--- a/lang/sk/maintenance.php
+++ b/lang/sk/maintenance.php
@@ -21,6 +21,7 @@ return [
         'duplicates-title' => 'Title duplicates per album',
         'duplicates-per-album' => 'Duplicates per album',
         'show' => 'Show duplicates',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Fixing Jobs History',

--- a/lang/sv/maintenance.php
+++ b/lang/sv/maintenance.php
@@ -21,6 +21,7 @@ return [
         'duplicates-title' => 'Title duplicates per album',
         'duplicates-per-album' => 'Duplicates per album',
         'show' => 'Show duplicates',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Fixing Jobs History',

--- a/lang/vi/maintenance.php
+++ b/lang/vi/maintenance.php
@@ -21,6 +21,7 @@ return [
         'duplicates-title' => 'Title duplicates per album',
         'duplicates-per-album' => 'Duplicates per album',
         'show' => 'Show duplicates',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Fixing Jobs History',

--- a/lang/zh_CN/maintenance.php
+++ b/lang/zh_CN/maintenance.php
@@ -21,6 +21,7 @@ return [
         'duplicates-title' => '每个相册中的标题重复项',
         'duplicates-per-album' => '每个相册中的重复项',
         'show' => '显示重复项',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => '修复任务历史',

--- a/lang/zh_TW/maintenance.php
+++ b/lang/zh_TW/maintenance.php
@@ -21,6 +21,7 @@ return [
         'duplicates-title' => 'Title duplicates per album',
         'duplicates-per-album' => 'Duplicates per album',
         'show' => 'Show duplicates',
+        'load' => 'Load counts',
     ],
     'fix-jobs' => [
         'title' => 'Fixing Jobs History',

--- a/resources/js/components/maintenance/MaintenanceDuplicateChecker.vue
+++ b/resources/js/components/maintenance/MaintenanceDuplicateChecker.vue
@@ -18,7 +18,7 @@
 						{{ $t("maintenance.duplicate-finder.duplicates-title") }}: {{ data.title_duplicates }}<br />
 						{{ $t("maintenance.duplicate-finder.duplicates-per-album") }}: {{ data.duplicates_within_album }}<br />
 					</p>
-					<ProgressSpinner v-if="data === undefined" class="w-full"></ProgressSpinner>
+					<ProgressSpinner v-if="data === undefined && isLoaded" class="w-full"></ProgressSpinner>
 				</div>
 			</div>
 			<div class="flex gap-4 mt-1">
@@ -31,27 +31,30 @@
 				>
 					{{ $t("maintenance.duplicate-finder.show") }}
 				</Button>
+				<Button v-if="!isLoaded" @click="load" severity="primary" class="w-full border-none self-end">
+					{{ $t("maintenance.duplicate-finder.load") }}
+				</Button>
 			</div>
 		</template>
 	</Card>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
+import { ref } from "vue";
 import Button from "primevue/button";
 import Card from "primevue/card";
 import ProgressSpinner from "primevue/progressspinner";
 import MaintenanceService from "@/services/maintenance-service";
 
 const data = ref<App.Http.Resources.Models.Duplicates.DuplicateCount | undefined>(undefined);
+const isLoaded = ref(false);
 
 function load() {
+	isLoaded.value = true;
 	MaintenanceService.getDuplicatesCount().then((response) => {
 		data.value = response.data;
 	});
 }
-
-onMounted(load);
 </script>
 
 <style lang="css" scoped>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The duplicate finder now features an explicit "Load counts" button. Users must click this button to initiate the duplicate scan, replacing the previous automatic loading behavior that occurred on initial page entry.

* **Localization**
  * Added the "Load counts" label text across all supported language translations to accommodate the new duplicate finder functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->