### PR TITLE
Copy built album-embed assets into Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,7 @@ COPY --from=composer --chown=www-data:www-data /app/vendor ./vendor
 
 # Copy built frontend assets from node stage
 COPY --from=node --chown=www-data:www-data /app/public/build ./public/build
+COPY --from=node --chown=www-data:www-data /app/public/embed ./public/embed
 
 # Ensure storage and bootstrap/cache are writable with minimal permissions
 RUN mkdir -p storage/framework/cache \

--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -134,6 +134,7 @@ COPY --from=composer --chown=www-data:www-data /app/vendor ./vendor
 
 # Copy built frontend assets from node stage
 COPY --from=node --chown=www-data:www-data /app/public/build ./public/build
+COPY --from=node --chown=www-data:www-data /app/public/embed ./public/embed
 
 # Ensure storage and bootstrap/cache are writable with minimal permissions
 RUN mkdir -p storage/framework/cache \


### PR DESCRIPTION
The album/stream embed widget is built to `public/embed/` (which is .gitignored) but only `public/build/` was copied from the node build stage. This caused embedded albums to be broken in Lychee 7.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image configurations to include embedding assets in production builds. Assets from `public/embed` are now available at runtime alongside existing public build assets, improving asset delivery capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->