### PR TITLE
Add option to have timeline only at root level

### DIFF
--- a/app/Http/Resources/GalleryConfigs/RootConfig.php
+++ b/app/Http/Resources/GalleryConfigs/RootConfig.php
@@ -43,7 +43,7 @@ class RootConfig extends Data
 	{
 		$is_logged_in = Auth::check();
 
-		$timeline_albums_enabled = request()->configs()->getValueAsBool('timeline_albums_enabled');
+		$timeline_albums_enabled = request()->configs()->getValueAsBool('timeline_albums_root_enabled');
 		$timeline_albums_public = request()->configs()->getValueAsBool('timeline_albums_public');
 		$this->is_album_timeline_enabled = $timeline_albums_enabled && ($is_logged_in || $timeline_albums_public);
 		$this->timeline_album_granularity = request()->configs()->getValueAsEnum('timeline_albums_granularity', TimelineAlbumGranularity::class);

--- a/database/migrations/2026_05_30_000001_add_timeline_albums_root_enabled.php
+++ b/database/migrations/2026_05_30_000001_add_timeline_albums_root_enabled.php
@@ -15,10 +15,11 @@ return new class() extends Migration {
 
 	public function up(): void
 	{
-		$val = DB::table('configs')->where('key', 'timeline_albums_enabled')->select('value')->get();
+		$val = DB::table('configs')->where('key', 'timeline_albums_enabled')->value('value');
+		$normalized_val = in_array($val, ['0', '1'], true) ? $val : '0';
 		DB::table('configs')->insert([
 			'key' => 'timeline_albums_root_enabled',
-			'value' => $val->isEmpty() ? '0' : $val[0]->value,
+			'value' => $normalized_val,
 			'cat' => self::CAT,
 			'type_range' => self::BOOL,
 			'description' => 'Enable timeline for albums at root',

--- a/database/migrations/2026_05_30_000001_add_timeline_albums_root_enabled.php
+++ b/database/migrations/2026_05_30_000001_add_timeline_albums_root_enabled.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class() extends Migration {
+	public const CAT = 'Mod Timeline';
+	public const BOOL = '0|1';
+
+	public function up(): void
+	{
+		$val = DB::table('configs')->where('key', 'timeline_albums_enabled')->select('value')->get();
+		DB::table('configs')->insert([
+			'key' => 'timeline_albums_root_enabled',
+			'value' => $val->isEmpty() ? '0' : $val[0]->value,
+			'cat' => self::CAT,
+			'type_range' => self::BOOL,
+			'description' => 'Enable timeline for albums at root',
+			'details' => '',
+			'is_secret' => false,
+			'is_expert' => false,
+			'level' => 0,
+			'order' => 11,
+		]);
+		DB::table('configs')->where('key', 'timeline_albums_enabled')->update(['details' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.']);
+	}
+
+	public function down(): void
+	{
+		DB::table('configs')->where('key', 'timeline_albums_root_enabled')->delete();
+		DB::table('configs')->where('key', 'timeline_albums_enabled')->update(['details' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.']);
+	}
+};

--- a/lang/ar/all_settings.php
+++ b/lang/ar/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/cz/all_settings.php
+++ b/lang/cz/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/el/all_settings.php
+++ b/lang/el/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/en/all_settings.php
+++ b/lang/en/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/es/all_settings.php
+++ b/lang/es/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/fa/all_settings.php
+++ b/lang/fa/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/hu/all_settings.php
+++ b/lang/hu/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/it/all_settings.php
+++ b/lang/it/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/ja/all_settings.php
+++ b/lang/ja/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/nl/all_settings.php
+++ b/lang/nl/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/no/all_settings.php
+++ b/lang/no/all_settings.php
@@ -505,7 +505,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/pl/all_settings.php
+++ b/lang/pl/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/pt/all_settings.php
+++ b/lang/pt/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/ru/all_settings.php
+++ b/lang/ru/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/sk/all_settings.php
+++ b/lang/sk/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/sv/all_settings.php
+++ b/lang/sv/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/tr/all_settings.php
+++ b/lang/tr/all_settings.php
@@ -506,7 +506,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/vi/all_settings.php
+++ b/lang/vi/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/zh_CN/all_settings.php
+++ b/lang/zh_CN/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',

--- a/lang/zh_TW/all_settings.php
+++ b/lang/zh_TW/all_settings.php
@@ -507,7 +507,7 @@ return [
         'timeline_photos_order' => 'This determines whether the captured date or the upload date will be used to order the photos.',
         'timeline_photos_layout' => '',
         'timeline_photos_pagination_limit' => '',
-        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums (and root). This can also be disabled/enabled per album.',
+        'timeline_albums_enabled' => 'Globally enable albums timelines in each albums. This can also be disabled/enabled per album.',
         'timeline_albums_public' => '',
         'timeline_albums_granularity' => '',
         'timeline_left_border_enabled' => '',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to independently enable/disable album timelines at the root level, affecting whether albums show a timeline on the site's root view.

* **Documentation**
  * Updated setting descriptions across all supported languages to clarify global vs. per-album timeline behavior and improve user-facing clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LycheeOrg/Lychee/pull/4383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->