### PR TITLE
Fix issue with filesize being 0 and add more coverage

### DIFF
--- a/app/Assets/Helpers.php
+++ b/app/Assets/Helpers.php
@@ -94,6 +94,10 @@ class Helpers
 	 */
 	public function getSymbolByQuantity(float $bytes): string
 	{
+		if ($bytes <= 0) {
+			return '0 B';
+		}
+
 		$symbols = [
 			'B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB',
 		];

--- a/tests/Unit/HelpersUnitTest.php
+++ b/tests/Unit/HelpersUnitTest.php
@@ -72,5 +72,65 @@ class HelpersUnitTest extends AbstractTestCase
 		self::assertEquals("90° 0' 0\" S", Helpers::decimalToDegreeMinutesSeconds(-90, true));
 		self::assertEquals("90° 0' 0\" E", Helpers::decimalToDegreeMinutesSeconds(90, false));
 		self::assertEquals("90° 0' 0\" W", Helpers::decimalToDegreeMinutesSeconds(-90, false));
+		self::assertEquals(null, Helpers::decimalToDegreeMinutesSeconds(null, true));
+		self::assertEquals(null, Helpers::decimalToDegreeMinutesSeconds(null, false));
+		self::assertEquals("45° 30' 0\" N", Helpers::decimalToDegreeMinutesSeconds(45.5, true));
+		self::assertEquals("12° 34' 29\" W", Helpers::decimalToDegreeMinutesSeconds(-12.575, false));
+	}
+
+	public function testGetSymbolByQuantity(): void
+	{
+		self::assertEquals('0 B', Helpers::getSymbolByQuantity(0));
+		self::assertEquals('0 B', Helpers::getSymbolByQuantity(-10));
+		self::assertEquals('512.00 B', Helpers::getSymbolByQuantity(512));
+		self::assertEquals('1.00 KB', Helpers::getSymbolByQuantity(1024));
+		self::assertEquals('1.00 MB', Helpers::getSymbolByQuantity(1024 * 1024));
+		self::assertEquals('1.00 GB', Helpers::getSymbolByQuantity(1024 * 1024 * 1024));
+		self::assertEquals('1.50 KB', Helpers::getSymbolByQuantity(1536));
+		self::assertEquals('2.25 MB', Helpers::getSymbolByQuantity(2.25 * 1024 * 1024));
+	}
+
+	public function testHasPermissions(): void
+	{
+		self::assertEquals(false, Helpers::hasPermissions('does-not-exist'));
+		// Test with existing readable/writable directory (storage path should exist)
+		$storagePath = storage_path();
+		if (file_exists($storagePath)) {
+			self::assertEquals(true, Helpers::hasPermissions($storagePath));
+		}
+	}
+
+	public function testSecondsToHMS(): void
+	{
+		self::assertEquals('0s', Helpers::secondsToHMS(0));
+		self::assertEquals('1s', Helpers::secondsToHMS(1));
+		self::assertEquals('59s', Helpers::secondsToHMS(59));
+		self::assertEquals('1m', Helpers::secondsToHMS(60));
+		self::assertEquals('1m30s', Helpers::secondsToHMS(90));
+		self::assertEquals('2m', Helpers::secondsToHMS(120));
+		self::assertEquals('1h', Helpers::secondsToHMS(3600));
+		self::assertEquals('1h30m', Helpers::secondsToHMS(5400));
+		self::assertEquals('1h1s', Helpers::secondsToHMS(3601));
+		self::assertEquals('2h30m45s', Helpers::secondsToHMS(9045));
+		self::assertEquals('1h', Helpers::secondsToHMS(3600.5)); // Test float
+	}
+
+	public function testCensor(): void
+	{
+		self::assertEquals('', Helpers::censor(''));
+		self::assertEquals('**c', Helpers::censor('abc'));
+		self::assertEquals('te****st', Helpers::censor('testtest'));
+		self::assertEquals('he*****rld', Helpers::censor('helloworld'));
+		self::assertEquals('pa****rd', Helpers::censor('password'));
+		// Test with different censoring percentage
+		self::assertEquals('p******d', Helpers::censor('password', 0.25));
+		self::assertEquals('pas**ord', Helpers::censor('password', 0.75));
+	}
+
+	public function testIsExecAvailable(): void
+	{
+		// This test will return true or false depending on the system configuration
+		$result = Helpers::isExecAvailable();
+		self::assertIsBool($result);
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed file size display to correctly show '0 B' when byte quantity is zero or negative

## Tests
* Added comprehensive test coverage for utility helper functions including size formatting, coordinate conversion, permissions checking, time conversion, and text processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->