### PR TITLE
Add support for toggle select on mobile view

### DIFF
--- a/lang/ar/gallery.php
+++ b/lang/ar/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'الصور',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'لا يوجد شيء هنا',
         'upload' => 'رفع الصور',
         'tabs' => [

--- a/lang/ar/gallery.php
+++ b/lang/ar/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'الصور',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'لا يوجد شيء هنا',
         'upload' => 'رفع الصور',

--- a/lang/bg/gallery.php
+++ b/lang/bg/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Снимки',
         'show_highlighted' => 'Филтрирай отбелязаните снимки',
         'copy_highlighted_names' => 'Копирай имената на маркираните снимки',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Няма какво да се покаже',
         'upload' => 'Качване на снимки',
         'tabs' => [

--- a/lang/bg/gallery.php
+++ b/lang/bg/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Снимки',
         'show_highlighted' => 'Филтрирай отбелязаните снимки',
         'copy_highlighted_names' => 'Копирай имената на маркираните снимки',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Няма какво да се покаже',
         'upload' => 'Качване на снимки',

--- a/lang/cz/gallery.php
+++ b/lang/cz/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Fotografie',
         'show_highlighted' => 'Filtrovat zvýrazněné obrázky',
         'copy_highlighted_names' => 'Kopírovat názvy zvýrazněných fotografií do schránky',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Zde není nic k vidění',
         'upload' => 'Nahrát fotografie',

--- a/lang/cz/gallery.php
+++ b/lang/cz/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Fotografie',
         'show_highlighted' => 'Filtrovat zvýrazněné obrázky',
         'copy_highlighted_names' => 'Kopírovat názvy zvýrazněných fotografií do schránky',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Zde není nic k vidění',
         'upload' => 'Nahrát fotografie',
         'tabs' => [

--- a/lang/de/gallery.php
+++ b/lang/de/gallery.php
@@ -139,7 +139,7 @@ return [
         'header_photos' => 'Fotos',
         'show_highlighted' => 'Favoriten filtern',
         'copy_highlighted_names' => 'Namen der Favoriten in die Zwischenablage kopieren',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Hier gibt es nichts zu sehen',
         'upload' => 'Fotos hochladen',

--- a/lang/de/gallery.php
+++ b/lang/de/gallery.php
@@ -139,6 +139,8 @@ return [
         'header_photos' => 'Fotos',
         'show_highlighted' => 'Favoriten filtern',
         'copy_highlighted_names' => 'Namen der Favoriten in die Zwischenablage kopieren',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Hier gibt es nichts zu sehen',
         'upload' => 'Fotos hochladen',
         'tabs' => [

--- a/lang/el/gallery.php
+++ b/lang/el/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',

--- a/lang/el/gallery.php
+++ b/lang/el/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'tabs' => [

--- a/lang/en/gallery.php
+++ b/lang/en/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',

--- a/lang/en/gallery.php
+++ b/lang/en/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'tabs' => [

--- a/lang/es/gallery.php
+++ b/lang/es/gallery.php
@@ -139,7 +139,7 @@ return [
         'header_photos' => 'Fotos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'No hay nada que ver aquí',
         'upload' => 'Subir fotos',

--- a/lang/es/gallery.php
+++ b/lang/es/gallery.php
@@ -139,6 +139,8 @@ return [
         'header_photos' => 'Fotos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'No hay nada que ver aquí',
         'upload' => 'Subir fotos',
         'tabs' => [

--- a/lang/fa/gallery.php
+++ b/lang/fa/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'عکس‌ها',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'اینجا چیزی برای نمایش نیست',
         'upload' => 'بارگذاری عکس‌ها',
         'tabs' => [

--- a/lang/fa/gallery.php
+++ b/lang/fa/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'عکس‌ها',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'اینجا چیزی برای نمایش نیست',
         'upload' => 'بارگذاری عکس‌ها',

--- a/lang/fr/gallery.php
+++ b/lang/fr/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Rien à voir ici',
         'upload' => 'Téléverser des photos',
         'tabs' => [

--- a/lang/fr/gallery.php
+++ b/lang/fr/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Rien à voir ici',
         'upload' => 'Téléverser des photos',

--- a/lang/hu/gallery.php
+++ b/lang/hu/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',

--- a/lang/hu/gallery.php
+++ b/lang/hu/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'tabs' => [

--- a/lang/it/gallery.php
+++ b/lang/it/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',

--- a/lang/it/gallery.php
+++ b/lang/it/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'tabs' => [

--- a/lang/ja/gallery.php
+++ b/lang/ja/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',

--- a/lang/ja/gallery.php
+++ b/lang/ja/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'tabs' => [

--- a/lang/nl/gallery.php
+++ b/lang/nl/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Foto’s',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Niets te zien hier',
         'upload' => 'Foto’s uploaden',
         'tabs' => [

--- a/lang/nl/gallery.php
+++ b/lang/nl/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Foto’s',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Niets te zien hier',
         'upload' => 'Foto’s uploaden',

--- a/lang/no/gallery.php
+++ b/lang/no/gallery.php
@@ -139,7 +139,7 @@ return [
         'header_photos' => 'Bilder',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Ingenting å se her',
         'upload' => 'Last opp bilder',

--- a/lang/no/gallery.php
+++ b/lang/no/gallery.php
@@ -139,6 +139,8 @@ return [
         'header_photos' => 'Bilder',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Ingenting å se her',
         'upload' => 'Last opp bilder',
         'tabs' => [

--- a/lang/pl/gallery.php
+++ b/lang/pl/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Zdjęcia',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Nie ma tu nic do oglądania',
         'upload' => 'Przesyłanie zdjęć',
         'tabs' => [

--- a/lang/pl/gallery.php
+++ b/lang/pl/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Zdjęcia',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Nie ma tu nic do oglądania',
         'upload' => 'Przesyłanie zdjęć',

--- a/lang/pt/gallery.php
+++ b/lang/pt/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',

--- a/lang/pt/gallery.php
+++ b/lang/pt/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'tabs' => [

--- a/lang/ru/gallery.php
+++ b/lang/ru/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Фотографии',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Здесь ничего нет',
         'upload' => 'Загрузить фотографии',
         'tabs' => [

--- a/lang/ru/gallery.php
+++ b/lang/ru/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Фотографии',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Здесь ничего нет',
         'upload' => 'Загрузить фотографии',

--- a/lang/sk/gallery.php
+++ b/lang/sk/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',

--- a/lang/sk/gallery.php
+++ b/lang/sk/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'tabs' => [

--- a/lang/sv/gallery.php
+++ b/lang/sv/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',

--- a/lang/sv/gallery.php
+++ b/lang/sv/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'tabs' => [

--- a/lang/tr/gallery.php
+++ b/lang/tr/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',

--- a/lang/tr/gallery.php
+++ b/lang/tr/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'tabs' => [

--- a/lang/vi/gallery.php
+++ b/lang/vi/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',

--- a/lang/vi/gallery.php
+++ b/lang/vi/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'tabs' => [

--- a/lang/zh_CN/gallery.php
+++ b/lang/zh_CN/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => '照片',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => '这里什么都没有',
         'upload' => '上传照片',
         'tabs' => [

--- a/lang/zh_CN/gallery.php
+++ b/lang/zh_CN/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => '照片',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => '这里什么都没有',
         'upload' => '上传照片',

--- a/lang/zh_TW/gallery.php
+++ b/lang/zh_TW/gallery.php
@@ -140,7 +140,7 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
-        'toggle_touch_select' => 'Toggle photo selection mode',
+        'toggle_touch_select' => 'Toggle selection mode',
         'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',

--- a/lang/zh_TW/gallery.php
+++ b/lang/zh_TW/gallery.php
@@ -140,6 +140,8 @@ return [
         'header_photos' => 'Photos',
         'show_highlighted' => 'Filter highlighted images',
         'copy_highlighted_names' => 'Copy highlighted photo names to clipboard',
+        'toggle_touch_select' => 'Toggle photo selection mode',
+        'photo_actions' => 'Photo actions',
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'tabs' => [

--- a/resources/js/components/gallery/albumModule/AlbumListItem.vue
+++ b/resources/js/components/gallery/albumModule/AlbumListItem.vue
@@ -1,13 +1,26 @@
 <template>
 	<div
-		class="group flex items-center gap-4 px-3 py-0.5 cursor-pointer hover:bg-primary-400/10 flex-row"
+		class="group relative flex items-center gap-4 px-3 py-0.5 cursor-pointer hover:bg-primary-400/10 flex-row"
 		:class="{
 			'bg-primary-100 dark:bg-primary-900/50': isSelected,
 		}"
 		:data-album-id="album.id"
-		@click="propagateClicked($event, album.id)"
+		@click="maySelect($event, album.id)"
 		@contextmenu.prevent="propagateContexted($event, album.id)"
 	>
+		<!-- Touch select overlay: sits above router-links so they don't capture clicks -->
+		<div v-if="is_touch_select_mode" class="absolute inset-0 z-10" />
+		<!-- Touch select mode indicator -->
+		<div
+			v-if="is_touch_select_mode"
+			class="relative z-20 shrink-0 w-5 h-5 rounded-full flex items-center justify-center"
+			:class="{
+				'bg-primary-500 border-2 border-white': isSelected,
+				'border-2 border-surface-400 bg-surface-100 dark:bg-surface-800': !isSelected,
+			}"
+		>
+			<i v-if="isSelected" class="pi pi-check text-white" style="font-size: 0.6rem" />
+		</div>
 		<!-- Thumbnail -->
 		<router-link
 			:to="{ name: 'album', params: { albumId: album.id } }"
@@ -79,11 +92,14 @@ import { useLycheeStateStore } from "@/stores/LycheeState";
 import { useAlbumsStore } from "@/stores/AlbumsState";
 import ListBadge from "./thumbs/ListBadge.vue";
 import { usePropagateAlbumEvents } from "@/composables/album/propagateEvents";
+import { useTogglablesStateStore } from "@/stores/ModalsState";
+import { storeToRefs } from "pinia";
 
 const albumStore = useAlbumStore();
 const albumsStore = useAlbumsStore();
-
 const lycheeStore = useLycheeStateStore();
+const togglableStore = useTogglablesStateStore();
+const { is_touch_select_mode } = storeToRefs(togglableStore);
 
 defineProps<{
 	album: App.Http.Resources.Models.ThumbAlbumResource;
@@ -92,10 +108,19 @@ defineProps<{
 
 const emits = defineEmits<{
 	clicked: [event: MouseEvent, id: string];
+	selected: [event: MouseEvent, id: string];
 	contexted: [event: MouseEvent, id: string];
 }>();
 
 const { propagateClicked, propagateContexted } = usePropagateAlbumEvents(emits);
+
+function maySelect(e: MouseEvent, id: string) {
+	if (is_touch_select_mode.value) {
+		emits("selected", e, id);
+		return;
+	}
+	propagateClicked(e, id);
+}
 
 const aspectRatio = computed(
 	() => albumStore.config?.album_thumb_css_aspect_ratio ?? albumsStore.rootConfig?.album_thumb_css_aspect_ratio ?? "aspect-square",

--- a/resources/js/components/gallery/albumModule/AlbumListView.vue
+++ b/resources/js/components/gallery/albumModule/AlbumListView.vue
@@ -6,6 +6,7 @@
 				:album="album"
 				:is-selected="selectedIds.includes(album.id)"
 				@clicked="propagateClicked"
+				@selected="(e: MouseEvent, id: string) => emits('selected', e, id)"
 				@contexted="propagateContexted"
 			/>
 		</template>
@@ -25,6 +26,7 @@ const props = defineProps<{
 
 const emits = defineEmits<{
 	clicked: [event: MouseEvent, id: string];
+	selected: [event: MouseEvent, id: string];
 	contexted: [event: MouseEvent, id: string];
 }>();
 

--- a/resources/js/components/gallery/albumModule/AlbumPanel.vue
+++ b/resources/js/components/gallery/albumModule/AlbumPanel.vue
@@ -9,6 +9,7 @@
 			@open-search="emits('openSearch')"
 			@go-back="emits('goBack')"
 			@show-selected="albumCallbacks.copyHighlighted()"
+			@open-context-menu="openContextMenuFromHeader"
 		/>
 		<template v-if="albumStore.album && albumStore.config && userStore.isLoaded">
 			<div id="galleryView" class="relative flex flex-wrap content-start w-full justify-start overflow-y-auto h-full select-none">
@@ -58,6 +59,7 @@
 						:selected-albums="selectedAlbumsIds"
 						:is-timeline="albumStore.config.is_album_timeline_enabled"
 						@clicked="albumSelect"
+						@selected="albumSelect"
 						@contexted="contextMenuAlbumOpen"
 					/>
 					<!-- Pagination for albums -->
@@ -242,6 +244,14 @@ const { photoRoute, getParentId } = usePhotoRoute(router);
 
 function photoClick(photoId: string, _e: MouseEvent) {
 	router.push(photoRoute(photoId));
+}
+
+function openContextMenuFromHeader(e: MouseEvent): void {
+	if (selectedPhotosIds.value.length > 0) {
+		contextMenuPhotoOpen(selectedPhotosIds.value[0], e);
+	} else if (selectedAlbumsIds.value.length > 0) {
+		contextMenuAlbumOpen(e, selectedAlbumsIds.value[0]);
+	}
 }
 
 function goToPhotosPage(page: number) {

--- a/resources/js/components/gallery/albumModule/AlbumThumbPanel.vue
+++ b/resources/js/components/gallery/albumModule/AlbumThumbPanel.vue
@@ -14,6 +14,7 @@
 				:albums="props.albums"
 				:selected-ids="props.selectedAlbums"
 				@clicked="propagateClicked"
+				@selected="propagateSelected"
 				@contexted="propagateContexted"
 			/>
 			<AlbumThumbPanelList
@@ -21,6 +22,7 @@
 				:albums="props.albums"
 				:selected-albums="props.selectedAlbums"
 				@clicked="propagateClicked"
+				@selected="propagateSelected"
 				@contexted="propagateContexted"
 			/>
 		</div>
@@ -113,9 +115,14 @@ const props = defineProps<{
 // bubble up.
 const emits = defineEmits<{
 	clicked: [event: MouseEvent, id: string];
+	selected: [event: MouseEvent, id: string];
 	contexted: [event: MouseEvent, id: string];
 }>();
 const { propagateClicked, propagateContexted } = usePropagateAlbumEvents(emits);
+
+function propagateSelected(event: MouseEvent, id: string) {
+	emits("selected", event, id);
+}
 
 const { spliter, verifyOrder } = useSplitter();
 

--- a/resources/js/components/gallery/albumModule/AlbumThumbPanelList.vue
+++ b/resources/js/components/gallery/albumModule/AlbumThumbPanelList.vue
@@ -6,6 +6,7 @@
 			:cover_id="null"
 			:is-selected="props.selectedAlbums.includes(album.id)"
 			@click="propagateClicked($event, album.id)"
+			@touch-select="(e: MouseEvent) => emits('selected', e, album.id)"
 			@contextmenu.prevent="propagateContexted($event, album.id)"
 		/>
 	</template>
@@ -27,6 +28,7 @@ const props = defineProps<{
 // bubble up.
 const emits = defineEmits<{
 	clicked: [event: MouseEvent, id: string];
+	selected: [event: MouseEvent, id: string];
 	contexted: [event: MouseEvent, id: string];
 }>();
 

--- a/resources/js/components/gallery/albumModule/PhotoThumbPanelList.vue
+++ b/resources/js/components/gallery/albumModule/PhotoThumbPanelList.vue
@@ -38,6 +38,7 @@ import { useRoute } from "vue-router";
 import { useLayoutStore } from "@/stores/LayoutState";
 import { useAlbumStore } from "@/stores/AlbumState";
 import { useCatalogStore } from "@/stores/CatalogState";
+import { useTogglablesStateStore } from "@/stores/ModalsState";
 
 const props = defineProps<{
 	photos: App.Http.Resources.Models.PhotoResource[];
@@ -50,6 +51,9 @@ const lycheeStore = useLycheeStateStore();
 const layoutStore = useLayoutStore();
 const albumStore = useAlbumStore();
 const catalogStore = useCatalogStore();
+const togglableStore = useTogglablesStateStore();
+
+const { is_touch_select_mode } = storeToRefs(togglableStore);
 
 const isBuyable = computed(() => catalogStore.catalog?.album_purchasable !== undefined && catalogStore.catalog.album_purchasable !== null);
 const { is_timeline_left_border_visible } = storeToRefs(lycheeStore);
@@ -69,7 +73,7 @@ const emits = defineEmits<{
 }>();
 
 function maySelect(id: string, e: MouseEvent) {
-	if (ctrlKeyState.value || metaKeyState.value || shiftKeyState.value) {
+	if (is_touch_select_mode.value || ctrlKeyState.value || metaKeyState.value || shiftKeyState.value) {
 		emits("selected", id, e);
 		return;
 	}

--- a/resources/js/components/gallery/albumModule/thumbs/AlbumThumb.vue
+++ b/resources/js/components/gallery/albumModule/thumbs/AlbumThumb.vue
@@ -64,6 +64,22 @@
 		</div>
 		<!-- v-if="props.config.album_decoration !== 'none'" -->
 		<AlbumThumbDecorations :album="props.album" />
+		<!-- Touch select overlay: stops the click from reaching the router-link navigate handler -->
+		<div
+			v-if="is_touch_select_mode"
+			class="absolute inset-0 z-20"
+			@click.stop="(e: MouseEvent) => emits('touchSelect', e)"
+		/>
+		<!-- Touch select mode indicator -->
+		<div
+			v-if="is_touch_select_mode"
+			class="absolute top-1.5 ltr:right-1.5 rtl:left-1.5 z-30 w-5 h-5 rounded-full pointer-events-none flex items-center justify-center"
+			:class="{
+				'border border-white bg-black/40': !props.isSelected,
+			}"
+		>
+			<i v-if="props.isSelected" class="pi pi-check-circle text-lg text-primary-400" />
+		</div>
 	</router-link>
 </template>
 <script setup lang="ts">
@@ -97,6 +113,10 @@ const props = defineProps<{
 	album: App.Http.Resources.Models.ThumbAlbumResource;
 }>();
 
+const emits = defineEmits<{
+	touchSelect: [event: MouseEvent];
+}>();
+
 const { canInteractAlbum } = useAlbumActions();
 const router = useRouter();
 const userStore = useUserStore();
@@ -108,6 +128,7 @@ const lycheeStore = useLycheeStateStore();
 const togglableStore = useTogglablesStateStore();
 const { getPlayIcon } = useImageHelpers();
 const { display_thumb_album_overlay } = storeToRefs(lycheeStore);
+const { is_touch_select_mode } = storeToRefs(togglableStore);
 
 const aspectRatio = computed(
 	() => albumStore.config?.album_thumb_css_aspect_ratio ?? albumsStore.rootConfig?.album_thumb_css_aspect_ratio ?? "aspect-square",

--- a/resources/js/components/gallery/albumModule/thumbs/AlbumThumb.vue
+++ b/resources/js/components/gallery/albumModule/thumbs/AlbumThumb.vue
@@ -65,11 +65,7 @@
 		<!-- v-if="props.config.album_decoration !== 'none'" -->
 		<AlbumThumbDecorations :album="props.album" />
 		<!-- Touch select overlay: stops the click from reaching the router-link navigate handler -->
-		<div
-			v-if="is_touch_select_mode"
-			class="absolute inset-0 z-20"
-			@click.stop="(e: MouseEvent) => emits('touchSelect', e)"
-		/>
+		<div v-if="is_touch_select_mode" class="absolute inset-0 z-20" @click.stop="(e: MouseEvent) => emits('touchSelect', e)" />
 		<!-- Touch select mode indicator -->
 		<div
 			v-if="is_touch_select_mode"

--- a/resources/js/components/gallery/albumModule/thumbs/PhotoThumb.vue
+++ b/resources/js/components/gallery/albumModule/thumbs/PhotoThumb.vue
@@ -78,7 +78,17 @@
 		>
 			<img class="absolute aspect-square w-fit h-fit" alt="play" :src="srcPlay" />
 		</div>
-		<div class="absolute top-0 ltr:right-0 rtl:left-0 w-1/4 flex flex-row-reverse px-1">
+		<!-- Touch select mode indicator -->
+		<div
+			v-if="is_touch_select_mode"
+			class="absolute top-1.5 ltr:right-1.5 rtl:left-1.5 z-10 w-5 h-5 rounded-full pointer-events-none flex items-center justify-center"
+			:class="{
+				'border border-white bg-black/40': !props.isSelected,
+			}"
+		>
+			<i v-if="props.isSelected" class="pi pi-check-circle text-lg text-primary-400" />
+		</div>
+		<div v-else class="absolute top-0 ltr:right-0 rtl:left-0 w-1/4 flex flex-row-reverse px-1">
 			<ThumbBuyMe :is-in-basket="isInBasket" @click="toggleBuyMe" v-if="props.isBuyable" />
 			<ThumbFavourite v-if="is_favourite_enabled" :is-favourite="isFavourite" @click="toggleFavourite" />
 		</div>
@@ -119,6 +129,7 @@ import { useOrderManagementStore } from "@/stores/OrderManagement";
 import { useUserStore } from "@/stores/UserState";
 import { useAlbumsStore } from "@/stores/AlbumsState";
 import { useAlbumStore } from "@/stores/AlbumState";
+import { useTogglablesStateStore } from "@/stores/ModalsState";
 
 const { getNoImageIcon, getPlayIcon } = useImageHelpers();
 
@@ -142,8 +153,10 @@ const lycheeStore = useLycheeStateStore();
 const orderStore = useOrderManagementStore();
 const albumsStore = useAlbumsStore();
 const albumStore = useAlbumStore();
+const togglableStore = useTogglablesStateStore();
 const { is_favourite_enabled, display_thumb_photo_overlay, photo_thumb_info, is_photo_thumb_tags_enabled, rating_album_view_mode } =
 	storeToRefs(lycheeStore);
+const { is_touch_select_mode } = storeToRefs(togglableStore);
 const srcPlay = ref(getPlayIcon());
 const srcNoImage = ref(getNoImageIcon());
 const isImageLoaded = ref(false);

--- a/resources/js/components/headers/AlbumHeader.vue
+++ b/resources/js/components/headers/AlbumHeader.vue
@@ -17,47 +17,68 @@
 
 		<template #end>
 			<Button
-				v-if="is_se_enabled && albumStore.album.rights?.can_edit"
-				v-tooltip.bottom="$t('gallery.album.copy_highlighted_names')"
-				icon="pi pi-copy"
-				class="border-none hover:text-color"
+				v-if="is_touch_select_mode && (selectedPhotosIds.length > 0 || selectedAlbumsIds.length > 0)"
+				v-tooltip.bottom="$t('gallery.album.photo_actions')"
+				icon="pi pi-ellipsis-v"
+				class="border-none"
 				severity="secondary"
 				text
-				@click="emits('showSelected')"
+				@click="(e: MouseEvent) => emits('openContextMenu', e)"
 			/>
-			<router-link v-if="orderManagementStore.hasItems" v-tooltip.bottom="'Basket'" :to="{ name: 'basket' }" class="hidden sm:block">
-				<Button
-					icon="pi pi-shopping-cart"
-					class="border-none"
-					:severity="orderManagementStore.order?.status === 'processing' ? 'danger' : 'secondary'"
-					text
-				/>
-			</router-link>
-			<router-link
-				v-if="is_favourite_enabled && (favourites.photos?.length ?? 0) > 0"
-				v-tooltip.bottom="'Favourites'"
-				:to="{ name: 'favourites' }"
-				class="hidden sm:block"
-			>
-				<Button icon="pi pi-heart" class="border-none" severity="secondary" text />
-			</router-link>
 			<Button
-				v-if="albumStore.config?.is_search_accessible"
-				icon="pi pi-search"
-				class="border-none hidden sm:inline-flex"
+				v-if="isTouchDevice() && canInteractPhoto()"
+				v-tooltip.bottom="$t('gallery.album.toggle_touch_select')"
+				:icon="is_touch_select_mode ? 'pi pi-check-square' : 'pi pi-stop'"
+				class="border-none"
+				:class="{ 'text-primary-400': is_touch_select_mode }"
 				severity="secondary"
 				text
-				@click="emits('openSearch')"
+				@click="togglableStore.toggleTouchSelectMode()"
 			/>
-			<Button v-if="albumStore.rights?.can_upload" icon="pi pi-plus" class="border-none" severity="secondary" text @click="openAddMenu" />
-			<template v-if="albumStore.rights?.can_edit">
+			<template v-if="!is_touch_select_mode">
 				<Button
-					:icon="is_album_edit_open ? 'pi pi-angle-up' : 'pi pi-angle-down'"
+					v-if="is_se_enabled && albumStore.album.rights?.can_edit"
+					v-tooltip.bottom="$t('gallery.album.copy_highlighted_names')"
+					icon="pi pi-copy"
+					class="border-none hover:text-color"
 					severity="secondary"
-					:class="{ 'ltr:mr-2 rtl:ml-2 border-none': true, 'text-primary-400': is_album_edit_open }"
 					text
-					@click="emits('toggleEdit')"
+					@click="emits('showSelected')"
 				/>
+				<router-link v-if="orderManagementStore.hasItems" v-tooltip.bottom="'Basket'" :to="{ name: 'basket' }" class="hidden sm:block">
+					<Button
+						icon="pi pi-shopping-cart"
+						class="border-none"
+						:severity="orderManagementStore.order?.status === 'processing' ? 'danger' : 'secondary'"
+						text
+					/>
+				</router-link>
+				<router-link
+					v-if="is_favourite_enabled && (favourites.photos?.length ?? 0) > 0"
+					v-tooltip.bottom="'Favourites'"
+					:to="{ name: 'favourites' }"
+					class="hidden sm:block"
+				>
+					<Button icon="pi pi-heart" class="border-none" severity="secondary" text />
+				</router-link>
+				<Button
+					v-if="albumStore.config?.is_search_accessible"
+					icon="pi pi-search"
+					class="border-none hidden sm:inline-flex"
+					severity="secondary"
+					text
+					@click="emits('openSearch')"
+				/>
+				<Button v-if="albumStore.rights?.can_upload" icon="pi pi-plus" class="border-none" severity="secondary" text @click="openAddMenu" />
+				<template v-if="albumStore.rights?.can_edit">
+					<Button
+						:icon="is_album_edit_open ? 'pi pi-angle-up' : 'pi pi-angle-down'"
+						severity="secondary"
+						:class="{ 'ltr:mr-2 rtl:ml-2 border-none': true, 'text-primary-400': is_album_edit_open }"
+						text
+						@click="emits('toggleEdit')"
+					/>
+				</template>
 			</template>
 		</template>
 	</Toolbar>
@@ -91,6 +112,8 @@ import GoBack from "./GoBack.vue";
 import { onMounted } from "vue";
 import { useAlbumStore } from "@/stores/AlbumState";
 import { useOrderManagementStore } from "@/stores/OrderManagement";
+import { isTouchDevice } from "@/utils/keybindings-utils";
+import { useAlbumActions } from "@/composables/album/albumActions";
 
 const togglableStore = useTogglablesStateStore();
 const lycheeStore = useLycheeStateStore();
@@ -99,7 +122,8 @@ const albumStore = useAlbumStore();
 const orderManagementStore = useOrderManagementStore();
 
 const { dropbox_api_key, is_favourite_enabled, is_se_enabled } = storeToRefs(lycheeStore);
-const { is_album_edit_open, is_full_screen } = storeToRefs(togglableStore);
+const { canInteractPhoto } = useAlbumActions();
+const { is_album_edit_open, is_full_screen, is_touch_select_mode, selectedPhotosIds, selectedAlbumsIds } = storeToRefs(togglableStore);
 
 const { toggleCreateAlbum, toggleImportFromLink, toggleImportFromDropbox, toggleUpload, toggleImportFromServer, toggleCameraCapture } =
 	useGalleryModals(togglableStore);
@@ -110,6 +134,7 @@ const emits = defineEmits<{
 	goBack: [];
 	openSearch: [];
 	showSelected: [];
+	openContextMenu: [event: MouseEvent];
 }>();
 
 function toggleUploadTrack() {

--- a/resources/js/composables/selections/selections.ts
+++ b/resources/js/composables/selections/selections.ts
@@ -76,7 +76,9 @@ export function useSelection(photosStore: PhotosStore, albumsStore: AlbumsStore,
 
 		// we do not support CTRL + SHIFT
 		const { isMod, isShift } = getMouseModifiers(e);
-		if (!isMod && !isShift) {
+		const isTouchSelect = togglableStore.is_touch_select_mode;
+
+		if (!isMod && !isShift && !isTouchSelect) {
 			return;
 		}
 
@@ -88,7 +90,8 @@ export function useSelection(photosStore: PhotosStore, albumsStore: AlbumsStore,
 			return;
 		}
 
-		if (isMod) {
+		// Touch select mode or Ctrl/Meta: toggle individual photo
+		if (isTouchSelect || isMod) {
 			handlePhotoCtrl(photoId);
 			return;
 		}
@@ -155,7 +158,9 @@ export function useSelection(photosStore: PhotosStore, albumsStore: AlbumsStore,
 
 		// we do not support CTRL + SHIFT
 		const { isMod, isShift } = getMouseModifiers(e);
-		if (!isMod && !isShift) {
+		const isTouchSelect = togglableStore.is_touch_select_mode;
+
+		if (!isMod && !isShift && !isTouchSelect) {
 			return;
 		}
 
@@ -168,7 +173,8 @@ export function useSelection(photosStore: PhotosStore, albumsStore: AlbumsStore,
 			return;
 		}
 
-		if (isMod) {
+		// Touch select mode or Ctrl/Meta: toggle individual album
+		if (isTouchSelect || isMod) {
 			handleAlbumCtrl(albumId);
 			return;
 		}

--- a/resources/js/stores/ModalsState.ts
+++ b/resources/js/stores/ModalsState.ts
@@ -57,6 +57,9 @@ export const useTogglablesStateStore = defineStore("togglables-store", {
 		selectedPhotosIds: [] as string[],
 		selectedAlbumsIds: [] as string[],
 
+		// Touch multi-select mode (mobile)
+		is_touch_select_mode: false,
+
 		// Selections via Click and Drag
 		isDragging: false,
 		nonHoverSelectablePhotosIdx: [] as string[], // contains photos ids that are currently hoved but not selected
@@ -96,6 +99,14 @@ export const useTogglablesStateStore = defineStore("togglables-store", {
 
 		rememberScrollThumb(photo_id: string | undefined) {
 			this.scroll_photo_id = photo_id;
+		},
+
+		toggleTouchSelectMode() {
+			this.is_touch_select_mode = !this.is_touch_select_mode;
+			if (!this.is_touch_select_mode) {
+				this.selectedPhotosIds = [];
+				this.selectedAlbumsIds = [];
+			}
 		},
 
 		recoverAndResetScrollThumb(thumbElem: HTMLElement) {


### PR DESCRIPTION
Fixes #1585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Touch-select mode for albums and photos with a header toggle, multi-select gestures, and context-menu integration
  * Visual selection indicators and overlays appear when touch-select mode is active

* **Localization**
  * Added UI strings for toggling touch-select mode and for photo actions across many languages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->