### PR TITLE
Hide list button if there are no albums

### DIFF
--- a/resources/js/components/gallery/albumModule/AlbumHero.vue
+++ b/resources/js/components/gallery/albumModule/AlbumHero.vue
@@ -103,14 +103,21 @@
 
 						<!-- Album view toggle buttons -->
 						<Button
-							v-if="lycheeStore.album_view_mode === 'list'"
+							v-if="lycheeStore.album_view_mode === 'list' && albumsStore.albums.length > 0"
 							icon="pi pi-th-large"
 							class="border-none"
 							severity="secondary"
 							text
 							@click="toggleAlbumView('grid')"
 						/>
-						<Button v-else icon="pi pi-list" class="border-none" severity="secondary" text @click="toggleAlbumView('list')" />
+						<Button
+							v-else-if="albumsStore.albums.length > 0"
+							icon="pi pi-list"
+							class="border-none"
+							severity="secondary"
+							text
+							@click="toggleAlbumView('list')"
+						/>
 
 						<template v-if="isTouchDevice() && userStore.isLoggedIn">
 							<a


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Album gallery view toggle buttons are now hidden when the album collection is empty. Previously, controls for switching between grid and list display layouts would appear even without any albums, creating a confusing user experience. This change ensures view controls only display when there is content to view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->