### PR TITLE
Refactor photo data to have standalone fps and duration

### DIFF
--- a/app/Actions/Photo/Pipes/Shared/HydrateMetadata.php
+++ b/app/Actions/Photo/Pipes/Shared/HydrateMetadata.php
@@ -65,6 +65,12 @@ class HydrateMetadata implements SharedPipe
 		if ($state->photo->focal === null) {
 			$state->photo->focal = $state->exif_info->focal;
 		}
+		if ($state->photo->duration === null) {
+			$state->photo->duration = $state->exif_info->duration;
+		}
+		if ($state->photo->fps === null) {
+			$state->photo->fps = $state->exif_info->fps;
+		}
 		if ($state->photo->taken_at === null) {
 			$state->photo->taken_at = $state->exif_info->taken_at;
 			$state->photo->initial_taken_at = $state->exif_info->taken_at;

--- a/app/Http/Resources/Embed/EmbedPhotoResource.php
+++ b/app/Http/Resources/Embed/EmbedPhotoResource.php
@@ -39,7 +39,6 @@ class EmbedPhotoResource extends Data
 		$this->description = $photo->description;
 		$this->is_video = $photo->isVideo();
 
-		// For videos, aperture field stores duration in seconds
 		$this->duration = $photo->duration !== null
 			? app(Helpers::class)->secondsToHMS(intval($photo->duration))
 			: null;

--- a/app/Http/Resources/Embed/EmbedPhotoResource.php
+++ b/app/Http/Resources/Embed/EmbedPhotoResource.php
@@ -40,8 +40,8 @@ class EmbedPhotoResource extends Data
 		$this->is_video = $photo->isVideo();
 
 		// For videos, aperture field stores duration in seconds
-		$this->duration = $this->is_video && $photo->aperture !== null
-			? app(Helpers::class)->secondsToHMS(intval($photo->aperture))
+		$this->duration = $photo->duration !== null
+			? app(Helpers::class)->secondsToHMS(intval($photo->duration))
 			: null;
 
 		// Reuse existing SizeVariantsResouce instead of duplicating logic

--- a/app/Http/Resources/Models/Utils/PreformattedPhotoData.php
+++ b/app/Http/Resources/Models/Utils/PreformattedPhotoData.php
@@ -65,8 +65,8 @@ class PreformattedPhotoData extends Data
 		$this->iso = sprintf(__('gallery.photo.details.iso'), $photo->iso);
 		$this->lens = $photo->lens ?? '';
 
-		$this->duration = Helpers::secondsToHMS(intval($photo->aperture));
-		$this->fps = $photo->focal === null ? $photo->focal . ' fps' : '';
+		$this->duration = Helpers::secondsToHMS(intval($photo->duration));
+		$this->fps = $photo->fps === null ? $photo->fps . ' fps' : '';
 
 		$this->filesize = $original?->filesize ?? '0';
 		$this->resolution = $original?->width . ' x ' . $original?->height;

--- a/app/Http/Resources/Models/Utils/PreformattedPhotoData.php
+++ b/app/Http/Resources/Models/Utils/PreformattedPhotoData.php
@@ -66,7 +66,7 @@ class PreformattedPhotoData extends Data
 		$this->lens = $photo->lens ?? '';
 
 		$this->duration = Helpers::secondsToHMS(intval($photo->duration));
-		$this->fps = $photo->fps === null ? $photo->fps . ' fps' : '';
+		$this->fps = $photo->fps !== null && $photo->fps !== '' ? $photo->fps . ' fps' : '';
 
 		$this->filesize = $original?->filesize ?? '0';
 		$this->resolution = $original?->width . ' x ' . $original?->height;

--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -47,6 +47,8 @@ class Extractor
 	public ?string $model = null;
 	public ?string $shutter = null;
 	public ?string $focal = null;
+	public ?string $duration = null;
+	public ?string $fps = null;
 	public ?Carbon $taken_at = null;
 	public ?string $lens = null;
 	/** @var string[] */
@@ -457,9 +459,8 @@ class Extractor
 				$metadata->focal = round(floatval($metadata->focal)) . self::SUFFIX_MM_UNIT;
 			}
 		} else {
-			// Media is a video: Reuse (exploit) fields aperture and focal for duration and framerate
-			$metadata->aperture = ($exif->getDuration() !== false) ? $exif->getDuration() : null;
-			$metadata->focal = ($exif->getFramerate() !== false) ? $exif->getFramerate() : null;
+			$metadata->duration = ($exif->getDuration() !== false) ? $exif->getDuration() : null;
+			$metadata->fps = ($exif->getFramerate() !== false) ? $exif->getFramerate() : null;
 		}
 
 		if ($metadata->title === null || $metadata->title === '') {

--- a/database/migrations/2026_01_16_100000_add_rating_avg_to_photos.php
+++ b/database/migrations/2026_01_16_100000_add_rating_avg_to_photos.php
@@ -47,7 +47,7 @@ return new class() extends Migration {
 				->where('statistics.rating_count', '>', 0)
 				->select('photos.id', 'statistics.rating_sum', 'statistics.rating_count')
 				->orderBy('photos.id')
-				->chunk(100, function ($photos) {
+				->chunkById(100, function ($photos) {
 					$update = $photos->map(function ($photo) {
 						$ratingAvg = round($photo->rating_sum / $photo->rating_count, 4);
 
@@ -60,7 +60,7 @@ return new class() extends Migration {
 					$key_name = 'id';
 					$photo_instance = new RatedPhoto();
 					batch()->update($photo_instance, $update, $key_name);
-				});
+				}, 'id');
 		});
 	}
 

--- a/database/migrations/2026_01_18_212133_refactor_photo_structure.php
+++ b/database/migrations/2026_01_18_212133_refactor_photo_structure.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;

--- a/database/migrations/2026_01_18_212133_refactor_photo_structure.php
+++ b/database/migrations/2026_01_18_212133_refactor_photo_structure.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+require_once 'TemporaryModels/PhotoVideo.php';
+
+return new class() extends Migration {
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		Schema::table('photos', function (Blueprint $table) {
+			$table->string('duration')->nullable()->after('focal');
+			$table->string('fps')->nullable()->after('duration');
+		});
+
+		DB::transaction(function () {
+			DB::table('photos')->select('id', 'aperture', 'focal')
+				->where('type', 'LIKE', 'video/%')
+				->chunkById(100, function ($photos) {
+					$update = $photos->map(fn ($photo) => [
+						'id' => $photo->id,
+						'duration' => $photo->aperture === null ? null : (string) $photo->aperture,
+						'fps' => $photo->focal === null ? null : (string) $photo->focal,
+					])->all();
+					$key_name = 'id';
+					$photo_instance = new PhotoVideo();
+					batch()->update($photo_instance, $update, $key_name);
+				}, 'id');
+
+			DB::table('photos')
+				->where('type', 'LIKE', 'video/%')
+				->update(['aperture' => null, 'focal' => null]);
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		DB::transaction(function () {
+			DB::table('photos')->select('id', 'duration', 'fps')
+				->where('type', 'LIKE', 'video/%')
+				->chunkById(100, function ($photos) {
+					$update = $photos->map(fn ($photo) => [
+						'id' => $photo->id,
+						'aperture' => $photo->duration === null ? null : (string) $photo->duration,
+						'focal' => $photo->fps === null ? null : (string) $photo->fps,
+					])->all();
+					$key_name = 'id';
+					$photo_instance = new PhotoVideo();
+					batch()->update($photo_instance, $update, $key_name);
+				}, 'id');
+		});
+
+		Schema::table('photos', function (Blueprint $table) {
+			$table->dropColumn(['duration', 'fps']);
+		});
+	}
+};

--- a/database/migrations/TemporaryModels/PhotoVideo.php
+++ b/database/migrations/TemporaryModels/PhotoVideo.php
@@ -9,7 +9,7 @@
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Model class specific for running the migration of rating average.
+ * Model class specific for running the migration of updating structure of photo table from focal/aperture to fps/duration.
  * We cannot use the Model directly as we need to make sure that all migrations can be run in sequence
  * without depending on the app code.
  */

--- a/database/migrations/TemporaryModels/PhotoVideo.php
+++ b/database/migrations/TemporaryModels/PhotoVideo.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Model class specific for running the migration of rating average.
+ * We cannot use the Model directly as we need to make sure that all migrations can be run in sequence
+ * without depending on the app code.
+ */
+class PhotoVideo extends Model
+{
+	protected $table = 'photos';
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit duration and frame-rate metadata fields for videos.

* **Bug Fixes**
  * Display and formatting now use the dedicated duration/fps fields.
  * Metadata hydration populates duration and fps when missing.

* **Chores**
  * Migration adds duration/fps columns and migrates existing video data; includes a small temporary model to support the migration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->