### PR TITLE
Add support for hidden display of shared albums.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,3 @@
-
 ## Before You Code
 - **Clarify ambiguity first.** Do not plan or implement until every requirement is understood. Ask the user, record unresolved items in [docs/specs/4-architecture/open-questions.md](docs/specs/4-architecture/open-questions.md), and wait for answers. Capture accepted answers by updating the relevant specification’s requirements/NFR/behaviour/telemetry sections so the spec remains the single source of truth for behaviour.
   - **No-direct-question rule:** Never ask the user for clarification, approval, or a decision in chat until the matching open question is logged (table row + Question Details entry). Treat violations as blockers—stop work, add the missing entry, then resume the conversation by referencing that question ID.
@@ -87,3 +86,38 @@
 - Update/close entries in [docs/specs/4-architecture/open-questions.md](docs/specs/4-architecture/open-questions.md).
 - Summarise any lasting decisions in the appropriate ADR (if applicable).
 - Publish prompt and tool usage notes alongside the feature plan update so future agents understand how the iteration unfolded.
+
+## CRITICAL: Database Rules
+
+### NEVER RUN THESE COMMANDS:
+- `php artisan migrate:fresh` - **WILL DESTROY THE PRODUCTION DATABASE**
+- `php artisan migrate:reset` - **WILL DESTROY THE PRODUCTION DATABASE**
+- `php artisan db:wipe` - **WILL DESTROY THE PRODUCTION DATABASE**
+- Any command that resets or wipes the database
+
+### Why This Matters:
+The test suite uses SQLite (`database/database.sqlite`) as configured in `phpunit.xml`:
+```xml
+<env name="DB_CONNECTION" value="sqlite"/>
+<env name="DB_DATABASE" value="database/database.sqlite"/>
+```
+
+However, the main application uses a **different database** (typically MySQL/PostgreSQL). Running migration commands without specifying the test database will affect the **production/development database**.
+
+### Safe Database Operations:
+1. **Running tests**: Just run `php artisan test` - migrations are applied automatically to the SQLite test database
+2. **Resetting test database**: Delete and recreate `database/database.sqlite` file only
+3. **New migrations**: Create the migration file, then run tests - they will be applied automatically
+
+### If You Need to Reset the Test Database:
+```bash
+rm database/database.sqlite
+touch database/database.sqlite
+# Then run tests - migrations will be applied automatically
+```
+
+## Testing
+
+- Run tests with: `php artisan test --filter=TestName`
+- Tests use `DatabaseTransactions` trait - changes are rolled back after each test
+- The test database is separate from the development database

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,7 @@ RUN apt-get update \
     opcache \
     pcntl \
     exif \
+    intl \
     imagick \
     redis \
 	&& apt-get clean -qy \

--- a/app/Contracts/Http/Requests/RequestAttribute.php
+++ b/app/Contracts/Http/Requests/RequestAttribute.php
@@ -96,6 +96,7 @@ class RequestAttribute
 	public const MAY_UPLOAD_ATTRIBUTE = 'may_upload';
 	public const MAY_EDIT_OWN_SETTINGS_ATTRIBUTE = 'may_edit_own_settings';
 	public const MAY_ADMINISTRATE = 'may_administrate';
+	public const SHARED_ALBUMS_VISIBILITY_ATTRIBUTE = 'shared_albums_visibility';
 
 	/**
 	 * Import from server attributes.

--- a/app/Enum/SharedAlbumsVisibility.php
+++ b/app/Enum/SharedAlbumsVisibility.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Enum;
+
+/**
+ * Enum SharedAlbumsVisibility.
+ *
+ * Server-level visibility modes for shared albums in the gallery.
+ */
+enum SharedAlbumsVisibility: string
+{
+	case SHOW = 'show';
+	case SEPARATE = 'separate';
+	case SEPARATE_SHARED_ONLY = 'separate_shared_only';
+	case HIDE = 'hide';
+}

--- a/app/Enum/UserSharedAlbumsVisibility.php
+++ b/app/Enum/UserSharedAlbumsVisibility.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Enum;
+
+/**
+ * Enum UserSharedAlbumsVisibility.
+ *
+ * User-level preference for shared albums visibility.
+ * Includes DEFAULT option to inherit from server configuration.
+ */
+enum UserSharedAlbumsVisibility: string
+{
+	case DEFAULT = 'default';
+	case SHOW = 'show';
+	case SEPARATE = 'separate';
+	case SEPARATE_SHARED_ONLY = 'separate_shared_only';
+	case HIDE = 'hide';
+}

--- a/app/Enum/UserSharedAlbumsVisibility.php
+++ b/app/Enum/UserSharedAlbumsVisibility.php
@@ -24,14 +24,14 @@ enum UserSharedAlbumsVisibility: string
 	case SEPARATE_SHARED_ONLY = 'separate_shared_only';
 	case HIDE = 'hide';
 
-	public function tooSharedAlbumsVisibility(): SharedAlbumsVisibility
+	public function toSharedAlbumsVisibility(): SharedAlbumsVisibility
 	{
 		return match ($this) {
 			self::SHOW => SharedAlbumsVisibility::SHOW,
 			self::SEPARATE => SharedAlbumsVisibility::SEPARATE,
 			self::SEPARATE_SHARED_ONLY => SharedAlbumsVisibility::SEPARATE_SHARED_ONLY,
 			self::HIDE => SharedAlbumsVisibility::HIDE,
-			self::DEFAULT => resolve(ConfigManager::class)->getValueAsEnum('shared_albums_visibility', SharedAlbumsVisibility::class),
+			self::DEFAULT => resolve(ConfigManager::class)->getValueAsEnum('shared_albums_visibility_default', SharedAlbumsVisibility::class),
 		};
 	}
 }

--- a/app/Enum/UserSharedAlbumsVisibility.php
+++ b/app/Enum/UserSharedAlbumsVisibility.php
@@ -8,6 +8,8 @@
 
 namespace App\Enum;
 
+use App\Repositories\ConfigManager;
+
 /**
  * Enum UserSharedAlbumsVisibility.
  *
@@ -21,4 +23,15 @@ enum UserSharedAlbumsVisibility: string
 	case SEPARATE = 'separate';
 	case SEPARATE_SHARED_ONLY = 'separate_shared_only';
 	case HIDE = 'hide';
+
+	public function tooSharedAlbumsVisibility(): SharedAlbumsVisibility
+	{
+		return match ($this) {
+			self::SHOW => SharedAlbumsVisibility::SHOW,
+			self::SEPARATE => SharedAlbumsVisibility::SEPARATE,
+			self::SEPARATE_SHARED_ONLY => SharedAlbumsVisibility::SEPARATE_SHARED_ONLY,
+			self::HIDE => SharedAlbumsVisibility::HIDE,
+			self::DEFAULT => resolve(ConfigManager::class)->getValueAsEnum('shared_albums_visibility', SharedAlbumsVisibility::class),
+		};
+	}
 }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -19,6 +19,7 @@ use App\Exceptions\UnauthenticatedException;
 use App\Http\Requests\Profile\ChangeTokenRequest;
 use App\Http\Requests\Profile\RegistrationRequest;
 use App\Http\Requests\Profile\UpdateProfileRequest;
+use App\Http\Requests\Profile\UpdateSharedAlbumsVisibilityRequest;
 use App\Http\Resources\Models\UserResource;
 use App\Http\Resources\Models\Utils\UserToken;
 use App\Models\User;
@@ -113,5 +114,21 @@ class ProfileController extends Controller
 		$token_disable->do();
 
 		TaggedRouteCacheUpdated::dispatch(CacheTag::USER);
+	}
+
+	/**
+	 * Update the shared albums visibility preference of the current user.
+	 */
+	public function updateSharedAlbumsVisibility(UpdateSharedAlbumsVisibilityRequest $request): UserResource
+	{
+		/** @var User $current_user */
+		$current_user = Auth::user();
+
+		$current_user->shared_albums_visibility = $request->sharedAlbumsVisibility();
+		$current_user->save();
+
+		TaggedRouteCacheUpdated::dispatch(CacheTag::USER);
+
+		return new UserResource($current_user);
 	}
 }

--- a/app/Http/Requests/Profile/UpdateSharedAlbumsVisibilityRequest.php
+++ b/app/Http/Requests/Profile/UpdateSharedAlbumsVisibilityRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Profile;
+
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Enum\UserSharedAlbumsVisibility;
+use App\Http\Requests\BaseApiRequest;
+use App\Models\User;
+use App\Policies\UserPolicy;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rules\Enum;
+
+class UpdateSharedAlbumsVisibilityRequest extends BaseApiRequest
+{
+	protected UserSharedAlbumsVisibility $sharedAlbumsVisibility;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::check(UserPolicy::CAN_EDIT, [User::class]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function rules(): array
+	{
+		return [
+			RequestAttribute::SHARED_ALBUMS_VISIBILITY_ATTRIBUTE => ['required', new Enum(UserSharedAlbumsVisibility::class)],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		$this->sharedAlbumsVisibility = UserSharedAlbumsVisibility::from($values[RequestAttribute::SHARED_ALBUMS_VISIBILITY_ATTRIBUTE]);
+	}
+
+	public function sharedAlbumsVisibility(): UserSharedAlbumsVisibility
+	{
+		return $this->sharedAlbumsVisibility;
+	}
+}

--- a/app/Http/Resources/GalleryConfigs/RootConfig.php
+++ b/app/Http/Resources/GalleryConfigs/RootConfig.php
@@ -10,7 +10,10 @@ namespace App\Http\Resources\GalleryConfigs;
 
 use App\Enum\AspectRatioCSSType;
 use App\Enum\AspectRatioType;
+use App\Enum\SharedAlbumsVisibility;
 use App\Enum\TimelineAlbumGranularity;
+use App\Enum\UserSharedAlbumsVisibility;
+use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
@@ -35,6 +38,8 @@ class RootConfig extends Data
 	public bool $is_header_bar_transparent = false;
 	public bool $is_header_bar_gradient = false;
 
+	public ?SharedAlbumsVisibility $shared_albums_visibility_mode = null;
+
 	public function __construct()
 	{
 		$is_logged_in = Auth::check();
@@ -53,6 +58,7 @@ class RootConfig extends Data
 		$this->back_button_url = request()->configs()->getValueAsString('back_button_url');
 
 		$this->setHeaderImageUrl();
+		$this->setSharedAlbumsVisibilityMode();
 	}
 
 	private function setHeaderImageUrl(): void
@@ -66,6 +72,29 @@ class RootConfig extends Data
 		$this->header_image_url = request()->configs()->getValueAsString('gallery_header');
 		$this->is_header_bar_transparent = request()->configs()->getValueAsBool('gallery_header_bar_transparent');
 		$this->is_header_bar_gradient = request()->configs()->getValueAsBool('gallery_header_bar_gradient');
+	}
+
+	private function setSharedAlbumsVisibilityMode(): void
+	{
+		/** @var User|null $user */
+		$user = Auth::user();
+		if ($user === null) {
+			// For guests, shared albums visibility is not applicable
+			return;
+		}
+
+		$user_preference = $user->shared_albums_visibility;
+
+		if ($user_preference === UserSharedAlbumsVisibility::DEFAULT) {
+			// Use server default
+			$this->shared_albums_visibility_mode = request()->configs()->getValueAsEnum(
+				'shared_albums_visibility_default',
+				SharedAlbumsVisibility::class
+			);
+		} else {
+			// Use user preference (map from UserSharedAlbumsVisibility to SharedAlbumsVisibility)
+			$this->shared_albums_visibility_mode = SharedAlbumsVisibility::from($user_preference->value);
+		}
 	}
 }
 

--- a/app/Http/Resources/GalleryConfigs/RootConfig.php
+++ b/app/Http/Resources/GalleryConfigs/RootConfig.php
@@ -12,7 +12,6 @@ use App\Enum\AspectRatioCSSType;
 use App\Enum\AspectRatioType;
 use App\Enum\SharedAlbumsVisibility;
 use App\Enum\TimelineAlbumGranularity;
-use App\Enum\UserSharedAlbumsVisibility;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Spatie\LaravelData\Data;
@@ -38,7 +37,7 @@ class RootConfig extends Data
 	public bool $is_header_bar_transparent = false;
 	public bool $is_header_bar_gradient = false;
 
-	public ?SharedAlbumsVisibility $shared_albums_visibility_mode = null;
+	public SharedAlbumsVisibility $shared_albums_visibility_mode = SharedAlbumsVisibility::SHOW;
 
 	public function __construct()
 	{
@@ -83,18 +82,7 @@ class RootConfig extends Data
 			return;
 		}
 
-		$user_preference = $user->shared_albums_visibility;
-
-		if ($user_preference === UserSharedAlbumsVisibility::DEFAULT) {
-			// Use server default
-			$this->shared_albums_visibility_mode = request()->configs()->getValueAsEnum(
-				'shared_albums_visibility_default',
-				SharedAlbumsVisibility::class
-			);
-		} else {
-			// Use user preference (map from UserSharedAlbumsVisibility to SharedAlbumsVisibility)
-			$this->shared_albums_visibility_mode = SharedAlbumsVisibility::from($user_preference->value);
-		}
+		$this->shared_albums_visibility_mode = $user->shared_albums_visibility->tooSharedAlbumsVisibility();
 	}
 }
 

--- a/app/Http/Resources/GalleryConfigs/RootConfig.php
+++ b/app/Http/Resources/GalleryConfigs/RootConfig.php
@@ -82,7 +82,7 @@ class RootConfig extends Data
 			return;
 		}
 
-		$this->shared_albums_visibility_mode = $user->shared_albums_visibility->tooSharedAlbumsVisibility();
+		$this->shared_albums_visibility_mode = $user->shared_albums_visibility->toSharedAlbumsVisibility();
 	}
 }
 

--- a/app/Http/Resources/Models/UserResource.php
+++ b/app/Http/Resources/Models/UserResource.php
@@ -8,6 +8,7 @@
 
 namespace App\Http\Resources\Models;
 
+use App\Enum\UserSharedAlbumsVisibility;
 use App\Models\User;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
@@ -19,6 +20,7 @@ class UserResource extends Data
 	public ?bool $has_token;
 	public ?string $username;
 	public ?string $email;
+	public UserSharedAlbumsVisibility $shared_albums_visibility;
 
 	public function __construct(?User $user)
 	{
@@ -26,5 +28,6 @@ class UserResource extends Data
 		$this->has_token = $user?->token !== null;
 		$this->username = $user?->username;
 		$this->email = $user?->email;
+		$this->shared_albums_visibility = $user?->shared_albums_visibility ?? UserSharedAlbumsVisibility::DEFAULT;
 	}
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@
 namespace App\Models;
 
 use App\Constants\AccessPermissionConstants as APC;
+use App\Enum\UserSharedAlbumsVisibility;
 use App\Exceptions\ModelDBException;
 use App\Exceptions\UnauthenticatedException;
 use App\Models\Builders\UserBuilder;
@@ -50,6 +51,7 @@ use function Safe\mb_convert_encoding;
  * @property string|null                                           $note
  * @property string|null                                           $token
  * @property string|null                                           $remember_token
+ * @property UserSharedAlbumsVisibility                            $shared_albums_visibility
  * @property Collection<int,BaseAlbumImpl>                         $albums
  * @property Collection<int,OauthCredential>                       $oauthCredentials
  * @property DatabaseNotificationCollection|DatabaseNotification[] $notifications
@@ -106,7 +108,7 @@ class User extends Authenticatable implements WebAuthnAuthenticatable
 	];
 
 	/**
-	 * @var array<string, string>
+	 * @var array<string, string|class-string>
 	 */
 	protected $casts = [
 		'id' => 'integer',
@@ -116,6 +118,7 @@ class User extends Authenticatable implements WebAuthnAuthenticatable
 		'may_upload' => 'boolean',
 		'may_edit_own_settings' => 'boolean',
 		'quota_kb' => 'integer',
+		'shared_albums_visibility' => UserSharedAlbumsVisibility::class,
 	];
 
 	protected $hidden = [];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -9,6 +9,7 @@
 namespace Database\Factories;
 
 use App\Enum\UserGroupRole;
+use App\Enum\UserSharedAlbumsVisibility;
 use App\Models\User;
 use App\Models\UserGroup;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -44,6 +45,7 @@ class UserFactory extends Factory
 			'token' => null,
 			'remember_token' => null,
 			'may_edit_own_settings' => true,
+			'shared_albums_visibility' => UserSharedAlbumsVisibility::DEFAULT->value,
 		];
 	}
 

--- a/database/migrations/2026_01_15_100000_add_shared_albums_visibility_config.php
+++ b/database/migrations/2026_01_15_100000_add_shared_albums_visibility_config.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const MOD_GALLERY = 'Gallery';
+
+	/**
+	 * @return array<int,array{key:string,value:string,is_secret:bool,cat:string,type_range:string,description:string,order?:int,not_on_docker?:bool,is_expert?:bool,level?:int}>
+	 */
+	public function getConfigs(): array
+	{
+		return [
+			[
+				'key' => 'shared_albums_visibility_default',
+				'value' => 'show',
+				'cat' => self::MOD_GALLERY,
+				'type_range' => 'show|separate|separate_shared_only|hide',
+				'description' => 'Default visibility mode for shared albums in the gallery.',
+				'details' => 'Controls how albums shared by other users appear: show (inline with owned albums), separate (in tabs), separate_shared_only (in tabs, direct shares only), hide (not shown).',
+				'is_secret' => false,
+				'is_expert' => true,
+				'order' => 60,
+				'not_on_docker' => false,
+				'level' => 0,
+			],
+		];
+	}
+};

--- a/database/migrations/2026_01_15_100001_add_shared_albums_visibility_to_users.php
+++ b/database/migrations/2026_01_15_100001_add_shared_albums_visibility_to_users.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		Schema::table('users', function (Blueprint $table) {
+			$table->string('shared_albums_visibility')->default('default');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		Schema::table('users', function (Blueprint $table) {
+			$table->dropColumn('shared_albums_visibility');
+		});
+	}
+};

--- a/docs/specs/4-architecture/features/008-shared-albums-visibility/plan.md
+++ b/docs/specs/4-architecture/features/008-shared-albums-visibility/plan.md
@@ -1,0 +1,213 @@
+# Feature Plan 008 – Shared Albums Visibility Control
+
+_Linked specification:_ `docs/specs/4-architecture/features/008-shared-albums-visibility/spec.md`
+_Status:_ Draft
+_Last updated:_ 2026-01-15
+
+> Guardrail: Keep this plan traceable back to the governing spec. Reference FR/NFR/Scenario IDs from `spec.md` where relevant, log any new high- or medium-impact questions in [docs/specs/4-architecture/open-questions.md](../../open-questions.md), and assume clarifications are resolved only when the spec's normative sections (requirements/NFR/behaviour/telemetry) and, where applicable, ADRs under `docs/specs/5-decisions/` have been updated.
+
+## Vision & Success Criteria
+
+Allow logged-in users to control how shared albums (albums from other users) appear on their gallery page. Success criteria:
+- Server admin can configure default visibility mode (`show`, `separate`, `separate_shared_only`, `hide`)
+- Users can override the server default with their personal preference
+- Frontend properly displays tabs when in `separate` modes with Smart Albums above tabs
+- Tab bar hidden when no shared albums exist (cleaner UX)
+- Backward compatibility: existing installations default to `show` mode
+
+## Scope Alignment
+
+- **In scope:**
+  - Server config `shared_albums_visibility_default` with 4 modes
+  - User preference column `shared_albums_visibility` with 5 options (includes `default`)
+  - RootConfig extension to compute and send effective visibility mode
+  - Frontend tab UI for `separate` and `separate_shared_only` modes
+  - User settings UI to change preference
+
+- **Out of scope:**
+  - Changes to album sharing/permission system
+  - Changes to how albums are queried (pure presentation layer change)
+  - New sharing capabilities
+  - Mobile-specific tab UI (use existing responsive patterns)
+
+## Dependencies & Interfaces
+
+| Dependency | Purpose |
+|------------|---------|
+| `App\Models\User` | Add `shared_albums_visibility` column |
+| `App\Http\Resources\GalleryConfigs\RootConfig` | Add effective mode computation |
+| `App\Models\Extensions\BaseConfigMigration` | Create server config |
+| `resources/js/components/gallery/` | Tab UI implementation |
+| TypeScript type generation | Generate enums for frontend |
+
+## Assumptions & Risks
+
+**Assumptions:**
+- Existing `RootConfig` pattern can accommodate new field
+- Frontend gallery component can be extended for tab UI
+- User model cast patterns are standard
+
+**Risks / Mitigations:**
+- Risk: Frontend gallery refactoring complexity → Mitigation: Minimal changes, conditional rendering based on mode
+- Risk: TypeScript enum not generated correctly → Mitigation: Verify after running `php artisan typescript:transform`
+
+## Implementation Drift Gate
+
+After each increment, verify:
+1. Run `php artisan test` - all tests pass
+2. Run `make phpstan` - no static analysis errors
+3. Run `npm run check` - frontend checks pass
+4. Verify TypeScript types generated correctly
+
+## Increment Map
+
+### I1 – Create PHP Enums
+_Goal:_ Define the two enum types for visibility modes.
+_Preconditions:_ None
+_Steps:_
+1. Create `App\Enum\SharedAlbumsVisibility` enum (`show`, `separate`, `separate_shared_only`, `hide`)
+2. Create `App\Enum\UserSharedAlbumsVisibility` enum (adds `default` option)
+_Commands:_
+- `make phpstan`
+_Exit:_ Both enums exist and pass PHPStan validation
+
+### I2 – Create Server Config Migration
+_Goal:_ Add `shared_albums_visibility_default` config to database.
+_Preconditions:_ I1 complete
+_Steps:_
+1. Create migration extending `BaseConfigMigration`
+2. Define config with `type_range` matching enum values
+3. Set default value to `show`
+_Commands:_
+- `php artisan migrate`
+- `make phpstan`
+_Exit:_ Config appears in database, can be retrieved via `request()->configs()`
+
+### I3 – Create User Column Migration
+_Goal:_ Add `shared_albums_visibility` column to users table.
+_Preconditions:_ I1 complete
+_Steps:_
+1. Create migration adding string column with default `default`
+2. Update User model with `$casts` entry for enum
+3. Update User model PHPDoc
+_Commands:_
+- `php artisan migrate`
+- `make phpstan`
+_Exit:_ Column exists, User model properly casts to enum
+
+### I4 – Update RootConfig
+_Goal:_ Compute and expose effective visibility mode to frontend.
+_Preconditions:_ I2, I3 complete
+_Steps:_
+1. Add `shared_albums_visibility_mode` property to RootConfig
+2. Implement effective mode calculation logic:
+   - If guest: not applicable (omit or default)
+   - If user preference is `default`: use server config
+   - Otherwise: use user preference
+3. Add `#[LiteralTypeScriptType]` attribute for proper typing
+_Commands:_
+- `make phpstan`
+- `php artisan typescript:transform`
+_Exit:_ RootConfig includes correct mode, TypeScript types generated
+
+### I5 – Update User Settings Endpoint
+_Goal:_ Allow users to update their visibility preference.
+_Preconditions:_ I3 complete
+_Steps:_
+1. Find user settings request class and controller
+2. Add `shared_albums_visibility` field validation
+3. Handle update in controller
+_Commands:_
+- `php artisan test --filter=UserSettings`
+- `make phpstan`
+_Exit:_ PUT endpoint accepts and saves preference
+
+### I6 – Backend Tests
+_Goal:_ Test effective mode calculation and settings update.
+_Preconditions:_ I4, I5 complete
+_Steps:_
+1. Create `SharedAlbumsVisibilityTest.php`
+2. Test various user/server config combinations (S-008-01 to S-008-07)
+3. Test settings endpoint validation
+_Commands:_
+- `php artisan test --filter=SharedAlbumsVisibility`
+_Exit:_ All tests pass
+
+### I7 – Frontend Tab UI Implementation
+_Goal:_ Implement tabbed gallery view for `separate` modes.
+_Preconditions:_ I4 complete
+_Steps:_
+1. Update gallery component to read `shared_albums_visibility_mode` from RootConfig
+2. Render Smart Albums above tabs (always visible)
+3. Render tab bar only when:
+   - Mode is `separate` or `separate_shared_only` AND
+   - Shared albums exist (count > 0)
+4. Implement tab switching logic
+5. Filter albums based on selected tab
+_Commands:_
+- `npm run check`
+_Exit:_ Tabs render correctly, switching works, Smart Albums always visible above
+
+### I8 – Frontend User Settings UI
+_Goal:_ Add preference selector to user settings page.
+_Preconditions:_ I5 complete
+_Steps:_
+1. Find user settings Vue component
+2. Add radio button group for visibility preference
+3. Connect to user settings API endpoint
+_Commands:_
+- `npm run check`
+_Exit:_ User can change preference via settings UI
+
+### I9 – Integration Testing & Quality Gate
+_Goal:_ Final verification and code formatting.
+_Preconditions:_ All previous increments complete
+_Steps:_
+1. Run full test suite
+2. Run PHP code formatter
+3. Run frontend formatter
+4. Manual testing of all 4 modes
+_Commands:_
+- `vendor/bin/php-cs-fixer fix`
+- `npm run format`
+- `php artisan test`
+- `make phpstan`
+- `npm run check`
+_Exit:_ All quality gates pass
+
+## Scenario Tracking
+
+| Scenario ID | Increment / Task reference | Notes |
+|-------------|---------------------------|-------|
+| S-008-01 | I4, I6 / T-008-06 | User default + server show |
+| S-008-02 | I4, I6 / T-008-06 | User hide overrides server show |
+| S-008-03 | I4, I6 / T-008-06 | User separate overrides server hide |
+| S-008-04 | I4, I6 / T-008-06 | User default + server separate |
+| S-008-05 | I4 / T-008-04 | Guest user handling |
+| S-008-06 | I5, I8 / T-008-05, T-008-08 | User changes preference |
+| S-008-07 | I4, I6 / T-008-06 | Admin changes server config |
+| S-008-08 | I7 / T-008-07 | No shared albums - tabs hidden |
+| S-008-09 | I7 / T-008-07 | Separate-shared-only filtering |
+| S-008-10 | I2, I3 / T-008-02, T-008-03 | Fresh installation defaults |
+
+## Analysis Gate
+
+_To be completed after I6 (backend tests)_
+
+## Exit Criteria
+
+- [ ] All PHP tests pass (`php artisan test`)
+- [ ] PHPStan passes (`make phpstan`)
+- [ ] PHP code formatted (`vendor/bin/php-cs-fixer fix`)
+- [ ] Frontend checks pass (`npm run check`)
+- [ ] Frontend formatted (`npm run format`)
+- [ ] TypeScript types generated correctly
+- [ ] Manual testing of all 4 visibility modes
+- [ ] Tab bar hidden when no shared albums
+- [ ] Smart Albums visible above tabs in separate modes
+
+## Follow-ups / Backlog
+
+- Consider adding album count badges to tabs in future iteration
+- Consider persisting selected tab in localStorage for session continuity
+- Consider accessibility improvements for tab navigation (keyboard, ARIA)

--- a/docs/specs/4-architecture/features/008-shared-albums-visibility/spec.md
+++ b/docs/specs/4-architecture/features/008-shared-albums-visibility/spec.md
@@ -1,0 +1,416 @@
+# Feature 008 – Shared Albums Visibility Control
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Last updated | 2026-01-15 |
+| Owners | Agent |
+| Linked plan | `docs/specs/4-architecture/features/008-shared-albums-visibility/plan.md` |
+| Linked tasks | `docs/specs/4-architecture/features/008-shared-albums-visibility/tasks.md` |
+| Roadmap entry | #008 |
+
+> Guardrail: This specification is the single normative source of truth for the feature. Track high- and medium-impact questions in [docs/specs/4-architecture/open-questions.md](../../open-questions.md), encode resolved answers directly in the Requirements/NFR/Behaviour/UI/Telemetry sections below (no per-feature `## Clarifications` sections), and use ADRs under `docs/specs/5-decisions/` for architecturally significant clarifications (referencing their IDs from the relevant spec sections).
+
+## Overview
+
+Currently, logged-in users see all albums they have access to on the gallery page: their own albums plus albums shared with them (by other users or public albums from other owners). This feature introduces configuration options at both server and user level to control how shared albums are displayed:
+
+- **Server config**: Defines the default behavior for all users
+- **User preference**: Allows individual users to override the server default
+
+Affected modules: database (migrations for config + user preference column), application (RootConfig, Top action), REST API (user settings endpoint), UI (Vue components for tabbed view + settings).
+
+## Goals
+
+- Add a global server configuration option to control shared album visibility mode
+- Add a per-user preference column to allow users to override the global setting
+- Support four visibility modes: SHOW (inline), SEPARATE (tabs), SEPARATE-SHARED-ONLY, HIDE
+- Send the effective visibility mode to the frontend via RootConfig
+- Update the gallery UI to support tabbed display when mode is SEPARATE or SEPARATE-SHARED-ONLY
+- Provide user settings UI to change the personal preference
+
+## Non-Goals
+
+- Changing the underlying album sharing/permission system
+- Modifying how albums are queried or filtered in the backend (only UI presentation)
+- Adding new sharing capabilities
+- Retroactive application of settings (purely a display preference)
+
+## Functional Requirements
+
+| ID | Requirement | Success path | Validation path | Failure path | Telemetry & traces | Source |
+|----|-------------|--------------|-----------------|--------------|--------------------|--------|
+| FR-008-01 | Server config for shared album visibility | Admin can set `shared_albums_visibility_default` config with values: `show`, `separate`, `separate_shared_only`, `hide` | Validate value is one of allowed enum values | Reject invalid value, keep existing | None | User request |
+| FR-008-02 | User preference column for shared album visibility | Users table has `shared_albums_visibility` column with values: `default`, `show`, `separate`, `separate_shared_only`, `hide` | Validate value is one of allowed enum values including `default` | Reject invalid value, keep existing | None | User request |
+| FR-008-03 | Effective mode calculation | When user has `default`, use server config; otherwise use user preference | N/A | N/A | None | User request |
+| FR-008-04 | Send effective mode to frontend | RootConfig includes `shared_albums_visibility_mode` field with the computed effective value | Mode sent only to authenticated users | For guests, field is omitted or set to `show` | None | User request |
+| FR-008-05 | SHOW mode behavior | Shared albums displayed inline below owned albums (current behavior) | N/A | N/A | None | User request |
+| FR-008-06 | SEPARATE mode behavior | Gallery shows two tabs: "My Albums" and "Shared with Me"; public albums from other owners included in "Shared with Me" | Tab visible only when shared_albums exist | N/A | None | User request |
+| FR-008-07 | SEPARATE-SHARED-ONLY mode behavior | Gallery shows two tabs: "My Albums" and "Shared with Me"; only non-public shared albums shown in "Shared with Me" tab (excludes public albums from other owners) | Tab visible only when non-public shared albums exist | N/A | None | User request |
+| FR-008-08 | HIDE mode behavior | Shared albums not displayed at all on gallery page; only owned albums shown | N/A | N/A | None | User request |
+| FR-008-09 | User can update their preference | PUT `/User::updateSettings` accepts `shared_albums_visibility` field | Validate field value | Return 422 if invalid value | None | User request |
+| FR-008-10 | Server config default value | Default server config is `show` to maintain backward compatibility | N/A | N/A | None | Backward compatibility |
+
+## Non-Functional Requirements
+
+| ID | Requirement | Driver | Measurement | Dependencies | Source |
+|----|-------------|--------|-------------|--------------|--------|
+| NFR-008-01 | Backward compatibility | Existing installations should behave identically after upgrade | Default config is `show`, users default to `default` → effective mode is `show` | Migration sets defaults | User expectation |
+| NFR-008-02 | No performance regression | Mode calculation should be negligible overhead | Effective mode computed once per request in RootConfig | Simple conditional logic | Performance requirement |
+| NFR-008-03 | TypeScript type safety | Frontend should have proper types for the enum values | TypeScript enum generated via Spatie TypeScriptTransformer | #[TypeScript] attribute on enum | Coding conventions |
+
+## UI / Interaction Mock-ups
+
+### Gallery Page - SHOW Mode (Current/Default Behavior)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Gallery                                           [⚙] [🔍] │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│ Smart Albums                                                │
+│ ┌────────┐ ┌────────┐ ┌────────┐                           │
+│ │ Recent │ │Starred │ │ On Map │                           │
+│ └────────┘ └────────┘ └────────┘                           │
+│                                                             │
+│ My Albums                                                   │
+│ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐               │
+│ │Vacation│ │ Family │ │ Work   │ │Hobbies │               │
+│ │ 45 📷  │ │ 120 📷 │ │ 30 📷  │ │ 85 📷  │               │
+│ └────────┘ └────────┘ └────────┘ └────────┘               │
+│                                                             │
+│ Shared Albums                                               │
+│ ┌────────┐ ┌────────┐                                      │
+│ │Friend's│ │Public  │   (from other users)                 │
+│ │ Trip   │ │Gallery │                                      │
+│ └────────┘ └────────┘                                      │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Gallery Page - SEPARATE Mode (Tabbed View - My Albums Tab)
+
+Smart Albums shown above tabs (per Q-008-02 decision), tabs only visible when shared albums exist (per Q-008-03 decision).
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Gallery                                           [⚙] [🔍] │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│ Smart Albums (always visible, above tabs)                   │
+│ ┌────────┐ ┌────────┐ ┌────────┐                           │
+│ │ Recent │ │Starred │ │ On Map │                           │
+│ └────────┘ └────────┘ └────────┘                           │
+│                                                             │
+│  [ My Albums ]  [ Shared with Me ]                          │
+│  ─────────────                                              │
+│                                                             │
+│ Albums                                                      │
+│ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐               │
+│ │Vacation│ │ Family │ │ Work   │ │Hobbies │               │
+│ │ 45 📷  │ │ 120 📷 │ │ 30 📷  │ │ 85 📷  │               │
+│ └────────┘ └────────┘ └────────┘ └────────┘               │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Gallery Page - SEPARATE Mode (Shared Tab Selected)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Gallery                                           [⚙] [🔍] │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│ Smart Albums (always visible, above tabs)                   │
+│ ┌────────┐ ┌────────┐ ┌────────┐                           │
+│ │ Recent │ │Starred │ │ On Map │                           │
+│ └────────┘ └────────┘ └────────┘                           │
+│                                                             │
+│  [ My Albums ]  [ Shared with Me ]                          │
+│                 ─────────────────                           │
+│                                                             │
+│ Shared Albums                                               │
+│ ┌────────┐ ┌────────┐ ┌────────┐                           │
+│ │Friend's│ │Public  │ │Collab  │   (all accessible albums  │
+│ │ Trip   │ │Gallery │ │Project │    from other users)      │
+│ │ 78 📷  │ │ 200 📷 │ │ 45 📷  │                           │
+│ └────────┘ └────────┘ └────────┘                           │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Gallery Page - SEPARATE Mode (No Shared Albums - Tabs Hidden)
+
+When user has no shared albums, tab bar is hidden and behaves like SHOW mode.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Gallery                                           [⚙] [🔍] │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│ Smart Albums                                                │
+│ ┌────────┐ ┌────────┐ ┌────────┐                           │
+│ │ Recent │ │Starred │ │ On Map │                           │
+│ └────────┘ └────────┘ └────────┘                           │
+│                                                             │
+│ Albums (no tabs shown - no shared albums available)         │
+│ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐               │
+│ │Vacation│ │ Family │ │ Work   │ │Hobbies │               │
+│ │ 45 📷  │ │ 120 📷 │ │ 30 📷  │ │ 85 📷  │               │
+│ └────────┘ └────────┘ └────────┘ └────────┘               │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Gallery Page - HIDE Mode
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Gallery                                           [⚙] [🔍] │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│ Smart Albums                                                │
+│ ┌────────┐ ┌────────┐ ┌────────┐                           │
+│ │ Recent │ │Starred │ │ On Map │                           │
+│ └────────┘ └────────┘ └────────┘                           │
+│                                                             │
+│ Albums                                                      │
+│ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐               │
+│ │Vacation│ │ Family │ │ Work   │ │Hobbies │               │
+│ │ 45 📷  │ │ 120 📷 │ │ 30 📷  │ │ 85 📷  │               │
+│ └────────┘ └────────┘ └────────┘ └────────┘               │
+│                                                             │
+│              (no shared albums section shown)               │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### User Settings - Shared Albums Preference
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Settings                                                    │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│ Display Preferences                                         │
+│ ───────────────────                                         │
+│                                                             │
+│ Shared Albums Visibility                                    │
+│ ┌─────────────────────────────────────────────────────────┐│
+│ │ ○ Use server default (currently: Show inline)          ││
+│ │ ○ Show inline with my albums                           ││
+│ │ ○ Show in separate tab                                 ││
+│ │ ○ Show in separate tab (shared only, no public)        ││
+│ │ ○ Hide shared albums                                   ││
+│ └─────────────────────────────────────────────────────────┘│
+│                                                             │
+│                                        [Cancel] [Save]      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Branch & Scenario Matrix
+
+| Scenario ID | Description / Expected outcome |
+|-------------|--------------------------------|
+| S-008-01 | User with preference=`default`, server config=`show` → Effective mode is `show`, shared albums inline |
+| S-008-02 | User with preference=`hide`, server config=`show` → Effective mode is `hide`, no shared albums shown |
+| S-008-03 | User with preference=`separate`, server config=`hide` → Effective mode is `separate`, tabs shown |
+| S-008-04 | User with preference=`default`, server config=`separate` → Effective mode is `separate`, tabs shown |
+| S-008-05 | Guest user (not logged in) → No shared albums section (guests only see public albums, treated as "their view") |
+| S-008-06 | User changes preference from `default` to `hide` via settings → Gallery immediately reflects change |
+| S-008-07 | Admin changes server config from `show` to `separate` → Users with `default` preference see tabs |
+| S-008-08 | User has no shared albums → Tabs hidden even in `separate` mode (nothing to show) |
+| S-008-09 | User has preference=`separate_shared_only`, has public albums from others but no direct shares → "Shared with Me" tab hidden |
+| S-008-10 | Fresh installation → Server config defaults to `show`, all users default to `default` |
+
+## Test Strategy
+
+- **Core:** Unit tests for effective mode calculation logic
+- **Application:** Feature tests for RootConfig returning correct effective mode based on user/server settings
+- **REST:** API tests for user settings endpoint accepting valid values, rejecting invalid
+- **UI (JS):** Component tests for tab rendering based on mode, settings form validation
+- **Migration:** Test that existing installations default to `show` mode after migration
+
+## Interface & Contract Catalogue
+
+### Domain Objects
+
+| ID | Description | Modules |
+|----|-------------|---------|
+| DO-008-01 | SharedAlbumsVisibility enum: `show`, `separate`, `separate_shared_only`, `hide` | core, application, REST, UI |
+| DO-008-02 | UserSharedAlbumsVisibility enum: `default`, `show`, `separate`, `separate_shared_only`, `hide` | core, application, REST, UI |
+| DO-008-03 | RootConfig.shared_albums_visibility_mode: SharedAlbumsVisibility (computed effective value) | application, REST, UI |
+
+### API Routes / Services
+
+| ID | Transport | Description | Notes |
+|----|-----------|-------------|-------|
+| API-008-01 | PUT /User::updateSettings | Update user settings including shared_albums_visibility | Existing endpoint, new field |
+| API-008-02 | GET /Gallery::Init | Returns RootConfig with shared_albums_visibility_mode | Existing endpoint, new field in response |
+
+### CLI Commands / Flags
+
+None required for this feature.
+
+### Telemetry Events
+
+None required for this feature.
+
+### Fixtures & Sample Data
+
+| ID | Path | Purpose |
+|----|------|---------|
+| FX-008-01 | tests/Feature_v2/SharedAlbumsVisibilityTest.php | Test various mode combinations |
+
+### UI States
+
+| ID | State | Trigger / Expected outcome |
+|----|-------|---------------------------|
+| UI-008-01 | Gallery inline mode | Mode is `show` → Shared albums section below owned albums |
+| UI-008-02 | Gallery tabbed mode | Mode is `separate` or `separate_shared_only` → Tab bar shown at top |
+| UI-008-03 | Gallery hidden mode | Mode is `hide` → No shared albums section or tab |
+| UI-008-04 | Settings radio selection | User selects preference → Option highlighted, save enabled |
+| UI-008-05 | Tab badge/count | Each tab shows count of albums in that category |
+
+## Telemetry & Observability
+
+No telemetry events required for this feature. Standard application logging for errors.
+
+## Documentation Deliverables
+
+- Update [knowledge-map.md](../../knowledge-map.md) with new config key and user preference column
+- Document admin configuration option in admin guide
+- Document user preference in user guide/settings documentation
+
+## Fixtures & Sample Data
+
+- Test fixtures with users having various preference settings
+- Test fixtures with albums in different sharing states (owned, shared directly, public from others)
+
+## Spec DSL
+
+```yaml
+domain_objects:
+  - id: DO-008-01
+    name: SharedAlbumsVisibility
+    type: enum
+    values:
+      - show
+      - separate
+      - separate_shared_only
+      - hide
+    description: Server-level configuration for shared albums display mode
+  - id: DO-008-02
+    name: UserSharedAlbumsVisibility
+    type: enum
+    values:
+      - default
+      - show
+      - separate
+      - separate_shared_only
+      - hide
+    description: User-level preference for shared albums display mode (includes default option)
+  - id: DO-008-03
+    name: RootConfig.shared_albums_visibility_mode
+    type: SharedAlbumsVisibility
+    description: Computed effective visibility mode sent to frontend
+
+routes:
+  - id: API-008-01
+    method: PUT
+    path: /User::updateSettings
+    parameters:
+      - shared_albums_visibility: UserSharedAlbumsVisibility (optional)
+    response: UserResource
+    notes: Existing endpoint with new optional field
+  - id: API-008-02
+    method: GET
+    path: /Gallery::Init
+    response: InitConfig (includes RootConfig.shared_albums_visibility_mode)
+    notes: Existing endpoint, response extended
+
+config_keys:
+  - id: CFG-008-01
+    key: shared_albums_visibility_default
+    type: enum
+    values: show|separate|separate_shared_only|hide
+    default: show
+    category: Gallery
+    description: Default visibility mode for shared albums
+
+user_columns:
+  - id: COL-008-01
+    column: shared_albums_visibility
+    type: enum
+    values: default|show|separate|separate_shared_only|hide
+    default: default
+    nullable: false
+    description: User preference for shared albums visibility
+
+ui_states:
+  - id: UI-008-01
+    description: Gallery inline mode (shared albums below owned)
+  - id: UI-008-02
+    description: Gallery tabbed mode (My Albums / Shared with Me tabs)
+  - id: UI-008-03
+    description: Gallery hidden mode (no shared albums visible)
+  - id: UI-008-04
+    description: Settings preference selection
+  - id: UI-008-05
+    description: Tab with album count badges
+```
+
+## Appendix
+
+### Existing Code References
+
+**Album retrieval with owned/shared partition:**
+File: [app/Actions/Albums/Top.php](../../../../app/Actions/Albums/Top.php)
+
+The `Top::get()` method already partitions albums into owned vs shared:
+```php
+if ($user_id !== null) {
+    list($owned, $shared) = $albums->partition(
+        fn ($album) => $album->owner_id === $user_id
+    );
+    return new TopAlbumDTO(
+        albums: $owned,
+        shared_albums: $shared
+    );
+}
+```
+
+**RootConfig sending gallery configuration:**
+File: [app/Http/Resources/GalleryConfigs/RootConfig.php](../../../../app/Http/Resources/GalleryConfigs/RootConfig.php)
+
+**User model columns for preferences:**
+File: [app/Models/User.php](../../../../app/Models/User.php)
+
+### Mode Behavior Summary
+
+| Mode | "Shared Albums" Section | Tab Display | What Albums Appear |
+|------|-------------------------|-------------|-------------------|
+| `show` | Inline below owned | No tabs | All accessible albums from other users |
+| `separate` | Hidden from main | Two tabs | All accessible albums from other users in "Shared" tab |
+| `separate_shared_only` | Hidden from main | Two tabs | Only directly shared albums (no public) in "Shared" tab |
+| `hide` | Hidden | No tabs | None - only owned albums shown |
+
+### SEPARATE vs SEPARATE-SHARED-ONLY
+
+- **SEPARATE**: The "Shared with Me" tab includes ALL albums the user can access that they don't own, including:
+  - Albums directly shared with the user (via access_permissions with user_id match)
+  - Albums shared with a group the user belongs to
+  - Public albums from other users (is_link_required = false, no specific user/group)
+
+- **SEPARATE-SHARED-ONLY**: The "Shared with Me" tab includes ONLY albums specifically shared:
+  - Albums directly shared with the user (via access_permissions with user_id match)
+  - Albums shared with a group the user belongs to
+  - EXCLUDES public albums from other users
+
+### User Decisions Summary
+
+All open questions (Q-008-01 through Q-008-03) have been resolved:
+
+- **Q-008-01:** User preference stored in users table column (Option A) - follows existing Lychee pattern
+- **Q-008-02:** Smart Albums shown above tabs, outside tab context (Option D) - clear that Smart Albums span all content
+- **Q-008-03:** Hide empty tabs (Option A) - cleaner UX when no shared albums exist

--- a/docs/specs/4-architecture/features/008-shared-albums-visibility/spec.md
+++ b/docs/specs/4-architecture/features/008-shared-albums-visibility/spec.md
@@ -48,7 +48,7 @@ Affected modules: database (migrations for config + user preference column), app
 | FR-008-06 | SEPARATE mode behavior | Gallery shows two tabs: "My Albums" and "Shared with Me"; public albums from other owners included in "Shared with Me" | Tab visible only when shared_albums exist | N/A | None | User request |
 | FR-008-07 | SEPARATE-SHARED-ONLY mode behavior | Gallery shows two tabs: "My Albums" and "Shared with Me"; only non-public shared albums shown in "Shared with Me" tab (excludes public albums from other owners) | Tab visible only when non-public shared albums exist | N/A | None | User request |
 | FR-008-08 | HIDE mode behavior | Shared albums not displayed at all on gallery page; only owned albums shown | N/A | N/A | None | User request |
-| FR-008-09 | User can update their preference | PUT `/User::updateSettings` accepts `shared_albums_visibility` field | Validate field value | Return 422 if invalid value | None | User request |
+| FR-008-09 | User can update their preference | POST `/Profile::updateSharedAlbumsVisibility` accepts `shared_albums_visibility` field | Validate field value | Return 422 if invalid value | None | User request |
 | FR-008-10 | Server config default value | Default server config is `show` to maintain backward compatibility | N/A | N/A | None | Backward compatibility |
 
 ## Non-Functional Requirements
@@ -245,7 +245,7 @@ When user has no shared albums, tab bar is hidden and behaves like SHOW mode.
 
 | ID | Transport | Description | Notes |
 |----|-----------|-------------|-------|
-| API-008-01 | PUT /User::updateSettings | Update user settings including shared_albums_visibility | Existing endpoint, new field |
+| API-008-01 | POST /Profile::updateSharedAlbumsVisibility | Update user's shared albums visibility preference | Dedicated endpoint for this setting |
 | API-008-02 | GET /Gallery::Init | Returns RootConfig with shared_albums_visibility_mode | Existing endpoint, new field in response |
 
 ### CLI Commands / Flags
@@ -317,12 +317,12 @@ domain_objects:
 
 routes:
   - id: API-008-01
-    method: PUT
-    path: /User::updateSettings
+    method: POST
+    path: /Profile::updateSharedAlbumsVisibility
     parameters:
-      - shared_albums_visibility: UserSharedAlbumsVisibility (optional)
+      - shared_albums_visibility: UserSharedAlbumsVisibility (required)
     response: UserResource
-    notes: Existing endpoint with new optional field
+    notes: Dedicated endpoint for updating shared albums visibility preference
   - id: API-008-02
     method: GET
     path: /Gallery::Init

--- a/docs/specs/4-architecture/features/008-shared-albums-visibility/tasks.md
+++ b/docs/specs/4-architecture/features/008-shared-albums-visibility/tasks.md
@@ -1,0 +1,126 @@
+# Feature 008 Tasks – Shared Albums Visibility Control
+
+_Status: Draft_
+_Last updated: 2026-01-15_
+
+> Keep this checklist aligned with the feature plan increments. Stage tests before implementation, record verification commands beside each task, and prefer bite-sized entries (≤90 minutes).
+> **Mark tasks `[x]` immediately** after each one passes verification—do not batch completions. Update the roadmap status when all tasks are done.
+
+## Checklist
+
+### Phase 1: Backend - Enums & Database
+
+- [ ] T-008-01 – Create SharedAlbumsVisibility enum (FR-008-01, DO-008-01).
+  _Intent:_ Create server-level visibility mode enum.
+  _Verification commands:_
+  - `make phpstan`
+  _Notes:_ Values: `show`, `separate`, `separate_shared_only`, `hide`
+
+- [ ] T-008-02 – Create UserSharedAlbumsVisibility enum (FR-008-02, DO-008-02).
+  _Intent:_ Create user-level preference enum (includes `default` option).
+  _Verification commands:_
+  - `make phpstan`
+  _Notes:_ Values: `default`, `show`, `separate`, `separate_shared_only`, `hide`
+
+- [ ] T-008-03 – Create server config migration (FR-008-01, FR-008-10, CFG-008-01).
+  _Intent:_ Add `shared_albums_visibility_default` config to database.
+  _Verification commands:_
+  - `php artisan migrate`
+  - `make phpstan`
+  _Notes:_ Default value `show`, category `Gallery`
+
+- [ ] T-008-04 – Create user column migration (FR-008-02, COL-008-01).
+  _Intent:_ Add `shared_albums_visibility` column to users table.
+  _Verification commands:_
+  - `php artisan migrate`
+  - `make phpstan`
+  _Notes:_ String column, default `default`
+
+- [ ] T-008-05 – Update User model (FR-008-02).
+  _Intent:_ Add cast for new column, update PHPDoc.
+  _Verification commands:_
+  - `make phpstan`
+  _Notes:_ Cast to `UserSharedAlbumsVisibility` enum
+
+### Phase 2: Backend - API & Logic
+
+- [ ] T-008-06 – Update RootConfig with effective mode (FR-008-03, FR-008-04, DO-008-03).
+  _Intent:_ Compute and expose effective visibility mode to frontend.
+  _Verification commands:_
+  - `make phpstan`
+  - `php artisan typescript:transform`
+  _Notes:_ Only for authenticated users; compute from user pref or server default
+
+- [ ] T-008-07 – Update user settings endpoint (FR-008-09, API-008-01).
+  _Intent:_ Accept `shared_albums_visibility` field in user settings update.
+  _Verification commands:_
+  - `make phpstan`
+  _Notes:_ Validate against UserSharedAlbumsVisibility enum
+
+- [ ] T-008-08 – Write backend tests (S-008-01 to S-008-07, S-008-10).
+  _Intent:_ Test effective mode calculation and settings update.
+  _Verification commands:_
+  - `php artisan test --filter=SharedAlbumsVisibility`
+  _Notes:_ Test various user/server config combinations
+
+### Phase 3: Frontend - Types & State
+
+- [ ] T-008-09 – Generate and verify TypeScript types.
+  _Intent:_ Ensure enums are available in frontend.
+  _Verification commands:_
+  - `php artisan typescript:transform`
+  - `npm run check`
+  _Notes:_ Verify `App.Enum.SharedAlbumsVisibility` exists
+
+### Phase 4: Frontend - UI Implementation
+
+- [ ] T-008-10 – Implement gallery tab UI (FR-008-06, FR-008-07, UI-008-02).
+  _Intent:_ Add tabbed view for separate modes with Smart Albums above tabs.
+  _Verification commands:_
+  - `npm run check`
+  _Notes:_ Hide tabs when no shared albums (S-008-08)
+
+- [ ] T-008-11 – Handle SHOW mode (FR-008-05, UI-008-01).
+  _Intent:_ Shared albums inline below owned albums (current behavior).
+  _Verification commands:_
+  - `npm run check`
+  _Notes:_ Default/backward compatible mode
+
+- [ ] T-008-12 – Handle HIDE mode (FR-008-08, UI-008-03).
+  _Intent:_ No shared albums shown at all.
+  _Verification commands:_
+  - `npm run check`
+  _Notes:_ Simply filter out shared albums
+
+- [ ] T-008-13 – Implement SEPARATE-SHARED-ONLY filtering (FR-008-07, S-008-09).
+  _Intent:_ In shared tab, exclude public albums from other owners.
+  _Verification commands:_
+  - `npm run check`
+  _Notes:_ Need to distinguish direct shares from public albums
+
+### Phase 5: Frontend - User Settings
+
+- [ ] T-008-14 – Add preference selector to user settings (UI-008-04).
+  _Intent:_ Radio button group for visibility preference.
+  _Verification commands:_
+  - `npm run check`
+  _Notes:_ 5 options including "Use server default"
+
+### Phase 6: Quality Gate
+
+- [ ] T-008-15 – Run full quality gate.
+  _Intent:_ Final verification and formatting.
+  _Verification commands:_
+  - `vendor/bin/php-cs-fixer fix`
+  - `npm run format`
+  - `php artisan test`
+  - `make phpstan`
+  - `npm run check`
+  _Notes:_ All gates must pass before completion
+
+## Notes / TODOs
+
+- The SEPARATE-SHARED-ONLY mode requires distinguishing between:
+  - Direct shares (access_permissions with user_id or user_group_id match)
+  - Public albums from other owners (no specific user/group, is_link_required=false)
+  - This filtering may need backend support or frontend logic based on album ownership

--- a/docs/specs/4-architecture/features/008-shared-albums-visibility/tasks.md
+++ b/docs/specs/4-architecture/features/008-shared-albums-visibility/tasks.md
@@ -1,6 +1,6 @@
 # Feature 008 Tasks – Shared Albums Visibility Control
 
-_Status: Draft_
+_Status: Complete_
 _Last updated: 2026-01-15_
 
 > Keep this checklist aligned with the feature plan increments. Stage tests before implementation, record verification commands beside each task, and prefer bite-sized entries (≤90 minutes).
@@ -10,113 +10,113 @@ _Last updated: 2026-01-15_
 
 ### Phase 1: Backend - Enums & Database
 
-- [ ] T-008-01 – Create SharedAlbumsVisibility enum (FR-008-01, DO-008-01).
+- [x] T-008-01 – Create SharedAlbumsVisibility enum (FR-008-01, DO-008-01).
   _Intent:_ Create server-level visibility mode enum.
   _Verification commands:_
-  - `make phpstan`
+  - `make phpstan` ✓
   _Notes:_ Values: `show`, `separate`, `separate_shared_only`, `hide`
 
-- [ ] T-008-02 – Create UserSharedAlbumsVisibility enum (FR-008-02, DO-008-02).
+- [x] T-008-02 – Create UserSharedAlbumsVisibility enum (FR-008-02, DO-008-02).
   _Intent:_ Create user-level preference enum (includes `default` option).
   _Verification commands:_
-  - `make phpstan`
+  - `make phpstan` ✓
   _Notes:_ Values: `default`, `show`, `separate`, `separate_shared_only`, `hide`
 
-- [ ] T-008-03 – Create server config migration (FR-008-01, FR-008-10, CFG-008-01).
+- [x] T-008-03 – Create server config migration (FR-008-01, FR-008-10, CFG-008-01).
   _Intent:_ Add `shared_albums_visibility_default` config to database.
   _Verification commands:_
-  - `php artisan migrate`
-  - `make phpstan`
+  - `php artisan migrate` ✓
+  - `make phpstan` ✓
   _Notes:_ Default value `show`, category `Gallery`
 
-- [ ] T-008-04 – Create user column migration (FR-008-02, COL-008-01).
+- [x] T-008-04 – Create user column migration (FR-008-02, COL-008-01).
   _Intent:_ Add `shared_albums_visibility` column to users table.
   _Verification commands:_
-  - `php artisan migrate`
-  - `make phpstan`
+  - `php artisan migrate` ✓
+  - `make phpstan` ✓
   _Notes:_ String column, default `default`
 
-- [ ] T-008-05 – Update User model (FR-008-02).
+- [x] T-008-05 – Update User model (FR-008-02).
   _Intent:_ Add cast for new column, update PHPDoc.
   _Verification commands:_
-  - `make phpstan`
+  - `make phpstan` ✓
   _Notes:_ Cast to `UserSharedAlbumsVisibility` enum
 
 ### Phase 2: Backend - API & Logic
 
-- [ ] T-008-06 – Update RootConfig with effective mode (FR-008-03, FR-008-04, DO-008-03).
+- [x] T-008-06 – Update RootConfig with effective mode (FR-008-03, FR-008-04, DO-008-03).
   _Intent:_ Compute and expose effective visibility mode to frontend.
   _Verification commands:_
-  - `make phpstan`
-  - `php artisan typescript:transform`
+  - `make phpstan` ✓
+  - `php artisan typescript:transform` ✓
   _Notes:_ Only for authenticated users; compute from user pref or server default
 
-- [ ] T-008-07 – Update user settings endpoint (FR-008-09, API-008-01).
+- [x] T-008-07 – Update user settings endpoint (FR-008-09, API-008-01).
   _Intent:_ Accept `shared_albums_visibility` field in user settings update.
   _Verification commands:_
-  - `make phpstan`
+  - `make phpstan` ✓
   _Notes:_ Validate against UserSharedAlbumsVisibility enum
 
-- [ ] T-008-08 – Write backend tests (S-008-01 to S-008-07, S-008-10).
+- [x] T-008-08 – Write backend tests (S-008-01 to S-008-07, S-008-10).
   _Intent:_ Test effective mode calculation and settings update.
   _Verification commands:_
-  - `php artisan test --filter=SharedAlbumsVisibility`
+  - `php artisan test --filter=SharedAlbumsVisibility` ✓
   _Notes:_ Test various user/server config combinations
 
 ### Phase 3: Frontend - Types & State
 
-- [ ] T-008-09 – Generate and verify TypeScript types.
+- [x] T-008-09 – Generate and verify TypeScript types.
   _Intent:_ Ensure enums are available in frontend.
   _Verification commands:_
-  - `php artisan typescript:transform`
-  - `npm run check`
-  _Notes:_ Verify `App.Enum.SharedAlbumsVisibility` exists
+  - `php artisan typescript:transform` ✓
+  - `npm run check` ✓
+  _Notes:_ Verify `App.Enum.SharedAlbumsVisibility` exists ✓ (line 54 of lychee.d.ts)
 
 ### Phase 4: Frontend - UI Implementation
 
-- [ ] T-008-10 – Implement gallery tab UI (FR-008-06, FR-008-07, UI-008-02).
+- [x] T-008-10 – Implement gallery tab UI (FR-008-06, FR-008-07, UI-008-02).
   _Intent:_ Add tabbed view for separate modes with Smart Albums above tabs.
   _Verification commands:_
-  - `npm run check`
-  _Notes:_ Hide tabs when no shared albums (S-008-08)
+  - `npm run check` ✓
+  _Notes:_ Hide tabs when no shared albums (S-008-08) ✓
 
-- [ ] T-008-11 – Handle SHOW mode (FR-008-05, UI-008-01).
+- [x] T-008-11 – Handle SHOW mode (FR-008-05, UI-008-01).
   _Intent:_ Shared albums inline below owned albums (current behavior).
   _Verification commands:_
-  - `npm run check`
-  _Notes:_ Default/backward compatible mode
+  - `npm run check` ✓
+  _Notes:_ Default/backward compatible mode ✓
 
-- [ ] T-008-12 – Handle HIDE mode (FR-008-08, UI-008-03).
+- [x] T-008-12 – Handle HIDE mode (FR-008-08, UI-008-03).
   _Intent:_ No shared albums shown at all.
   _Verification commands:_
-  - `npm run check`
-  _Notes:_ Simply filter out shared albums
+  - `npm run check` ✓
+  _Notes:_ Simply filter out shared albums ✓
 
-- [ ] T-008-13 – Implement SEPARATE-SHARED-ONLY filtering (FR-008-07, S-008-09).
+- [x] T-008-13 – Implement SEPARATE-SHARED-ONLY filtering (FR-008-07, S-008-09).
   _Intent:_ In shared tab, exclude public albums from other owners.
   _Verification commands:_
-  - `npm run check`
-  _Notes:_ Need to distinguish direct shares from public albums
+  - `npm run check` ✓
+  _Notes:_ Need to distinguish direct shares from public albums ✓
 
 ### Phase 5: Frontend - User Settings
 
-- [ ] T-008-14 – Add preference selector to user settings (UI-008-04).
+- [x] T-008-14 – Add preference selector to user settings (UI-008-04).
   _Intent:_ Radio button group for visibility preference.
   _Verification commands:_
-  - `npm run check`
-  _Notes:_ 5 options including "Use server default"
+  - `npm run check` ✓
+  _Notes:_ 5 options including "Use server default" ✓ (SetSharedAlbumsVisibility.vue created)
 
 ### Phase 6: Quality Gate
 
-- [ ] T-008-15 – Run full quality gate.
+- [x] T-008-15 – Run full quality gate.
   _Intent:_ Final verification and formatting.
   _Verification commands:_
-  - `vendor/bin/php-cs-fixer fix`
-  - `npm run format`
-  - `php artisan test`
-  - `make phpstan`
-  - `npm run check`
-  _Notes:_ All gates must pass before completion
+  - `vendor/bin/php-cs-fixer fix` ✓
+  - `npm run format` ✓
+  - `php artisan test` ✓
+  - `make phpstan` ✓
+  - `npm run check` ✓
+  _Notes:_ All gates passed
 
 ## Notes / TODOs
 

--- a/docs/specs/4-architecture/open-questions.md
+++ b/docs/specs/4-architecture/open-questions.md
@@ -10,7 +10,29 @@ Track unresolved high- and medium-impact questions here. Remove each row as soon
 
 ## Question Details
 
-_All Feature 007 questions have been resolved and moved to the resolved section below._
+### ~~Q-008-01: User Preference Storage Location~~ ✅ RESOLVED
+
+**Decision:** Option A - New column in users table
+**Rationale:** Follows existing Lychee pattern (user attributes in users table), simple implementation with single query, no new tables needed.
+**Updated in spec:** FR-008-02, COL-008-01, migration strategy
+
+---
+
+### ~~Q-008-02: Smart Albums in Tabbed View~~ ✅ RESOLVED
+
+**Decision:** Option D - Show above tabs (outside tab context)
+**Rationale:** Smart albums span all content (photos from both owned and shared albums), so they should be displayed above the tab bar and remain always visible regardless of selected tab.
+**Updated in spec:** UI mockups, FR-008-06, FR-008-07
+
+---
+
+### ~~Q-008-03: Tab Visibility When Empty~~ ✅ RESOLVED
+
+**Decision:** Option A - Hide empty tabs
+**Rationale:** Cleaner UX - if "Shared with Me" has no albums, don't show tab bar at all (behave like SHOW mode). Simpler for users with no shared albums.
+**Updated in spec:** S-008-08, UI-008-02
+
+---
 
 ---
 

--- a/lang/ar/gallery.php
+++ b/lang/ar/gallery.php
@@ -10,6 +10,10 @@ return [
     'pinned_albums' => 'الألبومات المثبتة',
     'albums' => 'الألبومات',
     'root' => 'الألبومات',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'المفضلة',
     'original' => 'الأصلي',
     'medium' => 'متوسط',

--- a/lang/ar/profile.php
+++ b/lang/ar/profile.php
@@ -57,4 +57,23 @@ return [
         'credential_registred' => 'تم التسجيل بنجاح!',
         '5_chars' => 'على الأقل 5 أحرف.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/cz/gallery.php
+++ b/lang/cz/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Připnutá alba',
     'albums' => 'Albums',
     'root' => 'Albums',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favourites',
     'original' => 'Original',
     'medium' => 'Medium',

--- a/lang/cz/profile.php
+++ b/lang/cz/profile.php
@@ -56,4 +56,23 @@ return [
         'credential_registred' => 'Registration successful!',
         '5_chars' => 'At least 5 chars.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/de/gallery.php
+++ b/lang/de/gallery.php
@@ -10,6 +10,10 @@ return [
     'pinned_albums' => 'Vorgeschlagene Alben',
     'albums' => 'Alben',
     'root' => 'Alben',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favoriten',
     'original' => 'Original',
     'medium' => 'Mittel',

--- a/lang/de/profile.php
+++ b/lang/de/profile.php
@@ -56,4 +56,23 @@ return [
         'credential_registred' => 'Anmeldung erfolgreich!',
         '5_chars' => 'Mindestens 5 Zeichen.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/el/gallery.php
+++ b/lang/el/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Καρφιτσωμένα άλμπουμ',
     'albums' => 'Albums',
     'root' => 'Albums',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favourites',
     'original' => 'Original',
     'medium' => 'Medium',

--- a/lang/el/profile.php
+++ b/lang/el/profile.php
@@ -57,4 +57,23 @@ return [
         'credential_registred' => 'Registration successful!',
         '5_chars' => 'At least 5 chars.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/en/gallery.php
+++ b/lang/en/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Featured Albums',
     'albums' => 'Albums',
     'root' => 'Albums',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favourites',
     'original' => 'Original',
     'medium' => 'Medium',

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -56,4 +56,23 @@ return [
         'credential_registred' => 'Registration successful!',
         '5_chars' => 'At least 5 chars.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/es/gallery.php
+++ b/lang/es/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Álbumes fijados',
     'albums' => 'Álbumes',
     'root' => 'Álbumes',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favoritos',
     'original' => 'Original',
     'medium' => 'Medio',

--- a/lang/es/profile.php
+++ b/lang/es/profile.php
@@ -56,4 +56,23 @@ return [
         'credential_registred' => '¡Registro exitoso!',
         '5_chars' => 'Al menos 5 caracteres.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/fa/gallery.php
+++ b/lang/fa/gallery.php
@@ -10,6 +10,10 @@ return [
     'pinned_albums' => 'آلبوم‌های سنجاق‌شده',
     'albums' => 'آلبوم‌ها',
     'root' => 'آلبوم‌ها',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'علاقه‌مندی‌ها',
     'original' => 'اصلی',
     'medium' => 'متوسط',

--- a/lang/fa/profile.php
+++ b/lang/fa/profile.php
@@ -56,4 +56,23 @@ return [
         'credential_registred' => 'ثبت‌نام موفقیت آمیز بود!',
         '5_chars' => 'حداقل ۵ کاراکتر.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/fr/gallery.php
+++ b/lang/fr/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Albums épinglés',
     'albums' => 'Albums',
     'root' => 'Albums',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Photo favorites',
     'original' => 'Original',
     'medium' => 'Moyen',

--- a/lang/fr/profile.php
+++ b/lang/fr/profile.php
@@ -57,4 +57,23 @@ return [
         'credential_registred' => 'Enregistrement réussi !',
         '5_chars' => 'Au moins 5 caractères.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/hu/gallery.php
+++ b/lang/hu/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Rögzített albumok',
     'albums' => 'Albums',
     'root' => 'Albums',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favourites',
     'original' => 'Original',
     'medium' => 'Medium',

--- a/lang/hu/profile.php
+++ b/lang/hu/profile.php
@@ -57,4 +57,23 @@ return [
         'error' => 'An error occurred while registering your account.',
         'success' => 'Your account has been successfully created.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/it/gallery.php
+++ b/lang/it/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Album fissati',
     'albums' => 'Albums',
     'root' => 'Albums',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favourites',
     'original' => 'Original',
     'medium' => 'Medium',

--- a/lang/it/profile.php
+++ b/lang/it/profile.php
@@ -57,4 +57,23 @@ return [
         'credential_registred' => 'Registration successful!',
         '5_chars' => 'At least 5 chars.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/ja/gallery.php
+++ b/lang/ja/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'ピン留めアルバム',
     'albums' => 'Albums',
     'root' => 'Albums',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favourites',
     'original' => 'Original',
     'medium' => 'Medium',

--- a/lang/ja/profile.php
+++ b/lang/ja/profile.php
@@ -57,4 +57,23 @@ return [
         'credential_registred' => 'Registration successful!',
         '5_chars' => 'At least 5 chars.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/nl/gallery.php
+++ b/lang/nl/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Vastgepinde albums',
     'albums' => 'Albums',
     'root' => 'Albums',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favorieten',
     'original' => 'Origineel',
     'medium' => 'Middelgroot',

--- a/lang/nl/profile.php
+++ b/lang/nl/profile.php
@@ -56,4 +56,23 @@ return [
         'credential_registred' => 'Registratie succesvol!',
         '5_chars' => 'Minimaal 5 tekens.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/no/gallery.php
+++ b/lang/no/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Festede album',
     'albums' => 'Album',
     'root' => 'Album',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favoritter',
     'original' => 'Original',
     'medium' => 'Medium',

--- a/lang/no/profile.php
+++ b/lang/no/profile.php
@@ -56,4 +56,23 @@ return [
         'credential_registred' => 'Registration successful!',
         '5_chars' => 'At least 5 chars.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/pl/gallery.php
+++ b/lang/pl/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Przypięte albumy',
     'albums' => 'Albumy',
     'root' => 'Albumy',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favourites',
     'original' => 'Oryginał',
     'medium' => 'Średni',

--- a/lang/pl/profile.php
+++ b/lang/pl/profile.php
@@ -57,4 +57,23 @@ return [
         'credential_registred' => 'Rejestracja zakończona sukcesem!',
         '5_chars' => 'Co najmniej 5 znaków.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/pt/gallery.php
+++ b/lang/pt/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Álbuns fixados',
     'albums' => 'Albums',
     'root' => 'Albums',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favourites',
     'original' => 'Original',
     'medium' => 'Medium',

--- a/lang/pt/profile.php
+++ b/lang/pt/profile.php
@@ -57,4 +57,23 @@ return [
         'credential_registred' => 'Registration successful!',
         '5_chars' => 'At least 5 chars.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/ru/gallery.php
+++ b/lang/ru/gallery.php
@@ -10,6 +10,10 @@ return [
     'pinned_albums' => 'Закреплённые альбомы',
     'albums' => 'Альбомы',
     'root' => 'Альбомы',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Избранные',
     'original' => 'Оригинал',
     'medium' => 'Средний',

--- a/lang/ru/profile.php
+++ b/lang/ru/profile.php
@@ -56,4 +56,23 @@ return [
         'credential_registred' => 'Регистрация прошла успешно!',
         '5_chars' => 'Не менее 5 символов.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/sk/gallery.php
+++ b/lang/sk/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Pripnuté albumy',
     'albums' => 'Albums',
     'root' => 'Albums',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favourites',
     'original' => 'Original',
     'medium' => 'Medium',

--- a/lang/sk/profile.php
+++ b/lang/sk/profile.php
@@ -57,4 +57,23 @@ return [
         'credential_registred' => 'Registration successful!',
         '5_chars' => 'At least 5 chars.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/sv/gallery.php
+++ b/lang/sv/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Fästa album',
     'albums' => 'Albums',
     'root' => 'Albums',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favourites',
     'original' => 'Original',
     'medium' => 'Medium',

--- a/lang/sv/profile.php
+++ b/lang/sv/profile.php
@@ -57,4 +57,23 @@ return [
         'credential_registred' => 'Registration successful!',
         '5_chars' => 'At least 5 chars.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/vi/gallery.php
+++ b/lang/vi/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => 'Album được ghim',
     'albums' => 'Albums',
     'root' => 'Albums',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favourites',
     'original' => 'Original',
     'medium' => 'Medium',

--- a/lang/vi/profile.php
+++ b/lang/vi/profile.php
@@ -57,4 +57,23 @@ return [
         'credential_registred' => 'Registration successful!',
         '5_chars' => 'At least 5 chars.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/zh_CN/gallery.php
+++ b/lang/zh_CN/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => '置顶相册',
     'albums' => '相册',
     'root' => '相册',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favourites',
     'original' => '原图',
     'medium' => '中等',

--- a/lang/zh_CN/profile.php
+++ b/lang/zh_CN/profile.php
@@ -57,4 +57,23 @@ return [
         'credential_registred' => '注册成功！',
         '5_chars' => '至少需要 5 个字符。',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/lang/zh_TW/gallery.php
+++ b/lang/zh_TW/gallery.php
@@ -11,6 +11,10 @@ return [
     'pinned_albums' => '釘選相冊',
     'albums' => 'Albums',
     'root' => 'Albums',
+    'tabs' => [
+        'my_albums' => 'My Albums',
+        'shared_with_me' => 'Shared with Me',
+    ],
     'favourites' => 'Favourites',
     'original' => 'Original',
     'medium' => 'Medium',

--- a/lang/zh_TW/profile.php
+++ b/lang/zh_TW/profile.php
@@ -56,4 +56,23 @@ return [
         'credential_registred' => 'Registration successful!',
         '5_chars' => 'At least 5 chars.',
     ],
+    'preferences' => [
+        'header' => 'Preferences',
+        'save' => 'Save Preference',
+        'reset' => 'Reset',
+        'change_saved' => 'Preference saved!',
+    ],
+    'shared_albums' => [
+        'instruction' => 'Choose how shared albums (albums from other users) appear in your gallery:',
+        'mode_default' => 'Use Server Default',
+        'mode_default_desc' => 'Inherit the server\'s default visibility mode.',
+        'mode_show' => 'Show Inline',
+        'mode_show_desc' => 'Shared albums appear below your own albums.',
+        'mode_separate' => 'Separate Tabs',
+        'mode_separate_desc' => 'View albums in separate "My Albums" and "Shared with Me" tabs.',
+        'mode_separate_shared_only' => 'Shared Only',
+        'mode_separate_shared_only_desc' => 'Separate tabs showing only directly shared albums (excludes public albums).',
+        'mode_hide' => 'Hide',
+        'mode_hide_desc' => 'Don\'t show any shared albums.',
+    ],
 ];

--- a/resources/js/components/forms/profile/SetSharedAlbumsVisibility.vue
+++ b/resources/js/components/forms/profile/SetSharedAlbumsVisibility.vue
@@ -1,0 +1,131 @@
+<template>
+	<Fieldset
+		v-if="user && user.id !== null"
+		:legend="$t('profile.preferences.header')"
+		:toggleable="true"
+		class="mb-4 hover:border-primary-500 pt-2 max-w-xl mx-auto"
+	>
+		<form>
+			<div class="w-full mb-6">
+				<div class="pb-4 text-muted-color">
+					{{ $t("profile.shared_albums.instruction") }}
+				</div>
+				<Select
+					v-model="selectedMode"
+					:options="visibilityOptions"
+					option-label="label"
+					option-value="value"
+					class="w-full border-none"
+					@change="markChanged"
+				>
+					<template #option="slotProps">
+						<div class="flex items-center justify-between w-full gap-3">
+							<span class="text-muted-color-emphasis w-full">{{ slotProps.option.label }}</span>
+							<span class="text-xs text-muted-color w-full ltr:text-right rtl:text-left">{{ slotProps.option.description }}</span>
+						</div>
+					</template>
+				</Select>
+			</div>
+			<div class="flex w-full mt-4">
+				<Button severity="contrast" class="w-full font-bold border-none shrink rounded-none ltr:rounded-l-xl rtl:rounded-r-xl" @click="save">
+					{{ $t("profile.preferences.save") }}
+				</Button>
+				<Button
+					severity="secondary"
+					class="w-full font-bold border-none shrink rounded-none ltr:rounded-r-xl rtl:rounded-l-xl"
+					@click="reset"
+				>
+					{{ $t("profile.preferences.reset") }}
+				</Button>
+			</div>
+		</form>
+	</Fieldset>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import Button from "primevue/button";
+import Select from "primevue/select";
+import { useToast } from "primevue/usetoast";
+import ProfileService from "@/services/profile-service";
+import { trans } from "laravel-vue-i18n";
+import Fieldset from "@/components/forms/basic/Fieldset.vue";
+import { useUserStore } from "@/stores/UserState";
+import { storeToRefs } from "pinia";
+
+const userStore = useUserStore();
+const { user } = storeToRefs(userStore);
+
+const selectedMode = ref<string>("default");
+
+const visibilityOptions = computed(() => [
+	{
+		value: "default",
+		label: trans("profile.shared_albums.mode_default"),
+		description: trans("profile.shared_albums.mode_default_desc"),
+	},
+	{
+		value: "show",
+		label: trans("profile.shared_albums.mode_show"),
+		description: trans("profile.shared_albums.mode_show_desc"),
+	},
+	{
+		value: "separate",
+		label: trans("profile.shared_albums.mode_separate"),
+		description: trans("profile.shared_albums.mode_separate_desc"),
+	},
+	{
+		value: "separate_shared_only",
+		label: trans("profile.shared_albums.mode_separate_shared_only"),
+		description: trans("profile.shared_albums.mode_separate_shared_only_desc"),
+	},
+	{
+		value: "hide",
+		label: trans("profile.shared_albums.mode_hide"),
+		description: trans("profile.shared_albums.mode_hide_desc"),
+	},
+]);
+const hasChanged = ref(false);
+const toast = useToast();
+
+function markChanged(): void {
+	hasChanged.value = true;
+}
+
+function reset(): void {
+	selectedMode.value = user.value?.shared_albums_visibility ?? "default";
+	hasChanged.value = false;
+}
+
+function save(): void {
+	if (!user.value) {
+		return;
+	}
+
+	ProfileService.updateSharedAlbumsVisibility(selectedMode.value as App.Enum.UserSharedAlbumsVisibility)
+		.then(() => {
+			toast.add({
+				severity: "success",
+				summary: trans("toasts.success"),
+				detail: trans("profile.preferences.change_saved"),
+				life: 3000,
+			});
+			hasChanged.value = false;
+			userStore.refresh();
+		})
+		.catch((error) => {
+			toast.add({
+				severity: "error",
+				summary: trans("toasts.error"),
+				detail: error.response?.data?.message || trans("toasts.error"),
+				life: 3000,
+			});
+		});
+}
+
+onMounted(() => {
+	if (user.value) {
+		selectedMode.value = user.value.shared_albums_visibility ?? "default";
+	}
+});
+</script>

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -62,6 +62,7 @@ declare namespace App.Enum {
 		| "license"
 		| "map_provider"
 		| "currency";
+	export type ConvertableImageType = "heic" | "heif";
 	export type CountType = "taken_at" | "created_at";
 	export type CoverFitType = "cover" | "fit";
 	export type DateOrderingType = "older_younger" | "younger_older";
@@ -133,6 +134,7 @@ declare namespace App.Enum {
 	export type PurchasableSizeVariantType = "medium" | "medium2x" | "original" | "full";
 	export type RenamerModeType = "first" | "all" | "regex" | "trim" | "strtolower" | "strtoupper" | "ucwords" | "ucfirst";
 	export type SeverityType = "emergency" | "alert" | "critical" | "error" | "warning" | "notice" | "info" | "debug";
+	export type SharedAlbumsVisibility = "show" | "separate" | "separate_shared_only" | "hide";
 	export type ShiftType = "relative" | "absolute";
 	export type ShiftX = "left" | "right";
 	export type ShiftY = "up" | "down";
@@ -145,6 +147,7 @@ declare namespace App.Enum {
 	export type TimelinePhotoGranularity = "default" | "disabled" | "year" | "month" | "day" | "hour";
 	export type UpdateStatus = 0 | 1 | 2 | 3;
 	export type UserGroupRole = "member" | "admin";
+	export type UserSharedAlbumsVisibility = "default" | "show" | "separate" | "separate_shared_only" | "hide";
 	export type VersionChannelType = "release" | "git" | "tag";
 	export type VisibilityType = "never" | "always" | "hover";
 	export type WatermarkPosition = "top-left" | "top" | "top-right" | "left" | "center" | "right" | "bottom-left" | "bottom" | "bottom-right";
@@ -485,6 +488,7 @@ declare namespace App.Http.Resources.GalleryConfigs {
 		header_image_url: string;
 		is_header_bar_transparent: boolean;
 		is_header_bar_gradient: boolean;
+		shared_albums_visibility_mode: App.Enum.SharedAlbumsVisibility;
 	};
 	export type SettingsConfig = {
 		default_old_settings: boolean;
@@ -815,6 +819,7 @@ declare namespace App.Http.Resources.Models {
 		has_token: boolean | null;
 		username: string | null;
 		email: string | null;
+		shared_albums_visibility: App.Enum.UserSharedAlbumsVisibility;
 	};
 	export type WebAuthnResource = {
 		id: string;

--- a/resources/js/services/profile-service.ts
+++ b/resources/js/services/profile-service.ts
@@ -2,12 +2,11 @@ import axios, { type AxiosResponse } from "axios";
 import Constants from "./constants";
 
 export type UpdateProfileRequest = {
-	old_password: string | null;
+	old_password: string;
 	username: string | null;
 	password: string | null;
 	password_confirmation: string | null;
 	email: string | null;
-	shared_albums_visibility?: App.Enum.UserSharedAlbumsVisibility;
 };
 
 const ProfileService = {

--- a/resources/js/services/profile-service.ts
+++ b/resources/js/services/profile-service.ts
@@ -2,16 +2,20 @@ import axios, { type AxiosResponse } from "axios";
 import Constants from "./constants";
 
 export type UpdateProfileRequest = {
-	old_password: string;
+	old_password: string | null;
 	username: string | null;
 	password: string | null;
 	password_confirmation: string | null;
 	email: string | null;
+	shared_albums_visibility?: App.Enum.UserSharedAlbumsVisibility;
 };
 
 const ProfileService = {
 	update(data: UpdateProfileRequest): Promise<AxiosResponse<App.Http.Resources.Models.UserResource>> {
 		return axios.post(`${Constants.getApiUrl()}Profile::update`, data);
+	},
+	updateSharedAlbumsVisibility(visibility: App.Enum.UserSharedAlbumsVisibility): Promise<AxiosResponse<App.Http.Resources.Models.UserResource>> {
+		return axios.post(`${Constants.getApiUrl()}Profile::updateSharedAlbumsVisibility`, { shared_albums_visibility: visibility });
 	},
 	resetToken(): Promise<AxiosResponse<App.Http.Resources.Models.Utils.UserToken>> {
 		return axios.post(`${Constants.getApiUrl()}Profile::resetToken`, {});

--- a/resources/js/stores/AlbumsState.ts
+++ b/resources/js/stores/AlbumsState.ts
@@ -9,6 +9,7 @@ import { useUserStore } from "./UserState";
 import { Router } from "vue-router";
 const { spliter } = useSplitter();
 
+export type { SplitData };
 export type AlbumsStore = ReturnType<typeof useAlbumsStore>;
 
 export const useAlbumsStore = defineStore("albums-store", {

--- a/resources/js/views/Profile.vue
+++ b/resources/js/views/Profile.vue
@@ -14,6 +14,7 @@
 		<SetLogin />
 		<SetOauth />
 		<SetSecondFactor v-if="is_webauthn_enabled" />
+		<SetSharedAlbumsVisibility />
 	</div>
 </template>
 <script setup lang="ts">
@@ -21,6 +22,7 @@ import Toolbar from "primevue/toolbar";
 import SetLogin from "@/components/forms/profile/SetLogin.vue";
 import SetSecondFactor from "@/components/forms/profile/SetSecondFactor.vue";
 import SetOauth from "@/components/forms/profile/SetOauth.vue";
+import SetSharedAlbumsVisibility from "@/components/forms/profile/SetSharedAlbumsVisibility.vue";
 import OpenLeftMenu from "@/components/headers/OpenLeftMenu.vue";
 import { useLycheeStateStore } from "@/stores/LycheeState";
 import { storeToRefs } from "pinia";

--- a/resources/js/views/gallery-panels/Albums.vue
+++ b/resources/js/views/gallery-panels/Albums.vue
@@ -354,7 +354,7 @@ onKeyStroke("k", () => !shouldIgnoreKeystroke() && !userStore.isLoggedIn && (is_
 const can_upload = computed(() => albumsStore.rootRights?.can_upload === true);
 
 // Shared albums visibility mode handling
-const sharedAlbumsVisibilityMode = computed(() => albumsStore.rootConfig?.shared_albums_visibility_mode ?? "separate");
+const sharedAlbumsVisibilityMode = computed(() => albumsStore.rootConfig?.shared_albums_visibility_mode ?? "show");
 
 // Active tab for tabbed view
 const activeTab = ref<string>("my-albums");

--- a/resources/js/views/gallery-panels/Albums.vue
+++ b/resources/js/views/gallery-panels/Albums.vue
@@ -17,6 +17,7 @@
 			<AlbumsHeader v-if="userStore.isLoaded" :title="title" @refresh="refresh" @help="is_keybindings_help_open = true" />
 		</Collapse>
 
+		<!-- Smart Albums (always visible, above tabs per spec) -->
 		<AlbumThumbPanel
 			v-if="albumsStore.smartAlbums.length > 0"
 			header="gallery.smart_albums"
@@ -27,45 +28,111 @@
 			:selected-albums="[]"
 			:is-timeline="false"
 		/>
-		<template v-if="albumsStore.pinnedAlbums.length > 0">
-			<AlbumThumbPanel
-				:is-timeline="false"
-				header="gallery.pinned_albums"
-				:album="null"
-				:albums="albumsStore.pinnedAlbums"
-				:is-alone="!albumsStore.sharedAlbums.length && !albumsStore.smartAlbums.length && !albumsStore.albums.length"
-				:idx-shift="0"
-				:selected-albums="selectedAlbumsIds"
-				@clicked="albumClick"
-				@contexted="albumMenuOpen"
-			/>
+
+		<!-- Tabbed view for SEPARATE and SEPARATE_SHARED_ONLY modes (only when shared albums exist) -->
+		<template v-if="shouldShowTabs">
+			<Tabs v-model:value="activeTab" class="w-full">
+				<TabList
+					class="mx-4 border-b border-surface-200 dark:border-surface-700"
+					:pt="{ tabList: { class: 'ltr:justify-end rtl:justify-start' }, activeBar: { class: 'hidden' } }"
+				>
+					<Tab value="my-albums" class="px-4 py-2" :class="{ 'border-b-2 border-primary-500': activeTab === 'my-albums' }">
+						{{ $t("gallery.tabs.my_albums") }}
+					</Tab>
+					<Tab value="shared" class="px-4 py-2" :class="{ 'border-b-2 border-primary-500': activeTab === 'shared' }">
+						{{ $t("gallery.tabs.shared_with_me") }}
+					</Tab>
+				</TabList>
+				<TabPanels class="p-0 pt-2">
+					<TabPanel value="my-albums">
+						<template v-if="albumsStore.pinnedAlbums.length > 0">
+							<AlbumThumbPanel
+								:is-timeline="false"
+								header="gallery.pinned_albums"
+								:album="null"
+								:albums="albumsStore.pinnedAlbums"
+								:is-alone="!displayAlbums.length"
+								:idx-shift="0"
+								:selected-albums="selectedAlbumsIds"
+								@clicked="albumClick"
+								@contexted="albumMenuOpen"
+							/>
+						</template>
+						<template v-if="displayAlbums.length > 0">
+							<AlbumThumbPanel
+								:is-timeline="albumsStore.rootConfig.is_album_timeline_enabled"
+								header="gallery.albums"
+								:album="null"
+								:albums="displayAlbums"
+								:is-alone="!albumsStore.pinnedAlbums.length"
+								:idx-shift="albumsStore.pinnedAlbums.length"
+								:selected-albums="selectedAlbumsIds"
+								@clicked="albumClick"
+								@contexted="albumMenuOpen"
+							/>
+						</template>
+					</TabPanel>
+					<TabPanel value="shared">
+						<template v-for="sharedAlbum in displaySharedAlbums" :key="sharedAlbum.header">
+							<AlbumThumbPanel
+								:header="sharedAlbum.header"
+								:album="undefined"
+								:albums="sharedAlbum.data"
+								:is-alone="displaySharedAlbums.length === 1"
+								:idx-shift="sharedAlbum.iter"
+								:selected-albums="selectedAlbumsIds"
+								:is-timeline="false"
+								@clicked="albumClick"
+								@contexted="albumMenuOpen"
+							/>
+						</template>
+					</TabPanel>
+				</TabPanels>
+			</Tabs>
 		</template>
-		<template v-if="albumsStore.albums.length > 0">
-			<AlbumThumbPanel
-				:is-timeline="albumsStore.rootConfig.is_album_timeline_enabled"
-				header="gallery.albums"
-				:album="null"
-				:albums="albumsStore.albums"
-				:is-alone="!albumsStore.sharedAlbums.length && !albumsStore.smartAlbums.length && !albumsStore.pinnedAlbums.length"
-				:idx-shift="albumsStore.pinnedAlbums.length"
-				:selected-albums="selectedAlbumsIds"
-				@clicked="albumClick"
-				@contexted="albumMenuOpen"
-			/>
-		</template>
-		<template v-for="sharedAlbum in albumsStore.sharedAlbums" :key="sharedAlbum.header">
-			<AlbumThumbPanel
-				v-if="albumsStore.sharedAlbums.length > 0"
-				:header="sharedAlbum.header"
-				:album="undefined"
-				:albums="sharedAlbum.data"
-				:is-alone="!albumsStore.albums.length"
-				:idx-shift="sharedAlbum.iter"
-				:selected-albums="selectedAlbumsIds"
-				:is-timeline="false"
-				@clicked="albumClick"
-				@contexted="albumMenuOpen"
-			/>
+
+		<!-- Non-tabbed view for SHOW and HIDE modes (or when no shared albums) -->
+		<template v-else>
+			<template v-if="albumsStore.pinnedAlbums.length > 0">
+				<AlbumThumbPanel
+					:is-timeline="false"
+					header="gallery.pinned_albums"
+					:album="null"
+					:albums="albumsStore.pinnedAlbums"
+					:is-alone="!shouldShowSharedAlbums && !albumsStore.smartAlbums.length && !displayAlbums.length"
+					:idx-shift="0"
+					:selected-albums="selectedAlbumsIds"
+					@clicked="albumClick"
+					@contexted="albumMenuOpen"
+				/>
+			</template>
+			<template v-if="displayAlbums.length > 0">
+				<AlbumThumbPanel
+					:is-timeline="albumsStore.rootConfig.is_album_timeline_enabled"
+					header="gallery.albums"
+					:album="null"
+					:albums="displayAlbums"
+					:is-alone="!shouldShowSharedAlbums && !albumsStore.smartAlbums.length && !albumsStore.pinnedAlbums.length"
+					:idx-shift="albumsStore.pinnedAlbums.length"
+					:selected-albums="selectedAlbumsIds"
+					@clicked="albumClick"
+					@contexted="albumMenuOpen"
+				/>
+			</template>
+			<template v-for="sharedAlbum in displaySharedAlbums" :key="sharedAlbum.header">
+				<AlbumThumbPanel
+					v-if="shouldShowSharedAlbums"
+					:header="sharedAlbum.header"
+					:album="undefined"
+					:albums="sharedAlbum.data"
+					:is-alone="!displayAlbums.length"
+					:idx-shift="sharedAlbum.iter"
+					:selected-albums="selectedAlbumsIds"
+					:is-timeline="false"
+					@clicked="albumClick"
+					@contexted="albumMenuOpen"
+				/>
+			</template>
 		</template>
 		<GalleryFooter v-once />
 		<ScrollTop target="parent" />
@@ -174,6 +241,11 @@ import { useAlbumStore } from "@/stores/AlbumState";
 import { usePhotoStore } from "@/stores/PhotoState";
 import { usePhotosStore } from "@/stores/PhotosState";
 import { useOrderManagementStore } from "@/stores/OrderManagement";
+import Tabs from "primevue/tabs";
+import TabList from "primevue/tablist";
+import Tab from "primevue/tab";
+import TabPanels from "primevue/tabpanels";
+import TabPanel from "primevue/tabpanel";
 
 const userStore = useUserStore();
 const lycheeStore = useLycheeStateStore();
@@ -280,6 +352,49 @@ onKeyStroke("l", () => !shouldIgnoreKeystroke() && !userStore.isLoggedIn && (is_
 onKeyStroke("k", () => !shouldIgnoreKeystroke() && !userStore.isLoggedIn && (is_webauthn_open.value = true));
 
 const can_upload = computed(() => albumsStore.rootRights?.can_upload === true);
+
+// Shared albums visibility mode handling
+const sharedAlbumsVisibilityMode = computed(() => albumsStore.rootConfig?.shared_albums_visibility_mode ?? "separate");
+
+// Active tab for tabbed view
+const activeTab = ref<string>("my-albums");
+
+// Always display owned albums (no merging)
+const displayAlbums = computed(() => {
+	return albumsStore.albums;
+});
+
+// Determine which shared albums to display based on visibility mode
+const displaySharedAlbums = computed(() => {
+	if (sharedAlbumsVisibilityMode.value === "hide") {
+		// HIDE: don't show shared albums at all
+		return [];
+	}
+	if (sharedAlbumsVisibilityMode.value === "separate_shared_only") {
+		// Filter to only show directly shared albums (not public albums owned by others)
+		// An album is "directly shared" if it's not public (is_public === false)
+		return albumsStore.sharedAlbums
+			.map((group) => ({
+				...group,
+				data: group.data.filter((album) => !album.is_public),
+			}))
+			.filter((group) => group.data.length > 0);
+	}
+	// SHOW and SEPARATE: show all shared albums grouped by owner
+	return albumsStore.sharedAlbums;
+});
+
+// Check if we should show shared albums section (for inline mode)
+const shouldShowSharedAlbums = computed(() => {
+	return displaySharedAlbums.value.length > 0;
+});
+
+// Check if we should show tabs (SEPARATE or SEPARATE_SHARED_ONLY mode with shared albums)
+const shouldShowTabs = computed(() => {
+	const mode = sharedAlbumsVisibilityMode.value;
+	const isSeparateMode = mode === "separate" || mode === "separate_shared_only";
+	return isSeparateMode && displaySharedAlbums.value.length > 0;
+});
 
 const { onPaste, dragEnd, dropUpload } = useMouseEvents(can_upload, is_upload_visible, list_upload_files);
 

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -171,6 +171,7 @@ Route::get('/Auth::config', [AuthController::class, 'getConfig']);
  * USER.
  */
 Route::post('/Profile::update', [ProfileController::class, 'update']);
+Route::post('/Profile::updateSharedAlbumsVisibility', [ProfileController::class, 'updateSharedAlbumsVisibility']);
 Route::post('/Profile::resetToken', [ProfileController::class, 'resetToken']);
 Route::post('/Profile::unsetToken', [ProfileController::class, 'unsetToken']);
 Route::put('/Profile', [ProfileController::class, 'register'])->name('register-api');

--- a/scripts/check_translations.php
+++ b/scripts/check_translations.php
@@ -1,0 +1,112 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+/**
+ * Translation Key Validation Script
+ * Checks that all translation keys exist across all language files.
+ */
+function getKeys(array $array, string $prefix = ''): array
+{
+	$keys = [];
+	foreach ($array as $key => $value) {
+		$full_key = $prefix !== '' ? $prefix . '.' . $key : $key;
+		if (is_array($value)) {
+			$keys = array_merge($keys, getKeys($value, $full_key));
+		} else {
+			$keys[] = $full_key;
+		}
+	}
+
+	return $keys;
+}
+
+function checkFile(string $filename, array $languages, string $lang_dir): array
+{
+	$en_file = $lang_dir . '/en/' . $filename;
+	if (!file_exists($en_file)) {
+		return ["Error: English file not found: $en_file"];
+	}
+
+	$en_keys = getKeys(require $en_file);
+	sort($en_keys);
+
+	$report = [];
+	$report[] = "\n" . str_repeat('=', 80);
+	$report[] = "Checking: $filename";
+	$report[] = str_repeat('=', 80);
+	$report[] = 'Total keys in English: ' . count($en_keys);
+
+	$all_missing = [];
+
+	foreach ($languages as $lang) {
+		if ($lang === 'en') {
+			continue;
+		}
+
+		$lang_file = $lang_dir . '/' . $lang . '/' . $filename;
+		if (!file_exists($lang_file)) {
+			$report[] = "\n[$lang] ❌ FILE MISSING: $lang_file";
+			$all_missing[$lang] = $en_keys;
+			continue;
+		}
+
+		$lang_keys = getKeys(require $lang_file);
+		$missing = array_diff($en_keys, $lang_keys);
+		$extra = array_diff($lang_keys, $en_keys);
+
+		if (count($missing) > 0 || count($extra) > 0) {
+			$report[] = "\n[$lang] Issues found:";
+			if (count($missing) > 0) {
+				$report[] = '  ❌ Missing ' . count($missing) . ' keys:';
+				foreach ($missing as $key) {
+					$report[] = "     - $key";
+				}
+				$all_missing[$lang] = $missing;
+			}
+			if (count($extra) > 0) {
+				$report[] = '  ⚠️  Extra ' . count($extra) . ' keys (not in English):';
+				foreach ($extra as $key) {
+					$report[] = "     + $key";
+				}
+			}
+		} else {
+			$report[] = "[$lang] ✅ All keys present (" . count($lang_keys) . ' keys)';
+		}
+	}
+
+	if (count($all_missing) === 0) {
+		$report[] = "\n🎉 All languages complete for $filename!";
+	} else {
+		$report[] = "\n⚠️  " . count($all_missing) . ' languages have missing keys';
+	}
+
+	return $report;
+}
+
+// Main execution
+$lang_dir = __DIR__ . '/../lang';
+$languages = ['ar', 'cz', 'de', 'el', 'en', 'es', 'fa', 'fr', 'hu', 'it', 'ja', 'nl', 'no', 'pl', 'pt', 'ru', 'sk', 'sv', 'vi', 'zh_CN', 'zh_TW'];
+
+$files_to_check = ['gallery.php', 'profile.php'];
+
+echo "Translation Validation Report\n";
+echo 'Generated: ' . date('Y-m-d H:i:s') . "\n";
+echo 'Languages checked: ' . implode(', ', array_filter($languages, fn ($l) => $l !== 'en')) . "\n";
+
+$all_reports = [];
+foreach ($files_to_check as $file) {
+	$all_reports = array_merge($all_reports, checkFile($file, $languages, $lang_dir));
+}
+
+foreach ($all_reports as $line) {
+	echo $line . "\n";
+}
+
+echo "\n" . str_repeat('=', 80) . "\n";
+echo "Validation complete\n";

--- a/tests/Feature_v2/Album/SharedAlbumsVisibilityTest.php
+++ b/tests/Feature_v2/Album/SharedAlbumsVisibilityTest.php
@@ -31,7 +31,7 @@ class SharedAlbumsVisibilityTest extends BaseApiWithDataTest
 		$this->assertOk($response);
 
 		// Guest should not have shared_albums_visibility_mode set
-		$this->assertNull($response->json('config.shared_albums_visibility_mode'));
+		$this->assertEquals('show', $response->json('config.shared_albums_visibility_mode'));
 	}
 
 	public function testUserReceivesDefaultSharedAlbumsVisibilityMode(): void

--- a/tests/Feature_v2/Album/SharedAlbumsVisibilityTest.php
+++ b/tests/Feature_v2/Album/SharedAlbumsVisibilityTest.php
@@ -30,7 +30,7 @@ class SharedAlbumsVisibilityTest extends BaseApiWithDataTest
 		$response = $this->getJson('Albums');
 		$this->assertOk($response);
 
-		// Guest should not have shared_albums_visibility_mode set
+		// Guest should have 'show' as default behavior (preserve current behavior)
 		$this->assertEquals('show', $response->json('config.shared_albums_visibility_mode'));
 	}
 

--- a/tests/Feature_v2/Album/SharedAlbumsVisibilityTest.php
+++ b/tests/Feature_v2/Album/SharedAlbumsVisibilityTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\Album;
+
+use App\Enum\SharedAlbumsVisibility;
+use App\Enum\UserSharedAlbumsVisibility;
+use App\Models\Configs;
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+
+class SharedAlbumsVisibilityTest extends BaseApiWithDataTest
+{
+	public function testGuestDoesNotReceiveSharedAlbumsVisibilityMode(): void
+	{
+		$response = $this->getJson('Albums');
+		$this->assertOk($response);
+
+		// Guest should not have shared_albums_visibility_mode set
+		$this->assertNull($response->json('config.shared_albums_visibility_mode'));
+	}
+
+	public function testUserReceivesDefaultSharedAlbumsVisibilityMode(): void
+	{
+		// Set server default to 'show'
+		Configs::set('shared_albums_visibility_default', 'show');
+
+		// Refresh user to ensure all attributes are loaded (including shared_albums_visibility)
+		$this->userMayUpload1->refresh();
+
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Albums');
+		$this->assertOk($response);
+
+		// User with DEFAULT preference should receive server default
+		$this->assertEquals('show', $response->json('config.shared_albums_visibility_mode'));
+	}
+
+	public function testUserReceivesServerDefaultWhenPreferenceIsDefault(): void
+	{
+		// Set server default to 'separate'
+		Configs::set('shared_albums_visibility_default', 'separate');
+
+		// Refresh user to ensure all attributes are loaded (including shared_albums_visibility)
+		$this->userMayUpload1->refresh();
+
+		// User preference is DEFAULT by default (from migration)
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Albums');
+		$this->assertOk($response);
+
+		$this->assertEquals('separate', $response->json('config.shared_albums_visibility_mode'));
+	}
+
+	public function testUserReceivesOwnPreferenceWhenSet(): void
+	{
+		// Set server default to 'show'
+		Configs::set('shared_albums_visibility_default', 'show');
+
+		// Set user preference to 'hide'
+		$this->userMayUpload1->shared_albums_visibility = UserSharedAlbumsVisibility::HIDE;
+		$this->userMayUpload1->save();
+
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Albums');
+		$this->assertOk($response);
+
+		// User should receive their own preference, not server default
+		$this->assertEquals('hide', $response->json('config.shared_albums_visibility_mode'));
+	}
+
+	public function testAllSharedAlbumsVisibilityModes(): void
+	{
+		// Refresh user to ensure all attributes are loaded (including shared_albums_visibility)
+		$this->userMayUpload1->refresh();
+
+		$modes = [
+			SharedAlbumsVisibility::SHOW,
+			SharedAlbumsVisibility::SEPARATE,
+			SharedAlbumsVisibility::SEPARATE_SHARED_ONLY,
+			SharedAlbumsVisibility::HIDE,
+		];
+
+		foreach ($modes as $mode) {
+			Configs::set('shared_albums_visibility_default', $mode->value);
+
+			$response = $this->actingAs($this->userMayUpload1)->getJson('Albums');
+			$this->assertOk($response);
+
+			$this->assertEquals($mode->value, $response->json('config.shared_albums_visibility_mode'));
+		}
+	}
+
+	public function testUpdateSharedAlbumsVisibilityPreference(): void
+	{
+		// Update user preference via profile endpoint
+		$response = $this->actingAs($this->userMayUpload1)->postJson('Profile::updateSharedAlbumsVisibility', [
+			'shared_albums_visibility' => 'separate',
+		]);
+		$this->assertCreated($response);
+
+		// Reload user and verify preference was saved
+		$this->userMayUpload1->refresh();
+		$this->assertEquals(UserSharedAlbumsVisibility::SEPARATE, $this->userMayUpload1->shared_albums_visibility);
+
+		// Verify the mode is returned correctly in Albums response
+		Configs::set('shared_albums_visibility_default', 'show');
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Albums');
+		$this->assertOk($response);
+		$this->assertEquals('separate', $response->json('config.shared_albums_visibility_mode'));
+	}
+
+	public function testUpdateSharedAlbumsVisibilityToDefault(): void
+	{
+		// First set a non-default preference
+		$this->userMayUpload1->shared_albums_visibility = UserSharedAlbumsVisibility::HIDE;
+		$this->userMayUpload1->save();
+
+		// Update user preference back to default
+		$response = $this->actingAs($this->userMayUpload1)->postJson('Profile::updateSharedAlbumsVisibility', [
+			'shared_albums_visibility' => 'default',
+		]);
+		$this->assertCreated($response);
+
+		// Reload user and verify preference was saved
+		$this->userMayUpload1->refresh();
+		$this->assertEquals(UserSharedAlbumsVisibility::DEFAULT, $this->userMayUpload1->shared_albums_visibility);
+
+		// Verify server default is now used
+		Configs::set('shared_albums_visibility_default', 'show');
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Albums');
+		$this->assertOk($response);
+		$this->assertEquals('show', $response->json('config.shared_albums_visibility_mode'));
+	}
+
+	public function testInvalidSharedAlbumsVisibilityRejected(): void
+	{
+		$response = $this->actingAs($this->userMayUpload1)->postJson('Profile::updateSharedAlbumsVisibility', [
+			'shared_albums_visibility' => 'invalid_value',
+		]);
+		$this->assertUnprocessable($response);
+	}
+
+	public function testLockedUserCannotUpdateSharedAlbumsVisibility(): void
+	{
+		$response = $this->actingAs($this->userLocked)->postJson('Profile::updateSharedAlbumsVisibility', [
+			'shared_albums_visibility' => 'hide',
+		]);
+		$this->assertForbidden($response);
+	}
+
+	public function testUpdateSharedAlbumsVisibilityRequiresAuthentication(): void
+	{
+		$response = $this->postJson('Profile::updateSharedAlbumsVisibility', [
+			'shared_albums_visibility' => 'hide',
+		]);
+		$this->assertUnauthorized($response);
+	}
+
+	public function testUpdateSharedAlbumsVisibilityRequiresField(): void
+	{
+		$response = $this->actingAs($this->userMayUpload1)->postJson('Profile::updateSharedAlbumsVisibility', []);
+		$this->assertUnprocessable($response);
+	}
+
+	public function testUpdateSharedAlbumsVisibilityAllModes(): void
+	{
+		$modes = [
+			UserSharedAlbumsVisibility::DEFAULT,
+			UserSharedAlbumsVisibility::SHOW,
+			UserSharedAlbumsVisibility::SEPARATE,
+			UserSharedAlbumsVisibility::SEPARATE_SHARED_ONLY,
+			UserSharedAlbumsVisibility::HIDE,
+		];
+
+		foreach ($modes as $mode) {
+			$response = $this->actingAs($this->userMayUpload1)->postJson('Profile::updateSharedAlbumsVisibility', [
+				'shared_albums_visibility' => $mode->value,
+			]);
+			$this->assertCreated($response);
+
+			$this->userMayUpload1->refresh();
+			$this->assertEquals($mode, $this->userMayUpload1->shared_albums_visibility);
+		}
+	}
+}


### PR DESCRIPTION

<img width="1673" height="1433" alt="image" src="https://github.com/user-attachments/assets/a89a5253-7f4e-46d9-b1d6-ac622636d874" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared Albums Visibility: server default + per-user preference, profile UI to choose mode, gallery now supports inline or tabbed views and updates via a new API.

* **Documentation**
  * Added full spec, plan, tasks and resolved open questions for the feature.

* **Localization**
  * Added gallery/profile translations across many locales for tabs and preference texts.

* **Tests**
  * Comprehensive backend tests covering modes, defaults, updates and access control.

* **Tools**
  * Translation validation script and DB migration/config for the new setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->