### PR TITLE
Ensure that the user is able to see the photo they are setting as highlighted

### DIFF
--- a/app/Http/Requests/Photo/SetPhotosHighlightedRequest.php
+++ b/app/Http/Requests/Photo/SetPhotosHighlightedRequest.php
@@ -48,7 +48,7 @@ class SetPhotosHighlightedRequest extends BaseApiRequest implements HasPhotos
 		/** @var array<int,string> $photos_ids */
 		$photos_ids = $values[RequestAttribute::PHOTO_IDS_ATTRIBUTE];
 		$this->photos = Photo::query()
-			->with(['size_variants', 'albums'])
+			->with(['size_variants', 'albums', 'albums.access_permissions'])
 			->findOrFail($photos_ids);
 		$this->is_highlighted = static::toBoolean($values[RequestAttribute::IS_HIGHLIGHTED_ATTRIBUTE]);
 	}

--- a/app/Policies/PhotoPolicy.php
+++ b/app/Policies/PhotoPolicy.php
@@ -290,8 +290,8 @@ class PhotoPolicy extends BasePolicy
 		$visibility = $config_manager->getValueAsEnum('photos_star_visibility', PhotoHighlightVisibilityType::class);
 
 		return match ($visibility) {
-			PhotoHighlightVisibilityType::ANONYMOUS => true,
-			PhotoHighlightVisibilityType::AUTHENTICATED => $user !== null,
+			PhotoHighlightVisibilityType::ANONYMOUS => $this->canSee($user, $photo),
+			PhotoHighlightVisibilityType::AUTHENTICATED => $user !== null && $this->canSee($user, $photo),
 			PhotoHighlightVisibilityType::EDITOR => $user !== null && $this->canEdit($user, $photo),
 			default => false,
 		};

--- a/tests/ImageProcessing/Photo/PhotoStarTest.php
+++ b/tests/ImageProcessing/Photo/PhotoStarTest.php
@@ -54,13 +54,13 @@ class PhotoStarTest extends BaseApiWithDataTest
 		$this->assertUnprocessable($response);
 
 		$response = $this->postJson('Photo::highlight', [
-			'photo_ids' => [$this->photo1->id],
+			'photo_ids' => [$this->photo4->id],
 			'is_highlighted' => true,
 		]);
 		$this->assertNoContent($response);
 
 		$response = $this->actingAs($this->userNoUpload)->postJson('Photo::highlight', [
-			'photo_ids' => [$this->photo1->id],
+			'photo_ids' => [$this->photo4->id],
 			'is_highlighted' => true,
 		]);
 		$this->assertNoContent($response);
@@ -74,13 +74,13 @@ class PhotoStarTest extends BaseApiWithDataTest
 		$this->assertUnprocessable($response);
 
 		$response = $this->postJson('Photo::highlight', [
-			'photo_ids' => [$this->photo1->id],
+			'photo_ids' => [$this->photo4->id],
 			'is_highlighted' => true,
 		]);
 		$this->assertUnauthorized($response);
 
 		$response = $this->actingAs($this->userNoUpload)->postJson('Photo::highlight', [
-			'photo_ids' => [$this->photo1->id],
+			'photo_ids' => [$this->photo4->id],
 			'is_highlighted' => true,
 		]);
 		// Under AUTHENTICATED visibility, any logged-in user can star


### PR DESCRIPTION
This pull request updates the logic for determining if a photo can be highlighted, ensuring that only users who have permission to view a photo can highlight it. Additionally, it improves the loading of related data for photos by eager-loading access permissions for albums.

**Authorization logic improvements:**

* Updated the `canHighlight` method in `PhotoPolicy` so that only users who can actually see a photo are allowed to highlight it, even for anonymous and authenticated users. This adds an extra layer of security by tying highlight permissions to view permissions.

**Data loading enhancements:**

* Modified the photo query in `SetPhotosHighlightedRequest.php` to also eager-load `albums.access_permissions`, ensuring that access permissions are available when processing highlighted photos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected photo highlighting authorization so anonymous and authenticated visibility modes are granted only when the user can actually view the photo.
  * Improved highlighted-photo handling to load the necessary album access details to enforce visibility consistently.
* **Tests**
  * Updated image processing authorization tests to use the correct photo IDs for non-owning user scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->