### PR TITLE
Remove user constraint on decoding Limiter

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -448,7 +448,7 @@ class AppServiceProvider extends ServiceProvider
 	private function registerThrottleQueues(): void
 	{
 		RateLimiter::for('geo-queue', function ($job) {
-			return Limit::perSecond(config('features.location_decoding_requests_per_second', 1))->by($job->user->id);
+			return Limit::perSecond(config('features.location_decoding_requests_per_second', 1));
 		});
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated geo-queue rate limiting to apply uniformly using default throttling behavior instead of per-request differentiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->