### PR TITLE
fix(csp): add 'self' to connect-src so API calls to own origin are allowed

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -543,6 +543,7 @@ return [
 
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src
 		'connect-src' => [
+			'self' => true,
 			'allow' => array_merge(
 				['https://lycheeorg.dev/update.json'],
 				explode(',', (string) env('SECURITY_HEADER_CSP_CONNECT_SRC', ''))


### PR DESCRIPTION
Commit fa1da391 ("Fix Connect src csp #4161") corrected the `connect-src` config format from a flat array to a structured array, which caused the secure-headers library to actually emit the directive.

However, it omitted `'self' => true`, so all XHR/fetch requests to the site's own origin (e.g. `/api/v2/*`) were blocked by the Content Security Policy.
