### PR TITLE
Fix deep link failure for non-initial page photos (#4260)

### DIFF
--- a/app/Http/Controllers/Gallery/PhotoController.php
+++ b/app/Http/Controllers/Gallery/PhotoController.php
@@ -24,6 +24,7 @@ use App\Http\Requests\Photo\DeletePhotosRequest;
 use App\Http\Requests\Photo\EditPhotoRequest;
 use App\Http\Requests\Photo\FromUrlRequest;
 use App\Http\Requests\Photo\GetPhotoAlbumsRequest;
+use App\Http\Requests\Photo\GetPhotoRequest;
 use App\Http\Requests\Photo\MovePhotosRequest;
 use App\Http\Requests\Photo\RenamePhotoRequest;
 use App\Http\Requests\Photo\RotatePhotoRequest;
@@ -61,6 +62,22 @@ use LycheeVerify\Contract\VerifyInterface;
  */
 class PhotoController extends Controller
 {
+	/**
+	 * Fetch a single photo.
+	 *
+	 * @param GetPhotoRequest $request
+	 *
+	 * @return PhotoResource
+	 */
+	public function get(GetPhotoRequest $request): PhotoResource
+	{
+		return new PhotoResource(
+			photo: $request->photo(),
+			album_id: null,
+			should_downgrade_size_variants: !Gate::check(PhotoPolicy::CAN_ACCESS_FULL_PHOTO, [Photo::class, $request->photo()])
+		);
+	}
+
 	/**
 	 * Upload a picture.
 	 */

--- a/app/Http/Requests/Photo/GetPhotoRequest.php
+++ b/app/Http/Requests/Photo/GetPhotoRequest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Photo;
+
+use App\Contracts\Http\Requests\HasPhoto;
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Http\Requests\BaseApiRequest;
+use App\Http\Requests\Traits\HasPhotoTrait;
+use App\Models\Photo;
+use App\Policies\PhotoPolicy;
+use App\Rules\RandomIDRule;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Request to fetch a single photo.
+ */
+class GetPhotoRequest extends BaseApiRequest implements HasPhoto
+{
+	use HasPhotoTrait;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::check(PhotoPolicy::CAN_SEE, [Photo::class, $this->photo]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+		];
+	}
+
+	/**
+	 * Merge route parameter into request data for validation.
+	 */
+	protected function prepareForValidation(): void
+	{
+		$this->merge([
+			RequestAttribute::PHOTO_ID_ATTRIBUTE => $this->route(RequestAttribute::PHOTO_ID_ATTRIBUTE) ?? $this->get(RequestAttribute::PHOTO_ID_ATTRIBUTE),
+		]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		/** @var string $photo_id */
+		$photo_id = $values[RequestAttribute::PHOTO_ID_ATTRIBUTE];
+
+		$this->photo = Photo::query()
+			->with(['albums', 'size_variants', 'tags', 'palette'])
+			->findOrFail($photo_id);
+	}
+}

--- a/database/migrations/2019_12_25_0600_config_exiftool_ternary.php
+++ b/database/migrations/2019_12_25_0600_config_exiftool_ternary.php
@@ -24,8 +24,12 @@ return new class() extends Migration {
 			// Let's run the check for exiftool right here
 			$has_exiftool = 2; // not set
 			try {
-				$path = exec('command -v exiftool');
-				if ($path === '') {
+				if (PHP_OS_FAMILY === 'Windows') {
+					$path = exec('where exiftool 2>NUL');
+				} else {
+					$path = exec('command -v exiftool 2>/dev/null');
+				}
+				if ($path === '' || $path === null) {
 					$has_exiftool = 0; // false
 				} else {
 					$has_exiftool = 1; // true

--- a/resources/js/stores/PhotoState.ts
+++ b/resources/js/stores/PhotoState.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { usePhotosStore } from "./PhotosState";
+import PhotoService from "@/services/photo-service";
 
 export enum ImageViewMode {
 	Original = "original",
@@ -36,7 +37,7 @@ export const usePhotoStore = defineStore("photo-store", {
 				this.transition = "slide-next";
 			}
 		},
-		load() {
+		async load() {
 			if (this.photoId === undefined) {
 				this.photo = undefined;
 				return;
@@ -48,11 +49,12 @@ export const usePhotoStore = defineStore("photo-store", {
 			}
 
 			const photosState = usePhotosStore();
-			if (photosState.photos.length === 0) {
-				this.photo = undefined;
-				return;
-			}
 			this.photo = photosState.photos.find((p) => p.id === this.photoId);
+
+			if (this.photo === undefined) {
+				const response = await PhotoService.get(this.photoId);
+				this.photo = response.data;
+			}
 		},
 	},
 	getters: {

--- a/resources/js/views/gallery-panels/Album.vue
+++ b/resources/js/views/gallery-panels/Album.vue
@@ -225,7 +225,7 @@ async function load() {
 	catalogStore.load();
 	orderManagement.load();
 	photoStore.photoId = photoId.value;
-	photoStore.load();
+	await photoStore.load();
 }
 
 async function refresh(isDelete: boolean = false) {
@@ -240,7 +240,7 @@ async function refresh(isDelete: boolean = false) {
 		return;
 	}
 	photoStore.photoId = photoId.value;
-	photoStore.load();
+	await photoStore.load();
 }
 
 // eslint-disable-next-line vue/no-dupe-keys
@@ -495,7 +495,7 @@ const debouncedPhotoMetrics = useDebounceFn(() => {
 
 watch(
 	() => [route.params.albumId, route.params.photoId],
-	([newAlbumId, newPhotoId], _) => {
+	async ([newAlbumId, newPhotoId], _) => {
 		unselect();
 
 		photoStore.setTransition(newPhotoId as string | undefined);
@@ -515,7 +515,7 @@ watch(
 		if (oldAlbumId === newAlbumId) {
 			// If we are navigating between photos of the same album, we don't need to reload the album.
 			// We just need to load the new photo.
-			photoStore.load();
+			await photoStore.load();
 
 			// TODO: Consider loading the next page if the photo is getting close to the end of the currently loaded photos.
 			return;

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -141,6 +141,7 @@ Route::get('/Import::browse', [Admin\ImportFromServerController::class, 'browse'
 /**
  * PHOTO.
  */
+Route::get('/Photo', [Gallery\PhotoController::class, 'get']);
 Route::get('/Photo::random', [Gallery\FrameController::class, 'random']);
 Route::post('/Photo::fromUrl', [Gallery\PhotoController::class, 'fromUrl']);
 Route::post('/Photo', [Gallery\PhotoController::class, 'upload'])


### PR DESCRIPTION
This PR resolves an issue where direct links (deep links) to photos would fail if the target photo was not part of the initial paginated load of the album. This happened because the frontend relied solely on the local photosStore cache and lacked a mechanism to fetch individual photo details from the backend when missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to fetch individual photos.
  * Improved photo loading behavior with dynamic API fetching when photos are not cached locally.

* **Chores**
  * Enhanced system tool detection during database configuration to better identify platform-specific executable paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->