### PR TITLE
Fix shared hosting tmp folder issue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -321,6 +321,10 @@ VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 
 # DISABLE_IMPORT_FROM_SERVER=false
 
+# On shared hosting where sys_get_temp_dir() is not readable/writable,
+# set to false to use storage/tmp/uploads_parts instead.
+# USE_SYSTEM_TEMP_DIR=true
+
 # When enabled, the request caching settings (cache_enabled, cache_ttl,
 # cache_event_logging) become visible in the admin settings panel.
 # ENABLE_REQUEST_CACHING=false

--- a/app/Actions/Diagnostics/Pipes/Checks/IniSettingsCheck.php
+++ b/app/Actions/Diagnostics/Pipes/Checks/IniSettingsCheck.php
@@ -133,15 +133,15 @@ class IniSettingsCheck implements DiagnosticPipe
 		}
 		// @codeCoverageIgnoreEnd
 
-		$path = sys_get_temp_dir();
+		$path = Helpers::getTmpDir();
 		if (!is_writable($path)) {
 			// @codeCoverageIgnoreStart
-			$data[] = DiagnosticData::error('sys_get_temp_dir() is not writable, this will prevent you from uploading pictures.', self::class);
+			$data[] = DiagnosticData::error('The temp directory (' . $path . ') is not writable, this will prevent you from uploading pictures. Set USE_SYSTEM_TEMP_DIR=false in .env to use storage/tmp/uploads_parts instead.', self::class);
 			// @codeCoverageIgnoreEnd
 		}
 		if (!is_readable($path)) {
 			// @codeCoverageIgnoreStart
-			$data[] = DiagnosticData::error('sys_get_temp_dir() is not readable, this will prevent you from uploading pictures.', self::class);
+			$data[] = DiagnosticData::error('The temp directory (' . $path . ') is not readable, this will prevent you from uploading pictures. Set USE_SYSTEM_TEMP_DIR=false in .env to use storage/tmp/uploads_parts instead.', self::class);
 			// @codeCoverageIgnoreEnd
 		}
 

--- a/app/Actions/InstallUpdate/DefaultConfig.php
+++ b/app/Actions/InstallUpdate/DefaultConfig.php
@@ -138,6 +138,10 @@ class DefaultConfig
 					$this->config['requirements']['php'][] = $db_possibility[1];
 				}
 			}
+
+			if (config('features.use-system-temp-dir') === false) {
+				$this->config['permissions']['storage/tmp/uploads_parts/'] = 'file_exists|is_readable|is_writable|is_executable';
+			}
 			// @codeCoverageIgnoreStart
 		} catch (BindingResolutionException|ContainerExceptionInterface $e) {
 			throw new FrameworkException('Laravel\'s container component', $e);

--- a/app/Assets/Helpers.php
+++ b/app/Assets/Helpers.php
@@ -14,6 +14,7 @@ use Illuminate\Http\Request;
 use Safe\Exceptions\FilesystemException;
 use Safe\Exceptions\InfoException;
 use function Safe\ini_get;
+use function Safe\mkdir;
 use function Safe\rmdir;
 use function Safe\unlink;
 
@@ -40,6 +41,26 @@ class Helpers
 		}
 
 		return (string) $short_id;
+	}
+
+	/**
+	 * Return the temporary directory path used for uploads.
+	 *
+	 * When features.use-system-temp-dir is true (default), returns sys_get_temp_dir().
+	 * Otherwise returns storage/tmp/uploads_parts, creating it if needed.
+	 */
+	public function getTmpDir(): string
+	{
+		if (config('features.use-system-temp-dir', true) === true) {
+			return sys_get_temp_dir();
+		}
+
+		$path = storage_path('tmp/uploads_parts');
+		if (!file_exists($path)) {
+			mkdir($path, 0755, true);
+		}
+
+		return $path;
 	}
 
 	/**

--- a/app/Facades/Helpers.php
+++ b/app/Facades/Helpers.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Facade;
  *
  * Keep the list of documented method in sync with {@link \App\Assets\Helpers}.
  *
+ * @method static string getTmpDir()
  * @method static string trancateIf32(string $id, int $prevShortId = 0, int $php_max)
  * @method static string getExtension(string $filename, bool $isURI = false)
  * @method static bool   hasPermissions(string $path)

--- a/app/Image/Files/TemporaryLocalFile.php
+++ b/app/Image/Files/TemporaryLocalFile.php
@@ -9,6 +9,7 @@
 namespace App\Image\Files;
 
 use App\Exceptions\MediaFileOperationException;
+use App\Facades\Helpers;
 
 /**
  * Class TemporaryLocalFile.
@@ -53,7 +54,7 @@ class TemporaryLocalFile extends NativeLocalFile
 	 */
 	protected function getFileBasePath(): string
 	{
-		return sys_get_temp_dir();
+		return Helpers::getTmpDir();
 	}
 
 	/**

--- a/app/Image/Handlers/ImagickHandler.php
+++ b/app/Image/Handlers/ImagickHandler.php
@@ -14,6 +14,7 @@ use App\Contracts\Image\StreamStats;
 use App\DTO\ImageDimension;
 use App\Exceptions\ImageProcessingException;
 use App\Exceptions\MediaFileOperationException;
+use App\Facades\Helpers;
 use App\Image\Files\FlysystemFile;
 use App\Image\Files\InMemoryBuffer;
 use App\Image\Files\NativeLocalFile;
@@ -105,7 +106,7 @@ class ImagickHandler extends BaseImageHandler
 				// .pdf path so Ghostscript recognises the format by extension. The outer
 				// try/finally guarantees the .pdf temp file is cleaned up even if fopen(),
 				// stream_copy_to_stream(), or readImage() throws.
-				$tmp_base = tempnam(sys_get_temp_dir(), 'lychee_');
+				$tmp_base = tempnam(Helpers::getTmpDir(), 'lychee_');
 				$tmp_path = $tmp_base . '.pdf';
 				rename($tmp_base, $tmp_path);
 				$pdf_path = $tmp_path;

--- a/config/features.php
+++ b/config/features.php
@@ -270,6 +270,17 @@ return [
 
 	/*
 	 |--------------------------------------------------------------------------
+	 | Use system temp directory for uploads
+	 |--------------------------------------------------------------------------
+	 |
+	 | When enabled, Lychee uses PHP's sys_get_temp_dir() for temporary upload
+	 | files. On shared hosting where that directory is not readable/writable,
+	 | set USE_SYSTEM_TEMP_DIR=false to use storage/tmp/uploads_parts instead.
+	 */
+	'use-system-temp-dir' => (bool) env('USE_SYSTEM_TEMP_DIR', true),
+
+	/*
+	 |--------------------------------------------------------------------------
 	 | Enable Request Caching
 	 |--------------------------------------------------------------------------
 	 |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable temporary directory option (`USE_SYSTEM_TEMP_DIR`) to support shared hosting environments where system temp directories are inaccessible.
  * Falls back to local storage path when system temp is unavailable.

* **Bug Fixes**
  * Improved diagnostic messages to reference the correct active temporary directory path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->