### PR TITLE
Fix notifications

### DIFF
--- a/app/Actions/Photo/Create.php
+++ b/app/Actions/Photo/Create.php
@@ -148,7 +148,6 @@ class Create
 		$pipes[] = Shared\Save::class;
 		$pipes[] = Shared\SetParent::class;
 		$pipes[] = Shared\SaveStatistics::class;
-		$pipes[] = Shared\NotifyAlbums::class;
 
 		try {
 			return app(Pipeline::class)
@@ -190,6 +189,7 @@ class Create
 			Standalone\ReplaceOriginalWithBackup::class,
 			Shared\UploadSizeVariantsToS3::class,
 			Shared\ExtractColourPalette::class,
+			Shared\NotifyAlbums::class,
 		];
 
 		return $this->executePipeOnDTO($pipes, $dto)->getPhoto();

--- a/app/Actions/User/Notify.php
+++ b/app/Actions/User/Notify.php
@@ -46,12 +46,16 @@ class Notify
 		// Admin user is always notified
 		$users = User::query()->where('may_administrate', '=', true)->get();
 
-		$albums = Album::query()->without(['thumbs', 'statistics', 'cover', 'min_privilege_cover', 'max_privilege_cover'])->join(PA::PHOTO_ALBUM, PA::ALBUM_ID, '=', 'album.id')
+		$albums = Album::query()
+			->without(['thumbs', 'statistics', 'cover', 'min_privilege_cover', 'max_privilege_cover'])
+			->join(PA::PHOTO_ALBUM, PA::ALBUM_ID, '=', 'albums.id')
 			->where(PA::PHOTO_ID, '=', $photo->id)
 			->get();
 
 		if ($albums->count() > 0) {
-			$shared_with = User::query()->join(APC::ACCESS_PERMISSIONS, APC::USER_ID, '=', 'user.id')
+			$shared_with = User::query()
+				->join(APC::ACCESS_PERMISSIONS, APC::USER_ID, '=', 'users.id')
+				->select(['users.*', APC::BASE_ALBUM_ID])
 				->whereIn(APC::BASE_ALBUM_ID, $albums->pluck('id'))
 				->get();
 			$users->push(...$shared_with->all());


### PR DESCRIPTION
Fixes email notifications not being sent by

1. Calling `Shared\NotifyAlbums` in `handleStandalone` rather than `handleDuplicate`. I don't think it makes any sense to send notifications when the uploaded photo is a duplicate.
2. Fixing the queries in `Notify`. Apart from the renamed tables `users` and `albums`, the join of `users` and `access_permissions` resulted in the `id` column of the latter overwriting the user id. I fixed this with a `select()`, but I'm not sure if there is a cleaner way.

See: https://github.com/LycheeOrg/Lychee/discussions/4244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed album notification behavior: Standalone photo imports now properly trigger notifications to users associated with affected albums, while duplicate photo handling has been adjusted to prevent redundant notifications.
* Improved notification recipient identification by correcting database query references to ensure all relevant album users and owners receive appropriate updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->