### PR TITLE
Fix(csp): remove unsafe-eval requirement for Vue3 production builds

### DIFF
--- a/app/Http/Middleware/DisableCSP.php
+++ b/app/Http/Middleware/DisableCSP.php
@@ -69,10 +69,6 @@ class DisableCSP
 	 */
 	private function handleVueJS()
 	{
-		// We have to disable unsafe-eval because Livewire requires it...
-		// So stupid....
-		config(['secure-headers.csp.script-src.unsafe-eval' => true]);
-
 		// if the public/hot file exists, it means that we need to disable CSP completely
 		// As we will be reloading on the fly the page and Vite has poor CSP support.
 		if (File::exists(public_path('hot'))) {

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -43,7 +43,7 @@ const langs = import.meta.glob("../../lang/*.json");
  * registering components with the application instance so they are ready
  * to use in your application's views. An example is included for you.
  */
-const app = createApp({});
+const app = createApp(AppComponent);
 app.config.globalProperties.window = window;
 app.use(pinia);
 app.use(PrimeVue, {
@@ -64,7 +64,6 @@ app.directive("ripple", Ripple);
 app.directive("focustrap", FocusTrap);
 app.directive("tooltip", Tooltip);
 
-app.component("App", AppComponent);
 app.use(router);
 app.use(ToastService);
 app.use(ConfirmationService);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -83,7 +83,7 @@ const baseConfig = {
 		alias: {
 			// @ts-ignore-next-line
 			"@": fileURLToPath(new URL("./resources/js/", import.meta.url)),
-			vue: "vue/dist/vue.esm-bundler.js",
+			vue: "vue/dist/vue.runtime.esm-bundler.js",
 		},
 	},
 	build: {

--- a/vite.embed.config.ts
+++ b/vite.embed.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			'@': fileURLToPath(new URL('./resources/js/', import.meta.url)),
-			vue: 'vue/dist/vue.esm-bundler.js',
+			vue: 'vue/dist/vue.runtime.esm-bundler.js',
 		},
 	},
 	build: {


### PR DESCRIPTION
Fixes #3764

- Switch from full Vue build (with compiler) to runtime-only build
- Runtime-only build doesn't require unsafe-eval CSP directive
- Update app initialization to pass root component to createApp()
- Explicitly disable unsafe-eval in DisableCSP middleware for production
- Development mode (with hot reload) continues to disable CSP entirely

The full Vue build includes template compiler which uses new Function() internally, requiring unsafe-eval. Since we use pre-compiled .vue SFCs, the runtime-only build is sufficient and more secure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Content Security Policy by removing unsafe-eval relaxation.

* **Refactor**
  * Updated Vue app initialization with AppComponent as root.
  * Removed global component registration of AppComponent.
  * Updated Vue build configuration to use runtime build variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->