### PR TITLE
Fixing discussion #4230 SyntaxError: [sprintf] unexpected placeholder…

### DIFF
--- a/lang/es/dialogs.php
+++ b/lang/es/dialogs.php
@@ -234,7 +234,7 @@ return [
         'copied' => '¡Foto(s) copiadas!',
     ],
     'photo_delete' => [
-        'confirm' => '¿Estás seguro de que quieres eliminar la foto "% s"?',
+        'confirm' => '¿Estás seguro de que quieres eliminar la foto "%s"?',
         'confirm_multiple' => '¿Estás seguro de que deseas eliminar las %d fotos seleccionadas?',
         'deleted' => '¡Foto(s) eliminadas!',
     ],

--- a/lang/es/profile.php
+++ b/lang/es/profile.php
@@ -41,7 +41,7 @@ return [
         'header' => 'OAuth',
         'header_not_available' => 'OAuth no está disponible',
         'setup_env' => 'Configura las credenciales en tu .env',
-        'token_registered' => 'Token% s registrado.',
+        'token_registered' => 'Token %s registrado.',
         'setup' => 'Configurar %s',
         'reset' => 'reiniciar',
         'credential_deleted' => '¡Credencial eliminada!',


### PR DESCRIPTION
When the application language is set to Spanish (es), attempting to view or delete a photo causes the delete button action to fail silently.
Expanding the browser console reveals the following error:

text
SyntaxError: [sprintf] unexpected placeholder
S https://yoursite/build/assets/sprintf-js-ur2aCr19.js:1
...
Because of this JavaScript exception, the deletion dialog never renders, and the user cannot delete photos.

The Root Cause
The sprintf-js library throws an exception when passing an incorrectly formatted placeholder mapping from the translation files through laravel-vue-i18n.

In the Spanish translation files, there was a typo where the placeholder string was written with an extra space (% s instead of %s).

The solution removes the errant space in the formatting placeholders inside the Spanish (es) translation files.

**Steps to reproduce the issue**
1- Change to use Spanish languaje.
2- Open a picture.
3- Right click and select Borrar(delete) option.
4- Click the Borrar (delete) icon.

Picture is not deleted.
Javascript console shows the reported exception

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spacing issues in Spanish translation strings for photo deletion confirmation dialogs
  * Fixed formatting in Spanish OAuth token registration messages to ensure proper text display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->