### PR TITLE
Refactoring tests to not use api/v2/album directly

### DIFF
--- a/tests/Feature_v2/Album/AlbumCreateTest.php
+++ b/tests/Feature_v2/Album/AlbumCreateTest.php
@@ -51,7 +51,7 @@ class AlbumCreateTest extends BaseApiWithDataTest
 		$new_album_id = $response->getOriginalContent();
 		$this->assertEquals(1, Statistics::where('album_id', $new_album_id)->count());
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::albums', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertSee($new_album_id);
 	}
@@ -65,7 +65,7 @@ class AlbumCreateTest extends BaseApiWithDataTest
 		self::assertEquals(200, $response->getStatusCode());
 		$new_album_id = $response->getOriginalContent();
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::albums', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertSee($new_album_id);
 		$this->assertEquals(1, Statistics::where('album_id', $new_album_id)->count());

--- a/tests/Feature_v2/Album/AlbumDeleteTest.php
+++ b/tests/Feature_v2/Album/AlbumDeleteTest.php
@@ -45,7 +45,7 @@ class AlbumDeleteTest extends BaseApiWithDataTest
 			'album_ids' => [$this->subAlbum1->id],
 		]);
 		$this->assertNoContent($response);
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::albums', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertDontSee($this->subAlbum1->id);
 	}

--- a/tests/Feature_v2/Album/AlbumMergeTest.php
+++ b/tests/Feature_v2/Album/AlbumMergeTest.php
@@ -52,7 +52,7 @@ class AlbumMergeTest extends BaseApiWithDataTest
 		$response->assertSee($this->album1->id);
 		$response->assertDontSee($this->album2->id);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::albums', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertSee($this->subAlbum1->id);
 		$response->assertSee($this->subAlbum2->id);

--- a/tests/Feature_v2/Album/AlbumRenameTest.php
+++ b/tests/Feature_v2/Album/AlbumRenameTest.php
@@ -47,7 +47,7 @@ class AlbumRenameTest extends BaseApiWithDataTest
 			'title' => 'new title',
 		]);
 		$this->assertNoContent($response);
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
 			'config' => [],

--- a/tests/Feature_v2/Album/AlbumSetCoverTest.php
+++ b/tests/Feature_v2/Album/AlbumSetCoverTest.php
@@ -52,7 +52,7 @@ class AlbumSetCoverTest extends BaseApiWithDataTest
 		]);
 		$this->assertNoContent($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
 			'config' => [
@@ -75,7 +75,7 @@ class AlbumSetCoverTest extends BaseApiWithDataTest
 		]);
 		$this->assertNoContent($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
 			'config' => [

--- a/tests/Feature_v2/Album/AlbumSetHeaderTest.php
+++ b/tests/Feature_v2/Album/AlbumSetHeaderTest.php
@@ -56,7 +56,7 @@ class AlbumSetHeaderTest extends BaseApiWithDataTest
 		]);
 		$this->assertNoContent($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
 			'config' => [
@@ -80,7 +80,7 @@ class AlbumSetHeaderTest extends BaseApiWithDataTest
 		]);
 		$this->assertNoContent($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
 			'config' => [
@@ -107,7 +107,7 @@ class AlbumSetHeaderTest extends BaseApiWithDataTest
 		]);
 		$this->assertNoContent($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
 			'config' => [
@@ -131,7 +131,7 @@ class AlbumSetHeaderTest extends BaseApiWithDataTest
 		]);
 		$this->assertNoContent($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
 			'config' => [

--- a/tests/Feature_v2/Album/AlbumSetPinnedTest.php
+++ b/tests/Feature_v2/Album/AlbumSetPinnedTest.php
@@ -50,7 +50,7 @@ class AlbumSetPinnedTest extends BaseApiWithDataTest
 		$this->assertNoContent($response);
 
 		// Verify the album is pinned
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
 			'config' => [],
@@ -68,7 +68,7 @@ class AlbumSetPinnedTest extends BaseApiWithDataTest
 		$this->assertNoContent($response);
 
 		// Verify the album is unpinned
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
 			'config' => [],
@@ -89,7 +89,7 @@ class AlbumSetPinnedTest extends BaseApiWithDataTest
 		$this->assertNoContent($response);
 
 		// Verify the album is pinned
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
 			'config' => [],

--- a/tests/Feature_v2/Album/AlbumTransferTest.php
+++ b/tests/Feature_v2/Album/AlbumTransferTest.php
@@ -50,7 +50,7 @@ class AlbumTransferTest extends BaseApiWithDataTest
 		$response = $this->actingAs($this->userLocked)->getJson('Albums');
 		$this->assertOk($response);
 		$response->assertSee($this->album1->id);
-		$response = $this->actingAs($this->userLocked)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userLocked)->getJsonWithData('Album::head', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 	}
 }

--- a/tests/Feature_v2/Album/AlbumUpdateTest.php
+++ b/tests/Feature_v2/Album/AlbumUpdateTest.php
@@ -138,7 +138,8 @@ class AlbumUpdateTest extends BaseApiWithDataTest
 		]);
 		$this->assertOk($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->tagAlbum1->id]);
+		// Verify album head metadata
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::head', ['album_id' => $this->tagAlbum1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
 			'config' => [
@@ -151,10 +152,13 @@ class AlbumUpdateTest extends BaseApiWithDataTest
 				'id' => $this->tagAlbum1->id,
 				'title' => 'title', // from modified above.
 				'show_tags' => ['tag1', 'tag2'],
-				'photos' => [],
 			],
 		]);
-		self::assertCount(0, $response->json('resource.photos'));
+
+		// Verify photos are empty (tags changed, so photo1 no longer matches)
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->tagAlbum1->id]);
+		$this->assertOk($response);
+		self::assertCount(0, $response->json('photos'));
 	}
 
 	public function testUpdateAlbumIsPinned(): void

--- a/tests/Feature_v2/Metrics/EventsFiredTest.php
+++ b/tests/Feature_v2/Metrics/EventsFiredTest.php
@@ -41,7 +41,7 @@ class EventsFiredTest extends BaseApiWithDataTest
 
 	public function testVisitSharedAlbum(): void
 	{
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album4->id]);
 		$this->assertOk($response);
 		$this->assertEquals(1, Statistics::where('album_id', $this->album4->id)->firstOrFail()->visit_count);
 
@@ -69,7 +69,7 @@ class EventsFiredTest extends BaseApiWithDataTest
 	public function testLoggedInUser(): void
 	{
 		$this->actingAs($this->userMayUpload1);
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$this->assertEquals(1, Statistics::where('album_id', $this->album1->id)->firstOrFail()->visit_count);
 
@@ -81,7 +81,7 @@ class EventsFiredTest extends BaseApiWithDataTest
 	public function testAdminuser(): void
 	{
 		$this->actingAs($this->admin);
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$this->assertEquals(0, Statistics::where('album_id', $this->album1->id)->firstOrFail()->visit_count);
 

--- a/tests/Feature_v2/Metrics/MetricsGetTest.php
+++ b/tests/Feature_v2/Metrics/MetricsGetTest.php
@@ -69,7 +69,7 @@ class MetricsGetTest extends BaseApiWithDataTest
 		Configs::set('live_metrics_enabled', true);
 		Configs::set('live_metrics_access', LiveMetricsAccess::LOGGEDIN);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->album4->id]);
 		$this->assertOk($response); // 1: - viewed album4
 		$response = $this->get('gallery/' . $this->album4->id);
 		$this->assertOk($response); // 2: - shared album4
@@ -81,12 +81,12 @@ class MetricsGetTest extends BaseApiWithDataTest
 		$this->assertOk($response); // 5: shared photo4
 
 		$this->assertEquals(5, LiveMetrics::count());
-		$response = $this->actingAs($this->userLocked)->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$response = $this->actingAs($this->userLocked)->getJsonWithData('Album::head', ['album_id' => $this->album4->id]);
 		$this->assertEquals(5, LiveMetrics::count()); // Still 5: We do not count the logged in users yet.
 		Configs::set('metrics_logged_in_users_enabed', true);
-		$response = $this->actingAs($this->userLocked)->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$response = $this->actingAs($this->userLocked)->getJsonWithData('Album::head', ['album_id' => $this->album4->id]);
 		$this->assertEquals(6, LiveMetrics::count()); // 6: We do count the logged in users now.
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::head', ['album_id' => $this->album4->id]);
 		$this->assertEquals(6, LiveMetrics::count()); // Still 6: We do not count the admin user though.
 
 		// Now we check/fetch the metrics data.

--- a/tests/Feature_v2/SecureImageLinksTest.php
+++ b/tests/Feature_v2/SecureImageLinksTest.php
@@ -44,9 +44,9 @@ class SecureImageLinksTest extends BaseApiWithDataTest
 	public function testSignedImage(): void
 	{
 		$this->setTemporaryLink();
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album4->id]);
 		$this->assertOk($response);
-		$url = $response->json('resource.photos.0.size_variants.medium.url');
+		$url = $response->json('photos.0.size_variants.medium.url');
 		$this->assertStringContainsString('/image/medium/', $url);
 
 		$response = $this->get($url);
@@ -66,9 +66,9 @@ class SecureImageLinksTest extends BaseApiWithDataTest
 	public function testBrokenSignature(): void
 	{
 		$this->setTemporaryLink();
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album4->id]);
 		$this->assertOk($response);
-		$url = $response->json('resource.photos.0.size_variants.medium.url');
+		$url = $response->json('photos.0.size_variants.medium.url');
 		$this->assertStringContainsString('/image/medium/', $url);
 
 		$unsigned_url = explode('?', $url)[0];
@@ -79,9 +79,9 @@ class SecureImageLinksTest extends BaseApiWithDataTest
 	public function testBrokenSignature2(): void
 	{
 		$this->setTemporaryLink();
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album4->id]);
 		$this->assertOk($response);
-		$url = $response->json('resource.photos.0.size_variants.medium.url');
+		$url = $response->json('photos.0.size_variants.medium.url');
 		$this->assertStringContainsString('/image/medium/', $url);
 
 		$unsigned_url = explode('?', $url)[0];
@@ -93,9 +93,9 @@ class SecureImageLinksTest extends BaseApiWithDataTest
 	{
 		$this->setSecureLink();
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album4->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album4->id]);
 		$this->assertOk($response);
-		$url = $response->json('resource.photos.0.size_variants.medium.url');
+		$url = $response->json('photos.0.size_variants.medium.url');
 		$this->assertStringContainsString('/image/', $url);
 
 		$response = $this->get($url);

--- a/tests/Feature_v2/SmartAlbums/BestPicturesAlbumTest.php
+++ b/tests/Feature_v2/SmartAlbums/BestPicturesAlbumTest.php
@@ -49,10 +49,10 @@ class BestPicturesAlbumTest extends BaseApiWithDataTest
 		]);
 
 		// Get best_pictures smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'best_pictures']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'best_pictures']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Should contain top 2 rated photos
 		$this->assertContains($this->photo1->id, $photoIds, 'Photo1 (5★) should be in BestPicturesAlbum');
@@ -84,10 +84,10 @@ class BestPicturesAlbumTest extends BaseApiWithDataTest
 		]);
 
 		// Get best_pictures smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'best_pictures']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'best_pictures']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Should contain both top-rated photos (even if > N)
 		$this->assertContains($this->photo1->id, $photoIds, 'Photo1 (5★) should be in BestPicturesAlbum');

--- a/tests/Feature_v2/SmartAlbums/RatingBucketAlbumsTest.php
+++ b/tests/Feature_v2/SmartAlbums/RatingBucketAlbumsTest.php
@@ -61,10 +61,10 @@ class RatingBucketAlbumsTest extends BaseApiWithDataTest
 		// Don't rate photo3 at all
 
 		// Get one_star smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'one_star']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'one_star']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Verify photo1 (1.5 average) is present
 		$this->assertContains($this->photo1->id, $photoIds, 'Photo with 1.5 rating should be in OneStarAlbum');
@@ -97,10 +97,10 @@ class RatingBucketAlbumsTest extends BaseApiWithDataTest
 		$this->assertEquals('2.0000', $this->photo1->rating_avg);
 
 		// Get one_star smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'one_star']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'one_star']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Photo with exactly 2.0 should NOT be in 1★ album
 		$this->assertNotContains($this->photo1->id, $photoIds, 'Photo with exactly 2.0 rating should NOT be in OneStarAlbum (boundary excluded)');
@@ -123,10 +123,10 @@ class RatingBucketAlbumsTest extends BaseApiWithDataTest
 		$this->assertEquals('1.0000', $this->photo1->rating_avg);
 
 		// Get one_star smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'one_star']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'one_star']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Photo with exactly 1.0 should be in 1★ album
 		$this->assertContains($this->photo1->id, $photoIds, 'Photo with exactly 1.0 rating should be in OneStarAlbum (boundary included)');
@@ -170,10 +170,10 @@ class RatingBucketAlbumsTest extends BaseApiWithDataTest
 		]);
 
 		// Get two_stars smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'two_stars']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'two_stars']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Verify photo1 (2.5 average) is present
 		$this->assertContains($this->photo1->id, $photoIds, 'Photo with 2.5 rating should be in TwoStarsAlbum');
@@ -202,10 +202,10 @@ class RatingBucketAlbumsTest extends BaseApiWithDataTest
 		$this->assertEquals('2.0000', $this->photo1->rating_avg);
 
 		// Get two_stars smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'two_stars']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'two_stars']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Photo with exactly 2.0 should be in 2★ album
 		$this->assertContains($this->photo1->id, $photoIds, 'Photo with exactly 2.0 rating should be in TwoStarsAlbum (boundary included)');
@@ -228,10 +228,10 @@ class RatingBucketAlbumsTest extends BaseApiWithDataTest
 		$this->assertEquals('3.0000', $this->photo1->rating_avg);
 
 		// Get two_stars smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'two_stars']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'two_stars']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Photo with exactly 3.0 should NOT be in 2★ album
 		$this->assertNotContains($this->photo1->id, $photoIds, 'Photo with exactly 3.0 rating should NOT be in TwoStarsAlbum (boundary excluded)');

--- a/tests/Feature_v2/SmartAlbums/RatingSmartAlbumSortTest.php
+++ b/tests/Feature_v2/SmartAlbums/RatingSmartAlbumSortTest.php
@@ -58,10 +58,10 @@ class RatingSmartAlbumSortTest extends BaseApiWithDataTest
 		]);
 
 		// Get one_star smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'one_star']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'one_star']);
 		$this->assertOk($response);
 
-		$photos = $response->json('resource.photos');
+		$photos = $response->json('photos');
 		$ratings = collect($photos)->pluck('rating.rating_avg')->map('floatval')->all();
 
 		// Should have 2 photos in 1-star range (both with rating 1.0)

--- a/tests/Feature_v2/SmartAlbums/RatingThresholdAlbumsTest.php
+++ b/tests/Feature_v2/SmartAlbums/RatingThresholdAlbumsTest.php
@@ -73,10 +73,10 @@ class RatingThresholdAlbumsTest extends BaseApiWithDataTest
 		]);
 
 		// Get three_stars smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'three_stars']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'three_stars']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Verify photo1 (3.5 average) is present
 		$this->assertContains($this->photo1->id, $photoIds, 'Photo with 3.5 rating should be in ThreeStarsAlbum');
@@ -108,10 +108,10 @@ class RatingThresholdAlbumsTest extends BaseApiWithDataTest
 		$this->assertEquals('3.0000', $this->photo1->rating_avg);
 
 		// Get three_stars smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'three_stars']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'three_stars']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Photo with exactly 3.0 should be in 3★+ album
 		$this->assertContains($this->photo1->id, $photoIds, 'Photo with exactly 3.0 rating should be in ThreeStarsAlbum (boundary included)');
@@ -151,10 +151,10 @@ class RatingThresholdAlbumsTest extends BaseApiWithDataTest
 		]);
 
 		// Get four_stars smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'four_stars']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'four_stars']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Verify photo1 (4.5 average) is present
 		$this->assertContains($this->photo1->id, $photoIds, 'Photo with 4.5 rating should be in FourStarsAlbum');
@@ -183,10 +183,10 @@ class RatingThresholdAlbumsTest extends BaseApiWithDataTest
 		$this->assertEquals('4.0000', $this->photo1->rating_avg);
 
 		// Get four_stars smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'four_stars']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'four_stars']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Photo with exactly 4.0 should be in 4★+ album
 		$this->assertContains($this->photo1->id, $photoIds, 'Photo with exactly 4.0 rating should be in FourStarsAlbum (boundary included)');
@@ -226,10 +226,10 @@ class RatingThresholdAlbumsTest extends BaseApiWithDataTest
 		]);
 
 		// Get five_stars smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'five_stars']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'five_stars']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Verify photo1 (5.0 average) is present
 		$this->assertContains($this->photo1->id, $photoIds, 'Photo with 5.0 rating should be in FiveStarsAlbum');
@@ -268,10 +268,10 @@ class RatingThresholdAlbumsTest extends BaseApiWithDataTest
 		$this->assertEquals('4.6667', $this->photo1->rating_avg);
 
 		// Get five_stars smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'five_stars']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'five_stars']);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('resource.photos'))->pluck('id')->all();
+		$photoIds = collect($response->json('photos'))->pluck('id')->all();
 
 		// Photo with 4.6667 average should NOT be in 5★ album
 		$this->assertNotContains($this->photo1->id, $photoIds, 'Photo with less than perfect 5.0 rating should NOT be in FiveStarsAlbum');

--- a/tests/Feature_v2/SmartAlbums/UnratedAlbumTest.php
+++ b/tests/Feature_v2/SmartAlbums/UnratedAlbumTest.php
@@ -51,10 +51,10 @@ class UnratedAlbumTest extends BaseApiWithDataTest
 		$this->assertEquals('3.0000', $this->photo2->rating_avg);
 
 		// Get unrated smart album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'unrated']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'unrated']);
 		$this->assertOk($response);
 
-		$photos = $response->json('resource.photos');
+		$photos = $response->json('photos');
 
 		// Verify photo1 (unrated) is present
 		$photoIds = collect($photos)->pluck('id')->all();
@@ -72,10 +72,10 @@ class UnratedAlbumTest extends BaseApiWithDataTest
 		Configs::set('enable_unrated', '1');
 
 		// Initially photo1 is unrated
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'unrated']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'unrated']);
 		$this->assertOk($response);
 
-		$initialPhotos = collect($response->json('resource.photos'))->pluck('id')->all();
+		$initialPhotos = collect($response->json('photos'))->pluck('id')->all();
 		$this->assertContains($this->photo1->id, $initialPhotos, 'Photo1 should be in UnratedAlbum initially');
 
 		// Rate photo1
@@ -85,10 +85,10 @@ class UnratedAlbumTest extends BaseApiWithDataTest
 		]);
 
 		// Verify photo1 is no longer in unrated album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'unrated']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'unrated']);
 		$this->assertOk($response);
 
-		$updatedPhotos = collect($response->json('resource.photos'))->pluck('id')->all();
+		$updatedPhotos = collect($response->json('photos'))->pluck('id')->all();
 		$this->assertNotContains($this->photo1->id, $updatedPhotos, 'Photo1 should NOT be in UnratedAlbum after rating');
 
 		// Remove rating
@@ -98,10 +98,10 @@ class UnratedAlbumTest extends BaseApiWithDataTest
 		]);
 
 		// Verify photo1 is back in unrated album
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => 'unrated']);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => 'unrated']);
 		$this->assertOk($response);
 
-		$finalPhotos = collect($response->json('resource.photos'))->pluck('id')->all();
+		$finalPhotos = collect($response->json('photos'))->pluck('id')->all();
 		$this->assertContains($this->photo1->id, $finalPhotos, 'Photo1 should be back in UnratedAlbum after removing rating');
 	}
 

--- a/tests/ImageProcessing/Album/DownloadTest.php
+++ b/tests/ImageProcessing/Album/DownloadTest.php
@@ -46,7 +46,7 @@ class DownloadTest extends BaseApiWithDataTest
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: $filename, album_id: $album_id);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $album_id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $album_id]);
 		$this->assertOk($response);
 
 		return $response;
@@ -60,7 +60,7 @@ class DownloadTest extends BaseApiWithDataTest
 	public function testSinglePhotoDownload(): void
 	{
 		$response = $this->uploadImage(filename: TestConstants::SAMPLE_FILE_NIGHT_IMAGE, album_id: $this->album5->id);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		$photoArchiveResponse = $this->download(
 			photo_ids: [$photo['id']],
@@ -96,12 +96,12 @@ class DownloadTest extends BaseApiWithDataTest
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: TestConstants::SAMPLE_FILE_MONGOLIA_IMAGE, album_id: $this->album5->id, file_name: TestConstants::PHOTO_MONGOLIA_TITLE . '.jpeg');
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(2, 'resource.photos');
+		$response->assertJsonCount(2, 'photos');
 
 		$photoArchiveResponse = $this->download(
-			photo_ids: [$response->json('resource.photos.0.id'), $response->json('resource.photos.1.id')],
+			photo_ids: [$response->json('photos.0.id'), $response->json('photos.1.id')],
 			from_id: $this->album5->id,
 			kind: DownloadVariantType::ORIGINAL
 		);
@@ -124,7 +124,7 @@ class DownloadTest extends BaseApiWithDataTest
 		static::assertHasFFMpegOrSkip();
 
 		$response = $this->uploadImage(filename: TestConstants::SAMPLE_FILE_GMP_IMAGE, album_id: $this->album5->id);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		$photoArchiveResponse = $this->download(
 			photo_ids: [$photo['id']],
@@ -162,9 +162,9 @@ class DownloadTest extends BaseApiWithDataTest
 		);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		// $this->postJson('Photo::copy', [
 		// 	'photo_ids' => [$photo['id']],
@@ -185,15 +185,15 @@ class DownloadTest extends BaseApiWithDataTest
 		]);
 		$this->assertNoContent($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(2, 'resource.photos');
+		$response->assertJsonCount(2, 'photos');
 
-		$photoID1 = $response->json('resource.photos.0.id');
-		$photoID2a = $response->json('resource.photos.1.id');
+		$photoID1 = $response->json('photos.0.id');
+		$photoID2a = $response->json('photos.1.id');
 
-		$response->assertJsonPath('resource.photos.0.title', TestConstants::PHOTO_NIGHT_TITLE . '.jpeg');
-		$response->assertJsonPath('resource.photos.1.title', TestConstants::PHOTO_NIGHT_TITLE . '.jpeg');
+		$response->assertJsonPath('photos.0.title', TestConstants::PHOTO_NIGHT_TITLE . '.jpeg');
+		$response->assertJsonPath('photos.1.title', TestConstants::PHOTO_NIGHT_TITLE . '.jpeg');
 
 		$photoArchiveResponse = $this->download([$photoID1, $photoID2a], kind: DownloadVariantType::ORIGINAL);
 
@@ -212,11 +212,11 @@ class DownloadTest extends BaseApiWithDataTest
 		);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(1, 'resource.photos');
+		$response->assertJsonCount(1, 'photos');
 
-		$id = $response->json('resource.photos.0.id');
+		$id = $response->json('photos.0.id');
 
 		$download = $this->download(
 			photo_ids: [$id],
@@ -260,13 +260,15 @@ class DownloadTest extends BaseApiWithDataTest
 		);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(1, 'resource.photos');
-		$response->assertJsonCount(1, 'resource.albums');
-		$response = $this->getJsonWithData('Album', ['album_id' => $album6->id]);
+		$response->assertJsonCount(1, 'photos');
+		$response = $this->getJsonWithData('Album::albums', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(1, 'resource.photos');
+		$response->assertJsonCount(1, 'data');
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $album6->id]);
+		$this->assertOk($response);
+		$response->assertJsonCount(1, 'photos');
 
 		$photoArchiveResponse = $this->download(album_ids: [$this->album5->id]);
 

--- a/tests/ImageProcessing/Commands/EncodePlaceholdersTest.php
+++ b/tests/ImageProcessing/Commands/EncodePlaceholdersTest.php
@@ -64,9 +64,9 @@ class EncodePlaceholdersTest extends BaseApiWithDataTest
 			->assertExitCode(0);
 
 		// Get updated photo and check if placeholder was encoded
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$photo2 = $response->json('resource.photos.0');
+		$photo2 = $response->json('photos.0');
 
 		// check for the file signature in the decoded base64 data.
 		Assert::assertStringContainsString('WEBPVP8', \Safe\base64_decode($photo2['size_variants']['placeholder']['url']));

--- a/tests/ImageProcessing/Commands/GenerateThumbsTest.php
+++ b/tests/ImageProcessing/Commands/GenerateThumbsTest.php
@@ -68,9 +68,9 @@ class GenerateThumbsTest extends BaseApiWithDataTest
 			->assertExitCode(0);
 
 		// Get updated photo and check if placeholder was encoded
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$photo2 = $response->json('resource.photos.0');
+		$photo2 = $response->json('photos.0');
 		self::assertNotNull($photo2['size_variants']['small']);
 		self::assertEquals($photo1['size_variants']['small']['width'], $photo2['size_variants']['small']['width']);
 		self::assertEquals($photo1['size_variants']['small']['height'], $photo2['size_variants']['small']['height']);

--- a/tests/ImageProcessing/Commands/TakeDateTest.php
+++ b/tests/ImageProcessing/Commands/TakeDateTest.php
@@ -55,9 +55,9 @@ class TakeDateTest extends BaseApiWithDataTest
 		])
 			->assertSuccessful();
 
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$photo2 = $response->json('resource.photos.0');
+		$photo2 = $response->json('photos.0');
 
 		$file_time = \Safe\filemtime(public_path($this->dropUrlPrefix($photo2['size_variants']['original']['url'])));
 		$carbon = new Carbon($photo2['created_at']);

--- a/tests/ImageProcessing/Commands/VideoDataTest.php
+++ b/tests/ImageProcessing/Commands/VideoDataTest.php
@@ -50,9 +50,9 @@ class VideoDataTest extends BaseApiWithDataTest
 			->assertExitCode(0);
 
 		// Get updated video and check if thumb has been re-created
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$photo2 = $response->json('resource.photos.0');
+		$photo2 = $response->json('photos.0');
 		self::assertNotNull($photo2['size_variants']['thumb']);
 		self::assertEquals($photo1['size_variants']['thumb']['width'], $photo2['size_variants']['thumb']['width']);
 		self::assertEquals($photo1['size_variants']['thumb']['height'], $photo2['size_variants']['thumb']['height']);

--- a/tests/ImageProcessing/Image/Handlers/BaseImageHandler.php
+++ b/tests/ImageProcessing/Image/Handlers/BaseImageHandler.php
@@ -49,7 +49,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: $filename, album_id: $this->album5->id);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
 
 		return $response;
@@ -70,7 +70,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		$taken_at = Carbon::create(
 			2019, 6, 1, 1, 28, 25, '+02:00'
 		);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 		self::assertEquals('f/2.8', $photo['aperture']);
 		self::assertEquals('16 mm', $photo['focal']);
 		self::assertEquals('1250', $photo['iso']);
@@ -112,7 +112,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		static::assertEquals('1', $config_manager->getValue('low_quality_image_placeholder'));
 
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_NIGHT_IMAGE);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 		self::assertEquals(16, $photo['size_variants']['placeholder']['width']);
 		self::assertEquals(16, $photo['size_variants']['placeholder']['height']);
 		$responseContent = $response->getContent();
@@ -139,7 +139,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		/*
 		 * Check some Exif data
 		 */
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 		self::assertEquals(480, $photo['size_variants']['small']['width']);
 		self::assertEquals(360, $photo['size_variants']['small']['height']);
 		self::assertEquals(1440, $photo['size_variants']['medium']['width']);
@@ -162,7 +162,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		/*
 		 * Check some Exif data
 		 */
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 		self::assertEquals(480, $photo['size_variants']['small']['width']);
 		self::assertEquals(360, $photo['size_variants']['small']['height']);
 		self::assertEquals(1440, $photo['size_variants']['medium']['width']);
@@ -185,7 +185,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		/*
 		 * Check some Exif data
 		 */
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 		self::assertEquals(480, $photo['size_variants']['small']['width']);
 		self::assertEquals(360, $photo['size_variants']['small']['height']);
 		self::assertEquals(1440, $photo['size_variants']['medium']['width']);
@@ -208,7 +208,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		/*
 		 * Check some Exif data
 		 */
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 		self::assertEquals(480, $photo['size_variants']['small']['width']);
 		self::assertEquals(360, $photo['size_variants']['small']['height']);
 		self::assertEquals(1440, $photo['size_variants']['medium']['width']);
@@ -231,7 +231,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		/*
 		 * Check some Exif data
 		 */
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 		self::assertEquals(480, $photo['size_variants']['small']['width']);
 		self::assertEquals(360, $photo['size_variants']['small']['height']);
 		self::assertEquals(1440, $photo['size_variants']['medium']['width']);
@@ -243,19 +243,19 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 	public function testPNGUpload(): void
 	{
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_PNG);
-		self::assertStringEndsWith('.png', $response->json('resource.photos.0.size_variants.original.url'));
+		self::assertStringEndsWith('.png', $response->json('photos.0.size_variants.original.url'));
 	}
 
 	public function testGIFUpload(): void
 	{
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_GIF);
-		self::assertStringEndsWith('.gif', $response->json('resource.photos.0.size_variants.original.url'));
+		self::assertStringEndsWith('.gif', $response->json('photos.0.size_variants.original.url'));
 	}
 
 	public function testWEBPUpload(): void
 	{
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_WEBP);
-		self::assertStringEndsWith('.webp', $response->json('resource.photos.0.size_variants.original.url'));
+		self::assertStringEndsWith('.webp', $response->json('photos.0.size_variants.original.url'));
 	}
 
 	/**
@@ -268,11 +268,11 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		$this->assertHasExifToolOrSkip();
 
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_TRAIN_IMAGE);
-		$id = $response->json('resource.photos.0.id');
+		$id = $response->json('photos.0.id');
 
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_TRAIN_VIDEO);
-		$photo = $response->json('resource.photos.0');
-		$id2 = $response->json('resource.photos.0.id');
+		$photo = $response->json('photos.0');
+		$id2 = $response->json('photos.0.id');
 
 		self::assertEquals($id, $id2);
 		self::assertEquals('E905E6C6-C747-4805-942F-9904A0281F02', $photo['live_photo_content_id']);
@@ -292,11 +292,11 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		$this->assertHasExifToolOrSkip();
 
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_TRAIN_VIDEO);
-		$id = $response->json('resource.photos.0.id');
+		$id = $response->json('photos.0.id');
 
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_TRAIN_IMAGE);
-		$photo = $response->json('resource.photos.0');
-		$id2 = $response->json('resource.photos.0.id');
+		$photo = $response->json('photos.0');
+		$id2 = $response->json('photos.0.id');
 
 		self::assertNotEquals($id, $id2);
 		self::assertEquals('E905E6C6-C747-4805-942F-9904A0281F02', $photo['live_photo_content_id']);
@@ -320,7 +320,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		$this->assertHasFFMpegOrSkip();
 
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_GMP_IMAGE);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		self::assertStringEndsWith('.mov', $photo['live_photo_url']);
 		self::assertEquals(pathinfo($photo['live_photo_url'], PATHINFO_DIRNAME), pathinfo($photo['size_variants']['original']['url'], PATHINFO_DIRNAME));
@@ -350,7 +350,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		file_put_contents(storage_path('logs/daily-' . date('Y-m-d') . '.log'), '');
 
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_GMP_BROKEN_IMAGE);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		// Size variants are generated, because they are extracted from the
 		// still part of the GMP, not the video part.
@@ -385,7 +385,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		$this->assertHasFFMpegOrSkip();
 
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_GAMING_VIDEO);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		self::assertEquals(TestConstants::SAMPLE_FILE_GAMING_VIDEO, $photo['title']);
 		self::assertEquals(TestConstants::MIME_TYPE_VID_MP4, $photo['type']);
@@ -421,7 +421,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		file_put_contents(storage_path('logs/daily-' . date('Y-m-d') . '.log'), '');
 
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_GAMING_VIDEO);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		self::assertEquals(TestConstants::SAMPLE_FILE_GAMING_VIDEO, $photo['title']);
 		self::assertEquals(TestConstants::MIME_TYPE_VID_MP4, $photo['type']);
@@ -463,7 +463,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		Configs::set(TestConstants::CONFIG_HAS_EXIF_TOOL, false);
 
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_UNDEFINED_EXIF_TAG);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		self::assertEquals('f/10.0', $photo['aperture']);
 		self::assertEquals('70 mm', $photo['focal']);
@@ -496,7 +496,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 	public function testUploadMultibyteTitle(): void
 	{
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_SUNSET_IMAGE);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		self::assertEquals('tests/Samples/fin de journée.jpg', $photo['title']);
 		self::assertEquals('f/8.0', $photo['aperture']);
@@ -538,7 +538,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		Configs::set(TestConstants::CONFIG_USE_LAST_MODIFIED_DATE_WHEN_NO_EXIF, true);
 
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_WITHOUT_EXIF);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		self::assertEquals('2023-03-14T20:05:03+00:00', $photo['taken_at']);
 		self::assertEquals('+00:00', $photo['taken_at_orig_tz']);
@@ -562,9 +562,9 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: TestConstants::SAMPLE_FILE_WITHOUT_EXIF, album_id: $this->album5->id, file_last_modified_time: 0);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		self::assertEquals('1970-01-01T00:00:00+00:00', $photo['taken_at']);
 		self::assertEquals('+00:00', $photo['taken_at_orig_tz']);
@@ -581,7 +581,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 	public function testTakenAtForPhotoUploadWithoutExif3(): void
 	{
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_WITHOUT_EXIF);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		self::assertEquals(null, $photo['taken_at']);
 		self::assertEquals(null, $photo['taken_at_orig_tz']);
@@ -600,7 +600,7 @@ abstract class BaseImageHandler extends BaseApiWithDataTest
 		Configs::set(TestConstants::CONFIG_USE_LAST_MODIFIED_DATE_WHEN_NO_EXIF, true);
 
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_NIGHT_IMAGE);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		self::assertEquals('2019-06-01T01:28:25+02:00', $photo['taken_at']);
 		self::assertEquals('+02:00', $photo['taken_at_orig_tz']);

--- a/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerGDTest.php
+++ b/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerGDTest.php
@@ -57,7 +57,7 @@ class PhotosAddHandlerGDTest extends BaseImageHandler
 			static::setAcceptedRawFormats('.tif');
 
 			$response = $this->uploadImage(TestConstants::SAMPLE_FILE_TIFF);
-			$photo = $response->json('resource.photos.0');
+			$photo = $response->json('photos.0');
 
 			self::assertStringEndsWith('.tif', $photo['size_variants']['original']['url']);
 			self::assertNull($photo['size_variants']['thumb']);

--- a/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerImagickTest.php
+++ b/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerImagickTest.php
@@ -56,7 +56,7 @@ class PhotosAddHandlerImagickTest extends BaseImageHandler
 			static::setAcceptedRawFormats('.tif');
 
 			$response = $this->uploadImage(TestConstants::SAMPLE_FILE_TIFF);
-			$photo = $response->json('resource.photos.0');
+			$photo = $response->json('photos.0');
 
 			self::assertStringEndsWith('.tif', $photo['size_variants']['original']['url']);
 			self::assertEquals(TestConstants::MIME_TYPE_IMG_TIFF, $photo['type']);

--- a/tests/ImageProcessing/Image/WatermarkerTest.php
+++ b/tests/ImageProcessing/Image/WatermarkerTest.php
@@ -98,7 +98,7 @@ class WatermarkerTest extends BaseImageHandler
 	public function testWatermarkerWorksNoOriginal(): void
 	{
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_PNG);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 		$photoId = $photo['id'];
 
 		$response = $this->actingAs($this->admin)->postJson('Photo::move', [
@@ -119,7 +119,7 @@ class WatermarkerTest extends BaseImageHandler
 
 		// Watermarker is enabled, Let's F-ing goooo.
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_NIGHT_IMAGE);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		self::assertStringEndsWith('_wmk.jpeg', $photo['size_variants']['thumb']['url']);
 		self::assertStringEndsWith('_wmk.jpeg', $photo['size_variants']['thumb2x']['url']);
@@ -132,10 +132,10 @@ class WatermarkerTest extends BaseImageHandler
 		// Public can access album 5.
 		AccessPermission::factory()->public()->visible()->grants_full_photo()->for_album($this->album5)->create();
 		Auth::logout();
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
 
-		$photo2 = $response->json('resource.photos.0');
+		$photo2 = $response->json('photos.0');
 		self::assertStringEndsNotWith('_wmk.jpeg', $photo2['size_variants']['thumb']['url']);
 		self::assertStringEndsNotWith('_wmk.jpeg', $photo2['size_variants']['thumb2x']['url']);
 		self::assertStringEndsNotWith('_wmk.jpeg', $photo2['size_variants']['small']['url']);
@@ -163,7 +163,7 @@ class WatermarkerTest extends BaseImageHandler
 	public function testWatermarkerWorksOriginal(): void
 	{
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_PNG);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 		$photoId = $photo['id'];
 
 		$response = $this->actingAs($this->admin)->postJson('Photo::move', [
@@ -185,7 +185,7 @@ class WatermarkerTest extends BaseImageHandler
 
 		// Watermarker is enabled, Let's F-ing goooo.
 		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_NIGHT_IMAGE);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		self::assertStringEndsNotWith('_wmk.jpeg', $photo['size_variants']['thumb']['url']);
 		self::assertStringEndsNotWith('_wmk.jpeg', $photo['size_variants']['thumb2x']['url']);
@@ -198,10 +198,10 @@ class WatermarkerTest extends BaseImageHandler
 		// Public can access album 5.
 		AccessPermission::factory()->public()->visible()->grants_full_photo()->for_album($this->album5)->create();
 		Auth::logout();
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
 
-		$photo2 = $response->json('resource.photos.0');
+		$photo2 = $response->json('photos.0');
 		self::assertStringEndsWith('_wmk.jpeg', $photo2['size_variants']['thumb']['url']);
 		self::assertStringEndsWith('_wmk.jpeg', $photo2['size_variants']['thumb2x']['url']);
 		self::assertStringEndsWith('_wmk.jpeg', $photo2['size_variants']['small']['url']);

--- a/tests/ImageProcessing/Jobs/ExtractColoursJobTest.php
+++ b/tests/ImageProcessing/Jobs/ExtractColoursJobTest.php
@@ -64,9 +64,9 @@ class ExtractColoursJobTest extends BaseApiWithDataTest
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: TestConstants::SAMPLE_FILE_NIGHT_IMAGE);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$id1 = $response->json('resource.photos.0.id');
+		$id1 = $response->json('photos.0.id');
 
 		$photo = Photo::with(['size_variants', 'palette'])->findOrFail($id1);
 

--- a/tests/ImageProcessing/Photo/PhotoAddTest.php
+++ b/tests/ImageProcessing/Photo/PhotoAddTest.php
@@ -51,7 +51,8 @@ class PhotoAddTest extends BaseApiWithDataTest
 		$this->assertCreated($response);
 		$this->catchFailureSilence = ["App\Exceptions\MediaFileOperationException"];
 
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		// Check album metadata
+		$response = $this->getJsonWithData('Album::head', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
 		$response->assertJson([
 			'config' => [
@@ -63,19 +64,25 @@ class PhotoAddTest extends BaseApiWithDataTest
 			'resource' => [
 				'id' => 'unsorted',
 				'title' => 'Unsorted',
-				'photos' => [
-					[
-						'title' => TestConstants::SAMPLE_FILE_NIGHT_IMAGE,
-					],
+			],
+		]);
+
+		// Check photos
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
+		$this->assertOk($response);
+		$response->assertJson([
+			'photos' => [
+				[
+					'title' => TestConstants::SAMPLE_FILE_NIGHT_IMAGE,
 				],
 			],
 		]);
-		$response = $this->deleteJson('Photo', ['photo_ids' => [$response->json('resource.photos.0.id')], 'from_id' => 'unsorted']);
+		$response = $this->deleteJson('Photo', ['photo_ids' => [$response->json('photos.0.id')], 'from_id' => 'unsorted']);
 		$this->assertNoContent($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$response->assertJsonCount(1, 'resource.photos');
+		$response->assertJsonCount(1, 'photos');
 	}
 
 	public function testDuplicate(): void
@@ -84,16 +91,16 @@ class PhotoAddTest extends BaseApiWithDataTest
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: TestConstants::SAMPLE_FILE_NIGHT_IMAGE);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
 
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: TestConstants::SAMPLE_FILE_NIGHT_IMAGE);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$id1 = $response->json('resource.photos.0.id');
-		$id2 = $response->json('resource.photos.1.id');
+		$id1 = $response->json('photos.0.id');
+		$id2 = $response->json('photos.1.id');
 
 		self::assertNotEquals($id1, $id2);
 
@@ -119,9 +126,9 @@ class PhotoAddTest extends BaseApiWithDataTest
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: TestConstants::SAMPLE_FILE_TRAIN_VIDEO);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		self::assertEquals('E905E6C6-C747-4805-942F-9904A0281F02', $photo['live_photo_content_id']);
 
@@ -138,9 +145,9 @@ class PhotoAddTest extends BaseApiWithDataTest
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: TestConstants::SAMPLE_FILE_TRAIN_IMAGE);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$photo = $response->json('resource.photos.0');
+		$photo = $response->json('photos.0');
 
 		self::assertEquals('E905E6C6-C747-4805-942F-9904A0281F02', $photo['live_photo_content_id']);
 
@@ -155,9 +162,9 @@ class PhotoAddTest extends BaseApiWithDataTest
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: TestConstants::SAMPLE_FILE_GMP_IMAGE);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$id = $response->json('resource.photos.0.id');
+		$id = $response->json('photos.0.id');
 		$response = $this->deleteJson('Photo', ['photo_ids' => [$id], 'from_id' => 'unsorted']);
 		$this->assertNoContent($response);
 	}
@@ -168,9 +175,9 @@ class PhotoAddTest extends BaseApiWithDataTest
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: TestConstants::SAMPLE_FILE_HEIC);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$id = $response->json('resource.photos.0.id');
+		$id = $response->json('photos.0.id');
 		$response = $this->deleteJson('Photo', ['photo_ids' => [$id], 'from_id' => 'unsorted']);
 		$this->assertNoContent($response);
 	}
@@ -181,9 +188,9 @@ class PhotoAddTest extends BaseApiWithDataTest
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: TestConstants::SAMPLE_FILE_HEIF);
 		$this->assertCreated($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$id = $response->json('resource.photos.0.id');
+		$id = $response->json('photos.0.id');
 		$response = $this->deleteJson('Photo', ['photo_ids' => [$id], 'from_id' => 'unsorted']);
 		$this->assertNoContent($response);
 	}

--- a/tests/ImageProcessing/Photo/PhotoCopyTest.php
+++ b/tests/ImageProcessing/Photo/PhotoCopyTest.php
@@ -51,12 +51,12 @@ class PhotoCopyTest extends BaseApiWithDataTest
 		]);
 		$this->assertForbidden($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(2, 'resource.photos');
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->subAlbum1->id]);
+		$response->assertJsonCount(2, 'photos');
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->subAlbum1->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(1, 'resource.photos');
+		$response->assertJsonCount(1, 'photos');
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Photo::copy', [
 			'photo_ids' => [$this->photo1->id],
@@ -64,12 +64,12 @@ class PhotoCopyTest extends BaseApiWithDataTest
 		]);
 		$this->assertNoContent($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(2, 'resource.photos');
+		$response->assertJsonCount(2, 'photos');
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->subAlbum1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->subAlbum1->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(2, 'resource.photos');
+		$response->assertJsonCount(2, 'photos');
 	}
 }

--- a/tests/ImageProcessing/Photo/PhotoDeleteTest.php
+++ b/tests/ImageProcessing/Photo/PhotoDeleteTest.php
@@ -51,9 +51,9 @@ class PhotoDeleteTest extends BaseApiWithDataTest
 		]);
 		$this->assertForbidden($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(2, 'resource.photos');
+		$response->assertJsonCount(2, 'photos');
 
 		$response = $this->actingAs($this->userMayUpload1)->deleteJson('Photo', [
 			'photo_ids' => [$this->photo1->id],
@@ -61,8 +61,8 @@ class PhotoDeleteTest extends BaseApiWithDataTest
 		]);
 		$this->assertNoContent($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(1, 'resource.photos');
+		$response->assertJsonCount(1, 'photos');
 	}
 }

--- a/tests/ImageProcessing/Photo/PhotoEditTest.php
+++ b/tests/ImageProcessing/Photo/PhotoEditTest.php
@@ -70,18 +70,18 @@ class PhotoEditTest extends BaseApiWithDataTest
 		]);
 		$this->assertOk($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
-		$photo0 = $response->json('resource.photos.0');
+		$photo0 = $response->json('photos.0');
 		$idx = $photo0['id'] === $this->photo1->id ? 0 : 1;
 
-		$response->assertJsonPath('resource.photos.' . $idx . '.id', $this->photo1->id);
-		$response->assertJsonPath('resource.photos.' . $idx . '.title', 'new title');
-		$response->assertJsonPath('resource.photos.' . $idx . '.description', 'new description');
-		$response->assertJsonPath('resource.photos.' . $idx . '.tags', ['tag1']);
-		$response->assertJsonPath('resource.photos.' . $idx . '.license', 'none');
-		$response->assertJsonPath('resource.photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
-		$response->assertJsonPath('resource.photos.' . $idx . '.precomputed.is_taken_at_modified', false);
+		$response->assertJsonPath('photos.' . $idx . '.id', $this->photo1->id);
+		$response->assertJsonPath('photos.' . $idx . '.title', 'new title');
+		$response->assertJsonPath('photos.' . $idx . '.description', 'new description');
+		$response->assertJsonPath('photos.' . $idx . '.tags', ['tag1']);
+		$response->assertJsonPath('photos.' . $idx . '.license', 'none');
+		$response->assertJsonPath('photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
+		$response->assertJsonPath('photos.' . $idx . '.precomputed.is_taken_at_modified', false);
 
 		// Test setting taken_at
 		$response = $this->actingAs($this->userMayUpload1)->patchJson('Photo', [
@@ -96,19 +96,19 @@ class PhotoEditTest extends BaseApiWithDataTest
 		]);
 		$this->assertOk($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 
-		$photo0 = $response->json('resource.photos.0');
+		$photo0 = $response->json('photos.0');
 		$idx = $photo0['id'] === $this->photo1->id ? 0 : 1;
-		$response->assertJsonPath('resource.photos.' . $idx . '.id', $this->photo1->id);
-		$response->assertJsonPath('resource.photos.' . $idx . '.title', 'new title');
-		$response->assertJsonPath('resource.photos.' . $idx . '.description', 'new description');
-		$response->assertJsonPath('resource.photos.' . $idx . '.tags', ['tag1']);
-		$response->assertJsonPath('resource.photos.' . $idx . '.license', 'none');
-		$response->assertJsonPath('resource.photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
-		$response->assertJsonPath('resource.photos.' . $idx . '.taken_at', '2021-01-01T00:00:00+00:00');
-		$response->assertJsonPath('resource.photos.' . $idx . '.precomputed.is_taken_at_modified', true);
+		$response->assertJsonPath('photos.' . $idx . '.id', $this->photo1->id);
+		$response->assertJsonPath('photos.' . $idx . '.title', 'new title');
+		$response->assertJsonPath('photos.' . $idx . '.description', 'new description');
+		$response->assertJsonPath('photos.' . $idx . '.tags', ['tag1']);
+		$response->assertJsonPath('photos.' . $idx . '.license', 'none');
+		$response->assertJsonPath('photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
+		$response->assertJsonPath('photos.' . $idx . '.taken_at', '2021-01-01T00:00:00+00:00');
+		$response->assertJsonPath('photos.' . $idx . '.precomputed.is_taken_at_modified', true);
 
 		// Reset taken_at
 		$response = $this->actingAs($this->userMayUpload1)->patchJson('Photo', [
@@ -123,18 +123,18 @@ class PhotoEditTest extends BaseApiWithDataTest
 		]);
 		$this->assertOk($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 
-		$photo0 = $response->json('resource.photos.0');
+		$photo0 = $response->json('photos.0');
 		$idx = $photo0['id'] === $this->photo1->id ? 0 : 1;
-		$response->assertJsonPath('resource.photos.' . $idx . '.id', $this->photo1->id);
-		$response->assertJsonPath('resource.photos.' . $idx . '.title', 'new title');
-		$response->assertJsonPath('resource.photos.' . $idx . '.description', 'new description');
-		$response->assertJsonPath('resource.photos.' . $idx . '.tags', ['tag1']);
-		$response->assertJsonPath('resource.photos.' . $idx . '.license', 'none');
-		$response->assertJsonPath('resource.photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
-		$response->assertJsonPath('resource.photos.' . $idx . '.precomputed.is_taken_at_modified', false);
+		$response->assertJsonPath('photos.' . $idx . '.id', $this->photo1->id);
+		$response->assertJsonPath('photos.' . $idx . '.title', 'new title');
+		$response->assertJsonPath('photos.' . $idx . '.description', 'new description');
+		$response->assertJsonPath('photos.' . $idx . '.tags', ['tag1']);
+		$response->assertJsonPath('photos.' . $idx . '.license', 'none');
+		$response->assertJsonPath('photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
+		$response->assertJsonPath('photos.' . $idx . '.precomputed.is_taken_at_modified', false);
 	}
 
 	public function testEditPhotoAuthorizedOwnerNullTakenDate(): void
@@ -154,19 +154,19 @@ class PhotoEditTest extends BaseApiWithDataTest
 		]);
 		$this->assertOk($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
-		$photo0 = $response->json('resource.photos.0');
+		$photo0 = $response->json('photos.0');
 		$idx = $photo0['id'] === $this->photo1->id ? 0 : 1;
 
-		$response->assertJsonPath('resource.photos.' . $idx . '.id', $this->photo1->id);
-		$response->assertJsonPath('resource.photos.' . $idx . '.title', 'new title');
-		$response->assertJsonPath('resource.photos.' . $idx . '.description', 'new description');
-		$response->assertJsonPath('resource.photos.' . $idx . '.tags', ['tag1']);
-		$response->assertJsonPath('resource.photos.' . $idx . '.license', 'none');
-		$response->assertJsonPath('resource.photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
-		$response->assertJsonPath('resource.photos.' . $idx . '.taken_at', null);
-		$response->assertJsonPath('resource.photos.' . $idx . '.precomputed.is_taken_at_modified', false);
+		$response->assertJsonPath('photos.' . $idx . '.id', $this->photo1->id);
+		$response->assertJsonPath('photos.' . $idx . '.title', 'new title');
+		$response->assertJsonPath('photos.' . $idx . '.description', 'new description');
+		$response->assertJsonPath('photos.' . $idx . '.tags', ['tag1']);
+		$response->assertJsonPath('photos.' . $idx . '.license', 'none');
+		$response->assertJsonPath('photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
+		$response->assertJsonPath('photos.' . $idx . '.taken_at', null);
+		$response->assertJsonPath('photos.' . $idx . '.precomputed.is_taken_at_modified', false);
 
 		// Test setting taken_at
 		$response = $this->actingAs($this->userMayUpload1)->patchJson('Photo', [
@@ -181,19 +181,19 @@ class PhotoEditTest extends BaseApiWithDataTest
 		]);
 		$this->assertOk($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 
-		$photo0 = $response->json('resource.photos.0');
+		$photo0 = $response->json('photos.0');
 		$idx = $photo0['id'] === $this->photo1->id ? 0 : 1;
-		$response->assertJsonPath('resource.photos.' . $idx . '.id', $this->photo1->id);
-		$response->assertJsonPath('resource.photos.' . $idx . '.title', 'new title');
-		$response->assertJsonPath('resource.photos.' . $idx . '.description', 'new description');
-		$response->assertJsonPath('resource.photos.' . $idx . '.tags', ['tag1']);
-		$response->assertJsonPath('resource.photos.' . $idx . '.license', 'none');
-		$response->assertJsonPath('resource.photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
-		$response->assertJsonPath('resource.photos.' . $idx . '.taken_at', '2021-01-01T00:00:00+00:00');
-		$response->assertJsonPath('resource.photos.' . $idx . '.precomputed.is_taken_at_modified', true);
+		$response->assertJsonPath('photos.' . $idx . '.id', $this->photo1->id);
+		$response->assertJsonPath('photos.' . $idx . '.title', 'new title');
+		$response->assertJsonPath('photos.' . $idx . '.description', 'new description');
+		$response->assertJsonPath('photos.' . $idx . '.tags', ['tag1']);
+		$response->assertJsonPath('photos.' . $idx . '.license', 'none');
+		$response->assertJsonPath('photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
+		$response->assertJsonPath('photos.' . $idx . '.taken_at', '2021-01-01T00:00:00+00:00');
+		$response->assertJsonPath('photos.' . $idx . '.precomputed.is_taken_at_modified', true);
 
 		// Reset taken_at
 		$response = $this->actingAs($this->userMayUpload1)->patchJson('Photo', [
@@ -208,18 +208,18 @@ class PhotoEditTest extends BaseApiWithDataTest
 		]);
 		$this->assertOk($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 
-		$photo0 = $response->json('resource.photos.0');
+		$photo0 = $response->json('photos.0');
 		$idx = $photo0['id'] === $this->photo1->id ? 0 : 1;
-		$response->assertJsonPath('resource.photos.' . $idx . '.id', $this->photo1->id);
-		$response->assertJsonPath('resource.photos.' . $idx . '.title', 'new title');
-		$response->assertJsonPath('resource.photos.' . $idx . '.description', 'new description');
-		$response->assertJsonPath('resource.photos.' . $idx . '.tags', ['tag1']);
-		$response->assertJsonPath('resource.photos.' . $idx . '.license', 'none');
-		$response->assertJsonPath('resource.photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
-		$response->assertJsonPath('resource.photos.' . $idx . '.taken_at', null);
-		$response->assertJsonPath('resource.photos.' . $idx . '.precomputed.is_taken_at_modified', false);
+		$response->assertJsonPath('photos.' . $idx . '.id', $this->photo1->id);
+		$response->assertJsonPath('photos.' . $idx . '.title', 'new title');
+		$response->assertJsonPath('photos.' . $idx . '.description', 'new description');
+		$response->assertJsonPath('photos.' . $idx . '.tags', ['tag1']);
+		$response->assertJsonPath('photos.' . $idx . '.license', 'none');
+		$response->assertJsonPath('photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
+		$response->assertJsonPath('photos.' . $idx . '.taken_at', null);
+		$response->assertJsonPath('photos.' . $idx . '.precomputed.is_taken_at_modified', false);
 	}
 }

--- a/tests/ImageProcessing/Photo/PhotoFromUrlTest.php
+++ b/tests/ImageProcessing/Photo/PhotoFromUrlTest.php
@@ -55,23 +55,21 @@ class PhotoFromUrlTest extends BaseApiWithDataTest
 		]);
 		$this->assertOk($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
 
 		$response->assertJson([
-			'resource' => [
-				'photos' => [[
-					'title' => 'mongolia',
-					'type' => TestConstants::MIME_TYPE_IMG_JPEG,
-					'size_variants' => [
-						'original' => [
-							'width' => 1280,
-							'height' => 850,
-							'filesize' => '196.60 KB',
-						],
+			'photos' => [[
+				'title' => 'mongolia',
+				'type' => TestConstants::MIME_TYPE_IMG_JPEG,
+				'size_variants' => [
+					'original' => [
+						'width' => 1280,
+						'height' => 850,
+						'filesize' => '196.60 KB',
 					],
-				]],
-			],
+				],
+			]],
 		]);
 	}
 
@@ -83,23 +81,21 @@ class PhotoFromUrlTest extends BaseApiWithDataTest
 		]);
 		$this->assertOk($response);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album5->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
 
 		$response->assertJson([
-			'resource' => [
-				'photos' => [[
-					'title' => 'mongolia',
-					'type' => TestConstants::MIME_TYPE_IMG_JPEG,
-					'size_variants' => [
-						'original' => [
-							'width' => 1280,
-							'height' => 850,
-							'filesize' => '196.60 KB',
-						],
+			'photos' => [[
+				'title' => 'mongolia',
+				'type' => TestConstants::MIME_TYPE_IMG_JPEG,
+				'size_variants' => [
+					'original' => [
+						'width' => 1280,
+						'height' => 850,
+						'filesize' => '196.60 KB',
 					],
-				]],
-			],
+				],
+			]],
 		]);
 	}
 }

--- a/tests/ImageProcessing/Photo/PhotoMoveTest.php
+++ b/tests/ImageProcessing/Photo/PhotoMoveTest.php
@@ -54,9 +54,9 @@ class PhotoMoveTest extends BaseApiWithDataTest
 		]);
 		$this->assertForbidden($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(2, 'resource.photos');
+		$response->assertJsonCount(2, 'photos');
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Photo::move', [
 			'from_id' => $this->album1->id,
@@ -65,19 +65,16 @@ class PhotoMoveTest extends BaseApiWithDataTest
 		]);
 		$this->assertNoContent($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(1, 'resource.photos');
+		$response->assertJsonCount(1, 'photos');
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->subAlbum1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->subAlbum1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
-			'config' => [],
-			'resource' => [
-				'photos' => [
-					[
-						'id' => $this->photo1->id,
-					],
+			'photos' => [
+				[
+					'id' => $this->photo1->id,
 				],
 			],
 		]);
@@ -85,14 +82,14 @@ class PhotoMoveTest extends BaseApiWithDataTest
 
 	public function testMovePhotoAuthorizedOwnerUnosorted(): void
 	{
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$response->assertJsonCount(1, 'resource.photos');
+		$response->assertJsonCount(1, 'photos');
 		$response->assertDontSee($this->photo1->id);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(2, 'resource.photos');
+		$response->assertJsonCount(2, 'photos');
 		$response->assertSee($this->photo1->id);
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Photo::move', [
@@ -102,14 +99,14 @@ class PhotoMoveTest extends BaseApiWithDataTest
 		]);
 		$this->assertNoContent($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(1, 'resource.photos');
+		$response->assertJsonCount(1, 'photos');
 		$response->assertDontSee($this->photo1->id);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
-		$response->assertJsonCount(2, 'resource.photos');
+		$response->assertJsonCount(2, 'photos');
 		$response->assertSee($this->photo1->id);
 
 		$response = $this->actingAs($this->userMayUpload1)->postJson('Photo::move', [

--- a/tests/ImageProcessing/Photo/PhotoRenameTest.php
+++ b/tests/ImageProcessing/Photo/PhotoRenameTest.php
@@ -47,16 +47,13 @@ class PhotoRenameTest extends BaseApiWithDataTest
 			'title' => 'new title',
 		]);
 		$this->assertNoContent($response);
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
-			'config' => [],
-			'resource' => [
-				'photos' => [
-					[
-						'id' => $this->photo1->id,
-						'title' => 'new title',
-					],
+			'photos' => [
+				[
+					'id' => $this->photo1->id,
+					'title' => 'new title',
 				],
 			],
 		]);

--- a/tests/ImageProcessing/Photo/PhotoRotateTest.php
+++ b/tests/ImageProcessing/Photo/PhotoRotateTest.php
@@ -109,9 +109,9 @@ class PhotoRotateTest extends BaseApiWithDataTest
 		]);
 		$this->assertOk($response);
 
-		$response = $this->actingAs($this->userMayUpload2)->getJsonWithData('Album', ['album_id' => $new_album_id]);
+		$response = $this->actingAs($this->userMayUpload2)->getJsonWithData('Album::photos', ['album_id' => $new_album_id]);
 		$this->assertOk($response);
-		$id1 = $response->json('resource.photos.0.id');
+		$id1 = $response->json('photos.0.id');
 
 		$response = $this->actingAs($this->userMayUpload2)->postJson('Photo::rotate', [
 			'photo_id' => $id1,

--- a/tests/ImageProcessing/Photo/PhotoStarTest.php
+++ b/tests/ImageProcessing/Photo/PhotoStarTest.php
@@ -51,16 +51,13 @@ class PhotoStarTest extends BaseApiWithDataTest
 		]);
 		$this->assertNoContent($response);
 
-		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->actingAs($this->userMayUpload1)->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
-			'config' => [],
-			'resource' => [
-				'photos' => [
-					[
-						'id' => $this->photo1->id,
-						'is_starred' => true,
-					],
+			'photos' => [
+				[
+					'id' => $this->photo1->id,
+					'is_starred' => true,
 				],
 			],
 		]);

--- a/tests/ImageProcessing/Photo/PhotoTagsTest.php
+++ b/tests/ImageProcessing/Photo/PhotoTagsTest.php
@@ -50,16 +50,13 @@ class PhotoTagsTest extends BaseApiWithDataTest
 			'shall_override' => true,
 		]);
 		$this->assertNoContent($response);
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
-			'config' => [],
-			'resource' => [
-				'photos' => [
-					[
-						'id' => $this->photo1->id,
-						'tags' => ['tag1'],
-					],
+			'photos' => [
+				[
+					'id' => $this->photo1->id,
+					'tags' => ['tag1'],
 				],
 			],
 		]);
@@ -80,16 +77,13 @@ class PhotoTagsTest extends BaseApiWithDataTest
 			'shall_override' => false,
 		]);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
-			'config' => [],
-			'resource' => [
-				'photos' => [
-					[
-						'id' => $this->photo1->id,
-						'tags' => ['tag1'],
-					],
+			'photos' => [
+				[
+					'id' => $this->photo1->id,
+					'tags' => ['tag1'],
 				],
 			],
 		]);
@@ -110,16 +104,13 @@ class PhotoTagsTest extends BaseApiWithDataTest
 			'shall_override' => false,
 		]);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
-			'config' => [],
-			'resource' => [
-				'photos' => [
-					[
-						'id' => $this->photo1->id,
-						'tags' => ['tag1', 'tag2'],
-					],
+			'photos' => [
+				[
+					'id' => $this->photo1->id,
+					'tags' => ['tag1', 'tag2'],
 				],
 			],
 		]);
@@ -140,16 +131,13 @@ class PhotoTagsTest extends BaseApiWithDataTest
 			'shall_override' => false,
 		]);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
-			'config' => [],
-			'resource' => [
-				'photos' => [
-					[
-						'id' => $this->photo1->id,
-						'tags' => ['tag1', 'tag2'],
-					],
+			'photos' => [
+				[
+					'id' => $this->photo1->id,
+					'tags' => ['tag1', 'tag2'],
 				],
 			],
 		]);
@@ -170,16 +158,13 @@ class PhotoTagsTest extends BaseApiWithDataTest
 			'shall_override' => true,
 		]);
 
-		$response = $this->getJsonWithData('Album', ['album_id' => $this->album1->id]);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => $this->album1->id]);
 		$this->assertOk($response);
 		$response->assertJson([
-			'config' => [],
-			'resource' => [
-				'photos' => [
-					[
-						'id' => $this->photo1->id,
-						'tags' => ['tag3'],
-					],
+			'photos' => [
+				[
+					'id' => $this->photo1->id,
+					'tags' => ['tag3'],
 				],
 			],
 		]);

--- a/tests/ImageProcessing/Photo/PhotoZipUploadTest.php
+++ b/tests/ImageProcessing/Photo/PhotoZipUploadTest.php
@@ -66,16 +66,16 @@ class PhotoZipUploadTest extends BaseApiWithDataTest
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: TestConstants::SAMPLE_TEST_ZIP, album_id: $this->album5->id);
 		$this->assertCreated($response);
 
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => $this->album5->id]);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::albums', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
-		$created_id = $response->json('resource.albums.0.id');
-		$response->assertJsonPath('resource.albums.0.title', 'test_photos');
+		$created_id = $response->json('data.0.id');
+		$response->assertJsonPath('data.0.title', 'test_photos');
 
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => $created_id]);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => $created_id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(2, 'resource.photos');
-		$response->assertJsonPath('resource.photos.0.title', 'night');
-		$response->assertJsonPath('resource.photos.1.title', 'sunset');
+		$response->assertJsonCount(2, 'photos');
+		$response->assertJsonPath('photos.0.title', 'night');
+		$response->assertJsonPath('photos.1.title', 'sunset');
 	}
 
 	public function testZipExtractInFolders(): void
@@ -95,10 +95,10 @@ class PhotoZipUploadTest extends BaseApiWithDataTest
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: TestConstants::SAMPLE_TEST_ZIP, album_id: $this->album5->id);
 		$this->assertCreated($response);
 
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => $this->album5->id]);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::albums', ['album_id' => $this->album5->id]);
 		$this->assertOk($response);
-		$response->assertJsonCount(2, 'resource.albums');
-		$albums = $response->json('resource.albums');
+		$response->assertJsonCount(2, 'data');
+		$albums = $response->json('data');
 		$idx_night = array_search('night', array_column($albums, 'title'), true);
 		$idx_sunset = array_search('sunset', array_column($albums, 'title'), true);
 		$this->assertIsInt($idx_night);
@@ -106,15 +106,15 @@ class PhotoZipUploadTest extends BaseApiWithDataTest
 		$id_night = $albums[$idx_night]['id'];
 		$id_sunset = $albums[$idx_sunset]['id'];
 
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => $id_night]);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => $id_night]);
 		$this->assertOk($response);
-		$response->assertJsonCount(1, 'resource.photos');
-		$response->assertJsonPath('resource.photos.0.title', 'night');
+		$response->assertJsonCount(1, 'photos');
+		$response->assertJsonPath('photos.0.title', 'night');
 
-		$response = $this->actingAs($this->admin)->getJsonWithData('Album', ['album_id' => $id_sunset]);
+		$response = $this->actingAs($this->admin)->getJsonWithData('Album::photos', ['album_id' => $id_sunset]);
 		$this->assertOk($response);
-		$response->assertJsonCount(1, 'resource.photos');
-		$response->assertJsonPath('resource.photos.0.title', 'sunset');
+		$response->assertJsonCount(1, 'photos');
+		$response->assertJsonPath('photos.0.title', 'sunset');
 	}
 
 	public function testBadZipExtract(): void

--- a/tests/Traits/CreatePhoto.php
+++ b/tests/Traits/CreatePhoto.php
@@ -28,9 +28,9 @@ trait CreatePhoto
 	{
 		$response = $this->actingAs($this->admin)->upload('Photo', filename: $filename);
 		$this->assertCreated($response);
-		$response = $this->getJsonWithData('Album', ['album_id' => 'unsorted']);
+		$response = $this->getJsonWithData('Album::photos', ['album_id' => 'unsorted']);
 		$this->assertOk($response);
 
-		return $response->json('resource.photos.0');
+		return $response->json('photos.0');
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test suite to match a refined Album API response shape: album metadata, photo lists, and child-album lists are now returned via separate endpoints. Tests for album actions, image links, metrics, smart albums, and image-processing flows were aligned to the new response structure to ensure consistent behavior and correct data access across scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->