### PR TITLE
Ignore CVE which does not apply to us

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -27,3 +27,6 @@ CVE-2026-30836
 # PHP's own hash_hmac() and openssl_sign() behave identically and have no CVEs for this.
 # NVD agrees — hence the Disputed tag and no score from NIST.
 CVE-2025-45769
+
+# We do not use JWT on the GOLANG side (frankenphp), so this CVE does not apply to us.
+CVE-2026-34986


### PR DESCRIPTION
We do not use JWT on golang side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to exclude a non-applicable vulnerability entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->