### PR TITLE
fix: show Back Home button on tablets and phones

### DIFF
--- a/resources/js/components/headers/AlbumsHeader.vue
+++ b/resources/js/components/headers/AlbumsHeader.vue
@@ -57,7 +57,9 @@
 				</Button>
 			</template>
 			<!-- Not logged in. -->
-			<BackLinkButton v-if="userStore.isGuest && albumsStore.rootConfig" :config="albumsStore.rootConfig" />
+			<div class="mr-12 lg:mr-0">
+				<BackLinkButton v-if="userStore.isGuest && albumsStore.rootConfig" :config="albumsStore.rootConfig" />
+			</div>
 			<!-- Maybe logged in. -->
 			<div class="hidden lg:block">
 				<template v-for="(item, idx) in menu" :key="`menu-item-${idx}`">

--- a/resources/js/components/headers/AlbumsHeader.vue
+++ b/resources/js/components/headers/AlbumsHeader.vue
@@ -56,6 +56,8 @@
 					{{ $t("profile.register.signup") }}
 				</Button>
 			</template>
+			<!-- Not logged in. -->
+			<BackLinkButton v-if="userStore.user?.id === null && albumsStore.rootConfig" :config="albumsStore.rootConfig" />
 			<!-- Maybe logged in. -->
 			<div class="hidden lg:block">
 				<template v-for="(item, idx) in menu" :key="`menu-item-${idx}`">
@@ -67,8 +69,6 @@
 						<Button :icon="item.icon" class="border-none" :severity="item.severity ?? 'secondary'" text @click="item.callback" />
 					</template>
 				</template>
-				<!-- Not logged in. -->
-				<BackLinkButton v-if="userStore.user?.id === null && albumsStore.rootConfig" :config="albumsStore.rootConfig" />
 			</div>
 			<SpeedDial
 				:model="menu"

--- a/resources/js/components/headers/AlbumsHeader.vue
+++ b/resources/js/components/headers/AlbumsHeader.vue
@@ -57,7 +57,7 @@
 				</Button>
 			</template>
 			<!-- Not logged in. -->
-			<BackLinkButton v-if="userStore.user?.id === null && albumsStore.rootConfig" :config="albumsStore.rootConfig" />
+			<BackLinkButton v-if="userStore.isGuest && albumsStore.rootConfig" :config="albumsStore.rootConfig" />
 			<!-- Maybe logged in. -->
 			<div class="hidden lg:block">
 				<template v-for="(item, idx) in menu" :key="`menu-item-${idx}`">

--- a/resources/js/components/headers/BackLinkButton.vue
+++ b/resources/js/components/headers/BackLinkButton.vue
@@ -7,8 +7,8 @@
 		class="border-none"
 		:class="props.config.back_button_enabled ? '' : 'hidden'"
 	>
-		<i class="pi pi-home sm:hidden" />
-		<span class="hidden sm:inline">{{ props.config.back_button_text }}</span>
+		<i class="pi pi-home lg:hidden" />
+		<span class="hidden lg:inline">{{ props.config.back_button_text }}</span>
 	</Button>
 </template>
 <script setup lang="ts">

--- a/resources/js/components/headers/TimelineHeader.vue
+++ b/resources/js/components/headers/TimelineHeader.vue
@@ -50,6 +50,8 @@
 					{{ $t("profile.register.signup") }}
 				</Button>
 			</template>
+			<!-- Not logged in. -->
+			<BackLinkButton v-if="userStore.isGuest && timelineStore.rootConfig" :config="timelineStore.rootConfig" />
 			<!-- Maybe logged in. -->
 			<div class="hidden lg:block">
 				<template v-for="(item, idx) in menu" :key="`menu-item-${idx}`">
@@ -61,8 +63,6 @@
 						<Button :icon="item.icon" class="border-none" severity="secondary" text @click="item.callback" />
 					</template>
 				</template>
-				<!-- Not logged in. -->
-				<BackLinkButton v-if="userStore.isGuest && timelineStore.rootConfig" :config="timelineStore.rootConfig" />
 			</div>
 			<SpeedDial
 				:model="menu"


### PR DESCRIPTION
Fixes #4233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Back link button is now visible on mobile devices, previously shown only on desktop screens.
  * Updated responsive layout breakpoints for consistent visibility across all screen sizes.
  * Enhanced button spacing and positioning for guest users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->