### PR TITLE
Fix ugly header bar in light mode when showing photo details

### DIFF
--- a/app/Http/Resources/GalleryConfigs/InitConfig.php
+++ b/app/Http/Resources/GalleryConfigs/InitConfig.php
@@ -51,6 +51,7 @@ class InitConfig extends Data
 	public bool $is_details_links_enabled;
 	public bool $is_desktop_dock_full_transparency_enabled;
 	public bool $is_mobile_dock_full_transparency_enabled;
+	public bool $is_photo_details_always_open;
 
 	// Thumbs configuration
 	public VisibilityType $display_thumb_album_overlay;
@@ -159,6 +160,7 @@ class InitConfig extends Data
 		}
 		$this->is_desktop_dock_full_transparency_enabled = request()->configs()->getValueAsBool('desktop_dock_full_transparency_enabled');
 		$this->is_mobile_dock_full_transparency_enabled = request()->configs()->getValueAsBool('mobile_dock_full_transparency_enabled');
+		$this->is_photo_details_always_open = request()->configs()->getValueAsBool('enable_photo_details_always_open');
 
 		// Thumbs configuration
 		$this->display_thumb_album_overlay = request()->configs()->getValueAsEnum('display_thumb_album_overlay', VisibilityType::class);

--- a/database/migrations/2026_01_27_170000_photo_details_always_open.php
+++ b/database/migrations/2026_01_27_170000_photo_details_always_open.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const MOD_GALLERY = 'Gallery';
+
+	/**
+	 * @return array<int,array{key:string,value:string,is_secret:bool,cat:string,type_range:string,description:string,order?:int,not_on_docker?:bool,is_expert?:bool}>
+	 */
+	public function getConfigs(): array
+	{
+		return [
+			[
+				'key' => 'enable_photo_details_always_open',
+				'value' => '0',
+				'cat' => self::MOD_GALLERY,
+				'type_range' => self::BOOL,
+				'description' => 'Photo details always visible.',
+				'details' => 'When opening the photo view, the photo details drawer is always visible.',
+				'is_secret' => false,
+				'is_expert' => true,
+				'order' => 80,
+				'not_on_docker' => false,
+				'level' => 0,
+			],
+		];
+	}
+};

--- a/database/migrations/2026_01_27_170000_photo_details_always_open.php
+++ b/database/migrations/2026_01_27_170000_photo_details_always_open.php
@@ -12,7 +12,7 @@ return new class() extends BaseConfigMigration {
 	public const MOD_GALLERY = 'Gallery';
 
 	/**
-	 * @return array<int,array{key:string,value:string,is_secret:bool,cat:string,type_range:string,description:string,order?:int,not_on_docker?:bool,is_expert?:bool}>
+	 * @return array<int,array{key:string,value:string,is_secret:bool,cat:string,type_range:string,description:string,order?:int,not_on_docker?:bool,is_expert?:bool,level?:int}>
 	 */
 	public function getConfigs(): array
 	{

--- a/lang/ar/all_settings.php
+++ b/lang/ar/all_settings.php
@@ -659,6 +659,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/ar/all_settings.php
+++ b/lang/ar/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/cz/all_settings.php
+++ b/lang/cz/all_settings.php
@@ -659,6 +659,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/cz/all_settings.php
+++ b/lang/cz/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/de/all_settings.php
+++ b/lang/de/all_settings.php
@@ -330,6 +330,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',
@@ -656,6 +657,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
     'category_name' => [
         'config' => 'Basics',

--- a/lang/el/all_settings.php
+++ b/lang/el/all_settings.php
@@ -659,6 +659,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/el/all_settings.php
+++ b/lang/el/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/en/all_settings.php
+++ b/lang/en/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',
@@ -658,6 +659,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/es/all_settings.php
+++ b/lang/es/all_settings.php
@@ -659,6 +659,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/es/all_settings.php
+++ b/lang/es/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/fa/all_settings.php
+++ b/lang/fa/all_settings.php
@@ -659,6 +659,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/fa/all_settings.php
+++ b/lang/fa/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/fr/all_settings.php
+++ b/lang/fr/all_settings.php
@@ -330,6 +330,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee est fourni sous licence MIT sans aucune garantie. La désactivation de cette option supprime la clause de non-responsabilité de la page de commande.',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'documentation' => [
         'version' => 'Version actuelle de Lychee',
@@ -656,6 +657,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Activer la clause de non-responsabilité de LycheeOrg',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
     'category_name' => [
         'config' => 'Les bases',

--- a/lang/hu/all_settings.php
+++ b/lang/hu/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/hu/all_settings.php
+++ b/lang/hu/all_settings.php
@@ -658,6 +658,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/it/all_settings.php
+++ b/lang/it/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/it/all_settings.php
+++ b/lang/it/all_settings.php
@@ -658,6 +658,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/ja/all_settings.php
+++ b/lang/ja/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/ja/all_settings.php
+++ b/lang/ja/all_settings.php
@@ -658,6 +658,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/nl/all_settings.php
+++ b/lang/nl/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/nl/all_settings.php
+++ b/lang/nl/all_settings.php
@@ -658,6 +658,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/no/all_settings.php
+++ b/lang/no/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/no/all_settings.php
+++ b/lang/no/all_settings.php
@@ -658,6 +658,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/pl/all_settings.php
+++ b/lang/pl/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/pl/all_settings.php
+++ b/lang/pl/all_settings.php
@@ -658,6 +658,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/pt/all_settings.php
+++ b/lang/pt/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/pt/all_settings.php
+++ b/lang/pt/all_settings.php
@@ -658,6 +658,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/ru/all_settings.php
+++ b/lang/ru/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/ru/all_settings.php
+++ b/lang/ru/all_settings.php
@@ -658,6 +658,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/sk/all_settings.php
+++ b/lang/sk/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/sk/all_settings.php
+++ b/lang/sk/all_settings.php
@@ -658,6 +658,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/sv/all_settings.php
+++ b/lang/sv/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/sv/all_settings.php
+++ b/lang/sv/all_settings.php
@@ -658,6 +658,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/vi/all_settings.php
+++ b/lang/vi/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/vi/all_settings.php
+++ b/lang/vi/all_settings.php
@@ -658,6 +658,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/zh_CN/all_settings.php
+++ b/lang/zh_CN/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/zh_CN/all_settings.php
+++ b/lang/zh_CN/all_settings.php
@@ -658,6 +658,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/lang/zh_TW/all_settings.php
+++ b/lang/zh_TW/all_settings.php
@@ -332,6 +332,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Enable LycheeOrg non-liability disclaimer',
         'webshop_auto_fulfill_enabled' => 'Enable auto-fulfillment of orders.',
         'webshop_manual_fulfill_enabled' => 'Enable auto-fulfillment of orders on manual action.',
+        'enable_photo_details_always_open' => 'Photo details always visible.',
     ],
     'details' => [
         'version' => '',

--- a/lang/zh_TW/all_settings.php
+++ b/lang/zh_TW/all_settings.php
@@ -658,6 +658,7 @@ return [
         'webshop_lycheeorg_disclaimer_enabled' => 'Lychee is provided under MIT license without any warranties. Disabling this option removes the disclaimer from the order page.',
         'webshop_auto_fulfill_enabled' => 'Once a payment is completed, the content is automatically made available to the user when possible.',
         'webshop_manual_fulfill_enabled' => 'When "Mark as Delivered" is clicked, the content is automatically made available to the user when possible.',
+        'enable_photo_details_always_open' => 'When opening the photo view, the photo details drawer is always visible.',
     ],
 
     'category_name' => [

--- a/resources/js/components/headers/PhotoHeader.vue
+++ b/resources/js/components/headers/PhotoHeader.vue
@@ -3,7 +3,7 @@
 		v-if="photoStore.photo"
 		id="lychee_toolbar_container"
 		:class="{
-			'absolute top-0 left-0 w-full flex-none z-10 bg-linear-to-b from-black h-14 rounded-none': true,
+			'absolute top-0 left-0 w-full flex-none z-10 h-14 rounded-none': true,
 			'opacity-100 md:opacity-0 md:hover:opacity-100': is_full_screen || is_slideshow_active,
 			'opacity-100 h-14': !is_full_screen && !is_slideshow_active,
 		}"

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -420,6 +420,7 @@ declare namespace App.Http.Resources.GalleryConfigs {
 		is_details_links_enabled: boolean;
 		is_desktop_dock_full_transparency_enabled: boolean;
 		is_mobile_dock_full_transparency_enabled: boolean;
+		is_photo_details_always_open: boolean;
 		display_thumb_album_overlay: App.Enum.VisibilityType;
 		display_thumb_photo_overlay: App.Enum.VisibilityType;
 		album_subtitle_type: App.Enum.ThumbAlbumSubtitleType;

--- a/resources/js/stores/LycheeState.ts
+++ b/resources/js/stores/LycheeState.ts
@@ -1,5 +1,6 @@
 import InitService from "@/services/init-service";
 import { defineStore } from "pinia";
+import { useTogglablesStateStore } from "./ModalsState";
 
 export type LycheeStateStore = ReturnType<typeof useLycheeStateStore>;
 
@@ -32,6 +33,7 @@ export const useLycheeStateStore = defineStore("lychee-store", {
 		is_details_links_enabled: false,
 		is_desktop_dock_full_transparency_enabled: false,
 		is_mobile_dock_full_transparency_enabled: false,
+		is_photo_details_always_open: false,
 
 		// keybinding help
 		show_keybinding_help_popup: false,
@@ -187,6 +189,10 @@ export const useLycheeStateStore = defineStore("lychee-store", {
 					this.is_details_links_enabled = data.is_details_links_enabled;
 					this.is_desktop_dock_full_transparency_enabled = data.is_desktop_dock_full_transparency_enabled;
 					this.is_mobile_dock_full_transparency_enabled = data.is_mobile_dock_full_transparency_enabled;
+					this.is_photo_details_always_open = data.is_photo_details_always_open;
+					const togglableStore = useTogglablesStateStore();
+					// Initialize the details togglable according to the always open config
+					togglableStore.are_details_open = data.is_photo_details_always_open;
 
 					this.is_registration_enabled = data.is_registration_enabled;
 

--- a/resources/js/views/gallery-panels/Album.vue
+++ b/resources/js/views/gallery-panels/Album.vue
@@ -389,7 +389,7 @@ onKeyStroke("Escape", () => {
 		return;
 	}
 
-	if (are_details_open.value) {
+	if (are_details_open.value && lycheeStore.is_photo_details_always_open === false) {
 		are_details_open.value = false;
 		return;
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Photo details always visible" setting to keep the photo details drawer open when viewing photos.

* **Behavior**
  * When the setting is enabled, the details drawer opens automatically and Escape no longer closes it.

* **Style**
  * Adjusted photo header background styling for a cleaner toolbar appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->