### PR TITLE
Make the tags clickable in the photo details

### DIFF
--- a/app/Http/Resources/Models/PhotoResource.php
+++ b/app/Http/Resources/Models/PhotoResource.php
@@ -12,12 +12,14 @@ use App\Enum\LicenseType;
 use App\Http\Resources\Models\Utils\PreComputedPhotoData;
 use App\Http\Resources\Models\Utils\PreformattedPhotoData;
 use App\Http\Resources\Models\Utils\TimelineData;
+use App\Http\Resources\Tags\PhotoTagResource;
 use App\Models\Photo;
 use App\Policies\PhotoPolicy;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
 #[TypeScript()]
@@ -35,7 +37,8 @@ class PhotoResource extends Data
 	public ?string $live_photo_url;
 	public string $original_checksum;
 	public SizeVariantsResouce $size_variants;
-	/** @var string[] */
+	/** @var PhotoTagResource[] */
+	#[LiteralTypeScriptType('App.Http.Resources.Tags.PhotoTagResource[]')]
 	public array $tags;
 	public ?string $taken_at;
 	public ?string $taken_at_orig_tz;
@@ -71,7 +74,7 @@ class PhotoResource extends Data
 		$this->live_photo_url = $photo->live_photo_url;
 		$this->original_checksum = $photo->original_checksum;
 		$this->size_variants = new SizeVariantsResouce($photo, $should_downgrade_size_variants);
-		$this->tags = $photo->tags->pluck('name')->all();
+		$this->tags = $photo->tags->map(fn ($tag) => new PhotoTagResource($tag->id, $tag->name))->all();
 		$this->taken_at = $photo->taken_at?->toIso8601String();
 		$this->taken_at_orig_tz = $photo->taken_at_orig_tz;
 		$this->title = (request()->configs()->getValueAsBool('file_name_hidden') && Auth::guest()) ? '' : $photo->title;

--- a/app/Http/Resources/Tags/PhotoTagResource.php
+++ b/app/Http/Resources/Tags/PhotoTagResource.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Tags;
+
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class PhotoTagResource extends Data
+{
+	public function __construct(
+		public int $id,
+		public string $name,
+	) {
+	}
+}

--- a/resources/js/components/drawers/PhotoDetails.vue
+++ b/resources/js/components/drawers/PhotoDetails.vue
@@ -74,10 +74,11 @@
 						<span class="pb-2 flex flex-wrap">
 							<a
 								v-for="tag in photoStore.photo.tags"
-								:key="`tag-${tag}`"
-								class="text-xs rounded-full py-1 px-2.5 mr-1.5 mb-2.5 bg-black/50"
+								:key="`tag-${tag.id}`"
+								class="text-xs rounded-full py-1 px-2.5 mr-1.5 mb-2.5 bg-black/50 cursor-pointer hover:bg-black/70 transition-colors"
+								@click="router.push({ name: 'tag', params: { tagId: tag.id } })"
 							>
-								{{ tag }}
+								{{ tag.name }}
 							</a>
 						</span>
 					</template>

--- a/resources/js/components/drawers/PhotoDetails.vue
+++ b/resources/js/components/drawers/PhotoDetails.vue
@@ -72,14 +72,14 @@
 							{{ $t("gallery.photo.details.tags") }}
 						</h2>
 						<span class="pb-2 flex flex-wrap">
-							<a
+							<RouterLink
 								v-for="tag in photoStore.photo.tags"
 								:key="`tag-${tag.id}`"
 								class="text-xs rounded-full py-1 px-2.5 mr-1.5 mb-2.5 bg-black/50 cursor-pointer hover:bg-black/70 transition-colors"
-								@click="router.push({ name: 'tag', params: { tagId: tag.id } })"
+								:to="{ name: 'tag', params: { tagId: tag.id } }"
 							>
 								{{ tag.name }}
-							</a>
+							</RouterLink>
 						</span>
 					</template>
 

--- a/resources/js/components/drawers/PhotoDetails.vue
+++ b/resources/js/components/drawers/PhotoDetails.vue
@@ -72,14 +72,25 @@
 							{{ $t("gallery.photo.details.tags") }}
 						</h2>
 						<span class="pb-2 flex flex-wrap">
-							<RouterLink
-								v-for="tag in photoStore.photo.tags"
-								:key="`tag-${tag.id}`"
-								class="text-xs rounded-full py-1 px-2.5 mr-1.5 mb-2.5 bg-black/50 cursor-pointer hover:bg-black/70 transition-colors"
-								:to="{ name: 'tag', params: { tagId: tag.id } }"
-							>
-								{{ tag.name }}
-							</RouterLink>
+							<template v-if="userStore.isLoggedIn">
+								<RouterLink
+									v-for="tag in photoStore.photo.tags"
+									:key="`tag-${tag.id}`"
+									class="text-xs rounded-full py-1 px-2.5 mr-1.5 mb-2.5 bg-black/50 cursor-pointer hover:bg-black/70 transition-colors"
+									:to="{ name: 'tag', params: { tagId: tag.id } }"
+								>
+									{{ tag.name }}
+								</RouterLink>
+							</template>
+							<template v-else>
+								<span
+									v-for="tag in photoStore.photo.tags"
+									:key="`tag-${tag.id}`"
+									class="text-xs rounded-full py-1 px-2.5 mr-1.5 mb-2.5 bg-black/50 cursor-default"
+								>
+									{{ tag.name }}
+								</span>
+							</template>
 						</span>
 					</template>
 
@@ -296,6 +307,7 @@ import FaceDetectionService from "@/services/face-detection-service";
 import { useToast } from "primevue/usetoast";
 import { trans } from "laravel-vue-i18n";
 import { isTouchDevice } from "@/utils/keybindings-utils";
+import { useUserStore } from "@/stores/UserState";
 
 const photoStore = usePhotoStore();
 const router = useRouter();
@@ -304,6 +316,7 @@ const leftMenuStore = useLeftMenuStateStore();
 const { initData } = storeToRefs(leftMenuStore);
 const toast = useToast();
 const isTouchDev = isTouchDevice();
+const userStore = useUserStore();
 
 const props = defineProps<{
 	isMapVisible: boolean;

--- a/resources/js/components/drawers/PhotoEdit.vue
+++ b/resources/js/components/drawers/PhotoEdit.vue
@@ -144,7 +144,7 @@ function load(photoToEdit: App.Http.Resources.Models.PhotoResource) {
 	photo_id.value = photoToEdit.id;
 	title.value = photoToEdit.title;
 	description.value = photoToEdit.description;
-	tags.value = photoToEdit.tags;
+	tags.value = photoToEdit.tags.map((t) => t.name);
 
 	const dataDate = (photoToEdit.created_at ?? "").slice(0, 19);
 	uploadTz.value = (photoToEdit.created_at ?? "").slice(19);

--- a/resources/js/components/gallery/albumModule/thumbs/PhotoThumb.vue
+++ b/resources/js/components/gallery/albumModule/thumbs/PhotoThumb.vue
@@ -62,7 +62,7 @@
 						:key="`photo-thumb${props.photo.id}-tag-${idx}`"
 						class="inline-block ltr:ml-3 rtl:mr-3 text-xs text-surface-300 bg-surface-800/50 rounded px-1.5 py-0.5"
 					>
-						{{ tag }}
+						{{ tag.name }}
 					</span>
 				</div>
 			</template>

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -973,7 +973,7 @@ declare namespace App.Http.Resources.Models {
 		live_photo_url: string | null;
 		original_checksum: string;
 		size_variants: App.Http.Resources.Models.SizeVariantsResouce;
-		tags: Array<string>;
+		tags: App.Http.Resources.Tags.PhotoTagResource[];
 		taken_at: string | null;
 		taken_at_orig_tz: string | null;
 		title: string;
@@ -1519,6 +1519,10 @@ declare namespace App.Http.Resources.Statistics {
 	};
 }
 declare namespace App.Http.Resources.Tags {
+	export type PhotoTagResource = {
+		id: number;
+		name: string;
+	};
 	export type TagResource = {
 		id: number;
 		name: string;

--- a/tests/ImageProcessing/Photo/PhotoEditTest.php
+++ b/tests/ImageProcessing/Photo/PhotoEditTest.php
@@ -78,7 +78,7 @@ class PhotoEditTest extends BaseApiWithDataTest
 		$response->assertJsonPath('photos.' . $idx . '.id', $this->photo1->id);
 		$response->assertJsonPath('photos.' . $idx . '.title', 'new title');
 		$response->assertJsonPath('photos.' . $idx . '.description', 'new description');
-		$response->assertJsonPath('photos.' . $idx . '.tags', ['tag1']);
+		$this->assertEquals(['tag1'], array_column($response->json('photos.' . $idx . '.tags'), 'name'));
 		$response->assertJsonPath('photos.' . $idx . '.license', 'none');
 		$response->assertJsonPath('photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
 		$response->assertJsonPath('photos.' . $idx . '.precomputed.is_taken_at_modified', false);
@@ -104,7 +104,7 @@ class PhotoEditTest extends BaseApiWithDataTest
 		$response->assertJsonPath('photos.' . $idx . '.id', $this->photo1->id);
 		$response->assertJsonPath('photos.' . $idx . '.title', 'new title');
 		$response->assertJsonPath('photos.' . $idx . '.description', 'new description');
-		$response->assertJsonPath('photos.' . $idx . '.tags', ['tag1']);
+		$this->assertEquals(['tag1'], array_column($response->json('photos.' . $idx . '.tags'), 'name'));
 		$response->assertJsonPath('photos.' . $idx . '.license', 'none');
 		$response->assertJsonPath('photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
 		$response->assertJsonPath('photos.' . $idx . '.taken_at', '2021-01-01T00:00:00+00:00');
@@ -131,7 +131,7 @@ class PhotoEditTest extends BaseApiWithDataTest
 		$response->assertJsonPath('photos.' . $idx . '.id', $this->photo1->id);
 		$response->assertJsonPath('photos.' . $idx . '.title', 'new title');
 		$response->assertJsonPath('photos.' . $idx . '.description', 'new description');
-		$response->assertJsonPath('photos.' . $idx . '.tags', ['tag1']);
+		$this->assertEquals(['tag1'], array_column($response->json('photos.' . $idx . '.tags'), 'name'));
 		$response->assertJsonPath('photos.' . $idx . '.license', 'none');
 		$response->assertJsonPath('photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
 		$response->assertJsonPath('photos.' . $idx . '.precomputed.is_taken_at_modified', false);
@@ -162,7 +162,7 @@ class PhotoEditTest extends BaseApiWithDataTest
 		$response->assertJsonPath('photos.' . $idx . '.id', $this->photo1->id);
 		$response->assertJsonPath('photos.' . $idx . '.title', 'new title');
 		$response->assertJsonPath('photos.' . $idx . '.description', 'new description');
-		$response->assertJsonPath('photos.' . $idx . '.tags', ['tag1']);
+		$this->assertEquals(['tag1'], array_column($response->json('photos.' . $idx . '.tags'), 'name'));
 		$response->assertJsonPath('photos.' . $idx . '.license', 'none');
 		$response->assertJsonPath('photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
 		$response->assertJsonPath('photos.' . $idx . '.taken_at', null);
@@ -189,7 +189,7 @@ class PhotoEditTest extends BaseApiWithDataTest
 		$response->assertJsonPath('photos.' . $idx . '.id', $this->photo1->id);
 		$response->assertJsonPath('photos.' . $idx . '.title', 'new title');
 		$response->assertJsonPath('photos.' . $idx . '.description', 'new description');
-		$response->assertJsonPath('photos.' . $idx . '.tags', ['tag1']);
+		$this->assertEquals(['tag1'], array_column($response->json('photos.' . $idx . '.tags'), 'name'));
 		$response->assertJsonPath('photos.' . $idx . '.license', 'none');
 		$response->assertJsonPath('photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
 		$response->assertJsonPath('photos.' . $idx . '.taken_at', '2021-01-01T00:00:00+00:00');
@@ -216,7 +216,7 @@ class PhotoEditTest extends BaseApiWithDataTest
 		$response->assertJsonPath('photos.' . $idx . '.id', $this->photo1->id);
 		$response->assertJsonPath('photos.' . $idx . '.title', 'new title');
 		$response->assertJsonPath('photos.' . $idx . '.description', 'new description');
-		$response->assertJsonPath('photos.' . $idx . '.tags', ['tag1']);
+		$this->assertEquals(['tag1'], array_column($response->json('photos.' . $idx . '.tags'), 'name'));
 		$response->assertJsonPath('photos.' . $idx . '.license', 'none');
 		$response->assertJsonPath('photos.' . $idx . '.created_at', '2021-01-01T00:00:00+00:00');
 		$response->assertJsonPath('photos.' . $idx . '.taken_at', null);

--- a/tests/ImageProcessing/Photo/PhotoTagsTest.php
+++ b/tests/ImageProcessing/Photo/PhotoTagsTest.php
@@ -56,7 +56,7 @@ class PhotoTagsTest extends BaseApiWithDataTest
 			'photos' => [
 				[
 					'id' => $this->photo1->id,
-					'tags' => ['tag1'],
+					'tags' => [['name' => 'tag1']],
 				],
 			],
 		]);
@@ -83,7 +83,7 @@ class PhotoTagsTest extends BaseApiWithDataTest
 			'photos' => [
 				[
 					'id' => $this->photo1->id,
-					'tags' => ['tag1'],
+					'tags' => [['name' => 'tag1']],
 				],
 			],
 		]);
@@ -110,7 +110,7 @@ class PhotoTagsTest extends BaseApiWithDataTest
 			'photos' => [
 				[
 					'id' => $this->photo1->id,
-					'tags' => ['tag1', 'tag2'],
+					'tags' => [['name' => 'tag1'], ['name' => 'tag2']],
 				],
 			],
 		]);
@@ -140,7 +140,7 @@ class PhotoTagsTest extends BaseApiWithDataTest
 				],
 			],
 		]);
-		$sorted_tags = $response->json('photos.0.tags');
+		$sorted_tags = array_column($response->json('photos.0.tags'), 'name');
 		sort($sorted_tags);
 		$this->assertEquals(['tag1', 'tag2'], $sorted_tags);
 	}
@@ -166,7 +166,7 @@ class PhotoTagsTest extends BaseApiWithDataTest
 			'photos' => [
 				[
 					'id' => $this->photo1->id,
-					'tags' => ['tag3'],
+					'tags' => [['name' => 'tag3']],
 				],
 			],
 		]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Photo tags are now handled as structured items (ID + name), enabling clickable tag chips that navigate to the related tag page while logged in.

* **Bug Fixes**
  * Updated photo details and thumbnails to display `name` from structured tags.
  * Updated photo editing to match the new tag format when loading and saving.

* **Tests**
  * Revised photo tag-related tests to assert the new object-based tag structure (using `name`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->