### PR TITLE
10 unlock request per minute

### DIFF
--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -56,7 +56,7 @@ Route::get('/Album::albums', [Gallery\AlbumChildrenController::class, 'get'])->m
 Route::get('/Album::photos', [Gallery\AlbumPhotosController::class, 'get'])->middleware(['login_required:album', 'cache_control']);
 Route::get('/Album::tags', [Gallery\AlbumTagsController::class, 'get'])->middleware(['login_required:album', 'cache_control']);
 Route::get('/Album::getTargetListAlbums', [Gallery\AlbumController::class, 'getTargetListAlbums'])->middleware(['login_required:album', 'cache_control']);
-Route::post('/Album::unlock', [Gallery\AlbumController::class, 'unlock']);
+Route::post('/Album::unlock', [Gallery\AlbumController::class, 'unlock'])->middleware(['throttle:10,1']);
 Route::post('/Album', [Gallery\AlbumController::class, 'createAlbum']);
 Route::patch('/Album', [Gallery\AlbumController::class, 'updateAlbum']);
 Route::patch('/Album::rename', [Gallery\AlbumController::class, 'rename']);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied rate limiting to the album unlock API endpoint, restricting requests to 10 per minute to improve service stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->