### PR TITLE
Display Camera Make in PhotoDetails Exif Data

### DIFF
--- a/resources/js/components/drawers/PhotoDetails.vue
+++ b/resources/js/components/drawers/PhotoDetails.vue
@@ -117,7 +117,7 @@
 									src="../../../img/icons/camera.png"
 									class="dark:invert opacity-50 w-6 h-6"
 								/>
-								<span class="text-sm">{{ photoStore.photo.preformatted.model }}</span>
+								<span class="text-sm">{{ photoStore.photo.preformatted.make }} - {{ photoStore.photo.preformatted.model }}</span>
 							</div>
 							<div v-if="photoStore.photo.preformatted.lens" class="flex w-full gap-2 mb-2">
 								<img

--- a/resources/js/components/drawers/PhotoDetails.vue
+++ b/resources/js/components/drawers/PhotoDetails.vue
@@ -117,7 +117,8 @@
 									src="../../../img/icons/camera.png"
 									class="dark:invert opacity-50 w-6 h-6"
 								/>
-								<span class="text-sm">{{ photoStore.photo.preformatted.make }} - {{ photoStore.photo.preformatted.model }}</span>
+								<span class="text-sm">{{ [photoStore.photo.preformatted.make, photoStore.photo.preformatted.model].filter(Boolean).join(' - ') }}</span>
+
 							</div>
 							<div v-if="photoStore.photo.preformatted.lens" class="flex w-full gap-2 mb-2">
 								<img

--- a/resources/js/components/drawers/PhotoDetails.vue
+++ b/resources/js/components/drawers/PhotoDetails.vue
@@ -117,8 +117,7 @@
 									src="../../../img/icons/camera.png"
 									class="dark:invert opacity-50 w-6 h-6"
 								/>
-								<span class="text-sm">{{ [photoStore.photo.preformatted.make, photoStore.photo.preformatted.model].filter(Boolean).join(' - ') }}</span>
-
+								<span class="text-sm">{{ cameraModel }}</span>
 							</div>
 							<div v-if="photoStore.photo.preformatted.lens" class="flex w-full gap-2 mb-2">
 								<img
@@ -229,7 +228,7 @@
 	</aside>
 </template>
 <script setup lang="ts">
-import { Ref, ref, watch } from "vue";
+import { Ref, ref, watch, computed } from "vue";
 import Card from "primevue/card";
 import ProgressSpinner from "primevue/progressspinner";
 import MapInclude from "@/components/gallery/photoModule/MapInclude.vue";
@@ -262,6 +261,24 @@ const albums = ref<App.Http.Resources.Models.PhotoAlbumResource[]>([]);
 const albums_loading = ref(false);
 const albums_error = ref(false);
 const albums_cached_photo_id = ref<string | null>(null);
+
+const cameraModel = computed(() => getModel());
+
+function getModel() {
+	if (photoStore.photo === null || photoStore.photo === undefined || photoStore.photo.preformatted.model === null) {
+		return "";
+	}
+
+	if (photoStore.photo.preformatted.make === null || photoStore.photo.preformatted.make === "") {
+		return photoStore.photo.preformatted.model ?? "";
+	}
+
+	if (photoStore.photo.preformatted.model.startsWith(photoStore.photo.preformatted.make)) {
+		return photoStore.photo.preformatted.model;
+	}
+
+	return `${photoStore.photo.preformatted.make} - ${photoStore.photo.preformatted.model}`;
+}
 
 function fetchAlbums(photo_id: string) {
 	if (albums_cached_photo_id.value === photo_id) {


### PR DESCRIPTION
Lychee is only Displaying «Model» in PhotoDetails Exif Data.  
Non-Canon Cameras do not include the Brand Name in the Camera Model - e.g. Sony and Leica will just display the model name. Though, the data is already present in Lychee Backend and Database.  
This Feature Displays the Camera Model in a very minimal way. 

Note: For Canon Cameara (and maybe others?) the Brand «Canon» will be duplicated, but I think this is ok. 


Current Behaviour with a Sony Camera: 

<img width="309" height="176" alt="Bildschirmfoto 2026-06-01 um 09 13 51" src="https://github.com/user-attachments/assets/249c77e1-c2ef-4936-8070-ac016d1f15a7" />






<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera info in photo details: EXIF now shows a cleaner camera string—empty when missing, just the model when make is absent or already included, or "Make - Model" otherwise. The EXIF row still only appears when camera data is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->