### PR TITLE
Fix #4117 - Fix going back to selected tag page.

### DIFF
--- a/resources/js/composables/contextMenus/leftMenu.ts
+++ b/resources/js/composables/contextMenus/leftMenu.ts
@@ -159,7 +159,7 @@ export function useLeftMenu(
 						label: "left-menu.messages",
 						icon: "pi pi-inbox",
 						route: "/contact-messages",
-						access: initData.value.modules.is_contact_enabled,
+						access: initData.value.modules.is_contact_enabled && canSeeAdmin.value,
 						num: initData.value.modules.messages_count,
 					},
 					{

--- a/resources/js/views/gallery-panels/Tag.vue
+++ b/resources/js/views/gallery-panels/Tag.vue
@@ -192,9 +192,8 @@ function goBack() {
 		return;
 	}
 
-	if (photoId.value !== undefined) {
+	if (photoStore.photoId !== undefined) {
 		photoStore.reset();
-
 		router.push({ name: albumRoutes().album, params: { tagId: tagId.value } });
 		return;
 	}


### PR DESCRIPTION
+ fix contact link displayed in menu when not logged in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted messages menu visibility to require admin access in addition to existing permissions.
  * Updated navigation logic in the gallery tag panel to properly respect application state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->