### PR TITLE
Fix renamer rule test

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,3 +49,9 @@ When dealing with monetary values in PHP, it's crucial to handle them with preci
 we use the `moneyphp/money` library, which provides a robust way to manage monetary values and currencies.
 
 Never use floats or doubles to represent monetary values. Instead, use integers to represent the smallest currency unit (e.g., cents for USD). This means that $10.99 should be stored as 1099 (cents).
+
+# Translations
+
+Translations files are located in the `resources/lang/` directory. Use snake_case for keys and group related translations in nested arrays.
+Ignore all the the `lang/*.json` files as they are auto generated
+and not tracked in git.

--- a/lang/ar/renamer.php
+++ b/lang/ar/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/cz/renamer.php
+++ b/lang/cz/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/de/renamer.php
+++ b/lang/de/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/el/renamer.php
+++ b/lang/el/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/en/renamer.php
+++ b/lang/en/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/es/renamer.php
+++ b/lang/es/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/fa/renamer.php
+++ b/lang/fa/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'اصلی',
     'test_result' => 'نتیجه',
     'test_failed' => 'آزمایش قوانین تغییر نام ناموفق بود',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/fr/renamer.php
+++ b/lang/fr/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/hu/renamer.php
+++ b/lang/hu/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/it/renamer.php
+++ b/lang/it/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/ja/renamer.php
+++ b/lang/ja/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/nl/renamer.php
+++ b/lang/nl/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/no/renamer.php
+++ b/lang/no/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/pl/renamer.php
+++ b/lang/pl/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/pt/renamer.php
+++ b/lang/pt/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/ru/renamer.php
+++ b/lang/ru/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/sk/renamer.php
+++ b/lang/sk/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/sv/renamer.php
+++ b/lang/sv/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/vi/renamer.php
+++ b/lang/vi/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/zh_CN/renamer.php
+++ b/lang/zh_CN/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/lang/zh_TW/renamer.php
+++ b/lang/zh_TW/renamer.php
@@ -104,4 +104,6 @@ return [
     'test_original' => 'Original',
     'test_result' => 'Result',
     'test_failed' => 'Failed to test renamer rules',
+    'apply_photo_rules' => 'Apply photo rules',
+    'apply_album_rules' => 'Apply album rules',
 ];

--- a/resources/js/services/renamer-service.ts
+++ b/resources/js/services/renamer-service.ts
@@ -25,6 +25,8 @@ export type UpdateRenamerRuleRequest = CreateRenamerRuleRequest & {
 
 export type TestRenamerRequest = {
 	candidate: string;
+	is_photo: boolean;
+	is_album: boolean;
 };
 
 export type TestRenamerResponse = {

--- a/resources/js/views/RenamerRules.vue
+++ b/resources/js/views/RenamerRules.vue
@@ -23,6 +23,16 @@
 									{{ $t("renamer.test_input_placeholder") }}
 								</label>
 							</FloatLabel>
+							<div class="grid grid-cols-2">
+								<div class="flex gap-2 items-center">
+									<ToggleSwitch v-model="is_photo" input-id="is_photo_toggle_test" />
+									<label class="text-muted-color-emphasis" for="is_photo_toggle_test">{{ "Apply photo rules" }}</label>
+								</div>
+								<div class="flex gap-2 items-center">
+									<ToggleSwitch v-model="is_album" input-id="is_album_toggle_test" />
+									<label class="text-muted-color-emphasis" for="is_album_toggle_test">{{ "Apply album rules" }}</label>
+								</div>
+							</div>
 							<ProgressBar v-if="isTestLoading" mode="indeterminate" class="w-full" />
 							<div v-if="testResult !== null" class="grid grid-cols-1 md:grid-cols-2 gap-4">
 								<div>
@@ -121,6 +131,7 @@ import InputText from "@/components/forms/basic/InputText.vue";
 import Card from "primevue/card";
 import FloatLabel from "primevue/floatlabel";
 import ProgressBar from "primevue/progressbar";
+import ToggleSwitch from "primevue/toggleswitch";
 
 const rules = ref<App.Http.Resources.Models.RenamerRuleResource[] | undefined>(undefined);
 const showCreateModal = ref(false);
@@ -130,6 +141,8 @@ const selectedRule = ref<App.Http.Resources.Models.RenamerRuleResource | undefin
 const testInput = ref("");
 const testResult = ref<TestRenamerResponse | null>(null);
 const isTestLoading = ref(false);
+const is_photo = ref(true);
+const is_album = ref(true);
 const testError = ref<string | null>(null);
 let testTimeout: NodeJS.Timeout | null = null;
 
@@ -160,7 +173,7 @@ function performTest() {
 	isTestLoading.value = true;
 	testError.value = null;
 
-	RenamerService.test({ candidate: testInput.value })
+	RenamerService.test({ candidate: testInput.value, is_photo: is_photo.value, is_album: is_album.value })
 		.then((response) => {
 			testResult.value = response.data;
 		})

--- a/resources/js/views/RenamerRules.vue
+++ b/resources/js/views/RenamerRules.vue
@@ -26,11 +26,11 @@
 							<div class="grid grid-cols-2">
 								<div class="flex gap-2 items-center">
 									<ToggleSwitch v-model="is_photo" input-id="is_photo_toggle_test" />
-									<label class="text-muted-color-emphasis" for="is_photo_toggle_test">{{ "Apply photo rules" }}</label>
+									<label class="text-muted-color-emphasis" for="is_photo_toggle_test">{{ $t("renamer.apply_photo_rules") }}</label>
 								</div>
 								<div class="flex gap-2 items-center">
 									<ToggleSwitch v-model="is_album" input-id="is_album_toggle_test" />
-									<label class="text-muted-color-emphasis" for="is_album_toggle_test">{{ "Apply album rules" }}</label>
+									<label class="text-muted-color-emphasis" for="is_album_toggle_test">{{ $t("renamer.apply_album_rules") }}</label>
 								</div>
 							</div>
 							<ProgressBar v-if="isTestLoading" mode="indeterminate" class="w-full" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two toggles in the Renamer test UI to independently apply photo and album rules; both default to enabled.
* **Localization**
  * Added "Apply photo rules" and "Apply album rules" translations across supported locales.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->