### PR TITLE
Fix deprecation warning

### DIFF
--- a/app/Actions/Import/Pipes/ImportPhotos.php
+++ b/app/Actions/Import/Pipes/ImportPhotos.php
@@ -80,7 +80,7 @@ class ImportPhotos implements ImportPipe
 		}
 
 		foreach ($image_paths as $idx => $image_path) {
-			$this->importSingleImage($image_path, $node->album, $idx / $total * 100);
+			$this->importSingleImage($image_path, $node->album, intval($idx / $total * 100));
 		}
 
 		// Dispatch recompute jobs for the album after importing photos


### PR DESCRIPTION
Fixes warning:

> Implicit conversion from float 67.21311475409836 to int loses precision in /app/app/Actions/Import/Pipes/ImportPhotos.php on line 138