### PR TITLE
Exclude random from requiring XSRF token

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -26,6 +26,7 @@ class VerifyCsrfToken extends Middleware
 		'/api/Session::init',
 		'/api/v2/Zip',
 		'/api/v2/Shop/Checkout/Finalize/*',
+		'/api/v2/Photo::random',
 	];
 
 	/**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the photo retrieval API endpoint to be accessible without CSRF token verification, allowing external requests to function properly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->