### PR TITLE
Fix Masonry (and other layout not being respected)

### DIFF
--- a/resources/js/components/gallery/albumModule/AlbumPanel.vue
+++ b/resources/js/components/gallery/albumModule/AlbumPanel.vue
@@ -14,10 +14,7 @@
 			<div id="galleryView" class="relative flex flex-wrap content-start w-full justify-start overflow-y-auto h-full select-none">
 				<SelectDrag :with-scroll="true" />
 				<AlbumEdit v-if="albumStore.rights?.can_edit" />
-				<div v-if="albumStore.isLoading" class="flex w-full h-full items-center justify-center">
-					<i class="pi pi-spin pi-spinner text-4xl text-primary-400" />
-				</div>
-				<div v-else-if="noData" class="flex w-full flex-col h-full items-center justify-center text-xl text-muted-color gap-8">
+				<div v-if="noData" class="flex w-full flex-col h-full items-center justify-center text-xl text-muted-color gap-8">
 					<span class="block">
 						{{ $t("gallery.album.no_results") }}
 					</span>
@@ -48,62 +45,67 @@
 						v-model:visible="areStatisticsOpen"
 					/>
 				</template>
-				<AlbumThumbPanel
-					v-if="albumsStore.albums.length > 0"
-					header="gallery.album.header_albums"
-					:albums="albumsStore.albums"
-					:config="albumPanelConfig"
-					:is-alone="photosStore.photos.length === 0"
-					:selected-albums="selectedAlbumsIds"
-					:is-timeline="albumStore.config.is_album_timeline_enabled"
-					@clicked="albumSelect"
-					@contexted="contextMenuAlbumOpen"
-				/>
-				<!-- Pagination for albums -->
-				<Pagination
-					v-if="albumsStore.albums.length > 0 && albumStore.hasAlbumsPagination"
-					:mode="lycheeStore.albums_pagination_mode"
-					:loading="albumStore.albums_loading"
-					:has-more="albumStore.hasMoreAlbums"
-					:current-page="albumStore.albums_current_page"
-					:last-page="albumStore.albums_last_page"
-					:per-page="albumStore.albums_per_page"
-					:total="albumStore.albums_total"
-					:remaining="albumStore.albumsRemainingCount"
-					resource-type="albums"
-					@load-more="albumStore.loadMoreAlbums()"
-					@go-to-page="goToAlbumsPage"
-				/>
-				<!-- Tag Filter -->
-				<PhotoThumbPanel
-					v-if="layoutStore.config && photosStore.photos.length > 0"
-					header="gallery.album.header_photos"
-					:photos="photosStore.filteredPhotos"
-					:photos-timeline="photosStore.filteredPhotosTimeline"
-					:selected-photos="selectedPhotosIds"
-					:is-timeline="albumStore.config.is_photo_timeline_enabled"
-					:with-control="true"
-					@clicked="photoClick"
-					@selected="photoSelect"
-					@contexted="contextMenuPhotoOpen"
-					@toggle-buy-me="toggleBuyMe"
-					ref="photoPanel"
-				/>
-				<!-- Pagination for photos -->
-				<Pagination
-					v-if="photosStore.photos.length > 0 && albumStore.hasPhotosPagination"
-					:mode="lycheeStore.photos_pagination_mode"
-					:loading="albumStore.photos_loading"
-					:has-more="albumStore.hasMorePhotos"
-					:current-page="albumStore.photos_current_page"
-					:last-page="albumStore.photos_last_page"
-					:per-page="albumStore.photos_per_page"
-					:total="albumStore.photos_total"
-					:remaining="albumStore.photosRemainingCount"
-					resource-type="photos"
-					@load-more="albumStore.loadMorePhotos()"
-					@go-to-page="goToPhotosPage"
-				/>
+				<div v-if="albumStore.isLoading" class="flex w-full items-center justify-center">
+					<i class="pi pi-spin pi-spinner text-4xl text-primary-400" />
+				</div>
+				<template v-else>
+					<AlbumThumbPanel
+						v-if="albumsStore.albums.length > 0"
+						header="gallery.album.header_albums"
+						:albums="albumsStore.albums"
+						:config="albumPanelConfig"
+						:is-alone="photosStore.photos.length === 0"
+						:selected-albums="selectedAlbumsIds"
+						:is-timeline="albumStore.config.is_album_timeline_enabled"
+						@clicked="albumSelect"
+						@contexted="contextMenuAlbumOpen"
+					/>
+					<!-- Pagination for albums -->
+					<Pagination
+						v-if="albumsStore.albums.length > 0 && albumStore.hasAlbumsPagination"
+						:mode="lycheeStore.albums_pagination_mode"
+						:loading="albumStore.albums_loading"
+						:has-more="albumStore.hasMoreAlbums"
+						:current-page="albumStore.albums_current_page"
+						:last-page="albumStore.albums_last_page"
+						:per-page="albumStore.albums_per_page"
+						:total="albumStore.albums_total"
+						:remaining="albumStore.albumsRemainingCount"
+						resource-type="albums"
+						@load-more="albumStore.loadMoreAlbums()"
+						@go-to-page="goToAlbumsPage"
+					/>
+					<!-- Tag Filter -->
+					<PhotoThumbPanel
+						v-if="layoutStore.config && photosStore.photos.length > 0"
+						header="gallery.album.header_photos"
+						:photos="photosStore.filteredPhotos"
+						:photos-timeline="photosStore.filteredPhotosTimeline"
+						:selected-photos="selectedPhotosIds"
+						:is-timeline="albumStore.config.is_photo_timeline_enabled"
+						:with-control="true"
+						@clicked="photoClick"
+						@selected="photoSelect"
+						@contexted="contextMenuPhotoOpen"
+						@toggle-buy-me="toggleBuyMe"
+						ref="photoPanel"
+					/>
+					<!-- Pagination for photos -->
+					<Pagination
+						v-if="photosStore.photos.length > 0 && albumStore.hasPhotosPagination"
+						:mode="lycheeStore.photos_pagination_mode"
+						:loading="albumStore.photos_loading"
+						:has-more="albumStore.hasMorePhotos"
+						:current-page="albumStore.photos_current_page"
+						:last-page="albumStore.photos_last_page"
+						:per-page="albumStore.photos_per_page"
+						:total="albumStore.photos_total"
+						:remaining="albumStore.photosRemainingCount"
+						resource-type="photos"
+						@load-more="albumStore.loadMorePhotos()"
+						@go-to-page="goToPhotosPage"
+					/>
+				</template>
 				<ScrollTop v-if="!props.isPhotoOpen" target="parent" />
 				<GalleryFooter v-once />
 			</div>

--- a/resources/js/components/gallery/albumModule/AlbumPanel.vue
+++ b/resources/js/components/gallery/albumModule/AlbumPanel.vue
@@ -14,10 +14,8 @@
 			<div id="galleryView" class="relative flex flex-wrap content-start w-full justify-start overflow-y-auto h-full select-none">
 				<SelectDrag :with-scroll="true" />
 				<AlbumEdit v-if="albumStore.rights?.can_edit" />
-				<div v-if="true">
-					<div class="flex w-full h-full items-center justify-center">
-						<i class="pi pi-spin pi-spinner text-4xl text-primary-400" />
-					</div>
+				<div v-if="albumStore.isLoading" class="flex w-full h-full items-center justify-center">
+					<i class="pi pi-spin pi-spinner text-4xl text-primary-400" />
 				</div>
 				<div v-else-if="noData" class="flex w-full flex-col h-full items-center justify-center text-xl text-muted-color gap-8">
 					<span class="block">

--- a/resources/js/components/gallery/albumModule/AlbumPanel.vue
+++ b/resources/js/components/gallery/albumModule/AlbumPanel.vue
@@ -14,7 +14,12 @@
 			<div id="galleryView" class="relative flex flex-wrap content-start w-full justify-start overflow-y-auto h-full select-none">
 				<SelectDrag :with-scroll="true" />
 				<AlbumEdit v-if="albumStore.rights?.can_edit" />
-				<div v-if="noData" class="flex w-full flex-col h-full items-center justify-center text-xl text-muted-color gap-8">
+				<div v-if="true">
+					<div class="flex w-full h-full items-center justify-center">
+						<i class="pi pi-spin pi-spinner text-4xl text-primary-400" />
+					</div>
+				</div>
+				<div v-else-if="noData" class="flex w-full flex-col h-full items-center justify-center text-xl text-muted-color gap-8">
 					<span class="block">
 						{{ $t("gallery.album.no_results") }}
 					</span>
@@ -205,7 +210,7 @@ const emits = defineEmits<{
 
 const { is_se_enabled } = storeToRefs(lycheeStore);
 const noData = computed(() => {
-	return albumsStore.albums.length === 0 && photosStore.photos.length === 0;
+	return !albumStore.isLoading && albumsStore.albums.length === 0 && photosStore.photos.length === 0;
 });
 
 const {

--- a/resources/js/stores/AlbumState.ts
+++ b/resources/js/stores/AlbumState.ts
@@ -349,13 +349,12 @@ export const useAlbumStore = defineStore("album-store", {
 					this.config = data.data.config;
 					layoutStore.layout = data.data.config.photo_layout;
 
-					const loader = [this.loadPhotos(1, false)]
+					const loader = [this.loadPhotos(1, false)];
 
 					if (data.data.config.is_model_album) {
 						this.modelAlbum = data.data.resource as App.Http.Resources.Models.HeadAlbumResource;
 						loader.push(this.loadAlbums(1, false));
-					}
-					else if (data.data.config.is_base_album) {
+					} else if (data.data.config.is_base_album) {
 						this.tagAlbum = data.data.resource as App.Http.Resources.Models.HeadTagAlbumResource;
 					} else {
 						this.smartAlbum = data.data.resource as App.Http.Resources.Models.HeadSmartAlbumResource;

--- a/resources/js/stores/AlbumState.ts
+++ b/resources/js/stores/AlbumState.ts
@@ -5,6 +5,7 @@ import { useTogglablesStateStore } from "./ModalsState";
 import { usePhotosStore } from "./PhotosState";
 import { useAlbumsStore } from "./AlbumsState";
 import { useLycheeStateStore } from "./LycheeState";
+import { useLayoutStore } from "./LayoutState";
 
 export type AlbumStore = ReturnType<typeof useAlbumStore>;
 
@@ -84,6 +85,7 @@ export const useAlbumStore = defineStore("album-store", {
 		 */
 		loadHead(): Promise<void> {
 			const togglableState = useTogglablesStateStore();
+			const layoutStore = useLayoutStore();
 
 			if (this.albumId === ALL || this.albumId === undefined) {
 				return Promise.resolve();
@@ -110,18 +112,18 @@ export const useAlbumStore = defineStore("album-store", {
 					if (this._loadingAlbumId !== requestedAlbumId) {
 						return;
 					}
+					this.config = data.data.config;
+					layoutStore.layout = data.data.config.photo_layout;
 
 					if (data.data.config.is_model_album) {
-						this.config = data.data.config;
 						this.modelAlbum = data.data.resource as App.Http.Resources.Models.HeadAlbumResource;
-					} else {
-						this.config = data.data.config;
-						if (data.data.config.is_base_album) {
-							this.tagAlbum = data.data.resource as App.Http.Resources.Models.HeadTagAlbumResource;
-						} else {
-							this.smartAlbum = data.data.resource as App.Http.Resources.Models.HeadSmartAlbumResource;
-						}
+						return;
 					}
+					if (data.data.config.is_base_album) {
+						this.tagAlbum = data.data.resource as App.Http.Resources.Models.HeadTagAlbumResource;
+						return;
+					}
+					this.smartAlbum = data.data.resource as App.Http.Resources.Models.HeadSmartAlbumResource;
 				})
 				.catch((error) => {
 					if (this.albumId !== requestedAlbumId) {
@@ -315,6 +317,7 @@ export const useAlbumStore = defineStore("album-store", {
 			const togglableState = useTogglablesStateStore();
 			const photosState = usePhotosStore();
 			const albumsStore = useAlbumsStore();
+			const layoutStore = useLayoutStore();
 
 			if (this.albumId === ALL || this.albumId === undefined) {
 				return Promise.resolve();
@@ -343,24 +346,21 @@ export const useAlbumStore = defineStore("album-store", {
 					albumsStore.reset();
 					photosState.reset();
 
-					// Model albums (regular albums): Load both children and photos in parallel
-					// This is efficient because they're independent queries
+					this.config = data.data.config;
+					layoutStore.layout = data.data.config.photo_layout;
+
+					const loader = [this.loadPhotos(1, false)]
+
 					if (data.data.config.is_model_album) {
-						this.config = data.data.config;
-						await Promise.all([this.loadAlbums(1, false), this.loadPhotos(1, false)]);
 						this.modelAlbum = data.data.resource as App.Http.Resources.Models.HeadAlbumResource;
-					} else {
-						// Tag/Smart albums: Only load photos (they don't have child albums)
-						await this.loadPhotos(1, false);
-						this.config = data.data.config;
-						if (data.data.config.is_base_album) {
-							// Tag album: Photos filtered by tag
-							this.tagAlbum = data.data.resource as App.Http.Resources.Models.HeadTagAlbumResource;
-						} else {
-							// Smart album: Recent, Highlighted, On This Day, Unsorted, Untagged
-							this.smartAlbum = data.data.resource as App.Http.Resources.Models.HeadSmartAlbumResource;
-						}
+						loader.push(this.loadAlbums(1, false));
 					}
+					else if (data.data.config.is_base_album) {
+						this.tagAlbum = data.data.resource as App.Http.Resources.Models.HeadTagAlbumResource;
+					} else {
+						this.smartAlbum = data.data.resource as App.Http.Resources.Models.HeadSmartAlbumResource;
+					}
+					await Promise.all(loader);
 				})
 				.catch((error) => {
 					if (this._loadingAlbumId !== requestedAlbumId) {


### PR DESCRIPTION
Fixes #4183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pagination controls and remaining-count indicators for photos and albums

* **Improvements**
  * Show centered loading spinner while album data is fetching
  * Faster data loading via parallelized album/photo requests
  * Layout-aware loading to better preserve display settings and restore layout on load

* **Bug Fixes**
  * No-data message only shown after loading completes (prevents premature empty-state)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->