### PR TITLE
Add configurable sharable preview

### DIFF
--- a/app/Enum/OgImageAlbumSourceType.php
+++ b/app/Enum/OgImageAlbumSourceType.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Enum;
+
+enum OgImageAlbumSourceType: string
+{
+	case HEADER = 'header';
+	case COVER = 'cover';
+}

--- a/app/View/Components/Meta.php
+++ b/app/View/Components/Meta.php
@@ -10,11 +10,14 @@ namespace App\View\Components;
 
 use App\Constants\FileSystem;
 use App\Contracts\Models\AbstractAlbum;
+use App\Enum\OgImageAlbumSourceType;
+use App\Enum\SizeVariantType;
 use App\Exceptions\ConfigurationKeyMissingException;
 use App\Http\Resources\Traits\HasHeaderUrl;
 use App\Models\Album;
 use App\Models\Extensions\BaseAlbum;
 use App\Models\Photo;
+use App\Models\SizeVariant;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\View\Component;
@@ -67,7 +70,10 @@ class Meta extends Component
 
 		$this->page_title = request()->configs()->getValueAsString('site_title');
 		$this->page_description = '';
-		$this->image_url = request()->configs()->getValueAsString('landing_background_landscape');
+
+		$sm_card_image_url = request()->configs()->getValueAsString('sm_card_image_url');
+		$sm_card_image_url = $sm_card_image_url !== '' ? $sm_card_image_url : request()->configs()->getValueAsString('landing_background_landscape');
+		$this->image_url = $this->resolveSmCardImageUrl($sm_card_image_url);
 
 		// processing photo and album data
 		if (session()->has('access')) {
@@ -92,7 +98,7 @@ class Meta extends Component
 			if ($this->album instanceof BaseAlbum) {
 				$this->page_description = $this->album->description ?? request()->configs()->getValueAsString('site_title');
 			}
-			$this->image_url = $this->getHeaderUrl($this->album) ?? $this->image_url;
+			$this->image_url = $this->getAlbumOgImageUrl($this->album) ?? $this->image_url;
 		}
 
 		if ($this->photo !== null) {
@@ -125,5 +131,73 @@ class Meta extends Component
 
 		/** @disregard P1013 */
 		return Storage::disk(FileSystem::DIST)->url($file_name) . $css_cache_busting;
+	}
+
+	/**
+	 * Returns the image used for integration in social medias.
+	 *
+	 * @param AbstractAlbum $album
+	 *
+	 * @return string|null
+	 */
+	private function getAlbumOgImageUrl(AbstractAlbum $album): ?string
+	{
+		$source = request()->configs()->getValueAsEnum('sm_card_album_source', OgImageAlbumSourceType::class);
+
+		if ($source === OgImageAlbumSourceType::COVER) {
+			return $this->getCoverUrl($album);
+		}
+
+		return $this->getHeaderUrl($album);
+	}
+
+	/**
+	 * Return cover url if exists.
+	 *
+	 * @param AbstractAlbum $album
+	 *
+	 * @return string|null
+	 */
+	private function getCoverUrl(AbstractAlbum $album): ?string
+	{
+		if (!$album instanceof Album) {
+			return null;
+		}
+
+		$cover_id = $album->cover_id ?? $album->auto_cover_id_least_privilege;
+		if ($cover_id === null) {
+			return null;
+		}
+
+		return SizeVariant::query()
+			->where('photo_id', '=', $cover_id)
+			->whereIn('type', [SizeVariantType::MEDIUM2X, SizeVariantType::MEDIUM, SizeVariantType::SMALL2X, SizeVariantType::SMALL])
+			->orderBy('type', 'asc')
+			->first()?->url;
+	}
+
+	/**
+	 * Return the image url if exists.
+	 *
+	 * @param string $value
+	 *
+	 * @return string
+	 */
+	private function resolveSmCardImageUrl(string $value): string
+	{
+		if (str_contains($value, '://') || str_starts_with($value, '/')) {
+			return $value;
+		}
+
+		$photo = Photo::query()->with(['size_variants'])->find($value);
+		if ($photo === null) {
+			return $value;
+		}
+
+		return $photo->size_variants->getMedium2x()?->url
+			?? $photo->size_variants->getMedium()?->url
+			?? $photo->size_variants->getSmall2x()?->url
+			?? $photo->size_variants->getSmall()?->url
+			?? $value;
 	}
 }

--- a/database/migrations/2026_06_24_200000_add_og_image_settings.php
+++ b/database/migrations/2026_06_24_200000_add_og_image_settings.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const CONFIG = 'config';
+
+	public function getConfigs(): array
+	{
+		return [
+			[
+				'key' => 'sm_card_album_source',
+				'value' => 'header',
+				'cat' => self::CONFIG,
+				'type_range' => 'header|cover',
+				'description' => 'Album photo source for social media cards',
+				'details' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+				'is_secret' => false,
+				'is_expert' => false,
+				'level' => 0,
+				'order' => 5,
+			],
+			[
+				'key' => 'sm_card_image_url',
+				'value' => '',
+				'cat' => self::CONFIG,
+				'type_range' => 'string',
+				'description' => 'Fallback image URL or photo ID for social media cards',
+				'details' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+				'is_secret' => false,
+				'is_expert' => false,
+				'level' => 0,
+				'order' => 6,
+			],
+		];
+	}
+};

--- a/lang/ar/all_settings.php
+++ b/lang/ar/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/bg/all_settings.php
+++ b/lang/bg/all_settings.php
@@ -352,6 +352,8 @@ return [
         'album_enhanced_display_enabled' => 'Активиране на разширени функции на заглавната част на албума',
         'album_header_size' => 'Размер на заглавната част на албума',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -700,6 +702,8 @@ return [
         'album_enhanced_display_enabled' => 'Опция за включване на нов стил на заглавната част с по-голямо заглавие, бутон „Отвори галерията“ и възможност за персонализиране на стила на заглавието.',
         'album_header_size' => 'Опция за конфигуриране на размера на изображението в заглавната част.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
     'category_name' => [
         'config' => 'Основни',

--- a/lang/cz/all_settings.php
+++ b/lang/cz/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/de/all_settings.php
+++ b/lang/de/all_settings.php
@@ -352,6 +352,8 @@ return [
         'album_enhanced_display_enabled' => 'Erweiterten Album-Header aktivieren',
         'album_header_size' => 'Größe des Album-Headers',
         'album_header_landing_title_enabled' => 'Landingpage-Titel im Album-Header anzeigen',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -700,6 +702,8 @@ return [
         'album_enhanced_display_enabled' => 'Aktiviert einen neuen Stil für den Album-Header mit größerem Titel, einer „Galerie öffnen“-Schaltfläche und anpassbarem Titelstil.',
         'album_header_size' => 'Konfiguration der Größe des Header-Bildes in der Albenansicht.',
         'album_header_landing_title_enabled' => 'Zeigt den Landingpage-Titel am unteren Rand des Album-Headers an. Der Titel kann in den Landingpage-Einstellungen konfiguriert werden.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
     'category_name' => [
         'config' => 'Grundeinstellungen',

--- a/lang/el/all_settings.php
+++ b/lang/el/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/en/all_settings.php
+++ b/lang/en/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/es/all_settings.php
+++ b/lang/es/all_settings.php
@@ -352,6 +352,8 @@ return [
         'album_enhanced_display_enabled' => 'Activar el encabezado mejorado del álbum',
         'album_header_size' => 'Tamaño de la cabecera del álbum',
         'album_header_landing_title_enabled' => 'Mostrar el título de la página de destino en el encabezado del álbum',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -700,6 +702,8 @@ return [
         'album_enhanced_display_enabled' => 'Opción para activar un nuevo estilo de encabezado de álbum con un título más grande, un botón «Abrir galería» y la posibilidad de personalizar el estilo del título del álbum.',
         'album_header_size' => 'Configuración del tamaño de la imagen de cabecera en la vista de álbum.',
         'album_header_landing_title_enabled' => 'Muestra el título de la página de destino en la parte inferior del encabezado del álbum. Puedes configurar el título de la página de destino en el módulo «Página de destino».',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
     'category_name' => [
         'config' => 'Conceptos básicos',

--- a/lang/fa/all_settings.php
+++ b/lang/fa/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/fr/all_settings.php
+++ b/lang/fr/all_settings.php
@@ -352,6 +352,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'documentation' => [
         'version' => 'Version actuelle de Lychee',
@@ -700,6 +702,8 @@ return [
         'album_enhanced_display_enabled' => 'Activer l\'en-tête d\'album amélioré',
         'album_header_size' => 'Taille de l\'en-tête de l\'album',
         'album_header_landing_title_enabled' => 'Afficher le titre de la page d\'accueil dans l\'en-tête de l\'album',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
     'category_name' => [
         'config' => 'Les bases',

--- a/lang/hu/all_settings.php
+++ b/lang/hu/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/it/all_settings.php
+++ b/lang/it/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/ja/all_settings.php
+++ b/lang/ja/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/nl/all_settings.php
+++ b/lang/nl/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/no/all_settings.php
+++ b/lang/no/all_settings.php
@@ -352,6 +352,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -700,6 +702,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
     'category_name' => [
         'config' => 'Basics',

--- a/lang/pl/all_settings.php
+++ b/lang/pl/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/pt/all_settings.php
+++ b/lang/pt/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/ru/all_settings.php
+++ b/lang/ru/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/sk/all_settings.php
+++ b/lang/sk/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/sv/all_settings.php
+++ b/lang/sv/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/tr/all_settings.php
+++ b/lang/tr/all_settings.php
@@ -353,6 +353,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -701,6 +703,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
     'category_name' => [
         'config' => 'Basics',

--- a/lang/vi/all_settings.php
+++ b/lang/vi/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/zh_CN/all_settings.php
+++ b/lang/zh_CN/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/lang/zh_TW/all_settings.php
+++ b/lang/zh_TW/all_settings.php
@@ -354,6 +354,8 @@ return [
         'album_enhanced_display_enabled' => 'Enable enhanced album header',
         'album_header_size' => 'Album header size',
         'album_header_landing_title_enabled' => 'Display landing title on album header',
+        'sm_card_album_source' => 'Album photo source for social media cards',
+        'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
     ],
     'details' => [
         'version' => '',
@@ -702,6 +704,8 @@ return [
         'album_enhanced_display_enabled' => 'Option to enable a new style of album header with a larger title, an "Open Gallery" button, and customize the album title style.',
         'album_header_size' => 'Configuration of the size of the header image in album view.',
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
+        'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
+        'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
     ],
 
     'category_name' => [

--- a/tests/Unit/View/Components/MetaTest.php
+++ b/tests/Unit/View/Components/MetaTest.php
@@ -30,21 +30,20 @@ use App\Repositories\ConfigManager;
 use App\View\Components\Meta;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Storage;
-use Mockery;
 use Mockery\MockInterface;
 use Tests\AbstractTestCase;
 
 class MetaTest extends AbstractTestCase
 {
-	private MockInterface&ConfigManager $configManager;
+	private MockInterface&ConfigManager $config_manager;
 
 	protected function setUp(): void
 	{
 		parent::setUp();
 		$this->withoutVite();
 
-		$this->configManager = Mockery::mock(ConfigManager::class);
-		request()->attributes->set('configs', $this->configManager);
+		$this->config_manager = \Mockery::mock(ConfigManager::class);
+		request()->attributes->set('configs', $this->config_manager);
 
 		$this->setUpDefaultConfig();
 		Storage::fake(FileSystem::DIST);
@@ -54,20 +53,20 @@ class MetaTest extends AbstractTestCase
 
 	private function setUpDefaultConfig(): void
 	{
-		$this->configManager->shouldReceive('getValueAsString')
+		$this->config_manager->shouldReceive('getValueAsString')
 			->with('site_owner')->andReturn('Test Owner')->byDefault();
-		$this->configManager->shouldReceive('getValueAsBool')
+		$this->config_manager->shouldReceive('getValueAsBool')
 			->with('rss_enable')->andReturn(false)->byDefault();
-		$this->configManager->shouldReceive('getValueAsString')
+		$this->config_manager->shouldReceive('getValueAsString')
 			->with('site_title')->andReturn('My Gallery')->byDefault();
-		$this->configManager->shouldReceive('getValueAsString')
+		$this->config_manager->shouldReceive('getValueAsString')
 			->with('sm_card_image_url')->andReturn('https://example.com/card.jpg')->byDefault();
-		$this->configManager->shouldReceive('getValueAsString')
+		$this->config_manager->shouldReceive('getValueAsString')
 			->with('landing_background_landscape')->andReturn('https://example.com/bg.jpg')->byDefault();
-		$this->configManager->shouldReceive('getValueAsEnum')
+		$this->config_manager->shouldReceive('getValueAsEnum')
 			->with('sm_card_album_source', OgImageAlbumSourceType::class)
 			->andReturn(OgImageAlbumSourceType::HEADER)->byDefault();
-		$this->configManager->shouldReceive('getValueAsBool')
+		$this->config_manager->shouldReceive('getValueAsBool')
 			->with('use_album_compact_header')->andReturn(true)->byDefault();
 	}
 
@@ -78,18 +77,18 @@ class MetaTest extends AbstractTestCase
 
 	private function makeSizeVariantMock(string $url): MockInterface&SizeVariant
 	{
-		$sv = Mockery::mock(SizeVariant::class);
+		$sv = \Mockery::mock(SizeVariant::class);
 		$sv->shouldReceive('offsetExists')->with('url')->andReturn(true);
 		$sv->shouldReceive('getAttribute')->with('url')->andReturn($url);
 
 		return $sv;
 	}
 
-	private function makePhotoMock(string $title, ?string $description, MockInterface $sizeVariants): MockInterface&Photo
+	private function makePhotoMock(string $title, ?string $description, MockInterface $size_variants): MockInterface&Photo
 	{
-		$photo = Mockery::mock(Photo::class)->makePartial();
+		$photo = \Mockery::mock(Photo::class)->makePartial();
 		$photo->forceFill(['title' => $title, 'description' => $description]);
-		$photo->setRelation('size_variants', $sizeVariants);
+		$photo->setRelation('size_variants', $size_variants);
 
 		return $photo;
 	}
@@ -107,7 +106,7 @@ class MetaTest extends AbstractTestCase
 
 	public function testRssEnabled(): void
 	{
-		$this->configManager->shouldReceive('getValueAsBool')
+		$this->config_manager->shouldReceive('getValueAsBool')
 			->with('rss_enable')->andReturn(true);
 
 		$meta = $this->buildMeta();
@@ -117,7 +116,7 @@ class MetaTest extends AbstractTestCase
 
 	public function testSmCardImageUrlFallsBackToLandingBackground(): void
 	{
-		$this->configManager->shouldReceive('getValueAsString')
+		$this->config_manager->shouldReceive('getValueAsString')
 			->with('sm_card_image_url')->andReturn('');
 
 		$meta = $this->buildMeta();
@@ -127,7 +126,7 @@ class MetaTest extends AbstractTestCase
 
 	public function testSmCardImageUrlWithAbsolutePath(): void
 	{
-		$this->configManager->shouldReceive('getValueAsString')
+		$this->config_manager->shouldReceive('getValueAsString')
 			->with('sm_card_image_url')->andReturn('/images/card.png');
 
 		$meta = $this->buildMeta();
@@ -137,7 +136,7 @@ class MetaTest extends AbstractTestCase
 
 	public function testSmCardImageUrlWithFullUrl(): void
 	{
-		$this->configManager->shouldReceive('getValueAsString')
+		$this->config_manager->shouldReceive('getValueAsString')
 			->with('sm_card_image_url')->andReturn('https://cdn.example.com/img.jpg');
 
 		$meta = $this->buildMeta();
@@ -186,7 +185,7 @@ class MetaTest extends AbstractTestCase
 
 	public function testAccessDeniedPreventsAlbumAndPhotoProcessing(): void
 	{
-		$album = Mockery::mock(Album::class);
+		$album = \Mockery::mock(Album::class);
 		$album->shouldReceive('get_title')->never();
 
 		session(['access' => false]);
@@ -200,13 +199,13 @@ class MetaTest extends AbstractTestCase
 
 	public function testAlbumInSessionSetsTitle(): void
 	{
-		$album = Mockery::mock(Album::class)->makePartial();
+		$album = \Mockery::mock(Album::class)->makePartial();
 		$album->shouldReceive('get_title')->andReturn('Vacation 2024');
 		$album->shouldReceive('getAttribute')->with('description')->andReturn('Summer photos');
 		$album->shouldReceive('getAttribute')->with('cover_id')->andReturn(null);
 		$album->shouldReceive('getAttribute')->with('auto_cover_id_least_privilege')->andReturn(null);
 
-		$this->configManager->shouldReceive('getValueAsEnum')
+		$this->config_manager->shouldReceive('getValueAsEnum')
 			->with('sm_card_album_source', OgImageAlbumSourceType::class)
 			->andReturn(OgImageAlbumSourceType::COVER);
 
@@ -220,13 +219,13 @@ class MetaTest extends AbstractTestCase
 
 	public function testAlbumWithNullDescriptionFallsBackToSiteTitle(): void
 	{
-		$album = Mockery::mock(Album::class)->makePartial();
+		$album = \Mockery::mock(Album::class)->makePartial();
 		$album->shouldReceive('get_title')->andReturn('Untitled');
 		$album->shouldReceive('getAttribute')->with('description')->andReturn(null);
 		$album->shouldReceive('getAttribute')->with('cover_id')->andReturn(null);
 		$album->shouldReceive('getAttribute')->with('auto_cover_id_least_privilege')->andReturn(null);
 
-		$this->configManager->shouldReceive('getValueAsEnum')
+		$this->config_manager->shouldReceive('getValueAsEnum')
 			->with('sm_card_album_source', OgImageAlbumSourceType::class)
 			->andReturn(OgImageAlbumSourceType::COVER);
 
@@ -240,7 +239,7 @@ class MetaTest extends AbstractTestCase
 
 	public function testNonBaseAlbumDoesNotSetDescription(): void
 	{
-		$album = Mockery::mock(AbstractAlbum::class);
+		$album = \Mockery::mock(AbstractAlbum::class);
 		$album->shouldReceive('get_title')->andReturn('Smart Album');
 		$album->shouldReceive('get_photos')->andReturn(new Collection());
 
@@ -256,7 +255,7 @@ class MetaTest extends AbstractTestCase
 	{
 		$svMock = $this->makeSizeVariantMock('https://example.com/medium.jpg');
 
-		$sizeVariants = Mockery::mock(SizeVariants::class);
+		$sizeVariants = \Mockery::mock(SizeVariants::class);
 		$sizeVariants->shouldReceive('getMedium')->andReturn($svMock);
 
 		$photo = $this->makePhotoMock('Sunset', 'A beautiful sunset', $sizeVariants);
@@ -272,7 +271,7 @@ class MetaTest extends AbstractTestCase
 
 	public function testPhotoWithNullDescriptionFallsBackToSiteTitle(): void
 	{
-		$sizeVariants = Mockery::mock(SizeVariants::class);
+		$sizeVariants = \Mockery::mock(SizeVariants::class);
 		$sizeVariants->shouldReceive('getMedium')->andReturn(null);
 		$sizeVariants->shouldReceive('getSmall')->andReturn(null);
 
@@ -291,7 +290,7 @@ class MetaTest extends AbstractTestCase
 	{
 		$svSmall = $this->makeSizeVariantMock('https://example.com/small.jpg');
 
-		$sizeVariants = Mockery::mock(SizeVariants::class);
+		$sizeVariants = \Mockery::mock(SizeVariants::class);
 		$sizeVariants->shouldReceive('getMedium')->andReturn(null);
 		$sizeVariants->shouldReceive('getSmall')->andReturn($svSmall);
 
@@ -306,7 +305,7 @@ class MetaTest extends AbstractTestCase
 
 	public function testPhotoFallsBackToDefaultWhenNoSizeVariants(): void
 	{
-		$sizeVariants = Mockery::mock(SizeVariants::class);
+		$sizeVariants = \Mockery::mock(SizeVariants::class);
 		$sizeVariants->shouldReceive('getMedium')->andReturn(null);
 		$sizeVariants->shouldReceive('getSmall')->andReturn(null);
 
@@ -321,19 +320,19 @@ class MetaTest extends AbstractTestCase
 
 	public function testPhotoOverridesAlbumWhenBothInSession(): void
 	{
-		$album = Mockery::mock(Album::class)->makePartial();
+		$album = \Mockery::mock(Album::class)->makePartial();
 		$album->shouldReceive('get_title')->andReturn('Album Title');
 		$album->shouldReceive('getAttribute')->with('description')->andReturn('Album Desc');
 		$album->shouldReceive('getAttribute')->with('cover_id')->andReturn(null);
 		$album->shouldReceive('getAttribute')->with('auto_cover_id_least_privilege')->andReturn(null);
 
-		$this->configManager->shouldReceive('getValueAsEnum')
+		$this->config_manager->shouldReceive('getValueAsEnum')
 			->with('sm_card_album_source', OgImageAlbumSourceType::class)
 			->andReturn(OgImageAlbumSourceType::COVER);
 
 		$svMedium = $this->makeSizeVariantMock('https://example.com/photo-medium.jpg');
 
-		$sizeVariants = Mockery::mock(SizeVariants::class);
+		$sizeVariants = \Mockery::mock(SizeVariants::class);
 		$sizeVariants->shouldReceive('getMedium')->andReturn($svMedium);
 
 		$photo = $this->makePhotoMock('Photo Title', 'Photo Desc', $sizeVariants);
@@ -349,11 +348,11 @@ class MetaTest extends AbstractTestCase
 
 	public function testSessionDataIsForgottenAfterConstruction(): void
 	{
-		$sizeVariants = Mockery::mock(SizeVariants::class);
+		$sizeVariants = \Mockery::mock(SizeVariants::class);
 		$sizeVariants->shouldReceive('getMedium')->andReturn(null);
 		$sizeVariants->shouldReceive('getSmall')->andReturn(null);
 
-		$album = Mockery::mock(AbstractAlbum::class);
+		$album = \Mockery::mock(AbstractAlbum::class);
 		$album->shouldReceive('get_title')->andReturn('T');
 		$album->shouldReceive('get_photos')->andReturn(new Collection());
 
@@ -398,11 +397,11 @@ class MetaTest extends AbstractTestCase
 
 	public function testAlbumWithCoverSourceAndNonAlbumTypeReturnsNull(): void
 	{
-		$album = Mockery::mock(AbstractAlbum::class);
+		$album = \Mockery::mock(AbstractAlbum::class);
 		$album->shouldReceive('get_title')->andReturn('Smart Album');
 		$album->shouldReceive('get_photos')->andReturn(new Collection());
 
-		$this->configManager->shouldReceive('getValueAsEnum')
+		$this->config_manager->shouldReceive('getValueAsEnum')
 			->with('sm_card_album_source', OgImageAlbumSourceType::class)
 			->andReturn(OgImageAlbumSourceType::COVER);
 
@@ -415,13 +414,13 @@ class MetaTest extends AbstractTestCase
 
 	public function testAlbumWithCoverSourceAndNullCoverIds(): void
 	{
-		$album = Mockery::mock(Album::class)->makePartial();
+		$album = \Mockery::mock(Album::class)->makePartial();
 		$album->shouldReceive('get_title')->andReturn('Album');
 		$album->shouldReceive('getAttribute')->with('description')->andReturn(null);
 		$album->shouldReceive('getAttribute')->with('cover_id')->andReturn(null);
 		$album->shouldReceive('getAttribute')->with('auto_cover_id_least_privilege')->andReturn(null);
 
-		$this->configManager->shouldReceive('getValueAsEnum')
+		$this->config_manager->shouldReceive('getValueAsEnum')
 			->with('sm_card_album_source', OgImageAlbumSourceType::class)
 			->andReturn(OgImageAlbumSourceType::COVER);
 
@@ -434,15 +433,15 @@ class MetaTest extends AbstractTestCase
 
 	public function testAlbumWithHeaderSourceAndCompactHeaderEnabled(): void
 	{
-		$album = Mockery::mock(Album::class)->makePartial();
+		$album = \Mockery::mock(Album::class)->makePartial();
 		$album->shouldReceive('get_title')->andReturn('Album');
 		$album->shouldReceive('getAttribute')->with('description')->andReturn('Desc');
 
-		$this->configManager->shouldReceive('getValueAsEnum')
+		$this->config_manager->shouldReceive('getValueAsEnum')
 			->with('sm_card_album_source', OgImageAlbumSourceType::class)
 			->andReturn(OgImageAlbumSourceType::HEADER);
 
-		$this->configManager->shouldReceive('getValueAsBool')
+		$this->config_manager->shouldReceive('getValueAsBool')
 			->with('use_album_compact_header')->andReturn(true);
 
 		session(['album' => $album]);
@@ -454,17 +453,17 @@ class MetaTest extends AbstractTestCase
 
 	public function testAlbumWithHeaderSourceAndCompactHeaderId(): void
 	{
-		$album = Mockery::mock(Album::class)->makePartial();
+		$album = \Mockery::mock(Album::class)->makePartial();
 		$album->shouldReceive('get_title')->andReturn('Album');
 		$album->shouldReceive('getAttribute')->with('description')->andReturn('Desc');
 		$album->shouldReceive('getAttribute')->with('header_id')->andReturn(AlbumController::COMPACT_HEADER);
 		$album->shouldReceive('get_photos')->andReturn(new Collection());
 
-		$this->configManager->shouldReceive('getValueAsEnum')
+		$this->config_manager->shouldReceive('getValueAsEnum')
 			->with('sm_card_album_source', OgImageAlbumSourceType::class)
 			->andReturn(OgImageAlbumSourceType::HEADER);
 
-		$this->configManager->shouldReceive('getValueAsBool')
+		$this->config_manager->shouldReceive('getValueAsBool')
 			->with('use_album_compact_header')->andReturn(false);
 
 		session(['album' => $album]);
@@ -476,17 +475,17 @@ class MetaTest extends AbstractTestCase
 
 	public function testAlbumWithHeaderSourceAndEmptyPhotos(): void
 	{
-		$album = Mockery::mock(Album::class)->makePartial();
+		$album = \Mockery::mock(Album::class)->makePartial();
 		$album->shouldReceive('get_title')->andReturn('Empty Album');
 		$album->shouldReceive('getAttribute')->with('description')->andReturn('No photos');
 		$album->shouldReceive('getAttribute')->with('header_id')->andReturn(null);
 		$album->shouldReceive('get_photos')->andReturn(new Collection());
 
-		$this->configManager->shouldReceive('getValueAsEnum')
+		$this->config_manager->shouldReceive('getValueAsEnum')
 			->with('sm_card_album_source', OgImageAlbumSourceType::class)
 			->andReturn(OgImageAlbumSourceType::HEADER);
 
-		$this->configManager->shouldReceive('getValueAsBool')
+		$this->config_manager->shouldReceive('getValueAsBool')
 			->with('use_album_compact_header')->andReturn(false);
 
 		session(['album' => $album]);
@@ -528,7 +527,7 @@ class MetaTest extends AbstractTestCase
 
 	public function testAccessTrueInSessionAllowsProcessing(): void
 	{
-		$album = Mockery::mock(AbstractAlbum::class);
+		$album = \Mockery::mock(AbstractAlbum::class);
 		$album->shouldReceive('get_title')->andReturn('Visible Album');
 		$album->shouldReceive('get_photos')->andReturn(new Collection());
 

--- a/tests/Unit/View/Components/MetaTest.php
+++ b/tests/Unit/View/Components/MetaTest.php
@@ -1,0 +1,541 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Unit\View\Components;
+
+use App\Constants\FileSystem;
+use App\Contracts\Models\AbstractAlbum;
+use App\Enum\OgImageAlbumSourceType;
+use App\Http\Controllers\Gallery\AlbumController;
+use App\Models\Album;
+use App\Models\Extensions\SizeVariants;
+use App\Models\Photo;
+use App\Models\SizeVariant;
+use App\Repositories\ConfigManager;
+use App\View\Components\Meta;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Storage;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\AbstractTestCase;
+
+class MetaTest extends AbstractTestCase
+{
+	private MockInterface&ConfigManager $configManager;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->withoutVite();
+
+		$this->configManager = Mockery::mock(ConfigManager::class);
+		request()->attributes->set('configs', $this->configManager);
+
+		$this->setUpDefaultConfig();
+		Storage::fake(FileSystem::DIST);
+
+		config(['app.dir_url' => '']);
+	}
+
+	private function setUpDefaultConfig(): void
+	{
+		$this->configManager->shouldReceive('getValueAsString')
+			->with('site_owner')->andReturn('Test Owner')->byDefault();
+		$this->configManager->shouldReceive('getValueAsBool')
+			->with('rss_enable')->andReturn(false)->byDefault();
+		$this->configManager->shouldReceive('getValueAsString')
+			->with('site_title')->andReturn('My Gallery')->byDefault();
+		$this->configManager->shouldReceive('getValueAsString')
+			->with('sm_card_image_url')->andReturn('https://example.com/card.jpg')->byDefault();
+		$this->configManager->shouldReceive('getValueAsString')
+			->with('landing_background_landscape')->andReturn('https://example.com/bg.jpg')->byDefault();
+		$this->configManager->shouldReceive('getValueAsEnum')
+			->with('sm_card_album_source', OgImageAlbumSourceType::class)
+			->andReturn(OgImageAlbumSourceType::HEADER)->byDefault();
+		$this->configManager->shouldReceive('getValueAsBool')
+			->with('use_album_compact_header')->andReturn(true)->byDefault();
+	}
+
+	private function buildMeta(): Meta
+	{
+		return new Meta();
+	}
+
+	private function makeSizeVariantMock(string $url): MockInterface&SizeVariant
+	{
+		$sv = Mockery::mock(SizeVariant::class);
+		$sv->shouldReceive('offsetExists')->with('url')->andReturn(true);
+		$sv->shouldReceive('getAttribute')->with('url')->andReturn($url);
+
+		return $sv;
+	}
+
+	private function makePhotoMock(string $title, ?string $description, MockInterface $sizeVariants): MockInterface&Photo
+	{
+		$photo = Mockery::mock(Photo::class)->makePartial();
+		$photo->forceFill(['title' => $title, 'description' => $description]);
+		$photo->setRelation('size_variants', $sizeVariants);
+
+		return $photo;
+	}
+
+	public function testDefaultConstruction(): void
+	{
+		$meta = $this->buildMeta();
+
+		self::assertSame('Test Owner', $meta->site_owner);
+		self::assertSame('My Gallery', $meta->page_title);
+		self::assertSame('', $meta->page_description);
+		self::assertSame('https://example.com/card.jpg', $meta->image_url);
+		self::assertFalse($meta->rss_enable);
+	}
+
+	public function testRssEnabled(): void
+	{
+		$this->configManager->shouldReceive('getValueAsBool')
+			->with('rss_enable')->andReturn(true);
+
+		$meta = $this->buildMeta();
+
+		self::assertTrue($meta->rss_enable);
+	}
+
+	public function testSmCardImageUrlFallsBackToLandingBackground(): void
+	{
+		$this->configManager->shouldReceive('getValueAsString')
+			->with('sm_card_image_url')->andReturn('');
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('https://example.com/bg.jpg', $meta->image_url);
+	}
+
+	public function testSmCardImageUrlWithAbsolutePath(): void
+	{
+		$this->configManager->shouldReceive('getValueAsString')
+			->with('sm_card_image_url')->andReturn('/images/card.png');
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('/images/card.png', $meta->image_url);
+	}
+
+	public function testSmCardImageUrlWithFullUrl(): void
+	{
+		$this->configManager->shouldReceive('getValueAsString')
+			->with('sm_card_image_url')->andReturn('https://cdn.example.com/img.jpg');
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('https://cdn.example.com/img.jpg', $meta->image_url);
+	}
+
+	public function testBaseUrlWithMatchingDirUrl(): void
+	{
+		$base = url('/');
+		$suffix = '/lychee';
+		config(['app.dir_url' => $suffix]);
+		$this->app['url']->forceRootUrl($base . $suffix);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame($base . $suffix, $meta->base_url);
+	}
+
+	public function testBaseUrlWithNonMatchingDirUrl(): void
+	{
+		config(['app.dir_url' => '/gallery']);
+
+		$meta = $this->buildMeta();
+
+		$expected = url('/gallery/');
+		self::assertSame($expected, $meta->base_url);
+	}
+
+	public function testBaseUrlWithEmptyDirUrl(): void
+	{
+		config(['app.dir_url' => '']);
+
+		$meta = $this->buildMeta();
+
+		$base = url('/');
+		self::assertSame($base, $meta->base_url);
+	}
+
+	public function testPageUrlIsCurrentUrl(): void
+	{
+		$meta = $this->buildMeta();
+
+		self::assertSame(url()->current(), $meta->page_url);
+	}
+
+	public function testAccessDeniedPreventsAlbumAndPhotoProcessing(): void
+	{
+		$album = Mockery::mock(Album::class);
+		$album->shouldReceive('get_title')->never();
+
+		session(['access' => false]);
+		session(['album' => $album]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('My Gallery', $meta->page_title);
+		self::assertSame('', $meta->page_description);
+	}
+
+	public function testAlbumInSessionSetsTitle(): void
+	{
+		$album = Mockery::mock(Album::class)->makePartial();
+		$album->shouldReceive('get_title')->andReturn('Vacation 2024');
+		$album->shouldReceive('getAttribute')->with('description')->andReturn('Summer photos');
+		$album->shouldReceive('getAttribute')->with('cover_id')->andReturn(null);
+		$album->shouldReceive('getAttribute')->with('auto_cover_id_least_privilege')->andReturn(null);
+
+		$this->configManager->shouldReceive('getValueAsEnum')
+			->with('sm_card_album_source', OgImageAlbumSourceType::class)
+			->andReturn(OgImageAlbumSourceType::COVER);
+
+		session(['album' => $album]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('Vacation 2024', $meta->page_title);
+		self::assertSame('Summer photos', $meta->page_description);
+	}
+
+	public function testAlbumWithNullDescriptionFallsBackToSiteTitle(): void
+	{
+		$album = Mockery::mock(Album::class)->makePartial();
+		$album->shouldReceive('get_title')->andReturn('Untitled');
+		$album->shouldReceive('getAttribute')->with('description')->andReturn(null);
+		$album->shouldReceive('getAttribute')->with('cover_id')->andReturn(null);
+		$album->shouldReceive('getAttribute')->with('auto_cover_id_least_privilege')->andReturn(null);
+
+		$this->configManager->shouldReceive('getValueAsEnum')
+			->with('sm_card_album_source', OgImageAlbumSourceType::class)
+			->andReturn(OgImageAlbumSourceType::COVER);
+
+		session(['album' => $album]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('Untitled', $meta->page_title);
+		self::assertSame('My Gallery', $meta->page_description);
+	}
+
+	public function testNonBaseAlbumDoesNotSetDescription(): void
+	{
+		$album = Mockery::mock(AbstractAlbum::class);
+		$album->shouldReceive('get_title')->andReturn('Smart Album');
+		$album->shouldReceive('get_photos')->andReturn(new Collection());
+
+		session(['album' => $album]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('Smart Album', $meta->page_title);
+		self::assertSame('', $meta->page_description);
+	}
+
+	public function testPhotoInSessionSetsMetadata(): void
+	{
+		$svMock = $this->makeSizeVariantMock('https://example.com/medium.jpg');
+
+		$sizeVariants = Mockery::mock(SizeVariants::class);
+		$sizeVariants->shouldReceive('getMedium')->andReturn($svMock);
+
+		$photo = $this->makePhotoMock('Sunset', 'A beautiful sunset', $sizeVariants);
+
+		session(['photo' => $photo]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('Sunset', $meta->page_title);
+		self::assertSame('A beautiful sunset', $meta->page_description);
+		self::assertSame('https://example.com/medium.jpg', $meta->image_url);
+	}
+
+	public function testPhotoWithNullDescriptionFallsBackToSiteTitle(): void
+	{
+		$sizeVariants = Mockery::mock(SizeVariants::class);
+		$sizeVariants->shouldReceive('getMedium')->andReturn(null);
+		$sizeVariants->shouldReceive('getSmall')->andReturn(null);
+
+		$photo = $this->makePhotoMock('No Description', null, $sizeVariants);
+
+		session(['photo' => $photo]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('No Description', $meta->page_title);
+		self::assertSame('My Gallery', $meta->page_description);
+		self::assertSame('https://example.com/card.jpg', $meta->image_url);
+	}
+
+	public function testPhotoFallsBackToSmallWhenNoMedium(): void
+	{
+		$svSmall = $this->makeSizeVariantMock('https://example.com/small.jpg');
+
+		$sizeVariants = Mockery::mock(SizeVariants::class);
+		$sizeVariants->shouldReceive('getMedium')->andReturn(null);
+		$sizeVariants->shouldReceive('getSmall')->andReturn($svSmall);
+
+		$photo = $this->makePhotoMock('Photo', 'Desc', $sizeVariants);
+
+		session(['photo' => $photo]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('https://example.com/small.jpg', $meta->image_url);
+	}
+
+	public function testPhotoFallsBackToDefaultWhenNoSizeVariants(): void
+	{
+		$sizeVariants = Mockery::mock(SizeVariants::class);
+		$sizeVariants->shouldReceive('getMedium')->andReturn(null);
+		$sizeVariants->shouldReceive('getSmall')->andReturn(null);
+
+		$photo = $this->makePhotoMock('Photo', 'Desc', $sizeVariants);
+
+		session(['photo' => $photo]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('https://example.com/card.jpg', $meta->image_url);
+	}
+
+	public function testPhotoOverridesAlbumWhenBothInSession(): void
+	{
+		$album = Mockery::mock(Album::class)->makePartial();
+		$album->shouldReceive('get_title')->andReturn('Album Title');
+		$album->shouldReceive('getAttribute')->with('description')->andReturn('Album Desc');
+		$album->shouldReceive('getAttribute')->with('cover_id')->andReturn(null);
+		$album->shouldReceive('getAttribute')->with('auto_cover_id_least_privilege')->andReturn(null);
+
+		$this->configManager->shouldReceive('getValueAsEnum')
+			->with('sm_card_album_source', OgImageAlbumSourceType::class)
+			->andReturn(OgImageAlbumSourceType::COVER);
+
+		$svMedium = $this->makeSizeVariantMock('https://example.com/photo-medium.jpg');
+
+		$sizeVariants = Mockery::mock(SizeVariants::class);
+		$sizeVariants->shouldReceive('getMedium')->andReturn($svMedium);
+
+		$photo = $this->makePhotoMock('Photo Title', 'Photo Desc', $sizeVariants);
+
+		session(['album' => $album, 'photo' => $photo]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('Photo Title', $meta->page_title);
+		self::assertSame('Photo Desc', $meta->page_description);
+		self::assertSame('https://example.com/photo-medium.jpg', $meta->image_url);
+	}
+
+	public function testSessionDataIsForgottenAfterConstruction(): void
+	{
+		$sizeVariants = Mockery::mock(SizeVariants::class);
+		$sizeVariants->shouldReceive('getMedium')->andReturn(null);
+		$sizeVariants->shouldReceive('getSmall')->andReturn(null);
+
+		$album = Mockery::mock(AbstractAlbum::class);
+		$album->shouldReceive('get_title')->andReturn('T');
+		$album->shouldReceive('get_photos')->andReturn(new Collection());
+
+		$photo = $this->makePhotoMock('P', 'D', $sizeVariants);
+
+		session(['access' => true, 'album' => $album, 'photo' => $photo]);
+
+		$this->buildMeta();
+
+		self::assertFalse(session()->has('access'));
+		self::assertFalse(session()->has('album'));
+		self::assertFalse(session()->has('photo'));
+	}
+
+	public function testGetUserCustomFilesWithExistingFile(): void
+	{
+		Storage::disk(FileSystem::DIST)->put('user.css', 'body{}');
+
+		$url = Meta::getUserCustomFiles('user.css');
+
+		self::assertStringContainsString('user.css', $url);
+		self::assertStringContainsString('?', $url);
+	}
+
+	public function testGetUserCustomFilesWithNonExistingFile(): void
+	{
+		$url = Meta::getUserCustomFiles('nonexistent.css');
+
+		self::assertStringContainsString('nonexistent.css', $url);
+		self::assertStringNotContainsString('?', $url);
+	}
+
+	public function testGetUserCustomFilesCustomJs(): void
+	{
+		Storage::disk(FileSystem::DIST)->put('custom.js', 'alert(1)');
+
+		$url = Meta::getUserCustomFiles('custom.js');
+
+		self::assertStringContainsString('custom.js', $url);
+		self::assertStringContainsString('?', $url);
+	}
+
+	public function testAlbumWithCoverSourceAndNonAlbumTypeReturnsNull(): void
+	{
+		$album = Mockery::mock(AbstractAlbum::class);
+		$album->shouldReceive('get_title')->andReturn('Smart Album');
+		$album->shouldReceive('get_photos')->andReturn(new Collection());
+
+		$this->configManager->shouldReceive('getValueAsEnum')
+			->with('sm_card_album_source', OgImageAlbumSourceType::class)
+			->andReturn(OgImageAlbumSourceType::COVER);
+
+		session(['album' => $album]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('https://example.com/card.jpg', $meta->image_url);
+	}
+
+	public function testAlbumWithCoverSourceAndNullCoverIds(): void
+	{
+		$album = Mockery::mock(Album::class)->makePartial();
+		$album->shouldReceive('get_title')->andReturn('Album');
+		$album->shouldReceive('getAttribute')->with('description')->andReturn(null);
+		$album->shouldReceive('getAttribute')->with('cover_id')->andReturn(null);
+		$album->shouldReceive('getAttribute')->with('auto_cover_id_least_privilege')->andReturn(null);
+
+		$this->configManager->shouldReceive('getValueAsEnum')
+			->with('sm_card_album_source', OgImageAlbumSourceType::class)
+			->andReturn(OgImageAlbumSourceType::COVER);
+
+		session(['album' => $album]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('https://example.com/card.jpg', $meta->image_url);
+	}
+
+	public function testAlbumWithHeaderSourceAndCompactHeaderEnabled(): void
+	{
+		$album = Mockery::mock(Album::class)->makePartial();
+		$album->shouldReceive('get_title')->andReturn('Album');
+		$album->shouldReceive('getAttribute')->with('description')->andReturn('Desc');
+
+		$this->configManager->shouldReceive('getValueAsEnum')
+			->with('sm_card_album_source', OgImageAlbumSourceType::class)
+			->andReturn(OgImageAlbumSourceType::HEADER);
+
+		$this->configManager->shouldReceive('getValueAsBool')
+			->with('use_album_compact_header')->andReturn(true);
+
+		session(['album' => $album]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('https://example.com/card.jpg', $meta->image_url);
+	}
+
+	public function testAlbumWithHeaderSourceAndCompactHeaderId(): void
+	{
+		$album = Mockery::mock(Album::class)->makePartial();
+		$album->shouldReceive('get_title')->andReturn('Album');
+		$album->shouldReceive('getAttribute')->with('description')->andReturn('Desc');
+		$album->shouldReceive('getAttribute')->with('header_id')->andReturn(AlbumController::COMPACT_HEADER);
+		$album->shouldReceive('get_photos')->andReturn(new Collection());
+
+		$this->configManager->shouldReceive('getValueAsEnum')
+			->with('sm_card_album_source', OgImageAlbumSourceType::class)
+			->andReturn(OgImageAlbumSourceType::HEADER);
+
+		$this->configManager->shouldReceive('getValueAsBool')
+			->with('use_album_compact_header')->andReturn(false);
+
+		session(['album' => $album]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('https://example.com/card.jpg', $meta->image_url);
+	}
+
+	public function testAlbumWithHeaderSourceAndEmptyPhotos(): void
+	{
+		$album = Mockery::mock(Album::class)->makePartial();
+		$album->shouldReceive('get_title')->andReturn('Empty Album');
+		$album->shouldReceive('getAttribute')->with('description')->andReturn('No photos');
+		$album->shouldReceive('getAttribute')->with('header_id')->andReturn(null);
+		$album->shouldReceive('get_photos')->andReturn(new Collection());
+
+		$this->configManager->shouldReceive('getValueAsEnum')
+			->with('sm_card_album_source', OgImageAlbumSourceType::class)
+			->andReturn(OgImageAlbumSourceType::HEADER);
+
+		$this->configManager->shouldReceive('getValueAsBool')
+			->with('use_album_compact_header')->andReturn(false);
+
+		session(['album' => $album]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('https://example.com/card.jpg', $meta->image_url);
+	}
+
+	public function testRenderReturnsView(): void
+	{
+		$meta = $this->buildMeta();
+
+		$view = $meta->render();
+
+		self::assertSame('components.meta', $view->name());
+	}
+
+	public function testNoSessionDataDoesNotAffectDefaults(): void
+	{
+		self::assertFalse(session()->has('access'));
+		self::assertFalse(session()->has('album'));
+		self::assertFalse(session()->has('photo'));
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('My Gallery', $meta->page_title);
+		self::assertSame('', $meta->page_description);
+		self::assertSame('Test Owner', $meta->site_owner);
+	}
+
+	public function testUserCssAndJsUrlsAreSet(): void
+	{
+		$meta = $this->buildMeta();
+
+		self::assertStringContainsString('user.css', $meta->user_css_url);
+		self::assertStringContainsString('custom.js', $meta->user_js_url);
+	}
+
+	public function testAccessTrueInSessionAllowsProcessing(): void
+	{
+		$album = Mockery::mock(AbstractAlbum::class);
+		$album->shouldReceive('get_title')->andReturn('Visible Album');
+		$album->shouldReceive('get_photos')->andReturn(new Collection());
+
+		session(['access' => true, 'album' => $album]);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('Visible Album', $meta->page_title);
+	}
+}

--- a/tests/Unit/View/Components/MetaTest.php
+++ b/tests/Unit/View/Components/MetaTest.php
@@ -21,14 +21,19 @@ namespace Tests\Unit\View\Components;
 use App\Constants\FileSystem;
 use App\Contracts\Models\AbstractAlbum;
 use App\Enum\OgImageAlbumSourceType;
+use App\Enum\SizeVariantType;
+use App\Enum\StorageDiskType;
 use App\Http\Controllers\Gallery\AlbumController;
+use App\Image\Watermarker;
 use App\Models\Album;
 use App\Models\Extensions\SizeVariants;
 use App\Models\Photo;
 use App\Models\SizeVariant;
 use App\Repositories\ConfigManager;
+use App\Services\UrlGenerator;
 use App\View\Components\Meta;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Mockery\MockInterface;
 use Tests\AbstractTestCase;
@@ -493,6 +498,82 @@ class MetaTest extends AbstractTestCase
 		$meta = $this->buildMeta();
 
 		self::assertSame('https://example.com/card.jpg', $meta->image_url);
+	}
+
+	public function testAlbumWithHeaderSourceSetsImageUrl(): void
+	{
+		$album = \Mockery::mock(Album::class)->makePartial();
+		$album->shouldReceive('get_title')->andReturn('Album');
+		$album->shouldReceive('getAttribute')->with('description')->andReturn('Desc');
+
+		$this->config_manager->shouldReceive('getValueAsEnum')
+			->with('sm_card_album_source', OgImageAlbumSourceType::class)
+			->andReturn(OgImageAlbumSourceType::HEADER);
+
+		session(['album' => $album]);
+
+		$meta = \Mockery::mock(Meta::class)
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+		$meta->shouldReceive('getHeaderUrl')
+			->once()
+			->andReturn('https://example.com/header.jpg');
+		$meta->__construct();
+
+		self::assertSame('https://example.com/header.jpg', $meta->image_url);
+		self::assertSame('Album', $meta->page_title);
+	}
+
+	public function testAlbumWithCoverSourceSetsImageUrl(): void
+	{
+		$album = \Mockery::mock(Album::class)->makePartial();
+		$album->shouldReceive('get_title')->andReturn('Album');
+		$album->shouldReceive('getAttribute')->with('description')->andReturn('Desc');
+		$album->shouldReceive('getAttribute')->with('cover_id')->andReturn('photo-123');
+		$album->shouldReceive('getAttribute')->with('auto_cover_id_least_privilege')->andReturn(null);
+
+		$this->config_manager->shouldReceive('getValueAsEnum')
+			->with('sm_card_album_source', OgImageAlbumSourceType::class)
+			->andReturn(OgImageAlbumSourceType::COVER);
+
+		session(['album' => $album]);
+
+		$mockStatement = \Mockery::mock(\PDOStatement::class);
+		$mockStatement->shouldReceive('setFetchMode')->andReturn(true);
+		$mockStatement->shouldReceive('bindValue')->andReturn(true);
+		$mockStatement->shouldReceive('execute')->andReturn(true);
+		$mockStatement->shouldReceive('fetchAll')->andReturn([
+			(object) [
+				'id' => 1,
+				'photo_id' => 'photo-123',
+				'type' => SizeVariantType::MEDIUM->value,
+				'short_path' => 'uploads/medium/test.jpg',
+				'short_path_watermarked' => null,
+				'storage_disk' => StorageDiskType::LOCAL->value,
+				'width' => 800,
+				'height' => 600,
+				'filesize' => 50000,
+				'ratio' => 1.33,
+			],
+		]);
+
+		$mockPdo = \Mockery::mock(\PDO::class);
+		$mockPdo->shouldReceive('prepare')->andReturn($mockStatement);
+
+		DB::connection()->setPdo($mockPdo);
+
+		$mockWatermarker = \Mockery::mock(Watermarker::class);
+		$mockWatermarker->shouldReceive('get_path')->andReturn('uploads/medium/test.jpg');
+		$this->app->instance(Watermarker::class, $mockWatermarker);
+
+		$mockUrlGen = \Mockery::mock(UrlGenerator::class);
+		$mockUrlGen->shouldReceive('pathToUrl')->andReturn('https://example.com/cover.jpg');
+		$this->app->instance(UrlGenerator::class, $mockUrlGen);
+
+		$meta = $this->buildMeta();
+
+		self::assertSame('https://example.com/cover.jpg', $meta->image_url);
+		self::assertSame('Album', $meta->page_title);
 	}
 
 	public function testRenderReturnsView(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added social sharing (Open Graph) settings to choose album **cover vs header** imagery.
  * Added configurable OG image fallback (**URL or Photo ID**) with automatic selection of the best available photo size.
  * Improved OG card image generation to use the album-selected image when an album is present.
* **Documentation**
  * Added/updated settings descriptions for the new options and fallback behavior across supported languages.
* **Tests**
  * Added unit coverage for OG image selection and fallback behavior in both album source modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->