### PR TITLE
Add missing tile for bulk album edit

### DIFF
--- a/resources/js/composables/useAdminTiles.ts
+++ b/resources/js/composables/useAdminTiles.ts
@@ -118,6 +118,15 @@ export function useAdminTiles(lycheeStore: LycheeStateStore, leftMenuStore: Left
 			visible: computed(() => (initData.value?.settings.can_edit ?? false) && (initData.value?.modules.is_ai_vision_enabled ?? false)),
 		},
 		{
+			key: "bulk-album-edit",
+			group: "core",
+			label: "bulk_album_edit.title",
+			icon: "pi pi-folder",
+			to: "/bulk-album-edit",
+			isExternal: false,
+			visible: computed(() => initData.value?.settings.can_edit ?? false),
+		},
+		{
 			key: "moderation",
 			group: "core",
 			label: "moderation.title",


### PR DESCRIPTION
Oups...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin tile for bulk album editing in the admin dashboard.
  * The tile appears under the core section, uses a folder icon, and opens an internal page.
  * Visibility is now controlled by editing permissions, so only eligible admins will see it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->