### PR TITLE
Prevent copy in non secure context

### DIFF
--- a/lang/ar/diagnostics.php
+++ b/lang/ar/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'معلومات',
         'copy' => 'تم نسخ التشخيصات إلى الحافظة!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/bg/diagnostics.php
+++ b/lang/bg/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'Информация',
         'copy' => 'Диагностиката е копирана в клипборда!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/cz/diagnostics.php
+++ b/lang/cz/diagnostics.php
@@ -18,4 +18,5 @@ return [
         'info' => 'Info',
         'copy' => 'Diagnostics copied to clipboard!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/de/diagnostics.php
+++ b/lang/de/diagnostics.php
@@ -18,4 +18,5 @@ return [
         'info' => 'Info',
         'copy' => 'Diagnosen in die Zwischenablage kopiert!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/el/diagnostics.php
+++ b/lang/el/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'Info',
         'copy' => 'Diagnostics copied to clipboard!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/en/diagnostics.php
+++ b/lang/en/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'Info',
         'copy' => 'Diagnostics copied to clipboard!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/es/diagnostics.php
+++ b/lang/es/diagnostics.php
@@ -18,4 +18,5 @@ return [
         'info' => 'Info',
         'copy' => '¡Diagnóstico copiado al portapapeles!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/fa/diagnostics.php
+++ b/lang/fa/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'اطلاعات',
         'copy' => 'نتیجه عیب یابی در کلیپ‌بورد کپی شد!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/fr/diagnostics.php
+++ b/lang/fr/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'Informations',
         'copy' => 'Diagnostics copiés dans le presse-papiers !',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/hu/diagnostics.php
+++ b/lang/hu/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'Info',
         'copy' => 'Diagnostics copied to clipboard!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/it/diagnostics.php
+++ b/lang/it/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'Info',
         'copy' => 'Diagnostics copied to clipboard!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/ja/diagnostics.php
+++ b/lang/ja/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'Info',
         'copy' => 'Diagnostics copied to clipboard!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/nl/diagnostics.php
+++ b/lang/nl/diagnostics.php
@@ -18,4 +18,5 @@ return [
         'info' => 'Informatie',
         'copy' => 'Diagnostieken gekopieerd naar klembord!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/no/diagnostics.php
+++ b/lang/no/diagnostics.php
@@ -18,4 +18,5 @@ return [
         'info' => 'Informasjon',
         'copy' => 'Diagnostikk kopiert til utklippstavlen!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/pl/diagnostics.php
+++ b/lang/pl/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'Info',
         'copy' => 'Diagnostyka skopiowana do schowka !',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/pt/diagnostics.php
+++ b/lang/pt/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'Info',
         'copy' => 'Diagnostics copied to clipboard!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/ru/diagnostics.php
+++ b/lang/ru/diagnostics.php
@@ -18,4 +18,5 @@ return [
         'info' => 'Информация',
         'copy' => 'Диагностика скопирована в буфер обмена!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/sk/diagnostics.php
+++ b/lang/sk/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'Info',
         'copy' => 'Diagnostics copied to clipboard!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/sv/diagnostics.php
+++ b/lang/sv/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'Info',
         'copy' => 'Diagnostics copied to clipboard!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/vi/diagnostics.php
+++ b/lang/vi/diagnostics.php
@@ -19,4 +19,5 @@ return [
         'info' => 'Info',
         'copy' => 'Diagnostics copied to clipboard!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/zh_CN/diagnostics.php
+++ b/lang/zh_CN/diagnostics.php
@@ -18,4 +18,5 @@ return [
         'info' => '提示',
         'copy' => '诊断信息已复制到剪贴板！',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/lang/zh_TW/diagnostics.php
+++ b/lang/zh_TW/diagnostics.php
@@ -18,4 +18,5 @@ return [
         'info' => '資料',
         'copy' => '診斷已複制到剪貼簿!',
     ],
+    'copy_on_secure_context' => 'Copying diagnostics is only available in secure contexts (HTTPS).',
 ];

--- a/resources/js/views/Diagnostics.vue
+++ b/resources/js/views/Diagnostics.vue
@@ -9,7 +9,16 @@
 		</template>
 
 		<template #end>
-			<Button v-tooltip="$t('diagnostics.copy_to_clipboard')" :disabled="!canCopy" text aria-label="Copy" icon="pi pi-copy" @click="copy" />
+			<Button
+				v-if="isSecureContext"
+				v-tooltip="$t('diagnostics.copy_to_clipboard')"
+				:disabled="!canCopy"
+				text
+				aria-label="Copy"
+				icon="pi pi-copy"
+				@click="copy"
+			/>
+			<Button v-else v-tooltip="$t('diagnostics.copy_on_secure_context')" :disabled="true" text aria-label="Copy" icon="pi pi-copy" />
 		</template>
 	</Toolbar>
 	<ErrorsDiagnotics @loaded="loadError" />
@@ -54,6 +63,8 @@ function loadInfo(val: string[]) {
 function loadConfig(val: string[]) {
 	configurationLoaded.value = val;
 }
+
+const isSecureContext = computed(() => window.isSecureContext);
 
 function copy() {
 	if (!canCopy.value) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added security restriction: the copy diagnostics feature is now only available in secure contexts (HTTPS). Users on non-secure connections will see a disabled copy button with an explanatory message.
  * Added multi-language support for the new secure context requirement message across 22 languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->