### PR TITLE
Fix unexpected password propagation behaviour

### DIFF
--- a/app/Actions/Album/Unlock.php
+++ b/app/Actions/Album/Unlock.php
@@ -13,6 +13,7 @@ use App\Exceptions\UnauthorizedException;
 use App\Models\BaseAlbumImpl;
 use App\Models\Extensions\BaseAlbum;
 use App\Policies\AlbumPolicy;
+use App\Repositories\ConfigManager;
 use Illuminate\Support\Facades\Hash;
 
 class Unlock
@@ -45,6 +46,9 @@ class Unlock
 				return;
 			}
 			if (Hash::check($password, $album_password)) {
+				$this->album_policy->unlock($album); // unlock the album
+
+				// propage the unlock to all albums with the same password
 				$this->propagate($password);
 
 				return;
@@ -60,6 +64,12 @@ class Unlock
 	 */
 	private function propagate(string $password): void
 	{
+		// Only propagate if the option is enabled
+		$config_manager = app(ConfigManager::class);
+		if ($config_manager->getValueAsBool('enable_propagate_unlock_option') === false) {
+			return;
+		}
+
 		// We add all the albums that the password unlocks so that the
 		// user is not repeatedly asked to enter the password as they
 		// browse through the hierarchy.  This should be safe as the

--- a/database/migrations/2026_01_22_000000_propagate_unlock_option.php
+++ b/database/migrations/2026_01_22_000000_propagate_unlock_option.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const MOD_GALLERY = 'Admin';
+
+	/**
+	 * @return array<int,array{key:string,value:string,is_secret:bool,cat:string,type_range:string,description:string,order?:int,not_on_docker?:bool,is_expert?:bool}>
+	 */
+	public function getConfigs(): array
+	{
+		return [
+			[
+				'key' => 'enable_propagate_unlock_option',
+				'value' => '0',
+				'cat' => self::MOD_GALLERY,
+				'type_range' => self::BOOL,
+				'description' => 'Enable unlock propagation.',
+				'details' => 'When unlocking an album with password, also unlock all albums with that same password.<br><i class="pi pi-exclamation-triangle text-orange-500"></i> This can lead to confidentiality issues if different users share the same album password.',
+				'is_secret' => false,
+				'is_expert' => true,
+				'order' => 25,
+				'not_on_docker' => false,
+				'level' => 0,
+			],
+		];
+	}
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Album unlock can now propagate to related albums sharing the same password.
  * Added expert-level configuration option to enable/disable unlock propagation (disabled by default).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->