### PR TITLE
Add link to owning albums.

### DIFF
--- a/app/Http/Requests/Photo/GetPhotoAlbumsRequest.php
+++ b/app/Http/Requests/Photo/GetPhotoAlbumsRequest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Photo;
+
+use App\Contracts\Http\Requests\HasPhoto;
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Http\Requests\BaseApiRequest;
+use App\Http\Requests\Traits\HasPhotoTrait;
+use App\Models\Photo;
+use App\Policies\PhotoPolicy;
+use App\Rules\RandomIDRule;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Request to fetch albums containing a photo.
+ *
+ * Supports both authenticated and guest users.
+ * Authorization uses PhotoPolicy::CAN_SEE to verify the user can see the photo.
+ */
+class GetPhotoAlbumsRequest extends BaseApiRequest implements HasPhoto
+{
+	use HasPhotoTrait;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::check(PhotoPolicy::CAN_SEE, [Photo::class, $this->photo]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+		];
+	}
+
+	/**
+	 * Merge route parameter into request data for validation.
+	 */
+	protected function prepareForValidation(): void
+	{
+		/** @disregard */
+		$this->merge([
+			RequestAttribute::PHOTO_ID_ATTRIBUTE => $this->route(RequestAttribute::PHOTO_ID_ATTRIBUTE),
+		]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		/** @var string $photo_id */
+		$photo_id = $values[RequestAttribute::PHOTO_ID_ATTRIBUTE];
+
+		$this->photo = Photo::query()
+			->with(['albums'])
+			->findOrFail($photo_id);
+	}
+}

--- a/app/Http/Resources/Models/PhotoAlbumResource.php
+++ b/app/Http/Resources/Models/PhotoAlbumResource.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Models;
+
+use App\Models\Album;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class PhotoAlbumResource extends Data
+{
+	public string $id;
+	public string $title;
+
+	public function __construct(Album $album)
+	{
+		$this->id = $album->id;
+		$this->title = $album->title;
+	}
+}

--- a/app/Metadata/Cache/RouteCacheManager.php
+++ b/app/Metadata/Cache/RouteCacheManager.php
@@ -41,6 +41,7 @@ final readonly class RouteCacheManager
 			'api/v2/Album::albums' => new RouteCacheConfig(tag: CacheTag::GALLERY, user_dependant: true, extra: [RequestAttribute::ALBUM_ID_ATTRIBUTE]),
 			'api/v2/Album::head' => new RouteCacheConfig(tag: CacheTag::GALLERY, user_dependant: true, extra: [RequestAttribute::ALBUM_ID_ATTRIBUTE]),
 			'api/v2/Album::getTargetListAlbums' => false, // TODO: cache me later.
+			'api/v2/Photo/{photo_id}/albums' => new RouteCacheConfig(tag: CacheTag::GALLERY, user_dependant: true),
 			'api/v2/Albums' => new RouteCacheConfig(tag: CacheTag::GALLERY, user_dependant: true),
 			'api/v2/Auth::config' => new RouteCacheConfig(tag: CacheTag::SETTINGS, user_dependant: true),
 			'api/v2/Auth::rights' => new RouteCacheConfig(tag: CacheTag::SETTINGS, user_dependant: true),

--- a/docs/specs/4-architecture/features/018-photo-albums-sidebar/plan.md
+++ b/docs/specs/4-architecture/features/018-photo-albums-sidebar/plan.md
@@ -1,0 +1,171 @@
+# Feature Plan 018 – Photo Albums Sidebar
+
+_Linked specification:_ `docs/specs/4-architecture/features/018-photo-albums-sidebar/spec.md`
+_Status:_ Draft
+_Last updated:_ 2026-02-26
+
+> Guardrail: Keep this plan traceable back to the governing spec. Reference FR/NFR/Scenario IDs from `spec.md` where relevant, log any new high- or medium-impact questions in [docs/specs/4-architecture/open-questions.md](../../open-questions.md), and assume clarifications are resolved only when the spec's normative sections (requirements/NFR/behaviour/telemetry) and, where applicable, ADRs under `docs/specs/5-decisions/` have been updated.
+
+## Vision & Success Criteria
+
+**User value:** Users can see all albums a photo belongs to directly from the photo detail sidebar, giving them spatial orientation within their library and surfacing cross-album membership that was previously hidden.
+
+**Success signals:**
+- `GET /api/v2/Photo/{photo_id}/albums` returns the correct, filtered album list within 200ms for typical usage
+- Sidebar displays album titles lazily on open, with no duplicate requests
+- All tests pass (feature tests for authorization, filtering, edge cases)
+- No N+1 queries
+- PHPStan level 6, php-cs-fixer, and frontend lint all pass
+
+## Scope Alignment
+
+- **In scope:**
+  - Backend: Request class with authorization, controller method, route, Spatie Data response resource
+  - Backend: Feature tests covering S-018-01 through S-018-07
+  - Frontend: `PhotoService.albums()` method
+  - Frontend: Albums section in `PhotoDetails.vue` with loading/empty/error states
+  - Translations: English labels, placeholders for other languages
+
+- **Out of scope:**
+  - Smart album inclusion
+  - Album add/remove from sidebar
+  - Photo edit drawer changes
+
+## Dependencies & Interfaces
+
+| Dependency | Description |
+|------------|-------------|
+| `Photo::albums()` | Existing `BelongsToMany` relationship via `photo_album` pivot |
+| `PhotoPolicy::CAN_SEE` | Existing policy gate for photo visibility |
+| `AlbumPolicy::canAccess()` | Existing policy method for album access check |
+| `PhotoDetails.vue` | Existing sidebar component to be extended |
+| `PhotoService` | Existing frontend service to receive new method |
+
+## Assumptions & Risks
+
+- **Assumptions:**
+  - The `photo_album` pivot table has proper indexes on `photo_id` and `album_id` (confirmed by existing usage patterns).
+  - Most photos belong to 1–5 albums; extreme cases (50+ albums) are rare.
+  - The `AlbumPolicy::canAccess()` check per album is acceptable at small scale; no batch optimization needed.
+
+- **Risks / Mitigations:**
+  - _Risk:_ N+1 queries when checking album access for many albums. _Mitigation:_ Eager-load album data in single query, then filter in PHP with policy checks.
+  - _Risk:_ Sidebar flicker on slow networks. _Mitigation:_ Show loading indicator; cache response per photo ID.
+
+## Implementation Drift Gate
+
+After each increment, verify:
+1. Feature tests pass: `php artisan test --filter=GetPhotoAlbumsTest`
+2. Static analysis: `make phpstan`
+3. Formatting: `vendor/bin/php-cs-fixer fix --dry-run`
+4. Frontend lint: `npm run check` (when frontend changes are made)
+
+Record any drift in this section.
+
+## Increment Map
+
+### I1 – Backend: Request, Controller, Route, Resource (~60 min)
+
+- _Goal:_ Create the API endpoint `GET /api/v2/Photo/{photo_id}/albums` with full authorization and album access filtering.
+- _Preconditions:_ Feature spec finalized.
+- _Steps:_
+  1. Create `PhotoAlbumResource` (Spatie Data) with `id` and `title` fields
+  2. Create `GetPhotoAlbumsRequest` extending `BaseApiRequest` with route parameter `photo_id` and `PhotoPolicy::CAN_SEE` authorization
+  3. Add `albums()` method to `PhotoController` accepting `GetPhotoAlbumsRequest`, returning `Collection<PhotoAlbumResource>`
+  4. Register `GET /api/v2/Photo/{photo_id}/albums` route in `routes/api_v2.php`
+  5. Implement album access filtering using `AlbumPolicy::canAccess()` per album
+- _Commands:_
+  - `php artisan test --filter=GetPhotoAlbumsTest`
+  - `make phpstan`
+  - `vendor/bin/php-cs-fixer fix`
+- _Exit:_ Endpoint returns correct filtered album list; request rejects unauthorized access.
+
+### I2 – Backend: Feature Tests (~45 min)
+
+- _Goal:_ Comprehensive test coverage for all scenarios S-018-01 through S-018-07.
+- _Preconditions:_ I1 complete.
+- _Steps:_
+  1. Create `GetPhotoAlbumsTest` extending `BaseApiWithDataTest`
+  2. Write test for owner seeing all albums (S-018-01)
+  3. Write test for shared user seeing accessible albums only (S-018-02, S-018-03)
+  4. Write test for guest seeing public albums (S-018-04)
+  5. Write test for guest denied on private photo (S-018-05)
+  6. Write test for non-existent photo returning 404 (S-018-06)
+  7. Write test for photo with no albums (S-018-07)
+- _Commands:_
+  - `php artisan test --filter=GetPhotoAlbumsTest`
+  - `make phpstan`
+- _Exit:_ All 7 scenario tests green.
+
+### I3 – Frontend: Service Method & Sidebar Section (~60 min)
+
+- _Goal:_ Add `albums()` method to `PhotoService` and display album list in `PhotoDetails.vue`.
+- _Preconditions:_ I1 complete (endpoint available).
+- _Steps:_
+  1. Add `albums(photo_id): Promise<AxiosResponse<PhotoAlbumEntry[]>>` to `PhotoService`
+  2. Add `PhotoAlbumEntry` type (if not auto-generated by TypeScript transformer)
+  3. Add Albums section to `PhotoDetails.vue` between Tags and EXIF sections
+  4. Implement lazy-loading logic: watch `areDetailsOpen` + `photoStore.photo.id`, fetch on change
+  5. Handle loading, empty, and error states
+  6. Cache album list per photo ID to prevent duplicate requests
+  7. Render album titles as clickable links using `router.push({ name: "album", params: { albumId } })`
+  8. On click: close sidebar (`are_details_open = false`), reset photo store, then navigate
+- _Commands:_
+  - `npm run check`
+  - `npm run format`
+- _Exit:_ Sidebar shows album list; loading/empty/error states work correctly.
+
+### I4 – Translations & Quality Gate (~30 min)
+
+- _Goal:_ Add translation keys and run full quality gate.
+- _Preconditions:_ I1–I3 complete.
+- _Steps:_
+  1. Add English translations for album section labels (`ALBUMS`, `NO_ALBUMS`, `ALBUMS_LOADING_ERROR`)
+  2. Add placeholder entries to all other language files (22 languages)
+  3. Run full quality gate: php-cs-fixer, npm format, npm check, php artisan test, make phpstan
+- _Commands:_
+  - `vendor/bin/php-cs-fixer fix`
+  - `npm run format`
+  - `npm run check`
+  - `php artisan test`
+  - `make phpstan`
+- _Exit:_ All checks green; feature ready for manual testing.
+
+## Scenario Tracking
+
+| Scenario ID | Increment / Task reference | Notes |
+|-------------|---------------------------|-------|
+| S-018-01 | I2 / T-018-05 | Owner sees all albums |
+| S-018-02 | I2 / T-018-06 | Shared user sees accessible albums |
+| S-018-03 | I2 / T-018-06 | Inaccessible albums filtered |
+| S-018-04 | I2 / T-018-07 | Guest sees public albums |
+| S-018-05 | I2 / T-018-08 | Guest denied on private photo |
+| S-018-06 | I2 / T-018-09 | Non-existent photo → 404 |
+| S-018-07 | I2 / T-018-10 | Photo with no albums → empty |
+| S-018-08 | I3 / T-018-12 | Sidebar shows albums |
+| S-018-09 | I3 / T-018-13 | No duplicate requests |
+| S-018-10 | I3 / T-018-13 | Different photo triggers new fetch |
+| S-018-11 | I3 / T-018-13 | Album click navigates to album |
+
+## Analysis Gate
+
+_Not yet completed. Run after I1–I2 implementation begins._
+
+## Exit Criteria
+
+- [ ] All feature tests pass (`GetPhotoAlbumsTest`)
+- [ ] PHPStan level 6 passes
+- [ ] php-cs-fixer clean
+- [ ] npm run check / npm run format clean
+- [ ] Sidebar displays albums section correctly (manual verification)
+- [ ] Clicking album title navigates to album view (manual verification)
+- [ ] No N+1 queries on album fetch
+- [ ] Translations added for all 22 languages
+- [ ] Knowledge map updated
+- [ ] Roadmap status updated to Complete
+
+## Follow-ups / Backlog
+
+- **Smart album display:** Consider showing smart albums (Highlighted, Recent) that include the photo.
+- **Album thumbnails:** Show small album cover thumbnails alongside titles.
+- **Batch pre-fetch:** Optionally prefetch album lists for visible photos in gallery view for perceived faster UX.

--- a/docs/specs/4-architecture/features/018-photo-albums-sidebar/spec.md
+++ b/docs/specs/4-architecture/features/018-photo-albums-sidebar/spec.md
@@ -1,0 +1,232 @@
+# Feature 018 – Photo Albums Sidebar
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Last updated | 2026-02-26 |
+| Owners | User |
+| Linked plan | `docs/specs/4-architecture/features/018-photo-albums-sidebar/plan.md` |
+| Linked tasks | `docs/specs/4-architecture/features/018-photo-albums-sidebar/tasks.md` |
+| Roadmap entry | #018 |
+
+> Guardrail: This specification is the single normative source of truth for the feature. Track high- and medium-impact questions in [docs/specs/4-architecture/open-questions.md](../../open-questions.md), encode resolved answers directly in the Requirements/NFR/Behaviour/UI/Telemetry sections below (no per-feature `## Clarifications` sections), and use ADRs under `docs/specs/5-decisions/` for architecturally significant clarifications (referencing their IDs from the relevant spec sections).
+
+## Overview
+
+When a user opens the detail sidebar for a photo, the sidebar currently shows metadata (title, dates, description, tags, EXIF, location, license, statistics, rating). This feature adds a new section listing all albums that contain the photo. The data is fetched on-demand (lazy-loaded) when the sidebar opens — it is not included in the standard `PhotoResource`. The backend endpoint verifies that the requesting user has access to the photo and filters the album list to only those the user is permitted to see.
+
+**Affected modules:** Application (new Request class, PhotoController endpoint), REST API (new `GET Photo::albums` route), UI (`PhotoDetails.vue` drawer component, `PhotoService`), Models (Photo, Album), Policies (PhotoPolicy, AlbumPolicy).
+
+## Goals
+
+- Show all albums containing a photo in the details sidebar, filtered to the user's access rights
+- Lazy-load the album list only when the sidebar is opened (not bundled with the photo resource)
+- Verify photo access before returning any data
+- Filter returned albums against the user's accessible albums via `AlbumPolicy::canAccess`
+- Provide album title and ID so users can navigate to the album
+- Keep the endpoint lightweight and fast
+
+## Non-Goals
+
+- Adding or removing album associations from the sidebar (this is read-only)
+- Showing albums in the photo edit drawer (`PhotoEdit.vue`)
+- Including smart albums (Highlighted, Recent, etc.) — only real `Album` records from the `photo_album` pivot
+- Prefetching album lists on photo load or gallery view
+- Deep album tree / hierarchy display (only flat list of album titles)
+
+## Functional Requirements
+
+| ID | Requirement | Success path | Validation path | Failure path | Telemetry & traces | Source |
+|----|-------------|--------------|-----------------|--------------|--------------------|--------|
+| FR-018-01 | New endpoint returns albums for a photo | `GET /api/v2/Photo/{photo_id}/albums` returns a JSON array of accessible albums (`id`, `title`) for the given photo. | `photo_id` must be a valid, existing photo ID (random string, max 24 chars). | 404 if photo not found. | No telemetry. | User requirement |
+| FR-018-02 | Photo access is verified before returning data | Endpoint checks `PhotoPolicy::CAN_SEE` for the requesting user. Guests and authenticated users are both supported. | Policy gate evaluated before any album query. | 403 Forbidden if the user cannot see the photo. 401 if authentication is required but not provided. | No telemetry. | Security requirement |
+| FR-018-03 | Album list filtered by user access | Only albums for which `AlbumPolicy::canAccess(user, album)` returns true are included in the response. Albums the user cannot access are silently omitted. | Iterate albums from the `photo_album` pivot and check access for each. | If user has access to zero albums, return an empty array (not an error). | No telemetry. | Security requirement |
+| FR-018-04 | Response contains album ID and title | Each album in the response includes at minimum `id` (string) and `title` (string). | Fields sourced from `Album` model. | N/A | No telemetry. | User requirement |
+| FR-018-05 | Sidebar section displays album list | The `PhotoDetails.vue` drawer shows a new "Albums" section listing album titles. Section appears after tags and before EXIF data. | Section visible whenever the sidebar is open. If albums list is empty, show "No albums" or equivalent. If loading, show a spinner/skeleton. | If fetch fails, show a brief error message in the section. | No telemetry. | User requirement |
+| FR-018-06 | Album list fetched lazily on sidebar open | The frontend requests the album list only when `areDetailsOpen` transitions to `true`. The request is not repeated while the sidebar remains open for the same photo. | Watch `areDetailsOpen` and `photoStore.photo.id` to trigger fetch. Cache response per photo ID during the session. | If request fails, section shows error state without blocking other sidebar content. | No telemetry. | Performance requirement |
+| FR-018-07 | Album titles are clickable links that navigate to the album | Each album title in the sidebar is a clickable link. Clicking navigates the user to the album gallery view (`/gallery/{albumId}`). The sidebar closes and the photo store resets before navigation. | Uses `router.push({ name: "album", params: { albumId } })`. Sidebar state (`are_details_open`) set to `false` before navigation. | N/A | No telemetry. | User requirement |
+
+## Non-Functional Requirements
+
+| ID | Requirement | Driver | Measurement | Dependencies | Source |
+|----|-------------|--------|-------------|--------------|--------|
+| NFR-018-01 | Endpoint responds within 200ms for photos with ≤50 albums | User experience | Measure response time in feature tests. Eager-load album titles. | Database indexing on `photo_album` pivot table (already indexed). | Performance standard |
+| NFR-018-02 | PHP code follows Lychee conventions | Maintainability | License headers, snake_case variables, strict comparison (`===`), PSR-4, no `empty()`, `in_array(..., true)`. | php-cs-fixer, phpstan level 6 | [coding-conventions.md](../../../3-reference/coding-conventions.md) |
+| NFR-018-03 | Frontend follows Vue3/TypeScript conventions | Maintainability | Template-first, Composition API, regular function declarations, `.then()` not async/await, axios in services directory. | Prettier, ESLint | [coding-conventions.md](../../../3-reference/coding-conventions.md) |
+| NFR-018-04 | Test coverage for endpoint scenarios | Correctness | Feature tests for: valid photo with accessible/inaccessible albums, photo not found, forbidden photo, unauthenticated user, empty album list. | BaseApiWithDataTest, in-memory SQLite | Testing standard |
+| NFR-018-05 | No N+1 queries | Performance | Eager-load albums in single query then filter in PHP. Verify with query count assertion or manual inspection. | Eloquent eager loading | Performance standard |
+
+## UI / Interaction Mock-ups
+
+### 1. Photo Details Sidebar — Albums Section
+
+```
+┌──────────────────────────────────────────────┐
+│  ✕  Photo Details                            │
+├──────────────────────────────────────────────┤
+│                                              │
+│  Title: Sunset at the Beach                  │
+│  Resolution: 4032 × 3024                     │
+│  Filesize: 5.2 MB                            │
+│                                              │
+│  ── Dates ──────────────────────────────     │
+│  Uploaded: 2026-01-15                        │
+│  Captured: 2025-12-28                        │
+│                                              │
+│  ── Description ────────────────────────     │
+│  A beautiful sunset captured from the pier.  │
+│                                              │
+│  ── Tags ───────────────────────────────     │
+│  [ sunset ] [ beach ] [ nature ]             │
+│                                              │
+│  ── Albums ─────────────────────────────     │  ← NEW SECTION
+│  • Vacation 2025              ←── clickable  │
+│  • Best of Nature             ←── clickable  │
+│  • Shared Favourites          ←── clickable  │
+│                                              │
+│  ── EXIF ───────────────────────────────     │
+│  Camera: Canon EOS R5                        │
+│  Lens: RF 24-70mm f/2.8L                     │
+│  ...                                         │
+│                                              │
+└──────────────────────────────────────────────┘
+```
+
+### 2. Albums Section — Loading State
+
+```
+│  ── Albums ─────────────────────────────     │
+│  ◌ Loading...                                │
+```
+
+### 3. Albums Section — Empty State
+
+```
+│  ── Albums ─────────────────────────────     │
+│  This photo is not in any album.             │
+```
+
+### 4. Albums Section — Error State
+
+```
+│  ── Albums ─────────────────────────────     │
+│  ⚠ Could not load albums.                   │
+```
+
+## Branch & Scenario Matrix
+
+| Scenario ID | Description / Expected outcome |
+|-------------|--------------------------------|
+| S-018-01 | Authenticated user requests albums for own photo in 3 albums: Returns all 3 albums with id/title |
+| S-018-02 | Authenticated user requests albums for photo shared with them: Returns only albums user can access |
+| S-018-03 | Authenticated user requests albums where some albums are inaccessible: Inaccessible albums silently filtered out |
+| S-018-04 | Guest requests albums for photo in public album: Returns public albums only |
+| S-018-05 | Guest requests albums for private photo: Returns 403 Forbidden |
+| S-018-06 | User requests albums for non-existent photo: Returns 404 Not Found |
+| S-018-07 | User requests albums for photo not in any album: Returns empty array `[]` |
+| S-018-08 | Sidebar opens and fetches album list: Albums section populates after loading state |
+| S-018-09 | Sidebar stays open, same photo: No duplicate request fired |
+| S-018-10 | Sidebar reopens for a different photo: New request fetches albums for the new photo |
+| S-018-11 | User clicks album title in sidebar: Sidebar closes, navigates to `/gallery/{albumId}` |
+
+## Test Strategy
+
+- **Application:** Feature tests for the `GET Photo/{photo_id}/albums` endpoint:
+  - Authenticated owner sees all their albums (S-018-01)
+  - Authenticated user sees only accessible albums (S-018-02, S-018-03)
+  - Guest sees public albums (S-018-04)
+  - Guest denied for private photo (S-018-05)
+  - Non-existent photo returns 404 (S-018-06)
+  - Photo with no albums returns empty array (S-018-07)
+- **REST:** Validate JSON structure (`id`, `title` fields present)
+- **UI (JS):** Manual verification:
+  - Sidebar shows albums section with correct data (S-018-08)
+  - No duplicate requests on same photo (S-018-09)
+  - Switching photos triggers new fetch (S-018-10)
+  - Clicking album title navigates to album (S-018-11)
+
+## Interface & Contract Catalogue
+
+### Domain Objects
+
+| ID | Description | Modules |
+|----|-------------|---------|
+| DO-018-01 | GetPhotoAlbumsRequest: Validates `photo_id` path parameter and authorizes access via `PhotoPolicy::CAN_SEE` | Application (Request validation) |
+| DO-018-02 | PhotoAlbumEntry: Lightweight Spatie Data resource with `id` (string) and `title` (string) | Application (Response resource) |
+
+### API Routes / Services
+
+| ID | Transport | Description | Notes |
+|----|-----------|-------------|-------|
+| API-018-01 | GET /api/v2/Photo/{photo_id}/albums | Returns list of accessible albums for the given photo | New endpoint. Response: `PhotoAlbumEntry[]` |
+
+### UI States
+
+| ID | State | Trigger / Expected outcome |
+|----|-------|---------------------------|
+| UI-018-01 | Albums loading | Sidebar opens → spinner shown in Albums section |
+| UI-018-02 | Albums loaded (non-empty) | Fetch completes → list of album titles displayed |
+| UI-018-03 | Albums loaded (empty) | Fetch completes with empty array → "This photo is not in any album." |
+| UI-018-04 | Albums error | Fetch fails → "Could not load albums." message |
+| UI-018-05 | Album click navigation | User clicks album title → sidebar closes, router navigates to `/gallery/{albumId}` |
+
+## Telemetry & Observability
+
+No custom telemetry events. Standard Laravel request logging applies.
+
+## Documentation Deliverables
+
+- Update knowledge map to document the new endpoint and its relationship to PhotoController / PhotoDetails sidebar.
+- No ADR required (straightforward read-only endpoint).
+
+## Spec DSL
+
+```yaml
+domain_objects:
+  - id: DO-018-01
+    name: GetPhotoAlbumsRequest
+    fields:
+      - name: photo_id
+        type: string
+        constraints: "required, exists in photos table"
+  - id: DO-018-02
+    name: PhotoAlbumEntry
+    fields:
+      - name: id
+        type: string
+      - name: title
+        type: string
+routes:
+  - id: API-018-01
+    method: GET
+    path: /api/v2/Photo/{photo_id}/albums
+    response: PhotoAlbumEntry[]
+ui_states:
+  - id: UI-018-01
+    description: Albums section loading spinner
+  - id: UI-018-02
+    description: Albums section with album list
+  - id: UI-018-03
+    description: Albums section empty state
+  - id: UI-018-04
+    description: Albums section error state
+  - id: UI-018-05
+    description: Album click navigates to album view
+```
+
+## Appendix
+
+### Response Example
+
+```json
+[
+  { "id": "abc123def456", "title": "Vacation 2025" },
+  { "id": "xyz789ghi012", "title": "Best of Nature" }
+]
+```
+
+### Empty Response
+
+```json
+[]
+```

--- a/docs/specs/4-architecture/features/018-photo-albums-sidebar/tasks.md
+++ b/docs/specs/4-architecture/features/018-photo-albums-sidebar/tasks.md
@@ -1,6 +1,6 @@
 # Feature 018 Tasks – Photo Albums Sidebar
 
-_Status: Draft_
+_Status: Implementation Complete_
 _Last updated: 2026-02-26_
 
 > Keep this checklist aligned with the feature plan increments. Stage tests before implementation, record verification commands beside each task, and prefer bite-sized entries (≤90 minutes).
@@ -10,25 +10,25 @@ _Last updated: 2026-02-26_
 
 ### Increment I1 – Backend: Request, Controller, Route, Resource
 
-- [ ] T-018-01 – Create PhotoAlbumResource Spatie Data class (FR-018-04, DO-018-02).
+- [x] T-018-01 – Create PhotoAlbumResource Spatie Data class (FR-018-04, DO-018-02).
   _Intent:_ Lightweight response resource with `id` (string) and `title` (string) fields extending `Spatie\LaravelData\Data`.
   _Verification commands:_
   - `make phpstan`
   _Notes:_ Place in `app/Http/Resources/Models/`. Add `#[TypeScript()]` annotation for frontend type generation.
 
-- [ ] T-018-02 – Create GetPhotoAlbumsRequest with authorization (FR-018-01, FR-018-02, DO-018-01).
+- [x] T-018-02 – Create GetPhotoAlbumsRequest with authorization (FR-018-01, FR-018-02, DO-018-01).
   _Intent:_ Request class extending `BaseApiRequest` that resolves `photo_id` from the route parameter, loads the `Photo` model, and authorizes via `PhotoPolicy::CAN_SEE`. Supports both authenticated and guest users.
   _Verification commands:_
   - `make phpstan`
   _Notes:_ Place in `app/Http/Requests/Photo/`. Use `Gate::check(PhotoPolicy::CAN_SEE, ...)` for authorization. Extract photo from route model binding or manual lookup.
 
-- [ ] T-018-03 – Add `albums()` method to PhotoController (FR-018-01, FR-018-03, API-018-01).
+- [x] T-018-03 – Add `albums()` method to PhotoController (FR-018-01, FR-018-03, API-018-01).
   _Intent:_ Controller method accepting `GetPhotoAlbumsRequest`, loading the photo's albums via the `BelongsToMany` relationship, filtering each album through `AlbumPolicy::canAccess()`, and returning a collection of `PhotoAlbumResource`.
   _Verification commands:_
   - `make phpstan`
   _Notes:_ Eager-load albums in a single query to avoid N+1 (NFR-018-05). Filter in PHP after loading.
 
-- [ ] T-018-04 – Register GET route in api_v2.php (API-018-01).
+- [x] T-018-04 – Register GET route in api_v2.php (API-018-01).
   _Intent:_ Add `GET /Photo/{photo_id}/albums` route pointing to `PhotoController::albums`.
   _Verification commands:_
   - `php artisan route:list --path=Photo`
@@ -37,43 +37,43 @@ _Last updated: 2026-02-26_
 
 ### Increment I2 – Backend: Feature Tests
 
-- [ ] T-018-05 – Test: owner sees all albums for their photo (S-018-01).
+- [x] T-018-05 – Test: owner sees all albums for their photo (S-018-01).
   _Intent:_ Create `GetPhotoAlbumsTest` extending `BaseApiWithDataTest`. Test that a photo owner receives all albums the photo belongs to.
   _Verification commands:_
   - `php artisan test --filter=GetPhotoAlbumsTest`
   _Notes:_ Set up photo in multiple albums owned by the same user.
 
-- [ ] T-018-06 – Test: shared user sees only accessible albums (S-018-02, S-018-03).
+- [x] T-018-06 – Test: shared user sees only accessible albums (S-018-02, S-018-03).
   _Intent:_ Test that a non-owner authenticated user only sees albums they have access to (via sharing or public access). Albums they cannot access are omitted.
   _Verification commands:_
   - `php artisan test --filter=GetPhotoAlbumsTest`
   _Notes:_ Set up photo in both shared and private albums.
 
-- [ ] T-018-07 – Test: guest sees public albums only (S-018-04).
+- [x] T-018-07 – Test: guest sees public albums only (S-018-04).
   _Intent:_ Test that an unauthenticated guest receives only albums with public access enabled.
   _Verification commands:_
   - `php artisan test --filter=GetPhotoAlbumsTest`
   _Notes:_ Photo must be in at least one public album to be visible to guest.
 
-- [ ] T-018-08 – Test: guest denied for private photo (S-018-05).
+- [x] T-018-08 – Test: guest denied for private photo (S-018-05).
   _Intent:_ Test that a guest requesting albums for a photo they cannot see receives 403 Forbidden.
   _Verification commands:_
   - `php artisan test --filter=GetPhotoAlbumsTest`
   _Notes:_ Photo only in private albums, no public access.
 
-- [ ] T-018-09 – Test: non-existent photo returns 404 (S-018-06).
+- [x] T-018-09 – Test: non-existent photo returns 404 (S-018-06).
   _Intent:_ Test that requesting albums for a photo ID that does not exist returns 404 Not Found.
   _Verification commands:_
   - `php artisan test --filter=GetPhotoAlbumsTest`
   _Notes:_ Use a random non-existent ID.
 
-- [ ] T-018-10 – Test: photo with no albums returns empty array (S-018-07).
+- [x] T-018-10 – Test: photo with no albums returns empty array (S-018-07).
   _Intent:_ Test that a photo not belonging to any album returns an empty JSON array `[]`.
   _Verification commands:_
   - `php artisan test --filter=GetPhotoAlbumsTest`
   _Notes:_ Create photo without album associations.
 
-- [ ] T-018-11 – Run full backend quality gate.
+- [x] T-018-11 – Run full backend quality gate.
   _Intent:_ Ensure all backend code passes static analysis and formatting after I1–I2.
   _Verification commands:_
   - `vendor/bin/php-cs-fixer fix`
@@ -83,13 +83,13 @@ _Last updated: 2026-02-26_
 
 ### Increment I3 – Frontend: Service Method & Sidebar Section
 
-- [ ] T-018-12 – Add `albums()` method to PhotoService (FR-018-06).
+- [x] T-018-12 – Add `albums()` method to PhotoService (FR-018-06).
   _Intent:_ Add method `albums(photo_id: string): Promise<AxiosResponse>` to `resources/js/services/photo-service.ts` calling `GET ${Constants.getApiUrl()}/Photo/${photo_id}/albums`.
   _Verification commands:_
   - `npm run check`
   _Notes:_ Follow existing service method patterns. Use `.then()` not async/await.
 
-- [ ] T-018-13 – Add Albums section to PhotoDetails.vue (FR-018-05, FR-018-06, FR-018-07, UI-018-01 to UI-018-05, S-018-11).
+- [x] T-018-13 – Add Albums section to PhotoDetails.vue (FR-018-05, FR-018-06, FR-018-07, UI-018-01 to UI-018-05, S-018-11).
   _Intent:_ Add a new section in `PhotoDetails.vue` between Tags and EXIF that:
   - Watches `areDetailsOpen` and `photoStore.photo.id` to trigger lazy fetch
   - Shows loading spinner while fetching
@@ -105,19 +105,19 @@ _Last updated: 2026-02-26_
 
 ### Increment I4 – Translations & Quality Gate
 
-- [ ] T-018-14 – Add English translation keys.
+- [x] T-018-14 – Add English translation keys.
   _Intent:_ Add keys to `lang/php_en.json`: `ALBUMS`, `NO_ALBUMS` ("This photo is not in any album."), `ALBUMS_LOADING_ERROR` ("Could not load albums.").
   _Verification commands:_
   - `npm run check`
   _Notes:_ Use snake_case keys.
 
-- [ ] T-018-15 – Add translation placeholders to other languages (21 languages).
+- [x] T-018-15 – Add translation placeholders to other languages (21 languages).
   _Intent:_ Add the same keys with English fallback text to all other language files (ar, bg, cz, de, el, es, fa, fr, hu, it, ja, nl, no, pl, pt, ru, sk, sv, vi, zh_CN, zh_TW).
   _Verification commands:_
   - `npm run check`
   _Notes:_ Placeholders only; native speakers can update later.
 
-- [ ] T-018-16 – Run full quality gate.
+- [x] T-018-16 – Run full quality gate.
   _Intent:_ Final validation that all code passes formatting, tests, and static analysis.
   _Verification commands:_
   - `vendor/bin/php-cs-fixer fix`

--- a/docs/specs/4-architecture/features/018-photo-albums-sidebar/tasks.md
+++ b/docs/specs/4-architecture/features/018-photo-albums-sidebar/tasks.md
@@ -1,0 +1,151 @@
+# Feature 018 Tasks – Photo Albums Sidebar
+
+_Status: Draft_
+_Last updated: 2026-02-26_
+
+> Keep this checklist aligned with the feature plan increments. Stage tests before implementation, record verification commands beside each task, and prefer bite-sized entries (≤90 minutes).
+> **Mark tasks `[x]` immediately** after each one passes verification—do not batch completions. Update the roadmap status when all tasks are done.
+
+## Checklist
+
+### Increment I1 – Backend: Request, Controller, Route, Resource
+
+- [ ] T-018-01 – Create PhotoAlbumResource Spatie Data class (FR-018-04, DO-018-02).
+  _Intent:_ Lightweight response resource with `id` (string) and `title` (string) fields extending `Spatie\LaravelData\Data`.
+  _Verification commands:_
+  - `make phpstan`
+  _Notes:_ Place in `app/Http/Resources/Models/`. Add `#[TypeScript()]` annotation for frontend type generation.
+
+- [ ] T-018-02 – Create GetPhotoAlbumsRequest with authorization (FR-018-01, FR-018-02, DO-018-01).
+  _Intent:_ Request class extending `BaseApiRequest` that resolves `photo_id` from the route parameter, loads the `Photo` model, and authorizes via `PhotoPolicy::CAN_SEE`. Supports both authenticated and guest users.
+  _Verification commands:_
+  - `make phpstan`
+  _Notes:_ Place in `app/Http/Requests/Photo/`. Use `Gate::check(PhotoPolicy::CAN_SEE, ...)` for authorization. Extract photo from route model binding or manual lookup.
+
+- [ ] T-018-03 – Add `albums()` method to PhotoController (FR-018-01, FR-018-03, API-018-01).
+  _Intent:_ Controller method accepting `GetPhotoAlbumsRequest`, loading the photo's albums via the `BelongsToMany` relationship, filtering each album through `AlbumPolicy::canAccess()`, and returning a collection of `PhotoAlbumResource`.
+  _Verification commands:_
+  - `make phpstan`
+  _Notes:_ Eager-load albums in a single query to avoid N+1 (NFR-018-05). Filter in PHP after loading.
+
+- [ ] T-018-04 – Register GET route in api_v2.php (API-018-01).
+  _Intent:_ Add `GET /Photo/{photo_id}/albums` route pointing to `PhotoController::albums`.
+  _Verification commands:_
+  - `php artisan route:list --path=Photo`
+  - `make phpstan`
+  _Notes:_ Place near existing Photo routes. Use route model binding or string parameter based on existing patterns.
+
+### Increment I2 – Backend: Feature Tests
+
+- [ ] T-018-05 – Test: owner sees all albums for their photo (S-018-01).
+  _Intent:_ Create `GetPhotoAlbumsTest` extending `BaseApiWithDataTest`. Test that a photo owner receives all albums the photo belongs to.
+  _Verification commands:_
+  - `php artisan test --filter=GetPhotoAlbumsTest`
+  _Notes:_ Set up photo in multiple albums owned by the same user.
+
+- [ ] T-018-06 – Test: shared user sees only accessible albums (S-018-02, S-018-03).
+  _Intent:_ Test that a non-owner authenticated user only sees albums they have access to (via sharing or public access). Albums they cannot access are omitted.
+  _Verification commands:_
+  - `php artisan test --filter=GetPhotoAlbumsTest`
+  _Notes:_ Set up photo in both shared and private albums.
+
+- [ ] T-018-07 – Test: guest sees public albums only (S-018-04).
+  _Intent:_ Test that an unauthenticated guest receives only albums with public access enabled.
+  _Verification commands:_
+  - `php artisan test --filter=GetPhotoAlbumsTest`
+  _Notes:_ Photo must be in at least one public album to be visible to guest.
+
+- [ ] T-018-08 – Test: guest denied for private photo (S-018-05).
+  _Intent:_ Test that a guest requesting albums for a photo they cannot see receives 403 Forbidden.
+  _Verification commands:_
+  - `php artisan test --filter=GetPhotoAlbumsTest`
+  _Notes:_ Photo only in private albums, no public access.
+
+- [ ] T-018-09 – Test: non-existent photo returns 404 (S-018-06).
+  _Intent:_ Test that requesting albums for a photo ID that does not exist returns 404 Not Found.
+  _Verification commands:_
+  - `php artisan test --filter=GetPhotoAlbumsTest`
+  _Notes:_ Use a random non-existent ID.
+
+- [ ] T-018-10 – Test: photo with no albums returns empty array (S-018-07).
+  _Intent:_ Test that a photo not belonging to any album returns an empty JSON array `[]`.
+  _Verification commands:_
+  - `php artisan test --filter=GetPhotoAlbumsTest`
+  _Notes:_ Create photo without album associations.
+
+- [ ] T-018-11 – Run full backend quality gate.
+  _Intent:_ Ensure all backend code passes static analysis and formatting after I1–I2.
+  _Verification commands:_
+  - `vendor/bin/php-cs-fixer fix`
+  - `php artisan test`
+  - `make phpstan`
+  _Notes:_ Fix any issues before proceeding to frontend.
+
+### Increment I3 – Frontend: Service Method & Sidebar Section
+
+- [ ] T-018-12 – Add `albums()` method to PhotoService (FR-018-06).
+  _Intent:_ Add method `albums(photo_id: string): Promise<AxiosResponse>` to `resources/js/services/photo-service.ts` calling `GET ${Constants.getApiUrl()}/Photo/${photo_id}/albums`.
+  _Verification commands:_
+  - `npm run check`
+  _Notes:_ Follow existing service method patterns. Use `.then()` not async/await.
+
+- [ ] T-018-13 – Add Albums section to PhotoDetails.vue (FR-018-05, FR-018-06, FR-018-07, UI-018-01 to UI-018-05, S-018-11).
+  _Intent:_ Add a new section in `PhotoDetails.vue` between Tags and EXIF that:
+  - Watches `areDetailsOpen` and `photoStore.photo.id` to trigger lazy fetch
+  - Shows loading spinner while fetching
+  - Displays album titles as clickable links
+  - On click: closes sidebar (`are_details_open = false`), resets photo store, navigates via `router.push({ name: "album", params: { albumId } })`
+  - Shows "This photo is not in any album." when empty
+  - Shows error message on fetch failure
+  - Caches result per photo ID to prevent duplicate requests
+  _Verification commands:_
+  - `npm run check`
+  - `npm run format`
+  _Notes:_ Use PrimeVue components where appropriate (e.g., `ProgressSpinner` for loading). Import `useRouter` from `vue-router`. Use regular function declarations, not arrow function assignments. Navigation uses named route `"album"` with `{ albumId }` param.
+
+### Increment I4 – Translations & Quality Gate
+
+- [ ] T-018-14 – Add English translation keys.
+  _Intent:_ Add keys to `lang/php_en.json`: `ALBUMS`, `NO_ALBUMS` ("This photo is not in any album."), `ALBUMS_LOADING_ERROR` ("Could not load albums.").
+  _Verification commands:_
+  - `npm run check`
+  _Notes:_ Use snake_case keys.
+
+- [ ] T-018-15 – Add translation placeholders to other languages (21 languages).
+  _Intent:_ Add the same keys with English fallback text to all other language files (ar, bg, cz, de, el, es, fa, fr, hu, it, ja, nl, no, pl, pt, ru, sk, sv, vi, zh_CN, zh_TW).
+  _Verification commands:_
+  - `npm run check`
+  _Notes:_ Placeholders only; native speakers can update later.
+
+- [ ] T-018-16 – Run full quality gate.
+  _Intent:_ Final validation that all code passes formatting, tests, and static analysis.
+  _Verification commands:_
+  - `vendor/bin/php-cs-fixer fix`
+  - `npm run format`
+  - `npm run check`
+  - `php artisan test`
+  - `make phpstan`
+  _Notes:_ All must pass before considering feature complete.
+
+### Post-Implementation
+
+- [ ] T-018-17 – Update knowledge map.
+  _Intent:_ Add entry for `GET Photo/{photo_id}/albums` endpoint and `PhotoAlbumResource` in `docs/specs/4-architecture/knowledge-map.md`.
+  _Verification commands:_ Manual review.
+  _Notes:_ Document relationship between PhotoController, PhotoDetails.vue, and PhotoService.
+
+- [ ] T-018-18 – Update roadmap to Complete.
+  _Intent:_ Move Feature 018 from Active to Completed in roadmap.
+  _Verification commands:_ Manual review.
+  _Notes:_ Include summary of delivered functionality.
+
+- [ ] T-018-19 – Manual testing (S-018-08, S-018-09, S-018-10, S-018-11).
+  _Intent:_ Verify sidebar behaviour in browser: albums section appears, loading state works, no duplicate requests on same photo, switching photos triggers new fetch, clicking an album title navigates to that album.
+  _Verification commands:_ Manual browser testing.
+  _Notes:_ Test with photos in multiple albums, single album, and no albums. Verify that clicking an album closes the sidebar and navigates to `/gallery/{albumId}`.
+
+## Notes / TODOs
+
+- The `photo_album` pivot table already has indexes on both `photo_id` and `album_id` columns, so no migration is needed.
+- If TypeScript type generation via Spatie TypeScript Transformer auto-generates the `PhotoAlbumResource` type, no manual type definition is needed in T-018-12.
+- The endpoint intentionally excludes smart albums — only real `Album` model records from the pivot table are returned.

--- a/docs/specs/4-architecture/roadmap.md
+++ b/docs/specs/4-architecture/roadmap.md
@@ -8,6 +8,7 @@ High-level planning document for Lychee features and architectural initiatives.
 |------------|------|--------|----------|----------|---------|---------|----------|
 | 016 | Bulk License Edit | In Progress | P2 | - | 2026-02-26 | 2026-02-27 | Backend complete (T-016-01 to T-016-04), next: quality gates & frontend |
 | 017 | Apply Renamer Rules & Watermark Confirm | Planning | P2 | - | 2026-02-26 | 2026-02-26 | Spec, plan, tasks drafted. Pending implementation. |
+| 018 | Photo Albums Sidebar | Planning | P2 | - | 2026-02-26 | 2026-02-26 | Spec, plan, tasks drafted. Pending implementation. |
 
 ## Paused Features
 

--- a/lang/ar/gallery.php
+++ b/lang/ar/gallery.php
@@ -189,6 +189,10 @@ return [
             'aperture' => 'فتحة العدسة',
             'focal' => 'طول البؤرة',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'الإحصائيات',
                 'number_of_visits' => 'عدد الزيارات',

--- a/lang/bg/gallery.php
+++ b/lang/bg/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Бленда',
             'focal' => 'Фокусно разстояние',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Статистика',
                 'number_of_visits' => 'Брой посещения',

--- a/lang/cz/gallery.php
+++ b/lang/cz/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Aperture',
             'focal' => 'Focal Length',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistics',
                 'number_of_visits' => 'Number of visits',

--- a/lang/de/gallery.php
+++ b/lang/de/gallery.php
@@ -189,6 +189,10 @@ return [
             'aperture' => 'Blende',
             'focal' => 'Brennweite',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistiken',
                 'number_of_visits' => 'Anzahl der Besuche',

--- a/lang/el/gallery.php
+++ b/lang/el/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Aperture',
             'focal' => 'Focal Length',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistics',
                 'number_of_visits' => 'Number of visits',

--- a/lang/en/gallery.php
+++ b/lang/en/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Aperture',
             'focal' => 'Focal Length',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistics',
                 'number_of_visits' => 'Number of visits',

--- a/lang/es/gallery.php
+++ b/lang/es/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Abertura',
             'focal' => 'Longitud focal',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Estadísticas',
                 'number_of_visits' => 'Número de visitas',

--- a/lang/fa/gallery.php
+++ b/lang/fa/gallery.php
@@ -189,6 +189,10 @@ return [
             'aperture' => 'دیافراگم',
             'focal' => 'فاصله کانونی',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'آمار',
                 'number_of_visits' => 'تعداد بازدیدها',

--- a/lang/fr/gallery.php
+++ b/lang/fr/gallery.php
@@ -189,6 +189,10 @@ return [
             'aperture' => 'Ouverture',
             'focal' => 'Longueur focale',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistiques',
                 'number_of_visits' => 'Nombre de visites',

--- a/lang/hu/gallery.php
+++ b/lang/hu/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Aperture',
             'focal' => 'Focal Length',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistics',
                 'number_of_visits' => 'Number of visits',

--- a/lang/it/gallery.php
+++ b/lang/it/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Aperture',
             'focal' => 'Focal Length',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistics',
                 'number_of_visits' => 'Number of visits',

--- a/lang/ja/gallery.php
+++ b/lang/ja/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Aperture',
             'focal' => 'Focal Length',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistics',
                 'number_of_visits' => 'Number of visits',

--- a/lang/nl/gallery.php
+++ b/lang/nl/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Diafragma',
             'focal' => 'Brandpuntsafstand',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistieken',
                 'number_of_visits' => 'Aantal bezoeken',

--- a/lang/no/gallery.php
+++ b/lang/no/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Blenderåpning',
             'focal' => 'Brennvidde',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistikk',
                 'number_of_visits' => 'Antall besøk',

--- a/lang/pl/gallery.php
+++ b/lang/pl/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Przysłona',
             'focal' => 'Ogniskowa',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistics',
                 'number_of_visits' => 'Number of visits',

--- a/lang/pt/gallery.php
+++ b/lang/pt/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Aperture',
             'focal' => 'Focal Length',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistics',
                 'number_of_visits' => 'Number of visits',

--- a/lang/ru/gallery.php
+++ b/lang/ru/gallery.php
@@ -189,6 +189,10 @@ return [
             'aperture' => 'Диафрагма',
             'focal' => 'Фокусное расстояние',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Статистика',
                 'number_of_visits' => 'Кол-во посещений',

--- a/lang/sk/gallery.php
+++ b/lang/sk/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Aperture',
             'focal' => 'Focal Length',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistics',
                 'number_of_visits' => 'Number of visits',

--- a/lang/sv/gallery.php
+++ b/lang/sv/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Aperture',
             'focal' => 'Focal Length',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistics',
                 'number_of_visits' => 'Number of visits',

--- a/lang/vi/gallery.php
+++ b/lang/vi/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Aperture',
             'focal' => 'Focal Length',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistics',
                 'number_of_visits' => 'Number of visits',

--- a/lang/zh_CN/gallery.php
+++ b/lang/zh_CN/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => '光圈',
             'focal' => '焦距',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistics',
                 'number_of_visits' => 'Number of visits',

--- a/lang/zh_TW/gallery.php
+++ b/lang/zh_TW/gallery.php
@@ -190,6 +190,10 @@ return [
             'aperture' => 'Aperture',
             'focal' => 'Focal Length',
             'iso' => 'ISO %s',
+            'albums' => 'Albums',
+            'albums_loading' => 'Loading...',
+            'no_albums' => 'This photo is not in any album.',
+            'albums_loading_error' => 'Could not load albums.',
             'stats' => [
                 'header' => 'Statistics',
                 'number_of_visits' => 'Number of visits',

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -664,6 +664,10 @@ declare namespace App.Http.Resources.Models {
 		title: string;
 		url: string | null;
 	};
+	export type PhotoAlbumResource = {
+		id: string;
+		title: string;
+	};
 	export type PhotoRatingResource = {
 		rating_user: number;
 		rating_count: number;
@@ -704,6 +708,11 @@ declare namespace App.Http.Resources.Models {
 		shared_count: number;
 		rating_count: number;
 		rating_avg: number | null;
+	};
+	export type RenamerPreviewResource = {
+		id: string;
+		original: string;
+		new: string;
 	};
 	export type RenamerRuleResource = {
 		id: number;

--- a/resources/js/services/photo-service.ts
+++ b/resources/js/services/photo-service.ts
@@ -84,6 +84,10 @@ const PhotoService = {
 	setRating(photo_id: string, rating: 0 | 1 | 2 | 3 | 4 | 5): Promise<AxiosResponse<App.Http.Resources.Models.PhotoResource>> {
 		return axios.post(`${Constants.getApiUrl()}Photo::setRating`, { photo_id: photo_id, rating: rating });
 	},
+
+	albums(photo_id: string): Promise<AxiosResponse<App.Http.Resources.Models.PhotoAlbumResource[]>> {
+		return axios.get(`${Constants.getApiUrl()}Photo/${photo_id}/albums`, { data: {} });
+	},
 };
 
 export default PhotoService;

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -146,6 +146,7 @@ Route::post('/Photo::highlight', [Gallery\PhotoController::class, 'highlight']);
 Route::post('/Photo::setRating', [Gallery\PhotoController::class, 'rate']);
 Route::post('/Photo::rotate', [Gallery\PhotoController::class, 'rotate']);
 Route::post('/Photo::watermark', [Gallery\PhotoController::class, 'watermark'])->middleware('support:se');
+Route::get('/Photo/{photo_id}/albums', [Gallery\PhotoController::class, 'albums']);
 Route::delete('/Photo', [Gallery\PhotoController::class, 'delete']);
 
 // Route::get('/Photo::getArchive', [PhotoController::class, 'getArchive'])

--- a/tests/Feature_v2/Photo/GetPhotoAlbumsTest.php
+++ b/tests/Feature_v2/Photo/GetPhotoAlbumsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\Photo;
+
+use App\Models\Album;
+use App\Models\Photo;
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+
+class GetPhotoAlbumsTest extends BaseApiWithDataTest
+{
+	/**
+	 * S-018-01: Owner sees all albums for their photo.
+	 */
+	public function testOwnerSeesAllAlbums(): void
+	{
+		// photo1 is in album1. Add it to subAlbum1 as well.
+		$this->photo1->albums()->syncWithoutDetaching([$this->subAlbum1->id]);
+
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Photo/' . $this->photo1->id . '/albums');
+		$this->assertOk($response);
+
+		$response->assertJsonCount(2);
+		$response->assertJsonFragment(['id' => $this->album1->id, 'title' => $this->album1->title]);
+		$response->assertJsonFragment(['id' => $this->subAlbum1->id, 'title' => $this->subAlbum1->title]);
+	}
+
+	/**
+	 * S-018-02, S-018-03: Shared user sees only accessible albums, inaccessible ones filtered.
+	 */
+	public function testSharedUserSeesAccessibleAlbumsOnly(): void
+	{
+		// photo1 is in album1 (shared with userMayUpload2 via perm1).
+		// Also place photo1 in album3 (owned by userNoUpload, NOT shared with userMayUpload2).
+		$this->photo1->albums()->syncWithoutDetaching([$this->album3->id]);
+
+		// userMayUpload2 can access album1 (via perm1) but NOT album3
+		$response = $this->actingAs($this->userMayUpload2)->getJson('Photo/' . $this->photo1->id . '/albums');
+		$this->assertOk($response);
+
+		$response->assertJsonCount(1);
+		$response->assertJsonFragment(['id' => $this->album1->id, 'title' => $this->album1->title]);
+		$response->assertJsonMissing(['id' => $this->album3->id]);
+	}
+
+	/**
+	 * S-018-04: Guest sees public albums only.
+	 */
+	public function testGuestSeesPublicAlbumsOnly(): void
+	{
+		// photo4 is in album4 (public via perm4). Also place it in album1 (private).
+		$this->photo4->albums()->syncWithoutDetaching([$this->album1->id]);
+
+		$response = $this->getJson('Photo/' . $this->photo4->id . '/albums');
+		$this->assertOk($response);
+
+		$response->assertJsonCount(1);
+		$response->assertJsonFragment(['id' => $this->album4->id, 'title' => $this->album4->title]);
+		$response->assertJsonMissing(['id' => $this->album1->id]);
+	}
+
+	/**
+	 * S-018-05: Guest denied for private photo.
+	 */
+	public function testGuestDeniedForPrivatePhoto(): void
+	{
+		$response = $this->getJson('Photo/' . $this->photo1->id . '/albums');
+		$this->assertUnauthorized($response);
+	}
+
+	/**
+	 * S-018-06: Non-existent photo returns 404.
+	 */
+	public function testNonExistentPhotoReturns404(): void
+	{
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Photo/AAAAAAAAAAAAAAAAAAAAAAAA/albums');
+		$this->assertNotFound($response);
+	}
+
+	/**
+	 * S-018-07: Photo with no albums returns empty array.
+	 */
+	public function testPhotoWithNoAlbumsReturnsEmptyArray(): void
+	{
+		// photoUnsorted has no album associations
+		$response = $this->actingAs($this->userMayUpload1)->getJson('Photo/' . $this->photoUnsorted->id . '/albums');
+		$this->assertOk($response);
+
+		$response->assertJsonCount(0);
+		$response->assertExactJson([]);
+	}
+}


### PR DESCRIPTION
Fixes #4062

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Photo Details sidebar now shows an Albums section (lazy-loaded) with loading, empty, and error states; album links navigate to the chosen album.
  * New backend API to fetch albums for a photo to power the UI.

* **Documentation**
  * Full spec, plan and task list added for the Photo Albums Sidebar feature.

* **Translations**
  * Album-related UI strings added across multiple language packs.

* **Tests**
  * Backend feature tests covering access scenarios and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->