### PR TITLE
Fix logic about de-duplication

### DIFF
--- a/database/migrations/2026_01_19_193315_refactor_photo_avoid_duplicates.php
+++ b/database/migrations/2026_01_19_193315_refactor_photo_avoid_duplicates.php
@@ -49,7 +49,7 @@ return new class() extends Migration {
 				try {
 					DB::table('photo_album')->where('photo_id', '=', $photo_id)->whereNotIn('album_id', $album_ids)->update(['photo_id' => $photo_to_keep]);
 				} catch (\Exception) {
-					// If this crashes this meeans that the link already exists between the photo and the album.
+					// If this crashes this means that the link already exists between the photo and the album.
 					// We ignore it.
 				}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved photo database maintenance to process items individually with better error handling so single-item issues won't abort whole cleanup.
  * Preserved cleanup of related photo data (variants, purchasable links, statistics, album entries) to keep storage consistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->