### PR TITLE
Allow filtering embedded albums/streams by author using data-author attribute

### DIFF
--- a/.ai/embeds/demo.html
+++ b/.ai/embeds/demo.html
@@ -195,8 +195,8 @@
                 </div>
 
                 <div class="form-group">
-                    <label for="author">Author Filter (username, optional)</label>
-                    <input type="text" id="author" placeholder="e.g. admin">
+                    <label for="author">Author Filter (username(s), optional)</label>
+                    <input type="text" id="author" placeholder="e.g. admin or admin,alice">
                 </div>
 
                 <div class="grid-2">

--- a/.ai/embeds/demo.html
+++ b/.ai/embeds/demo.html
@@ -194,6 +194,11 @@
                     <input type="text" id="albumId" placeholder="abc123">
                 </div>
 
+                <div class="form-group">
+                    <label for="author">Author Filter (username, optional)</label>
+                    <input type="text" id="author" placeholder="e.g. admin">
+                </div>
+
                 <div class="grid-2">
                     <div class="form-group">
                         <label for="layout">Layout</label>
@@ -349,6 +354,15 @@
      data-mode="stream"
      data-layout="masonry"
      data-max-photos="50"&gt;
+&lt;/div&gt;
+
+&lt;!-- Stream Mode filtered by author --&gt;
+&lt;div data-lychee-embed
+     data-api-url="https://your-lychee.com"
+     data-mode="stream"
+     data-layout="justified"
+     data-author="admin"
+     data-max-photos="30"&gt;
 &lt;/div&gt;</div>
         </div>
     </div>
@@ -409,6 +423,7 @@
             const showDescription = document.getElementById('showDescription').checked;
             const showCaptions = document.getElementById('showCaptions').checked;
             const showExif = document.getElementById('showExif').checked;
+            const author = document.getElementById('author').value.trim();
 
             // Create embed element
             const embedDiv = document.createElement('div');
@@ -428,6 +443,9 @@
             embedDiv.setAttribute('data-show-description', showDescription);
             embedDiv.setAttribute('data-show-captions', showCaptions);
             embedDiv.setAttribute('data-show-exif', showExif);
+            if (author) {
+                embedDiv.setAttribute('data-author', author);
+            }
 
             container.appendChild(embedDiv);
 
@@ -450,6 +468,11 @@
             // Add albumId only for album mode
             if (mode === 'album') {
                 widgetConfig.albumId = albumId;
+            }
+
+            // Add author filter if specified
+            if (author) {
+                widgetConfig.author = author;
             }
 
             // Initialize widget

--- a/app/Http/Requests/Embed/EmbededRequest.php
+++ b/app/Http/Requests/Embed/EmbededRequest.php
@@ -22,6 +22,7 @@ class EmbededRequest extends BaseApiRequest implements HasBaseAlbum
 	public ?int $limit = null;
 	public int $offset = 0;
 	public ?string $sort = null;
+	public ?string $author = null;
 
 	/**
 	 * Determine if the user is authorized to make this request.
@@ -75,6 +76,12 @@ class EmbededRequest extends BaseApiRequest implements HasBaseAlbum
 			$this->sort = null; // Invalid value, use default
 		} else {
 			$this->sort = $sort;
+		}
+
+		// Parse author filter
+		$author = $this->query('author', null);
+		if ($author !== null && is_string($author) && $author !== '') {
+			$this->author = $author;
 		}
 
 		$album_id = $this->route(RequestAttribute::ALBUM_ID_ATTRIBUTE, null);

--- a/app/Http/Requests/Embed/EmbededRequest.php
+++ b/app/Http/Requests/Embed/EmbededRequest.php
@@ -22,7 +22,8 @@ class EmbededRequest extends BaseApiRequest implements HasBaseAlbum
 	public ?int $limit = null;
 	public int $offset = 0;
 	public ?string $sort = null;
-	public ?string $author = null;
+	/** @var string[]|null */
+	public ?array $authors = null;
 
 	/**
 	 * Determine if the user is authorized to make this request.
@@ -78,10 +79,13 @@ class EmbededRequest extends BaseApiRequest implements HasBaseAlbum
 			$this->sort = $sort;
 		}
 
-		// Parse author filter
+		// Parse author filter (supports comma-separated usernames)
 		$author = $this->query('author', null);
 		if ($author !== null && is_string($author) && $author !== '') {
-			$this->author = $author;
+			$authors = array_filter(array_map('trim', explode(',', $author)), fn ($v) => $v !== '');
+			if (count($authors) > 0) {
+				$this->authors = array_values($authors);
+			}
 		}
 
 		$album_id = $this->route(RequestAttribute::ALBUM_ID_ATTRIBUTE, null);

--- a/resources/js/embed/api.ts
+++ b/resources/js/embed/api.ts
@@ -17,10 +17,11 @@ export class EmbedApiClient {
 	 * @param limit   Optional maximum number of photos to fetch (1-500)
 	 * @param offset  Optional number of photos to skip (default: 0)
 	 * @param sort    Optional sort order ('asc' or 'desc')
+	 * @param author  Optional username to filter photos by uploader
 	 * @returns Album and photos data
 	 * @throws Error if fetch fails or album is not accessible
 	 */
-	fetchAlbum(albumId: string, limit?: number, offset?: number, sort?: "asc" | "desc"): Promise<EmbedApiResponse> {
+	fetchAlbum(albumId: string, limit?: number, offset?: number, sort?: "asc" | "desc", author?: string): Promise<EmbedApiResponse> {
 		// Build URL with optional pagination parameters
 		const url = new URL(`${this.apiUrl}/api/v2/Embed/${encodeURIComponent(albumId)}`);
 		if (limit !== undefined) {
@@ -31,6 +32,9 @@ export class EmbedApiClient {
 		}
 		if (sort !== undefined) {
 			url.searchParams.set("sort", sort);
+		}
+		if (author !== undefined) {
+			url.searchParams.set("author", author);
 		}
 
 		return fetch(url.toString(), {
@@ -65,10 +69,11 @@ export class EmbedApiClient {
 	 * @param limit  Optional maximum number of photos to fetch (1-500, default: 100)
 	 * @param offset Optional number of photos to skip (default: 0)
 	 * @param sort   Optional sort order ('asc' or 'desc', default: 'desc')
+	 * @param author Optional username to filter photos by uploader
 	 * @returns Public photos data
 	 * @throws Error if fetch fails
 	 */
-	fetchStream(limit?: number, offset?: number, sort?: "asc" | "desc"): Promise<EmbedStreamApiResponse> {
+	fetchStream(limit?: number, offset?: number, sort?: "asc" | "desc", author?: string): Promise<EmbedStreamApiResponse> {
 		// Build URL with optional pagination parameters
 		const url = new URL(`${this.apiUrl}/api/v2/Embed/stream`);
 		if (limit !== undefined) {
@@ -79,6 +84,9 @@ export class EmbedApiClient {
 		}
 		if (sort !== undefined) {
 			url.searchParams.set("sort", sort);
+		}
+		if (author !== undefined) {
+			url.searchParams.set("author", author);
 		}
 
 		return fetch(url.toString(), {

--- a/resources/js/embed/components/EmbedWidget.vue
+++ b/resources/js/embed/components/EmbedWidget.vue
@@ -361,7 +361,7 @@ onMounted(() => {
 		// Fetch public stream
 		const limit = props.config.maxPhotos === "none" ? 500 : props.config.maxPhotos;
 		const sort = props.config.sortOrder ?? "desc";
-		loadPromise = apiClient.fetchStream(limit, 0, sort).then((streamData) => ({
+		loadPromise = apiClient.fetchStream(limit, 0, sort, props.config.author).then((streamData) => ({
 			album: {
 				id: "",
 				title: "Public Photo Stream",
@@ -378,7 +378,7 @@ onMounted(() => {
 		} else {
 			const limit = props.config.maxPhotos === "none" ? undefined : props.config.maxPhotos;
 			const sort = props.config.sortOrder; // Pass undefined if not set (use album default)
-			loadPromise = apiClient.fetchAlbum(props.config.albumId, limit, 0, sort);
+			loadPromise = apiClient.fetchAlbum(props.config.albumId, limit, 0, sort, props.config.author);
 		}
 	}
 

--- a/resources/js/embed/config.ts
+++ b/resources/js/embed/config.ts
@@ -117,6 +117,7 @@ export function validateConfig(config: Partial<EmbedConfig>): EmbedConfig {
 		showCaptions: config.showCaptions ?? DEFAULT_CONFIG.showCaptions!,
 		showExif: config.showExif ?? DEFAULT_CONFIG.showExif!,
 		headerPlacement,
+		author: config.author,
 		containerClass: config.containerClass,
 	};
 }
@@ -214,6 +215,11 @@ export function parseDataAttributes(element: HTMLElement): Partial<EmbedConfig> 
 	// Header placement
 	if (element.dataset.headerPlacement) {
 		config.headerPlacement = element.dataset.headerPlacement as HeaderPlacement;
+	}
+
+	// Author filter
+	if (element.dataset.author) {
+		config.author = element.dataset.author;
 	}
 
 	// Custom class

--- a/resources/js/embed/types.ts
+++ b/resources/js/embed/types.ts
@@ -58,6 +58,8 @@ export interface EmbedConfig {
 	showExif?: boolean;
 	/** Header placement: 'top' (full header), 'bottom' (simple link), or 'none' */
 	headerPlacement?: HeaderPlacement;
+	/** Filter photos by uploader username */
+	author?: string;
 	/** Custom CSS class for widget container */
 	containerClass?: string;
 }

--- a/tests/Feature_v2/Embed/EmbedAlbumTest.php
+++ b/tests/Feature_v2/Embed/EmbedAlbumTest.php
@@ -184,30 +184,30 @@ class EmbedAlbumTest extends BaseApiWithDataTest
 		// album4 is public, owned by userLocked, contains photo4
 		// Add a photo owned by a different user to the same album
 		/** @disregard */
-		$otherPhoto = Photo::factory()->owned_by($this->userMayUpload1)->with_GPS_coordinates()->in($this->album4)->create();
+		$other_photo = Photo::factory()->owned_by($this->userMayUpload1)->with_GPS_coordinates()->in($this->album4)->create();
 
 		// Without author filter: should return both photos
 		$response = $this->getJson('Embed/' . $this->album4->id);
 		$this->assertOk($response);
-		$allPhotoIds = collect($response->json('photos'))->pluck('id')->toArray();
-		$this->assertContains($this->photo4->id, $allPhotoIds);
-		$this->assertContains($otherPhoto->id, $allPhotoIds);
+		$all_photo_ids = collect($response->json('photos'))->pluck('id')->toArray();
+		$this->assertContains($this->photo4->id, $all_photo_ids);
+		$this->assertContains($other_photo->id, $all_photo_ids);
 
 		// With author filter: should return only the matching user's photo
 		$response = $this->getJson('Embed/' . $this->album4->id . '?author=' . $this->userLocked->username);
 		$this->assertOk($response);
-		$filteredPhotoIds = collect($response->json('photos'))->pluck('id')->toArray();
-		$this->assertContains($this->photo4->id, $filteredPhotoIds);
-		$this->assertNotContains($otherPhoto->id, $filteredPhotoIds);
+		$filtered_photo_ids = collect($response->json('photos'))->pluck('id')->toArray();
+		$this->assertContains($this->photo4->id, $filtered_photo_ids);
+		$this->assertNotContains($other_photo->id, $filtered_photo_ids);
 
 		// Verify photo_count reflects the filtered count
 		$response->assertJson([
 			'album' => [
-				'photo_count' => count($filteredPhotoIds),
+				'photo_count' => count($filtered_photo_ids),
 			],
 		]);
 
-		$otherPhoto->delete();
+		$other_photo->delete();
 	}
 
 	/**
@@ -218,23 +218,23 @@ class EmbedAlbumTest extends BaseApiWithDataTest
 		// album4 is public, owned by userLocked, contains photo4
 		// Add a photo owned by a different user to the same album
 		/** @disregard */
-		$otherPhoto = Photo::factory()->owned_by($this->userMayUpload1)->with_GPS_coordinates()->in($this->album4)->create();
+		$other_photo = Photo::factory()->owned_by($this->userMayUpload1)->with_GPS_coordinates()->in($this->album4)->create();
 
 		// Filter by both authors: should return photos from both users
 		$response = $this->getJson('Embed/' . $this->album4->id . '?author=' . $this->userLocked->username . ',' . $this->userMayUpload1->username);
 		$this->assertOk($response);
-		$photoIds = collect($response->json('photos'))->pluck('id')->toArray();
-		$this->assertContains($this->photo4->id, $photoIds, 'photo4 owned by userLocked should be included');
-		$this->assertContains($otherPhoto->id, $photoIds, 'otherPhoto owned by userMayUpload1 should be included');
+		$photo_ids = collect($response->json('photos'))->pluck('id')->toArray();
+		$this->assertContains($this->photo4->id, $photo_ids, 'photo4 owned by userLocked should be included');
+		$this->assertContains($other_photo->id, $photo_ids, 'other_photo owned by userMayUpload1 should be included');
 
 		// Filter by only one author: should exclude the other
 		$response = $this->getJson('Embed/' . $this->album4->id . '?author=' . $this->userMayUpload1->username);
 		$this->assertOk($response);
-		$filteredIds = collect($response->json('photos'))->pluck('id')->toArray();
-		$this->assertContains($otherPhoto->id, $filteredIds);
-		$this->assertNotContains($this->photo4->id, $filteredIds);
+		$filtered_ids = collect($response->json('photos'))->pluck('id')->toArray();
+		$this->assertContains($other_photo->id, $filtered_ids);
+		$this->assertNotContains($this->photo4->id, $filtered_ids);
 
-		$otherPhoto->delete();
+		$other_photo->delete();
 	}
 
 	/**

--- a/tests/Feature_v2/Embed/EmbedStreamTest.php
+++ b/tests/Feature_v2/Embed/EmbedStreamTest.php
@@ -324,26 +324,26 @@ class EmbedStreamTest extends BaseApiWithDataTest
 	{
 		// Add a photo owned by a different user to the same public album
 		/** @disregard */
-		$otherPhoto = Photo::factory()->owned_by($this->userMayUpload1)->with_GPS_coordinates()->in($this->album4)->create();
+		$other_photo = Photo::factory()->owned_by($this->userMayUpload1)->with_GPS_coordinates()->in($this->album4)->create();
 
 		// Without author filter: should include the other user's photo
 		$response = $this->getJson('Embed/stream');
 		$this->assertOk($response);
-		$allPhotoIds = collect($response->json('photos'))->pluck('id')->toArray();
-		$this->assertContains($otherPhoto->id, $allPhotoIds);
+		$all_photo_ids = collect($response->json('photos'))->pluck('id')->toArray();
+		$this->assertContains($other_photo->id, $all_photo_ids);
 
 		// With author filter: should return only userLocked's photos
 		$response = $this->getJson('Embed/stream?author=' . $this->userLocked->username);
 		$this->assertOk($response);
 
 		$data = $response->json();
-		$photoIds = collect($data['photos'])->pluck('id')->toArray();
+		$photo_ids = collect($data['photos'])->pluck('id')->toArray();
 
-		$this->assertContains($this->photo4->id, $photoIds, 'photo4 owned by userLocked should be included');
-		$this->assertContains($this->subPhoto4->id, $photoIds, 'subPhoto4 owned by userLocked should be included');
-		$this->assertNotContains($otherPhoto->id, $photoIds, 'otherPhoto owned by userMayUpload1 should be excluded');
+		$this->assertContains($this->photo4->id, $photo_ids, 'photo4 owned by userLocked should be included');
+		$this->assertContains($this->subPhoto4->id, $photo_ids, 'subPhoto4 owned by userLocked should be included');
+		$this->assertNotContains($other_photo->id, $photo_ids, 'other_photo owned by userMayUpload1 should be excluded');
 
-		$otherPhoto->delete();
+		$other_photo->delete();
 	}
 
 	/**
@@ -353,24 +353,24 @@ class EmbedStreamTest extends BaseApiWithDataTest
 	{
 		// Add a photo owned by userMayUpload1 in a public album
 		/** @disregard */
-		$otherPhoto = Photo::factory()->owned_by($this->userMayUpload1)->with_GPS_coordinates()->in($this->album4)->create();
+		$other_photo = Photo::factory()->owned_by($this->userMayUpload1)->with_GPS_coordinates()->in($this->album4)->create();
 
 		// Filter by both authors
 		$response = $this->getJson('Embed/stream?author=' . $this->userLocked->username . ',' . $this->userMayUpload1->username);
 		$this->assertOk($response);
 
-		$photoIds = collect($response->json('photos'))->pluck('id')->toArray();
-		$this->assertContains($this->photo4->id, $photoIds, 'photo4 owned by userLocked should be included');
-		$this->assertContains($otherPhoto->id, $photoIds, 'otherPhoto owned by userMayUpload1 should be included');
+		$photo_ids = collect($response->json('photos'))->pluck('id')->toArray();
+		$this->assertContains($this->photo4->id, $photo_ids, 'photo4 owned by userLocked should be included');
+		$this->assertContains($other_photo->id, $photo_ids, 'other_photo owned by userMayUpload1 should be included');
 
 		// Filter by only userMayUpload1: should exclude userLocked's photos
 		$response = $this->getJson('Embed/stream?author=' . $this->userMayUpload1->username);
 		$this->assertOk($response);
-		$filteredIds = collect($response->json('photos'))->pluck('id')->toArray();
-		$this->assertContains($otherPhoto->id, $filteredIds, 'otherPhoto should be included');
-		$this->assertNotContains($this->photo4->id, $filteredIds, 'photo4 should not be included when filtering by other user');
+		$filtered_ids = collect($response->json('photos'))->pluck('id')->toArray();
+		$this->assertContains($other_photo->id, $filtered_ids, 'other_photo should be included');
+		$this->assertNotContains($this->photo4->id, $filtered_ids, 'photo4 should not be included when filtering by other user');
 
-		$otherPhoto->delete();
+		$other_photo->delete();
 	}
 
 	/**
@@ -396,10 +396,10 @@ class EmbedStreamTest extends BaseApiWithDataTest
 		$data = $response->json();
 		$this->assertCount(1, $data['photos'], 'Should return exactly 1 photo with author filter and limit=1');
 
-		$photoIds = collect($data['photos'])->pluck('id')->toArray();
+		$photo_ids = collect($data['photos'])->pluck('id')->toArray();
 		// The single returned photo should be owned by userLocked
 		$this->assertTrue(
-			in_array($this->photo4->id, $photoIds, true) || in_array($this->subPhoto4->id, $photoIds, true),
+			in_array($this->photo4->id, $photo_ids, true) || in_array($this->subPhoto4->id, $photo_ids, true),
 			'Returned photo should be one of userLocked\'s public photos'
 		);
 	}

--- a/tests/Feature_v2/Embed/EmbedStreamTest.php
+++ b/tests/Feature_v2/Embed/EmbedStreamTest.php
@@ -391,7 +391,7 @@ class EmbedStreamTest extends BaseApiWithDataTest
 		$photoIds = collect($data['photos'])->pluck('id')->toArray();
 		// The single returned photo should be owned by userLocked
 		$this->assertTrue(
-			in_array($this->photo4->id, $photoIds) || in_array($this->subPhoto4->id, $photoIds),
+			in_array($this->photo4->id, $photoIds, true) || in_array($this->subPhoto4->id, $photoIds, true),
 			'Returned photo should be one of userLocked\'s public photos'
 		);
 	}


### PR DESCRIPTION
This PR allows filtering embedded albums/streams by setting the data-author attribute to a Lychee user's username. Only that user's photos will be included in the embed.

As of https://github.com/LycheeOrg/Lychee/pull/4083/commits/62fa810f467ca827332ac07740b3ff67943efce7 , multiple usernames may be included in the `data-author` attribute, separated by commas.

This feature was developed with Claude Code and tested manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added author filter for embed configurations so embeds can show photos from specific uploader(s).
  * Added data-author HTML attribute support for embed elements; author setting is respected for album and public stream embeds.

* **Tests**
  * Added tests covering single/multi-author filters, non-existent authors, and pagination with author filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->