### PR TITLE
Fix downloading image directly from smart album

### DIFF
--- a/app/Http/Requests/Album/ZipRequest.php
+++ b/app/Http/Requests/Album/ZipRequest.php
@@ -24,8 +24,8 @@ use App\Models\Photo;
 use App\Policies\AlbumPolicy;
 use App\Policies\PhotoPolicy;
 use App\Rules\AlbumIDListRule;
+use App\Rules\AlbumIDRule;
 use App\Rules\RandomIDListRule;
-use App\Rules\RandomIDRule;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rules\Enum;
 
@@ -71,7 +71,7 @@ class ZipRequest extends BaseApiRequest implements HasAlbums, HasPhotos, HasSize
 			RequestAttribute::ALBUM_IDS_ATTRIBUTE => ['sometimes', new AlbumIDListRule()],
 			RequestAttribute::PHOTO_IDS_ATTRIBUTE => ['sometimes', new RandomIDListRule()],
 			RequestAttribute::SIZE_VARIANT_ATTRIBUTE => ['required_if_accepted:photos_ids', new Enum(DownloadVariantType::class)],
-			RequestAttribute::FROM_ID_ATTRIBUTE => ['required_if_accepted:photos_ids', new RandomIDRule(true)],
+			RequestAttribute::FROM_ID_ATTRIBUTE => ['required_if_accepted:photos_ids', new AlbumIDRule(true)],
 		];
 	}
 

--- a/tests/Unit/Http/Requests/Album/ZipRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/ZipRequestTest.php
@@ -17,8 +17,8 @@ use App\Http\Requests\Album\ZipRequest;
 use App\Models\TagAlbum;
 use App\Policies\AlbumPolicy;
 use App\Rules\AlbumIDListRule;
+use App\Rules\AlbumIDRule;
 use App\Rules\RandomIDListRule;
-use App\Rules\RandomIDRule;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rules\Enum;
 use Tests\Unit\Http\Requests\Base\BaseRequestTest;
@@ -63,7 +63,7 @@ class ZipRequestTest extends BaseRequestTest
 			RequestAttribute::ALBUM_IDS_ATTRIBUTE => ['sometimes', new AlbumIDListRule()],
 			RequestAttribute::PHOTO_IDS_ATTRIBUTE => ['sometimes', new RandomIDListRule()],
 			RequestAttribute::SIZE_VARIANT_ATTRIBUTE => ['required_if_accepted:photos_ids', new Enum(DownloadVariantType::class)],
-			RequestAttribute::FROM_ID_ATTRIBUTE => ['required_if_accepted:photos_ids', new RandomIDRule(true)],
+			RequestAttribute::FROM_ID_ATTRIBUTE => ['required_if_accepted:photos_ids', new AlbumIDRule(true)],
 		];
 		$this->assertCount(count($expectedRuleMap), $rules); // only validating the first 7 rules & the GRANTS_UPLOAD_ATTRIBUTE is tested afterwards
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of smart albums with paginated photo sets to ensure reliable archival and compression across all pages.

* **Improvements**
  * Optimized photo compression flow to avoid duplicate processing and ensure consistent results.
  * Enhanced album ID validation for more accurate and consistent request validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->