### PR TITLE
Unfortunately, we have to enable unsafe-inline if we are using Paypal

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -545,7 +545,11 @@ return [
 		'connect-src' => [
 			'self' => true,
 			'allow' => array_merge(
-				['https://lycheeorg.dev/update.json'],
+				[
+					'https://lycheeorg.dev/update.json',
+					'https://www.sandbox.paypal.com',
+					'https://www.paypal.com',
+				],
 				explode(',', (string) env('SECURITY_HEADER_CSP_CONNECT_SRC', ''))
 			),
 		],
@@ -593,6 +597,7 @@ return [
 					'https://a.osm.rrze.fau.de/osmhd/',
 					'https://b.osm.rrze.fau.de/osmhd/',
 					'https://c.osm.rrze.fau.de/osmhd/',
+					'https://www.paypalobjects.com',
 					'data:', // required by openstreetmap
 					'blob:', // required for "live" photos
 				],
@@ -701,7 +706,12 @@ return [
 			'report-sample' => true,
 
 			'allow' => array_merge(
-				['https://www.dropbox.com/static/api/1/dropins.js', 'https://js.mollie.com', 'https://js.stripe.com'],
+				[
+					'https://www.dropbox.com/static/api/1/dropins.js',
+					'https://js.mollie.com',
+					'https://js.stripe.com',
+					'https://www.paypal.com/sdk/js',
+				],
 				explode(',', (string) env('SECURITY_HEADER_SCRIPT_SRC_ALLOW', ''))
 			),
 
@@ -711,7 +721,8 @@ return [
 			],
 
 			/* followings are only work for `script` and `style` related directives */
-			'unsafe-inline' => false,
+			// We need this one for PayPal SDK sadly.
+			'unsafe-inline' => env('PAYPAL_CLIENT_ID', '') !== '',
 
 			'unsafe-eval' => false,
 
@@ -725,7 +736,7 @@ return [
 
 			// Those should be removed if we drop v4 legacy support completely.
 			'hashes' => [
-				'sha256' => [
+				'sha256' => env('PAYPAL_CLIENT_ID', '') !== '' ? [] : [
 					// 'sha256-hash-value-with-base64-encode',
 
 					// lychee.startDrag(event)

--- a/resources/js/components/webshop/OrderSummary.vue
+++ b/resources/js/components/webshop/OrderSummary.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="flex flex-col max-h-[75vh] p-8 bg-surface-50 dark:bg-surface-950/25 rounded border border-surface-200 dark:border-surface-700 min-h-[400px]"
+		class="flex flex-col max-h-[75vh] p-8 bg-surface-50 dark:bg-surface-950/25 rounded border border-surface-200 dark:border-surface-700 min-h-100"
 		v-if="order"
 	>
 		<div class="text-lg font-bold text-center mb-12">{{ $t("webshop.orderSummary.title") }}</div>


### PR DESCRIPTION
https://developer.paypal.com/sdk/js/best-practices/

> Our CSP recommendation: use 'unsafe-inline'

However `unsafe-inline` is ignored as soon as there is a hash in the list. So we need to also disable the hash list...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PayPal payment option now integrated into the checkout process with enhanced security protocols configured.

* **Style**
  * Layout adjustments made for improved component presentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->