### PR TITLE
Fix loading photos on paginated

### DIFF
--- a/resources/js/components/pagination/PaginationInfiniteScroll.vue
+++ b/resources/js/components/pagination/PaginationInfiniteScroll.vue
@@ -40,9 +40,11 @@ let scrollContainer: HTMLElement | null = null;
  */
 function handleIntersect(entries: IntersectionObserverEntry[]) {
 	const entry = entries[0];
-	console.debug(
-		`[InfiniteScroll] intersect: isIntersecting=${entry.isIntersecting}, hasMore=${props.hasMore}, loading=${props.loading}, isEmitting=${isEmitting}`,
-	);
+	if (LycheeState.is_debug_enabled) {
+		console.debug(
+			`[InfiniteScroll] intersect: isIntersecting=${entry.isIntersecting}, hasMore=${props.hasMore}, loading=${props.loading}, isEmitting=${isEmitting}`,
+		);
+	}
 	// Guard against duplicate emissions during rapid intersection callbacks
 	if (entry.isIntersecting && props.hasMore && !props.loading && !isEmitting) {
 		// console.log("[InfiniteScroll] => emitting loadMore");

--- a/resources/js/views/gallery-panels/Album.vue
+++ b/resources/js/views/gallery-panels/Album.vue
@@ -495,7 +495,8 @@ watch(
 
 		photoStore.setTransition(newPhotoId as string | undefined);
 
-		if (newAlbumId !== albumStore.albumId) {
+		const oldAlbumId = albumId.value;
+		if (newAlbumId !== oldAlbumId) {
 			current_page.value = 1; // Reset the page if we change album
 		}
 		albumId.value = newAlbumId as string;
@@ -506,6 +507,18 @@ watch(
 			togglableStore.rememberScrollThumb(photoId.value);
 		}
 
+		if (oldAlbumId === newAlbumId) {
+			// If we are navigating between photos of the same album, we don't need to reload the album.
+			// We just need to load the new photo.
+			photoStore.load();
+
+			// TODO: Consider loading the next page if the photo is getting close to the end of the currently loaded photos.
+			return;
+		}
+
+		// If we are navigating to a different album, we need to
+		// 1. load the new album
+		// 2. set the scroll position to the photo if we have a photoId, or to the top if we don't have a photoId
 		load().then(() => {
 			if (photoId.value === undefined) {
 				setScroll();


### PR DESCRIPTION
<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Photo navigation within the same album now loads only the targeted photo, avoiding full album reloads and improving responsiveness.

* **Chores**
  * Debug logging is now controllable via a runtime flag for better configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->