### PR TITLE
Add option to disable the second line on album thumbs

### DIFF
--- a/app/Enum/ThumbAlbumSubtitleType.php
+++ b/app/Enum/ThumbAlbumSubtitleType.php
@@ -15,6 +15,7 @@ namespace App\Enum;
  */
 enum ThumbAlbumSubtitleType: string
 {
+	case DISABLED = 'disabled';
 	case DESCRIPTION = 'description';
 	case TAKEDATE = 'takedate';
 	case CREATION = 'creation';

--- a/database/migrations/2026_06_28_000000_add_disabled_album_subtitle_type.php
+++ b/database/migrations/2026_06_28_000000_add_disabled_album_subtitle_type.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class() extends Migration {
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		$this->down();
+		$type_range = DB::table('configs')->select('type_range')->where('key', 'album_subtitle_type')->first()->type_range;
+		DB::table('configs')->where('key', 'album_subtitle_type')->update(['type_range' => 'disabled|' . $type_range]);
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		$type_range = DB::table('configs')->select('type_range')->where('key', 'album_subtitle_type')->first()->type_range;
+		DB::table('configs')->where('key', 'album_subtitle_type')->update(['type_range' => str_replace('disabled|', '', $type_range)]);
+	}
+};

--- a/resources/js/components/gallery/albumModule/thumbs/AlbumThumbOverlay.vue
+++ b/resources/js/components/gallery/albumModule/thumbs/AlbumThumbOverlay.vue
@@ -17,6 +17,7 @@
 			{{ props.album.title }}
 		</h1>
 		<span
+			v-if="album_subtitle_type !== 'disabled'"
 			:class="{
 				'hidden sm:block mt-0 mb-1.5 sm:mb-3 text-2xs text-surface-300': true,
 				'mr-0 ml-2 sm:ml-3 md:ml-4': isLTR(),

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -218,7 +218,15 @@ declare namespace App.Enum {
 		| "my_rated_pictures"
 		| "my_best_pictures";
 	export type StorageDiskType = "images" | "s3";
-	export type ThumbAlbumSubtitleType = "description" | "takedate" | "creation" | "oldstyle" | "num_photos" | "num_albums" | "num_photos_albums";
+	export type ThumbAlbumSubtitleType =
+		| "disabled"
+		| "description"
+		| "takedate"
+		| "creation"
+		| "oldstyle"
+		| "num_photos"
+		| "num_albums"
+		| "num_photos_albums";
 	export type TimelineAlbumGranularity = "default" | "disabled" | "year" | "month" | "day";
 	export type TimelinePhotoGranularity = "default" | "disabled" | "year" | "month" | "day" | "hour";
 	export type UpdateStatus = 0 | 1 | 2 | 3;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “disabled” option for album subtitles.
* **Bug Fixes**
  * Album subtitles are now hidden when the disabled option is selected, preventing empty subtitle text from appearing.
* **Documentation**
  * Updated the app’s type definitions to include the new subtitle option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->