### PR TITLE
Add support for max execution time & memory limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,8 +130,8 @@ RUN mkdir -p storage/framework/cache \
     && cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini \
     && echo "upload_max_filesize=110M" > $PHP_INI_DIR/conf.d/custom.ini \
     && echo "post_max_size=110M" >> $PHP_INI_DIR/conf.d/custom.ini \
-    && echo "memory_limit=\${PHP_MEMORY_LIMIT}" >> $PHP_INI_DIR/conf.d/custom.ini \
-    && echo "max_execution_time=\${PHP_MAX_EXECUTION_TIME:-30}" >> $PHP_INI_DIR/conf.d/custom.ini \
+    && echo "memory_limit=\${PHP_MEMORY_LIMIT:-1024M}" >> $PHP_INI_DIR/conf.d/custom.ini \
+    && echo "max_execution_time=\${PHP_MAX_EXECUTION_TIME:-3000}" >> $PHP_INI_DIR/conf.d/custom.ini \
     && echo "expose_php=Off" >> $PHP_INI_DIR/conf.d/custom.ini \
     && echo "display_errors=Off" >> $PHP_INI_DIR/conf.d/custom.ini \
     && echo "log_errors=On" >> $PHP_INI_DIR/conf.d/custom.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,8 +130,8 @@ RUN mkdir -p storage/framework/cache \
     && cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini \
     && echo "upload_max_filesize=110M" > $PHP_INI_DIR/conf.d/custom.ini \
     && echo "post_max_size=110M" >> $PHP_INI_DIR/conf.d/custom.ini \
-    && echo "memory_limit=\${PHP_MEMORY_LIMIT:-3000}" >> $PHP_INI_DIR/conf.d/custom.ini \
-    && echo "max_execution_time=\${PHP_MAX_EXECUTION_TIME}" >> $PHP_INI_DIR/conf.d/custom.ini \
+    && echo "memory_limit=\${PHP_MEMORY_LIMIT}" >> $PHP_INI_DIR/conf.d/custom.ini \
+    && echo "max_execution_time=\${PHP_MAX_EXECUTION_TIME:-30}" >> $PHP_INI_DIR/conf.d/custom.ini \
     && echo "expose_php=Off" >> $PHP_INI_DIR/conf.d/custom.ini \
     && echo "display_errors=Off" >> $PHP_INI_DIR/conf.d/custom.ini \
     && echo "log_errors=On" >> $PHP_INI_DIR/conf.d/custom.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,8 @@ RUN mkdir -p storage/framework/cache \
     && cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini \
     && echo "upload_max_filesize=110M" > $PHP_INI_DIR/conf.d/custom.ini \
     && echo "post_max_size=110M" >> $PHP_INI_DIR/conf.d/custom.ini \
-    && echo "max_execution_time=3000" >> $PHP_INI_DIR/conf.d/custom.ini \
+    && echo "memory_limit=\${PHP_MEMORY_LIMIT:-3000}" >> $PHP_INI_DIR/conf.d/custom.ini \
+    && echo "max_execution_time=\${PHP_MAX_EXECUTION_TIME}" >> $PHP_INI_DIR/conf.d/custom.ini \
     && echo "expose_php=Off" >> $PHP_INI_DIR/conf.d/custom.ini \
     && echo "display_errors=Off" >> $PHP_INI_DIR/conf.d/custom.ini \
     && echo "log_errors=On" >> $PHP_INI_DIR/conf.d/custom.ini

--- a/config/octane.php
+++ b/config/octane.php
@@ -211,5 +211,5 @@ return [
 	|
 	*/
 
-	'max_execution_time' => 30,
+	'max_execution_time' => env('PHP_MAX_EXECUTION_TIME', 3000),
 ];

--- a/config/octane.php
+++ b/config/octane.php
@@ -211,5 +211,5 @@ return [
 	|
 	*/
 
-	'max_execution_time' => intval(env('PHP_MAX_EXECUTION_TIME', 30)),
+	'max_execution_time' => intval(env('LYCHEE_MAX_EXECUTION_TIME', 30)),
 ];

--- a/config/octane.php
+++ b/config/octane.php
@@ -211,5 +211,5 @@ return [
 	|
 	*/
 
-	'max_execution_time' => intval(env('PHP_MAX_EXECUTION_TIME', 3000))/100,
+	'max_execution_time' => intval(env('PHP_MAX_EXECUTION_TIME', 30)),
 ];

--- a/config/octane.php
+++ b/config/octane.php
@@ -211,5 +211,5 @@ return [
 	|
 	*/
 
-	'max_execution_time' => env('PHP_MAX_EXECUTION_TIME', 3000),
+	'max_execution_time' => intval(env('PHP_MAX_EXECUTION_TIME', 3000))/100,
 ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PHP memory and execution time limits are now configurable via environment variables for greater deployment flexibility.
  * Server runtime timeout behavior now reads a configurable value, ensuring consistent, integer-typed execution-time settings across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->