### PR TITLE
Make ldap optional

### DIFF
--- a/app/DTO/LdapConfiguration.php
+++ b/app/DTO/LdapConfiguration.php
@@ -35,10 +35,14 @@ final class LdapConfiguration
 	public readonly int $connection_timeout;
 
 	/**
-	 * @throws LdapConfigurationException if required LDAP config missing
+	 * @throws LdapConfigurationException if required LDAP config missing or ext-ldap absent
 	 */
 	public function __construct()
 	{
+		if (!extension_loaded('ldap')) {
+			throw new LdapConfigurationException('LDAP configuration error: the PHP ldap extension is not installed');
+		}
+
 		// Validate required connection settings
 		$this->host = $this->requireString(config('ldap.connections.default.hosts')[0], 'LDAP_HOST', 'ldap.example.com');
 		$this->port = $this->requireInt(config('ldap.connections.default.port'), 'LDAP_PORT');

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -122,7 +122,10 @@ class AuthController extends Controller
 	 */
 	protected function isLdapEnabled(Request $request): bool
 	{
-		return $request->verify()->is_supporter() && config('ldap.auth.enabled', false) === true;
+		return $request->verify()->is_supporter() &&
+			config('ldap.auth.enabled', false) === true &&
+			extension_loaded('ldap') &&
+			class_exists(\LdapRecord\Connection::class);
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -167,6 +167,9 @@
             "php-http/discovery": false
         }
     },
+    "suggest": {
+        "ext-ldap": "Required to enable LDAP authentication (LDAP_ENABLED=true)"
+    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/config/ldap.php
+++ b/config/ldap.php
@@ -28,12 +28,12 @@ return [
 			'use_ssl' => env('LDAP_PORT', 389) === 636, // Auto-detect LDAPS from port
 
 			// Additional connection options
-			'options' => [
-				// TLS certificate verification
+			// LDAP constants require ext-ldap; skip when the extension is absent
+			'options' => extension_loaded('ldap') ? [
 				LDAP_OPT_X_TLS_REQUIRE_CERT => ((bool) env('LDAP_TLS_VERIFY_PEER', true))
 					? LDAP_OPT_X_TLS_DEMAND
 					: LDAP_OPT_X_TLS_ALLOW,
-			],
+			] : [],
 		],
 	],
 

--- a/public/index.php
+++ b/public/index.php
@@ -18,15 +18,6 @@ define('LARAVEL_START', microtime(true));
  */
 require_once __DIR__ . '/../bootstrap/PanicAttack.php';
 
-/**
- * Check if the required extensions are loaded and if not, display a nice error page.
- * This is a sanity check to prevent the user from seeing a blank page with an error in the top left corner.
- */
-if (!extension_loaded('ldap')) {
-	$panic_attack = new PanicAttack();
-	$panic_attack->ldap();
-}
-
 /*
  |--------------------------------------------------------------------------
  | Initialize before loading composer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced LDAP authentication validation with earlier detection of missing PHP extensions and improved error messaging.

* **Chores**
  * Added documentation for recommended LDAP PHP extension dependency to enable LDAP authentication support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->