### PR TITLE
Add maintenance recompute 

### DIFF
--- a/resources/js/components/maintenance/MaintenanceBackfillAlbumSizes.vue
+++ b/resources/js/components/maintenance/MaintenanceBackfillAlbumSizes.vue
@@ -1,6 +1,6 @@
 <template>
 	<Card
-		v-if="data !== undefined && data > 0"
+		v-if="data !== undefined && data !== 0"
 		class="min-h-40 dark:bg-surface-800 shadow shadow-surface-950/30 rounded-lg relative"
 		pt:body:class="min-h-40 h-full"
 		pt:content:class="h-full flex justify-between flex-col"

--- a/resources/js/components/maintenance/MaintenanceBackfillAlbumSizes.vue
+++ b/resources/js/components/maintenance/MaintenanceBackfillAlbumSizes.vue
@@ -16,7 +16,7 @@
 				<ProgressSpinner v-if="loading" class="w-full"></ProgressSpinner>
 			</ScrollPanel>
 			<div class="flex gap-4 mt-1">
-				<Button v-if="data !== 0 && data !== undefined && !loading" severity="primary" class="w-full border-none" @click="exec">
+				<Button v-if="data !== 0 && !loading" severity="primary" class="w-full border-none" @click="exec">
 					{{ $t("maintenance.backfill-album-sizes.button") }}
 				</Button>
 			</div>

--- a/resources/js/components/maintenance/MaintenanceFulfillPrecompute.vue
+++ b/resources/js/components/maintenance/MaintenanceFulfillPrecompute.vue
@@ -1,6 +1,6 @@
 <template>
 	<Card
-		v-if="data !== undefined && data > 0"
+		v-if="data !== undefined && data !== 0"
 		class="min-h-40 dark:bg-surface-800 shadow shadow-surface-950/30 rounded-lg relative"
 		pt:body:class="min-h-40 h-full"
 		pt:content:class="h-full flex justify-between flex-col"
@@ -16,7 +16,7 @@
 				<ProgressSpinner v-if="loading" class="w-full"></ProgressSpinner>
 			</ScrollPanel>
 			<div class="flex gap-4 mt-1">
-				<Button v-if="data > 0 && !loading" severity="primary" class="w-full border-none" @click="exec">
+				<Button v-if="data !== 0 && !loading" severity="primary" class="w-full border-none" @click="exec">
 					{{ $t("maintenance.fulfill-precompute.button") }}
 				</Button>
 			</div>
@@ -40,6 +40,9 @@ const loading = ref(false);
 const toast = useToast();
 
 const description = computed(() => {
+	if (data.value === -1) {
+		return "";
+	}
 	return sprintf(trans("maintenance.fulfill-precompute.description"), data.value);
 });
 


### PR DESCRIPTION
On async mode, the value returned is -1, which lead to not seeing the Maintenance tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Adjusted maintenance feature card visibility to display in broader scenarios
* Refined button availability conditions to better align with card visibility
* Improved edge case handling in maintenance-related interface components

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->