### PR TITLE
fix: Improved support for group authorization for Album delete & edit

### DIFF
--- a/app/Policies/AlbumPolicy.php
+++ b/app/Policies/AlbumPolicy.php
@@ -285,9 +285,11 @@ class AlbumPolicy extends BasePolicy
 		if (
 			AccessPermission::query()
 			->where(APC::BASE_ALBUM_ID, '=', $abstract_album->parent_id)
-			->where(APC::USER_ID, '=', $user->id)
+			->where(fn ($query) => $query->where(APC::USER_ID, '=', $user->id)
+					->orWhereIn(APC::USER_GROUP_ID, $user->user_groups->pluck('id'))
+			)
 			->where(APC::GRANTS_DELETE, '=', true)
-			->count() === 1
+			->count() >= 1
 		) {
 			return true;
 		}
@@ -379,9 +381,13 @@ class AlbumPolicy extends BasePolicy
 
 		if (
 			AccessPermission::query()
+			->select(APC::BASE_ALBUM_ID)
 			->whereIn(APC::BASE_ALBUM_ID, $album_ids)
-			->where(APC::USER_ID, '=', $user->id)
+			->where(fn ($query) => $query->where(APC::USER_ID, '=', $user->id)
+					->orWhereIn(APC::USER_GROUP_ID, $user->user_groups->pluck('id'))
+			)
 			->where(APC::GRANTS_EDIT, '=', true)
+			->distinct()
 			->count() === $num_albums
 		) {
 			return true;
@@ -430,9 +436,13 @@ class AlbumPolicy extends BasePolicy
 
 		if (
 			AccessPermission::query()
+			->select(APC::BASE_ALBUM_ID)
 			->whereIn(APC::BASE_ALBUM_ID, $album_ids)
-			->where(APC::USER_ID, '=', $user->id)
+			->where(fn ($query) => $query->where(APC::USER_ID, '=', $user->id)
+					->orWhereIn(APC::USER_GROUP_ID, $user->user_groups->pluck('id'))
+			)
 			->where(APC::GRANTS_DELETE, '=', true)
+			->distinct()
 			->count() === $num_albums
 		) {
 			return true;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permission checks for album deletion and editing now recognize group-based permissions in addition to direct user permissions, enabling authorized actions through group membership.
  * Fixed bulk edit and delete operations to correctly process all albums when users have multiple permission grants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->