### PR TITLE
Add middleware to check if feature is enabled

### DIFF
--- a/app/Exceptions/FeatureDisabledException.php
+++ b/app/Exceptions/FeatureDisabledException.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Exceptions;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class FeatureDisabledException extends BaseLycheeException
+{
+	public function __construct(string $feature)
+	{
+		parent::__construct(Response::HTTP_NOT_IMPLEMENTED, sprintf("Feature '%s' is disabled", $feature), null);
+	}
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -109,5 +109,6 @@ class Kernel extends HttpKernel
 		'response_cache' => \App\Http\Middleware\Caching\ResponseCache::class,
 		'album_cache_refresher' => \App\Http\Middleware\Caching\AlbumRouteCacheRefresher::class,
 		'legacy_id_redirect' => \App\Http\Middleware\LegacyLocalIdRedirect::class,
+		'feature' => \App\Http\Middleware\FeatureEnabled::class,
 	];
 }

--- a/app/Http/Middleware/FeatureEnabled.php
+++ b/app/Http/Middleware/FeatureEnabled.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Http\Middleware;
+
+use App\Exceptions\ConfigurationKeyMissingException;
+use App\Exceptions\FeatureDisabledException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Class FeatureEnabled.
+ *
+ * This middleware checks whether a feature flag is enabled via the `features`
+ * config file. If the flag resolves to false, a 501 Not Implemented response
+ * is returned. Use as `feature:feature_name` in route definitions.
+ */
+class FeatureEnabled
+{
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @param Request  $request      the incoming request to serve
+	 * @param \Closure $next         the next operation to be applied to the request
+	 * @param string   $feature_name the key to look up in config('features')
+	 *
+	 * @throws FeatureDisabledException
+	 */
+	public function handle(Request $request, \Closure $next, string $feature_name): mixed
+	{
+		$key = 'features.' . $feature_name;
+
+		if (!Config::has($key)) {
+			throw new ConfigurationKeyMissingException(sprintf("Feature key '%s' does not exist in config", $key));
+		}
+
+		if (config($key) !== true) {
+			throw new FeatureDisabledException($feature_name);
+		}
+
+		return $next($request);
+	}
+}

--- a/tests/Unit/Middleware/FeatureEnabledTest.php
+++ b/tests/Unit/Middleware/FeatureEnabledTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Unit\Middleware;
+
+use App\Exceptions\ConfigurationKeyMissingException;
+use App\Exceptions\FeatureDisabledException;
+use App\Http\Middleware\FeatureEnabled;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\Request;
+use Tests\AbstractTestCase;
+
+class FeatureEnabledTest extends AbstractTestCase
+{
+	use DatabaseTransactions;
+
+	public function testFeatureEnabled(): void
+	{
+		config(['features.some_feature' => true]);
+
+		$request = $this->mock(Request::class);
+		$middleware = new FeatureEnabled();
+
+		self::assertEquals(1, $middleware->handle($request, fn () => 1, 'some_feature'));
+	}
+
+	public function testFeatureDisabled(): void
+	{
+		config(['features.some_feature' => false]);
+
+		$request = $this->mock(Request::class);
+		$middleware = new FeatureEnabled();
+
+		$this->assertThrows(
+			fn () => $middleware->handle($request, fn () => 1, 'some_feature'),
+			FeatureDisabledException::class
+		);
+	}
+
+	public function testFeatureNotDefined(): void
+	{
+		$request = $this->mock(Request::class);
+		$middleware = new FeatureEnabled();
+
+		$this->assertThrows(
+			fn () => $middleware->handle($request, fn () => 1, 'undefined_feature'),
+			ConfigurationKeyMissingException::class
+		);
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a feature flag system allowing administrators to enable or disable specific features via configuration. Requests to disabled features receive a 501 NOT_IMPLEMENTED response.

* **Tests**
  * Added unit tests for feature flag validation middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->