### PR TITLE
fix: Populate photo neighbors and album context when deep linking

### DIFF
--- a/app/Actions/Photo/GetNeighbors.php
+++ b/app/Actions/Photo/GetNeighbors.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Actions\Photo;
+
+use App\Contracts\Models\AbstractAlbum;
+use App\Models\Photo;
+use Illuminate\Database\Eloquent\Builder;
+
+class GetNeighbors
+{
+	/**
+	 * Returns the ID of the next and previous photo in the sorted album.
+	 *
+	 * @param Photo         $photo
+	 * @param AbstractAlbum $album
+	 *
+	 * @return array{previous_photo_id: ?string, next_photo_id: ?string}
+	 */
+	public function do(Photo $photo, AbstractAlbum $album): array
+	{
+		$sorting = $album->getEffectivePhotoSorting();
+		$column = $sorting->column->toColumn();
+		$order = $sorting->order->toOrder();
+
+		$prev = $this->getNeighbor($photo, $album, $column, $order, true);
+		$next = $this->getNeighbor($photo, $album, $column, $order, false);
+
+		return [
+			'previous_photo_id' => $prev?->id,
+			'next_photo_id' => $next?->id,
+		];
+	}
+
+	/**
+	 * @param Photo         $photo
+	 * @param AbstractAlbum $album
+	 * @param string        $column
+	 * @param string        $order
+	 * @param bool          $is_previous
+	 *
+	 * @return Photo|null
+	 */
+	private function getNeighbor(Photo $photo, AbstractAlbum $album, string $column, string $order, bool $is_previous): ?Photo
+	{
+		$query = $album->photos()->getQuery();
+
+		$current_value = $photo->{$column};
+		$current_id = $photo->id;
+
+		// If we want the previous photo:
+		// In ASC order: value < current_value OR (value == current_value AND id < current_id)
+		// In DESC order: value > current_value OR (value == current_value AND id > current_id)
+
+		// If we want the next photo:
+		// In ASC order: value > current_value OR (value == current_value AND id > current_id)
+		// In DESC order: value < current_value OR (value == current_value AND id < current_id)
+
+		$is_asc = ($order === 'asc');
+		$look_for_less = ($is_previous && $is_asc) || (!$is_previous && !$is_asc);
+
+		$query->where(function (Builder $q) use ($column, $current_value, $current_id, $look_for_less) {
+			$op = $look_for_less ? '<' : '>';
+			$q->where($column, $op, $current_value)
+			  ->orWhere(function (Builder $q2) use ($column, $current_value, $current_id, $op) {
+			  	$q2->where($column, '=', $current_value)
+					 ->where('id', $op, $current_id);
+			  });
+		});
+
+		// Order the results to get the closest one
+		$sort_order = $look_for_less ? 'desc' : 'asc';
+		$query->orderBy($column, $sort_order);
+		$query->orderBy('id', $sort_order);
+
+		return $query->first();
+	}
+}

--- a/app/Http/Controllers/Gallery/PhotoController.php
+++ b/app/Http/Controllers/Gallery/PhotoController.php
@@ -10,6 +10,7 @@ namespace App\Http\Controllers\Gallery;
 
 use App\Actions\Import\FromUrl;
 use App\Actions\Photo\Delete;
+use App\Actions\Photo\GetNeighbors;
 use App\Actions\Photo\MoveOrDuplicate;
 use App\Actions\Photo\Rating;
 use App\Actions\Photo\Rotate;
@@ -69,12 +70,22 @@ class PhotoController extends Controller
 	 *
 	 * @return PhotoResource
 	 */
-	public function get(GetPhotoRequest $request): PhotoResource
+	public function get(GetPhotoRequest $request, GetNeighbors $get_neighbors): PhotoResource
 	{
+		$photo = $request->photo();
+		$album = $photo->albums()->first();
+		$neighbors = ['previous_photo_id' => null, 'next_photo_id' => null];
+
+		if ($album !== null) {
+			$neighbors = $get_neighbors->do($photo, $album);
+		}
+
 		return new PhotoResource(
-			photo: $request->photo(),
-			album_id: null,
-			should_downgrade_size_variants: !Gate::check(PhotoPolicy::CAN_ACCESS_FULL_PHOTO, [Photo::class, $request->photo()])
+			photo: $photo,
+			album_id: $album?->id,
+			should_downgrade_size_variants: !Gate::check(PhotoPolicy::CAN_ACCESS_FULL_PHOTO, [Photo::class, $photo]),
+			next_photo_id: $neighbors['next_photo_id'],
+			previous_photo_id: $neighbors['previous_photo_id']
 		);
 	}
 

--- a/app/Http/Controllers/Gallery/PhotoController.php
+++ b/app/Http/Controllers/Gallery/PhotoController.php
@@ -24,6 +24,7 @@ use App\Http\Requests\Photo\DeletePhotosRequest;
 use App\Http\Requests\Photo\EditPhotoRequest;
 use App\Http\Requests\Photo\FromUrlRequest;
 use App\Http\Requests\Photo\GetPhotoAlbumsRequest;
+use App\Http\Requests\Photo\GetPhotoRequest;
 use App\Http\Requests\Photo\MovePhotosRequest;
 use App\Http\Requests\Photo\RenamePhotoRequest;
 use App\Http\Requests\Photo\RotatePhotoRequest;
@@ -61,6 +62,22 @@ use LycheeVerify\Contract\VerifyInterface;
  */
 class PhotoController extends Controller
 {
+	/**
+	 * Fetch a single photo.
+	 *
+	 * @param GetPhotoRequest $request
+	 *
+	 * @return PhotoResource
+	 */
+	public function get(GetPhotoRequest $request): PhotoResource
+	{
+		return new PhotoResource(
+			photo: $request->photo(),
+			album_id: null,
+			should_downgrade_size_variants: !Gate::check(PhotoPolicy::CAN_ACCESS_FULL_PHOTO, [Photo::class, $request->photo()])
+		);
+	}
+
 	/**
 	 * Upload a picture.
 	 */

--- a/app/Http/Requests/Photo/GetPhotoRequest.php
+++ b/app/Http/Requests/Photo/GetPhotoRequest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Photo;
+
+use App\Contracts\Http\Requests\HasPhoto;
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Http\Requests\BaseApiRequest;
+use App\Http\Requests\Traits\HasPhotoTrait;
+use App\Models\Photo;
+use App\Policies\PhotoPolicy;
+use App\Rules\RandomIDRule;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Request to fetch a single photo.
+ */
+class GetPhotoRequest extends BaseApiRequest implements HasPhoto
+{
+	use HasPhotoTrait;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::check(PhotoPolicy::CAN_SEE, [Photo::class, $this->photo]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function rules(): array
+	{
+		return [
+			RequestAttribute::PHOTO_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+		];
+	}
+
+	/**
+	 * Merge route parameter into request data for validation.
+	 */
+	protected function prepareForValidation(): void
+	{
+		$this->merge([
+			RequestAttribute::PHOTO_ID_ATTRIBUTE => $this->route(RequestAttribute::PHOTO_ID_ATTRIBUTE) ?? $this->get(RequestAttribute::PHOTO_ID_ATTRIBUTE),
+		]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		/** @var string $photo_id */
+		$photo_id = $values[RequestAttribute::PHOTO_ID_ATTRIBUTE];
+
+		$this->photo = Photo::query()
+			->with(['albums', 'size_variants', 'tags', 'palette'])
+			->findOrFail($photo_id);
+	}
+}

--- a/app/Http/Resources/Models/PhotoResource.php
+++ b/app/Http/Resources/Models/PhotoResource.php
@@ -54,8 +54,13 @@ class PhotoResource extends Data
 	public ?PhotoStatisticsResource $statistics = null;
 	public ?PhotoRatingResource $rating = null;
 
-	public function __construct(Photo $photo, ?string $album_id, bool $should_downgrade_size_variants)
-	{
+	public function __construct(
+		Photo $photo,
+		?string $album_id,
+		bool $should_downgrade_size_variants,
+		?string $next_photo_id = null,
+		?string $previous_photo_id = null,
+	) {
 		$this->id = $photo->id;
 		$this->album_id = $album_id;
 		$this->checksum = $photo->checksum;
@@ -74,8 +79,8 @@ class PhotoResource extends Data
 		$this->title = (request()->configs()->getValueAsBool('file_name_hidden') && Auth::guest()) ? '' : $photo->title;
 		$this->type = $photo->type;
 		$this->updated_at = $photo->updated_at->toIso8601String();
-		$this->next_photo_id = null;
-		$this->previous_photo_id = null;
+		$this->next_photo_id = $next_photo_id;
+		$this->previous_photo_id = $previous_photo_id;
 		$include_exif_data = request()->configs()->getValueAsBool('display_exif_data');
 		$this->preformatted = new PreformattedPhotoData($photo, $include_exif_data, $this->size_variants->original);
 		$this->precomputed = new PreComputedPhotoData($photo, $include_exif_data);

--- a/database/migrations/2019_12_25_0600_config_exiftool_ternary.php
+++ b/database/migrations/2019_12_25_0600_config_exiftool_ternary.php
@@ -24,8 +24,12 @@ return new class() extends Migration {
 			// Let's run the check for exiftool right here
 			$has_exiftool = 2; // not set
 			try {
-				$path = exec('command -v exiftool');
-				if ($path === '') {
+				if (PHP_OS_FAMILY === 'Windows') {
+					$path = exec('where exiftool 2>NUL');
+				} else {
+					$path = exec('command -v exiftool 2>/dev/null');
+				}
+				if ($path === '' || $path === null) {
 					$has_exiftool = 0; // false
 				} else {
 					$has_exiftool = 1; // true

--- a/resources/js/stores/PhotoState.ts
+++ b/resources/js/stores/PhotoState.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { usePhotosStore } from "./PhotosState";
+import PhotoService from "@/services/photo-service";
 
 export enum ImageViewMode {
 	Original = "original",
@@ -36,7 +37,7 @@ export const usePhotoStore = defineStore("photo-store", {
 				this.transition = "slide-next";
 			}
 		},
-		load() {
+		async load() {
 			if (this.photoId === undefined) {
 				this.photo = undefined;
 				return;
@@ -48,11 +49,12 @@ export const usePhotoStore = defineStore("photo-store", {
 			}
 
 			const photosState = usePhotosStore();
-			if (photosState.photos.length === 0) {
-				this.photo = undefined;
-				return;
-			}
 			this.photo = photosState.photos.find((p) => p.id === this.photoId);
+
+			if (this.photo === undefined) {
+				const response = await PhotoService.get(this.photoId);
+				this.photo = response.data;
+			}
 		},
 	},
 	getters: {

--- a/resources/js/views/gallery-panels/Album.vue
+++ b/resources/js/views/gallery-panels/Album.vue
@@ -225,7 +225,7 @@ async function load() {
 	catalogStore.load();
 	orderManagement.load();
 	photoStore.photoId = photoId.value;
-	photoStore.load();
+	await photoStore.load();
 }
 
 async function refresh(isDelete: boolean = false) {
@@ -240,7 +240,7 @@ async function refresh(isDelete: boolean = false) {
 		return;
 	}
 	photoStore.photoId = photoId.value;
-	photoStore.load();
+	await photoStore.load();
 }
 
 // eslint-disable-next-line vue/no-dupe-keys
@@ -495,7 +495,7 @@ const debouncedPhotoMetrics = useDebounceFn(() => {
 
 watch(
 	() => [route.params.albumId, route.params.photoId],
-	([newAlbumId, newPhotoId], _) => {
+	async ([newAlbumId, newPhotoId], _) => {
 		unselect();
 
 		photoStore.setTransition(newPhotoId as string | undefined);
@@ -515,7 +515,7 @@ watch(
 		if (oldAlbumId === newAlbumId) {
 			// If we are navigating between photos of the same album, we don't need to reload the album.
 			// We just need to load the new photo.
-			photoStore.load();
+			await photoStore.load();
 
 			// TODO: Consider loading the next page if the photo is getting close to the end of the currently loaded photos.
 			return;

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -141,6 +141,7 @@ Route::get('/Import::browse', [Admin\ImportFromServerController::class, 'browse'
 /**
  * PHOTO.
  */
+Route::get('/Photo', [Gallery\PhotoController::class, 'get']);
 Route::get('/Photo::random', [Gallery\FrameController::class, 'random']);
 Route::post('/Photo::fromUrl', [Gallery\PhotoController::class, 'fromUrl']);
 Route::post('/Photo', [Gallery\PhotoController::class, 'upload'])


### PR DESCRIPTION
This Pull Request addresses the issue where deep-linking directly to a photo (e.g., gallery/<photo_id>) results in a lack of navigation context (Next/Previous photo) and a null album ID on the frontend.

Previously, the backend's PhotoController@get method hardcoded album_id as null and did not provide information about surrounding photos. This forced the frontend to manually manage state, which failed for non-initial page photos and direct entry points.

Changes:
Backend Calculation of Neighbors: Introduced a new action app/Actions/Photo/GetNeighbors.php that calculates the previous and next photo IDs within a given album's context, respecting its specific sorting settings (column and order).
PhotoResource Update: Modified the PhotoResource constructor to accept and return next_photo_id and previous_photo_id.
Controller Logic: Updated PhotoController@get to identify a suitable album for the photo (if it belongs to any) and use the GetNeighbors action to populate the navigation context.
This ensures that direct links have fully functional navigation buttons from the moment they are loaded.

Related Issues
Fixes #4260 (indirectly, as part of the discussion in #4272).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced API endpoint to fetch individual photos, including information about neighboring photos for seamless album navigation
  * Improved photo loading mechanism with enhanced asynchronous synchronization when switching between photos in albums

* **Bug Fixes**
  * Resolved exiftool detection compatibility issues on Windows systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->