### PR TITLE
ldap is no longer required

### DIFF
--- a/app/Actions/InstallUpdate/DefaultConfig.php
+++ b/app/Actions/InstallUpdate/DefaultConfig.php
@@ -37,7 +37,6 @@ class DefaultConfig
 				'filter', // Required by dependencies
 				'gd',
 				'json', // Required by Laravel
-				'ldap', // Required by dependencies
 				'libxml', // Required by dependencies
 				'mbstring', // Required by Laravel
 				'openssl', // Required by Laravel


### PR DESCRIPTION
Avoid blocking manual install when installing on webhosting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LDAP PHP extension is no longer required as a system dependency. Users can now proceed with installation and operation without needing LDAP installed on their server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->