### PR TITLE
Add cover to tag albums

### DIFF
--- a/app/DTO/Delete/PhotosToBeDeletedDTO.php
+++ b/app/DTO/Delete/PhotosToBeDeletedDTO.php
@@ -101,6 +101,7 @@ final class PhotosToBeDeletedDTO
 		collect($this->force_delete_photo_ids)->chunk(self::CHUNK_SIZE)->each(function ($chunk): void {
 			DB::table('albums')->whereIn('header_id', $chunk->all())->update(['header_id' => null]);
 			DB::table('albums')->whereIn('cover_id', $chunk->all())->update(['cover_id' => null]);
+			DB::table('tag_albums')->whereIn('cover_id', $chunk->all())->update(['cover_id' => null]);
 		});
 
 		// Maybe consider doing multiple queries for the different storage types.

--- a/app/Http/Requests/Album/SetAsCoverRequest.php
+++ b/app/Http/Requests/Album/SetAsCoverRequest.php
@@ -8,25 +8,30 @@
 
 namespace App\Http\Requests\Album;
 
-use App\Contracts\Http\Requests\HasAlbum;
 use App\Contracts\Http\Requests\HasPhoto;
 use App\Contracts\Http\Requests\RequestAttribute;
 use App\Contracts\Models\AbstractAlbum;
 use App\Http\Requests\BaseApiRequest;
-use App\Http\Requests\Traits\HasAlbumTrait;
 use App\Http\Requests\Traits\HasPhotoTrait;
 use App\Models\Album;
 use App\Models\Photo;
+use App\Models\TagAlbum;
 use App\Policies\AlbumPolicy;
 use App\Policies\PhotoPolicy;
 use App\Rules\RandomIDRule;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\ValidationException;
 
-class SetAsCoverRequest extends BaseApiRequest implements HasAlbum, HasPhoto
+class SetAsCoverRequest extends BaseApiRequest implements HasPhoto
 {
-	use HasAlbumTrait;
 	use HasPhotoTrait;
+
+	protected Album|TagAlbum|null $album = null;
+
+	public function album(): Album|TagAlbum|null
+	{
+		return $this->album;
+	}
 
 	public function authorize(): bool
 	{
@@ -55,7 +60,7 @@ class SetAsCoverRequest extends BaseApiRequest implements HasAlbum, HasPhoto
 			$values[RequestAttribute::ALBUM_ID_ATTRIBUTE]
 		);
 
-		if (!$album instanceof Album) {
+		if (!$album instanceof Album && !$album instanceof TagAlbum) {
 			throw ValidationException::withMessages([RequestAttribute::ALBUM_ID_ATTRIBUTE => 'album type not supported.']);
 		}
 

--- a/app/Http/Resources/Editable/EditableBaseAlbumResource.php
+++ b/app/Http/Resources/Editable/EditableBaseAlbumResource.php
@@ -73,6 +73,7 @@ class EditableBaseAlbumResource extends Data
 		}
 
 		if ($album instanceof TagAlbum) {
+			$this->cover_id = $album->cover_id;
 			$this->tags = $album->tags->map(fn ($t) => $t->name)->all();
 			$this->is_and = $album->is_and;
 		}

--- a/app/Http/Resources/Models/HeadTagAlbumResource.php
+++ b/app/Http/Resources/Models/HeadTagAlbumResource.php
@@ -30,6 +30,7 @@ class HeadTagAlbumResource extends Data
 	public ?string $slug;
 	public ?string $owner_name;
 	public ?string $copyright;
+	public ?string $cover_id;
 	public bool $is_tag_album;
 
 	/** @var string[] */
@@ -51,6 +52,7 @@ class HeadTagAlbumResource extends Data
 		$this->slug = request()->verify()->is_supporter() ? $tag_album->slug : null;
 		$this->owner_name = Auth::check() ? $tag_album->owner->name : null;
 		$this->is_tag_album = true;
+		$this->cover_id = $tag_album->cover_id;
 		$this->show_tags = $tag_album->tags->map(fn ($t) => $t->name)->all();
 		$this->copyright = $tag_album->copyright;
 

--- a/app/Models/TagAlbum.php
+++ b/app/Models/TagAlbum.php
@@ -18,11 +18,14 @@ use App\Relations\HasManyPhotosByTag;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 
 /**
  * App\Models\TagAlbum.
  *
+ * @property string|null         $cover_id
+ * @property Photo|null          $cover
  * @property Collection<int,Tag> $tags
  * @property bool                $is_and
  *
@@ -75,6 +78,7 @@ class TagAlbum extends BaseAlbum
 	 */
 	protected $attributes = [
 		'id' => null,
+		'cover_id' => null,
 		'is_and' => null,
 	];
 
@@ -106,6 +110,14 @@ class TagAlbum extends BaseAlbum
 	protected $appends = [
 		'thumb',
 	];
+
+	/**
+	 * @return HasOne<Photo,$this>
+	 */
+	public function cover(): HasOne
+	{
+		return $this->hasOne(Photo::class, 'id', 'cover_id');
+	}
 
 	/**
 	 * @phpstan-ignore method.childReturnType, method.childReturnType
@@ -141,6 +153,10 @@ class TagAlbum extends BaseAlbum
 	 */
 	protected function getThumbAttribute(): ?Thumb
 	{
+		if ($this->cover_id !== null) {
+			return Thumb::createFromPhoto($this->cover);
+		}
+
 		// Note, `photos()` already applies a "security filter" and
 		// only returns photos which are accessible by the current
 		// user

--- a/database/migrations/2026_06_28_000000_add_cover_id_to_tag_albums.php
+++ b/database/migrations/2026_06_28_000000_add_cover_id_to_tag_albums.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+	private const RANDOM_ID_LENGTH = 24;
+
+	public function up(): void
+	{
+		Schema::table('tag_albums', function (Blueprint $table) {
+			$table->char('cover_id', self::RANDOM_ID_LENGTH)->nullable()->default(null)->after('id');
+			$table->foreign('cover_id')->references('id')->on('photos')->nullOnDelete();
+		});
+	}
+
+	public function down(): void
+	{
+		Schema::table('tag_albums', function (Blueprint $table) {
+			$table->dropForeign(['cover_id']);
+			$table->dropColumn('cover_id');
+		});
+	}
+};

--- a/docs/specs/4-architecture/features/046-tag-album-cover/plan.md
+++ b/docs/specs/4-architecture/features/046-tag-album-cover/plan.md
@@ -1,0 +1,160 @@
+# Feature Plan 046 – Tag Album Custom Cover
+
+_Linked specification:_ [spec.md](spec.md)
+_Status:_ Draft
+_Last updated:_ 2026-06-28
+
+> Guardrail: Keep this plan traceable back to the governing spec. Reference FR/NFR/Scenario IDs from `spec.md` where relevant.
+
+## Vision & Success Criteria
+
+Tag album owners can set a custom cover photo via the context menu, just like regular album owners. A new `cover_id` column on `tag_albums` stores the selection. The `albums` table and `HasAlbumThumb` relation remain untouched. All existing album cover functionality continues to work. Tests pass, PHPStan clean, front-end type-checks pass.
+
+## Scope Alignment
+
+- **In scope:**
+  - Database migration: add `cover_id` to `tag_albums` (FR-046-01)
+  - Model changes: `TagAlbum` gains `cover_id` attribute, `cover()` relationship, eager-loading (FR-046-02)
+  - Back-end: widen `SetAsCoverRequest` and controller to accept `TagAlbum` (FR-046-03, FR-046-04)
+  - API resources: `HeadTagAlbumResource`, `EditableBaseAlbumResource` (FR-046-05, FR-046-06)
+  - Front-end: split context menu guard, show "Set as cover" for tag albums (FR-046-07, FR-046-08)
+  - Tag album thumb resolution respects `cover_id` (FR-046-09)
+  - Tests for tag album cover scenarios
+
+- **Out of scope:**
+  - Precomputed covers for tag albums (NG1)
+  - Header photo for tag albums (NG2)
+  - Smart album covers (NG3)
+  - Any changes to `albums.cover_id` or `HasAlbumThumb` (NG4)
+
+## Dependencies & Interfaces
+
+- `TagAlbum` model (`app/Models/TagAlbum.php`) — add `cover_id`, `cover()`, eager-loading
+- `SetAsCoverRequest` (`app/Http/Requests/Album/SetAsCoverRequest.php`) — remove `instanceof Album` guard
+- `AlbumController::cover()` (`app/Http/Controllers/Gallery/AlbumController.php`) — already generic enough
+- `HeadTagAlbumResource` (`app/Http/Resources/Models/HeadTagAlbumResource.php`) — add `cover_id`
+- `EditableBaseAlbumResource` (`app/Http/Resources/Editable/EditableBaseAlbumResource.php`) — move `cover_id` assignment outside `instanceof Album` block
+- Front-end `contextMenu.ts` (`resources/js/composables/contextMenus/contextMenu.ts`) — split guard at lines 126–148
+- Front-end `AlbumState.ts` — `tagAlbum` store state already available
+- `photo-service.ts` — `setAsCover()` already generic, no changes needed
+
+## Assumptions & Risks
+
+- **Assumptions:**
+  - `TagAlbum` attributes work like `Album` attributes — the `ForwardsToParentImplementation` trait handles `cover_id` on the child table correctly (it should, since `TagAlbum::$attributes` is where child-specific columns are listed).
+  - The `photo-service.ts::setAsCover()` call is type-agnostic — it sends `album_id` and `photo_id` without caring about album type.
+
+- **Risks / Mitigations:**
+  | Risk | Likelihood | Impact | Mitigation |
+  |------|-----------|--------|------------|
+  | `ForwardsToParentImplementation` miscategorises `cover_id` (tries to save to `base_albums`) | Low | High | Verify by adding `cover_id` to `TagAlbum::$attributes` array explicitly |
+  | Context menu split introduces regression for regular album header menu | Low | Medium | Keep header guard `is_model_album`-only; test both album types manually |
+
+## Increment Map
+
+### I1 – Database Migration (~15 min)
+
+- _Goal:_ Add `cover_id` to `tag_albums`.
+- _Preconditions:_ None.
+- _Steps:_
+  1. Create migration file.
+  2. `up()`: Add nullable `cover_id` char(24) to `tag_albums`. Add FK constraint to `photos.id` with SET NULL on delete.
+  3. `down()`: Drop FK, drop column.
+  4. Run tests (migrations auto-apply to test SQLite DB).
+- _Commands:_ `php artisan test`
+- _Exit:_ Migration applies and rolls back cleanly; existing tests pass.
+- _Covers:_ FR-046-01, NFR-046-01
+
+### I2 – Model Layer (~30 min)
+
+- _Goal:_ `TagAlbum` gains `cover_id`, `cover()` relationship, eager-loading, and updated thumb resolution.
+- _Preconditions:_ I1 applied.
+- _Steps:_
+  1. Add `'cover_id' => null` to `TagAlbum::$attributes`.
+  2. Add `cover()` HasOne relationship to `TagAlbum` (same pattern as `Album::cover()`).
+  3. Add `'cover', 'cover.size_variants'` to `TagAlbum::$with` (or define a `$with` property if not present) for eager-loading (NFR-046-04).
+  4. Update `TagAlbum::getThumbAttribute()`: if `$this->cover_id !== null`, return `Thumb::createFromPhoto($this->cover)` instead of the dynamic query.
+  5. Run PHPStan and tests.
+- _Commands:_ `make phpstan`, `php artisan test`
+- _Exit:_ PHPStan clean, all existing tests pass, `TagAlbum::cover()` works.
+- _Covers:_ FR-046-02, FR-046-09, NFR-046-02, NFR-046-03, NFR-046-04
+
+### I3 – Back-end API (~20 min)
+
+- _Goal:_ Widen `SetAsCoverRequest`, update resource serialisation.
+- _Preconditions:_ I2 complete.
+- _Steps:_
+  1. In `SetAsCoverRequest::processValidatedValues()`: replace `if (!$album instanceof Album)` with a check that accepts both `Album` and `TagAlbum` (reject only non-BaseAlbum types like smart albums). Update `$this->album` typing accordingly.
+  2. Verify `AlbumController::cover()` — it accesses `$album->cover_id` which will work for `TagAlbum` now. No changes expected.
+  3. In `EditableBaseAlbumResource`: move `$this->cover_id = $album->cover_id` outside the `instanceof Album` block so tag albums also get their `cover_id` serialised.
+  4. In `HeadTagAlbumResource`: add `public ?string $cover_id` property, populate with `$tag_album->cover_id`.
+  5. In `PhotosToBeDeletedDTO::forceDelete()`: add `DB::table('tag_albums')->whereIn('cover_id', $chunk->all())->update(['cover_id' => null])` alongside the existing `albums.cover_id` nullification (line 103). This ensures tag album covers are cleared when the referenced photo is deleted via the application delete path.
+  6. Run PHPStan.
+- _Commands:_ `make phpstan`, `php artisan test`
+- _Exit:_ API accepts cover-setting for tag albums; resources serialise `cover_id`; photo deletion clears tag album covers.
+- _Covers:_ FR-046-03, FR-046-04, FR-046-05, FR-046-06, FR-046-10, S-046-01, S-046-02, S-046-04, S-046-08
+
+### I4 – Front-end (~30 min)
+
+- _Goal:_ Show "Set as cover" for tag album photos; keep "Set as header" album-only.
+- _Preconditions:_ I3 complete.
+- _Steps:_
+  1. In `contextMenu.ts`, split the guard block at lines 126–148:
+     - "Set as cover": show when `is_model_album === true` OR `albumStore.tagAlbum !== undefined` (and user has `can_edit`).
+     - "Set as header" / "Remove header": keep existing `is_model_album === true` guard.
+  2. For tag albums, `selectors.album.value` is a `HeadTagAlbumResource`. The callback `photoCallbacks.setAsCover` needs to use `selectors.album.value.id` — verify this works for both resource types.
+  3. Update TypeScript types if `HeadTagAlbumResource` now includes `cover_id` (regenerate via `php artisan typescript:transform` or update `lychee.d.ts` manually).
+  4. Run `npm run check`.
+- _Commands:_ `npm run format`, `npm run check`
+- _Exit:_ Context menu works correctly for both album types.
+- _Covers:_ FR-046-07, FR-046-08, UI-046-01, UI-046-02, UI-046-03, S-046-05, S-046-06, S-046-07
+
+### I5 – Tests (~30 min)
+
+- _Goal:_ Feature tests for tag album cover.
+- _Preconditions:_ I3 complete.
+- _Steps:_
+  1. Create `tests/Feature_v2/TagAlbum/TagAlbumSetCoverTest.php`.
+  2. Test S-046-01: Set cover on tag album → verify `cover_id` persisted.
+  3. Test S-046-02: Toggle cover off (same photo) → verify `cover_id` null.
+  4. Test S-046-04: Delete cover photo → verify `cover_id` null (FK cascade).
+  5. Test authorization: user without edit permission gets 403.
+  6. Verify existing `AlbumSetCoverTest` still passes (S-046-03).
+  7. Full test suite.
+- _Commands:_ `php artisan test`, `make phpstan`
+- _Exit:_ All tests green.
+- _Covers:_ S-046-01 through S-046-06, NFR-046-03
+
+## Scenario Tracking
+
+| Scenario ID | Increment / Task reference | Notes |
+|-------------|---------------------------|-------|
+| S-046-01 | I3 / I5 | Set cover on tag album |
+| S-046-02 | I3 / I5 | Toggle cover off |
+| S-046-03 | I2 / I5 | Existing album cover unchanged |
+| S-046-04 | I5 | FK cascade test |
+| S-046-05 | I4 | Context menu visible with edit |
+| S-046-06 | I4 | Context menu hidden without edit |
+| S-046-07 | I4 | No "Set as header" for tag albums |
+| S-046-08 | I3 | API returns cover_id |
+
+## Analysis Gate
+
+All open questions resolved (Q-046-01 B, Q-046-02 B, Q-046-03 N/A). Ready for implementation.
+
+## Exit Criteria
+
+- [ ] All tasks checked off
+- [ ] `php artisan test` — all tests green
+- [ ] `make phpstan` — 0 errors
+- [ ] `vendor/bin/php-cs-fixer fix` — no changes
+- [ ] `npm run format` — no changes
+- [ ] `npm run check` — clean
+- [ ] Existing `AlbumSetCoverTest` passes
+- [ ] New `TagAlbumSetCoverTest` passes
+- [ ] Manual verification: context menu shows "Set as cover" (not "Set as header") in tag album
+
+## Follow-ups / Backlog
+
+- Precomputed automatic covers for tag albums (deferred — see NG1).
+- Header photo support for tag albums (deferred — see NG2).

--- a/docs/specs/4-architecture/features/046-tag-album-cover/spec.md
+++ b/docs/specs/4-architecture/features/046-tag-album-cover/spec.md
@@ -1,0 +1,176 @@
+# Feature 046 – Tag Album Custom Cover
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Feature ID | F-046 |
+| Author(s) | ildyria |
+| Created | 2026-06-28 |
+| Last updated | 2026-06-28 |
+| Related features | F-003 (Album Decorations) |
+| ADRs | — |
+
+> Guardrail: This specification is the single normative source of truth for the feature. Track high- and medium-impact questions in [docs/specs/4-architecture/open-questions.md](../../open-questions.md), encode resolved answers directly in the Requirements/NFR/Behaviour/UI/Telemetry sections below, and use ADRs under `docs/specs/5-decisions/` for architecturally significant clarifications.
+
+## Overview
+
+Tag albums currently have no mechanism for setting a custom cover photo; their thumbnail is dynamically computed from the first matching photo. Regular `Album` models support an explicit `cover_id` FK on the `albums` table. This feature adds a `cover_id` column to the `tag_albums` table so that tag albums can also have a user-selected cover photo. The `albums.cover_id` column remains untouched. The front-end context menu, API route, request validation, and resource serialisation are updated to support both album types.
+
+## Resolved Clarifications
+
+- **Q-046-01 (B):** `cover_id` is added to `tag_albums` only. `albums.cover_id` stays where it is. This avoids touching `HasAlbumThumb` which is tightly coupled to the `Album` model with its precomputed cover fields (`auto_cover_id_max_privilege`, `auto_cover_id_least_privilege`).
+- **Q-046-02 (B):** Front-end guard uses `is_model_album || albumStore.tagAlbum !== undefined` (or equivalent check against the store's `tagAlbum` state). No new `AlbumConfig` flag needed.
+- **Q-046-03 (resolved — not applicable):** Since `cover_id` stays per-model, each model defines its own `cover()` relationship. `TagAlbum` eager-loads its cover photo.
+
+## Goals
+
+- G1: Allow tag album owners to set a custom cover photo via the same "Set as cover" interaction available on regular albums.
+- G2: Add `cover_id` to the `tag_albums` table with its own FK to `photos.id`.
+- G3: Maintain full backward compatibility for existing albums — `albums.cover_id` is not modified.
+- G4: Expose the tag album `cover_id` through the existing API endpoint (`POST /api/v2/Album::cover`) and serialise it in `HeadTagAlbumResource` and `EditableBaseAlbumResource`.
+
+## Non-Goals
+
+- NG1: Automatic cover computation for tag albums (precomputed `auto_cover_id_*` columns). Tag albums resolve photos dynamically via tag matching; precomputed covers require a fundamentally different approach and are out of scope.
+- NG2: Header photo support for tag albums. Headers are album-specific (hero banners with colour palettes, title position, etc.).
+- NG3: Smart album cover support. Smart albums have a different architecture and are out of scope.
+- NG4: Moving `cover_id` to `base_albums`. Decided against (Q-046-01) to avoid `HasAlbumThumb` coupling issues.
+
+## Functional Requirements
+
+| ID | Requirement | Success path | Validation path | Failure path | Telemetry & traces | Source |
+|----|-------------|--------------|-----------------|--------------|-------------------|--------|
+| FR-046-01 | Add nullable `cover_id` char(24) column to `tag_albums` table with FK to `photos.id` (SET NULL on delete). | Column created, FK enforced. | Migration runs cleanly. | Migration fails → rollback. | — | G2 |
+| FR-046-02 | `TagAlbum` model gains `cover_id` attribute and `cover()` HasOne relationship, eager-loaded. | `$tagAlbum->cover_id` and `$tagAlbum->cover` are accessible. | `cover_id` must reference an existing photo or be null. | — | — | G2 |
+| FR-046-03 | `SetAsCoverRequest` accepts both `Album` and `TagAlbum` (remove the `instanceof Album` guard). | Request validates successfully for both album types. | Album ID must resolve to a `BaseAlbum` (not a smart album). Photo ID must exist. | Returns 422 if album is a smart album or IDs are invalid. | — | G1 |
+| FR-046-04 | `AlbumController::cover()` works for both `Album` and `TagAlbum`. | Cover is toggled (set or cleared) on either album type. | — | — | — | G1 |
+| FR-046-05 | `HeadTagAlbumResource` includes `cover_id` in its serialised output. | Front-end receives `cover_id` for tag albums. | — | — | — | G4 |
+| FR-046-06 | `EditableBaseAlbumResource` populates `cover_id` for both album types (remove the `instanceof Album` guard for cover). | Editable resource always returns the cover_id. | — | — | — | G4 |
+| FR-046-07 | Front-end context menu shows "Set as cover" for photos inside tag albums (separate from "Set as header" which remains album-only). | The `is_model_album` guard is split: "Set as cover" shown for model albums and tag albums; "Set as header" shown only for model albums. | User must have `can_edit` permission. | Menu item hidden if no edit permission. | — | G1 |
+| FR-046-08 | Front-end "Set as cover" callback sends the correct API request for tag albums. | `photo-service.setAsCover()` is called with the tag album ID. | — | — | — | G1 |
+| FR-046-09 | Tag album thumb resolution respects explicit `cover_id` over dynamic first-photo. | If `cover_id` is set, `getThumbAttribute()` returns that photo's thumb via the eager-loaded `cover` relationship. If null, falls back to existing dynamic behaviour. | — | — | — | G1 |
+| FR-046-10 | `PhotosToBeDeletedDTO::forceDelete()` nullifies `tag_albums.cover_id` when the referenced photo is deleted. | `tag_albums.cover_id` set to null for any tag album referencing a deleted photo, matching the existing `albums.cover_id` nullification pattern at `PhotosToBeDeletedDTO:103`. | — | Orphaned `cover_id` reference if omitted (FK SET NULL handles DB-level, but the application-level bulk-delete path bypasses FK checks on some DB drivers). | — | G2 |
+
+## Non-Functional Requirements
+
+| ID | Requirement | Driver | Measurement | Dependencies | Source |
+|----|-------------|--------|-------------|-------------|--------|
+| NFR-046-01 | Migration must be reversible. | Data safety | `migrate:rollback` succeeds. | — | G3 |
+| NFR-046-02 | `albums.cover_id` and `HasAlbumThumb` must not be modified. | Stability | Existing Album cover tests pass unchanged. | — | G3 |
+| NFR-046-03 | Existing tests for album cover (`AlbumSetCoverTest`) continue to pass. | Regression prevention | `php artisan test --filter=AlbumSetCoverTest` green. | — | G3 |
+| NFR-046-04 | Tag album cover photo is eager-loaded to avoid N+1 queries on album listing. | Performance | `TagAlbum::$with` includes `cover`. | — | G1 |
+
+## UI / Interaction Mock-ups
+
+### Photo context menu inside a tag album (current vs. new)
+
+```
+CURRENT (tag album):                    NEW (tag album):
++---------------------------+           +---------------------------+
+| ★ Highlight               |           | ★ Highlight               |
+|                           |           | 🖼 Set as cover            |  ← NEW
+| 🏷 Tag                    |           | 🏷 Tag                    |
+| 📄 License                |           | 📄 License                |
+| ✏️ Rename                  |           | ✏️ Rename                  |
+| 📋 Copy to…               |           | 📋 Copy to…               |
+| 📁 Move                   |           | 📁 Move                   |
+| 🗑 Delete                 |           | 🗑 Delete                 |
+| ⬇ Download               |           | ⬇ Download               |
++---------------------------+           +---------------------------+
+```
+
+Note: "Set as header" is NOT shown for tag albums (NG2). The existing guard block in `contextMenu.ts` (lines 126–148) must be split so that "Set as cover" has a broader guard (model album OR tag album) while "Set as header" keeps the `is_model_album`-only guard.
+
+## Branch & Scenario Matrix
+
+| Scenario ID | Description / Expected outcome |
+|-------------|--------------------------------|
+| S-046-01 | Set cover on a tag album → `cover_id` persisted in `tag_albums`, thumb displays selected photo. |
+| S-046-02 | Toggle cover off (same photo) on a tag album → `cover_id` set to null, thumb reverts to dynamic. |
+| S-046-03 | Set cover on a regular album → existing behaviour unchanged (`albums.cover_id` used). |
+| S-046-04 | Delete the cover photo via application delete action → `PhotosToBeDeletedDTO::forceDelete()` nullifies `tag_albums.cover_id` (matching existing `albums.cover_id` nullification at line 103). |
+| S-046-05 | Context menu on tag album photo shows "Set as cover" when user has edit permission. |
+| S-046-06 | Context menu on tag album photo hides "Set as cover" when user lacks edit permission. |
+| S-046-07 | Context menu on tag album photo does NOT show "Set as header". |
+| S-046-08 | API returns `cover_id` in `HeadTagAlbumResource` response. |
+
+## Test Strategy
+
+- **Unit:** Test `TagAlbum` model has `cover()` relationship. Test `TagAlbum::getThumbAttribute()` respects `cover_id`.
+- **Feature:** Create `TagAlbumSetCoverTest` for S-046-01, S-046-02, S-046-04. Verify S-046-03 passes via existing `AlbumSetCoverTest`.
+- **UI:** Manual verification of context menu visibility (S-046-05, S-046-06, S-046-07) and cover display.
+
+## Interface & Contract Catalogue
+
+### Domain Objects
+
+| ID | Description | Modules |
+|----|-------------|---------|
+| DO-046-01 | `tag_albums.cover_id` — nullable char(24) FK to `photos.id` (SET NULL on delete) | Migration |
+| DO-046-02 | `TagAlbum::cover()` — HasOne relationship to Photo, eager-loaded | Model |
+
+### API Routes / Services
+
+| ID | Transport | Description | Notes |
+|----|-----------|-------------|-------|
+| API-046-01 | POST /api/v2/Album::cover | Set/toggle cover — now accepts both Album and TagAlbum | Existing route, widened scope |
+
+### UI States
+
+| ID | State | Trigger / Expected outcome |
+|----|-------|---------------------------|
+| UI-046-01 | "Set as cover" visible in tag album photo context menu | User has `can_edit` on tag album |
+| UI-046-02 | "Set as cover" hidden in tag album photo context menu | User lacks `can_edit` on tag album |
+| UI-046-03 | "Set as header" NOT visible in tag album photo context menu | Tag album — header is album-only |
+
+## Telemetry & Observability
+
+No new telemetry events. The existing cover-setting flow does not emit events.
+
+## Documentation Deliverables
+
+- Update knowledge map with `TagAlbum.cover_id` relationship.
+
+## Rollout & Migration
+
+1. Laravel migration adds `cover_id` to `tag_albums` with FK to `photos.id` (SET NULL on delete).
+2. Down method drops the column.
+3. No feature flag needed — the change is additive.
+
+## Open Questions
+
+All resolved — see "Resolved Clarifications" section above.
+
+| Question ID | Short description | Resolution |
+|-------------|-------------------|------------|
+| ~~Q-046-01~~ | `cover_id` location | B — add to `tag_albums` only |
+| ~~Q-046-02~~ | Front-end guard mechanism | B — check `is_model_album \|\| tagAlbum` in context menu |
+| ~~Q-046-03~~ | `cover()` relationship location | N/A — per-model, eager-load on TagAlbum |
+
+## Spec DSL
+
+```yaml
+domain_objects:
+  - id: DO-046-01
+    name: tag_albums.cover_id
+    fields:
+      - name: cover_id
+        type: "char(24), nullable"
+        constraints: "FK photos.id, SET NULL on delete"
+  - id: DO-046-02
+    name: TagAlbum::cover
+    type: HasOne<Photo>
+    eager_loaded: true
+routes:
+  - id: API-046-01
+    method: POST
+    path: /api/v2/Album::cover
+    changes: "Accept Album and TagAlbum (was Album-only)"
+ui_states:
+  - id: UI-046-01
+    description: "Set as cover visible in tag album context menu"
+  - id: UI-046-02
+    description: "Set as cover hidden without edit permission"
+  - id: UI-046-03
+    description: "Set as header NOT visible for tag albums"
+```

--- a/docs/specs/4-architecture/features/046-tag-album-cover/tasks.md
+++ b/docs/specs/4-architecture/features/046-tag-album-cover/tasks.md
@@ -1,0 +1,172 @@
+# Feature 046 Tasks – Tag Album Custom Cover
+
+_Status: Draft_
+_Last updated: 2026-06-28_
+
+> Keep this checklist aligned with the feature plan increments. Stage tests before implementation, record verification commands beside each task, and prefer bite-sized entries (≤90 minutes).
+> **Mark tasks `[x]` immediately** after each one passes verification — do not batch completions.
+
+## Phase 1 – Database Migration (I1)
+
+- [ ] T-046-01 – Create migration to add `cover_id` to `tag_albums` (FR-046-01) (~15 min)
+  _Intent:_ Add nullable `cover_id` char(24) column to `tag_albums` with FK to `photos.id` (SET NULL on delete).
+  _Sub-steps:_
+  - Create migration file
+  - `up()`: add nullable char(24) `cover_id`, add FK to `photos.id` with SET NULL on delete
+  - `down()`: drop FK constraint, drop column
+  _Verification commands:_
+  - `php artisan test --filter=AlbumSetCoverTest`
+  - `php artisan test`
+  _Notes:_ Simple additive migration — no data copy needed.
+
+### Phase 1 verification
+- [ ] Migration applies cleanly on test database
+- [ ] Migration rollback works
+- [ ] Existing `AlbumSetCoverTest` passes
+
+## Phase 2 – Model Layer (I2)
+
+- [ ] T-046-02 – Add `cover_id` attribute and `cover()` relationship to `TagAlbum` (FR-046-02, NFR-046-04) (~15 min)
+  _Intent:_ Give `TagAlbum` cover support with eager-loading.
+  _Sub-steps:_
+  - Add `'cover_id' => null` to `TagAlbum::$attributes` array
+  - Add `cover()` HasOne relationship: `$this->hasOne(Photo::class, 'id', 'cover_id')`
+  - Add `'cover', 'cover.size_variants'` to eager-loading (define `protected $with` on `TagAlbum`)
+  - Update PHPDoc block to document `cover_id` and `cover` properties
+  _Verification commands:_
+  - `make phpstan`
+  - `php artisan test`
+
+- [ ] T-046-03 – Update `TagAlbum::getThumbAttribute()` to respect `cover_id` (FR-046-09) (~15 min)
+  _Intent:_ When a tag album has an explicit `cover_id`, return that photo's thumb; otherwise fall back to existing dynamic query.
+  _Sub-steps:_
+  - At the start of `getThumbAttribute()`, check `$this->cover_id !== null`
+  - If set, return `Thumb::createFromPhoto($this->cover)`
+  - Otherwise, keep existing `Thumb::createFromQueryable()` logic
+  _Verification commands:_
+  - `make phpstan`
+  - `php artisan test`
+
+### Phase 2 verification
+- [ ] All phase 2 tasks checked off
+- [ ] PHPStan 0 errors
+- [ ] All existing tests pass
+
+## Phase 3 – Back-end API (I3)
+
+- [ ] T-046-04 – Widen `SetAsCoverRequest` to accept `TagAlbum` (FR-046-03) (~10 min)
+  _Intent:_ Remove the `instanceof Album` guard so tag albums can have covers set via the API.
+  _Sub-steps:_
+  - In `processValidatedValues()`, change `if (!$album instanceof Album)` to accept `BaseAlbum` instances (both `Album` and `TagAlbum`)
+  - Smart albums are already excluded by `findBaseAlbumOrFail()` returning only `BaseAlbum` types
+  _Verification commands:_
+  - `make phpstan`
+  - `php artisan test`
+
+- [ ] T-046-05 – Update `EditableBaseAlbumResource` to include `cover_id` for tag albums (FR-046-06) (~10 min)
+  _Intent:_ Move `$this->cover_id = $album->cover_id` outside the `instanceof Album` block.
+  _Sub-steps:_
+  - In constructor, set `$this->cover_id = $album->cover_id` unconditionally (both `Album` and `TagAlbum` now have it)
+  _Verification commands:_
+  - `make phpstan`
+
+- [ ] T-046-06 – Add `cover_id` to `HeadTagAlbumResource` (FR-046-05, S-046-08) (~10 min)
+  _Intent:_ Serialise `cover_id` for tag album API responses.
+  _Sub-steps:_
+  - Add `public ?string $cover_id` property
+  - Populate `$this->cover_id = $tag_album->cover_id` in constructor
+  _Verification commands:_
+  - `make phpstan`
+
+- [ ] T-046-07 – Verify `AlbumController::cover()` works for tag albums (FR-046-04) (~5 min)
+  _Intent:_ Confirm the controller sets `cover_id` and calls `save()` — both work for `TagAlbum` since it has `cover_id` in `$attributes`.
+  _Verification commands:_
+  - `php artisan test`
+
+- [ ] T-046-08 – Nullify `tag_albums.cover_id` on photo deletion in `PhotosToBeDeletedDTO` (FR-046-10, S-046-04) (~10 min)
+  _Intent:_ When a photo is force-deleted, clear any `tag_albums.cover_id` referencing it — matching the existing `albums.cover_id` nullification at `PhotosToBeDeletedDTO:103`.
+  _Sub-steps:_
+  - In `forceDelete()`, inside the existing chunk loop (after line 103), add: `DB::table('tag_albums')->whereIn('cover_id', $chunk->all())->update(['cover_id' => null]);`
+  _Verification commands:_
+  - `make phpstan`
+  - `php artisan test`
+
+### Phase 3 verification
+- [ ] All phase 3 tasks checked off
+- [ ] PHPStan 0 errors
+- [ ] API accepts cover-setting for tag albums
+- [ ] Photo deletion clears tag album covers
+
+## Phase 4 – Front-end (I4)
+
+- [ ] T-046-09 – Split context menu guard: "Set as cover" for tag albums, "Set as header" album-only (FR-046-07, UI-046-01, UI-046-02, UI-046-03) (~20 min)
+  _Intent:_ The block at `contextMenu.ts:126–148` currently guards both "Set as cover" and "Set as header" behind `is_model_album`. Split into two blocks:
+  - "Set as cover": show when `is_model_album || albumStore.tagAlbum !== undefined` (and `can_edit`)
+  - "Set as header" / "Remove header": keep `is_model_album`-only guard
+  _Sub-steps:_
+  - Import `useAlbumStore` if not already available in the closure
+  - Create separate guard for "Set as cover" that includes tag albums
+  - Keep the header guard `is_model_album`-only
+  - Ensure `selectors.album.value.id` is used for the API call (works for both resource types)
+  _Verification commands:_
+  - `npm run format`
+  - `npm run check`
+
+- [ ] T-046-10 – Update TypeScript types for `HeadTagAlbumResource.cover_id` (FR-046-05) (~10 min)
+  _Intent:_ Regenerate or manually add `cover_id` to the `HeadTagAlbumResource` TypeScript type.
+  _Sub-steps:_
+  - Run `php artisan typescript:transform` or update `lychee.d.ts` manually
+  - Verify `npm run check` passes
+  _Verification commands:_
+  - `npm run check`
+
+### Phase 4 verification
+- [ ] All phase 4 tasks checked off
+- [ ] `npm run check` clean
+- [ ] Context menu shows "Set as cover" for tag album photos
+- [ ] Context menu does NOT show "Set as header" for tag album photos
+
+## Phase 5 – Tests (I5)
+
+- [ ] T-046-11 – Create `TagAlbumSetCoverTest` feature test (S-046-01, S-046-02, S-046-04, S-046-05, S-046-06) (~30 min)
+  _Intent:_ Feature tests covering all tag album cover scenarios.
+  _Sub-steps:_
+  - Create `tests/Feature_v2/TagAlbum/TagAlbumSetCoverTest.php`
+  - Test set cover on tag album (authorized user) → verify `cover_id` persisted
+  - Test toggle cover off (same photo ID) → verify `cover_id` null
+  - Test unauthorized user gets 403
+  - Test deleting cover photo sets `cover_id` to null (via `PhotosToBeDeletedDTO::forceDelete()`)
+  _Verification commands:_
+  - `php artisan test --filter=TagAlbumSetCoverTest`
+  - `php artisan test`
+
+- [ ] T-046-12 – Verify existing `AlbumSetCoverTest` still passes (S-046-03, NFR-046-03) (~5 min)
+  _Intent:_ Regression check — regular album covers unaffected.
+  _Verification commands:_
+  - `php artisan test --filter=AlbumSetCoverTest`
+
+### Phase 5 verification
+- [ ] All phase 5 tasks checked off
+- [ ] All tests green
+- [ ] PHPStan 0 errors
+
+## Phase 6 – Quality Gate & Cleanup
+
+- [ ] T-046-13 – Run full quality gate (~10 min)
+  _Intent:_ Final check before commit.
+  _Verification commands:_
+  - `vendor/bin/php-cs-fixer fix`
+  - `npm run format`
+  - `npm run check`
+  - `php artisan test`
+  - `make phpstan`
+
+- [ ] T-046-14 – Update knowledge map (~5 min)
+  _Intent:_ Document `TagAlbum.cover_id` and `TagAlbum::cover()` in knowledge map.
+  _Verification commands:_ N/A
+
+## Notes / TODOs
+
+- `HasAlbumThumb` is not modified — it remains `Album`-only with its precomputed cover fields.
+- `albums.cover_id` is untouched.
+- The context menu split is the most delicate front-end change — verify both album types manually.

--- a/docs/specs/4-architecture/open-questions.md
+++ b/docs/specs/4-architecture/open-questions.md
@@ -18,6 +18,9 @@ Track unresolved high- and medium-impact questions here. Remove each row as soon
 | Q-043-15 | 043 | Low | Naming inconsistency: existing `CatalogController` vs new `CatalogueSizesController` | Open | 2026-05-31 | 2026-05-31 |
 | Q-043-16 | 043 | Low | Translation key placement: which new strings belong in `webshop.php` vs `dialogs.php`? | Open | 2026-05-31 | 2026-05-31 |
 | Q-043-17 | 043 | Medium | `is_print` must be exposed in basket GET response (via `OrderItemResource`) before frontend `hasPrints` computed can work — cross-increment dependency not captured in tasks | Open | 2026-05-31 | 2026-05-31 |
+| ~~Q-046-01~~ | 046 – Tag Album Cover | High | Should `cover_id` move from `albums` to `base_albums`, or be added only to `tag_albums`? | Resolved (B – add to `tag_albums` only) | 2026-06-28 | 2026-06-28 |
+| ~~Q-046-02~~ | 046 – Tag Album Cover | Medium | Front-end guard: replace `is_model_album` with `has_cover_support` flag, or widen check to include tag albums? | Resolved (B – check `is_model_album \|\| tagAlbum` in context menu) | 2026-06-28 | 2026-06-28 |
+| ~~Q-046-03~~ | 046 – Tag Album Cover | Medium | Should `cover()` relationship and eager-loading live on `BaseAlbumImpl` or remain per-model? | Resolved (N/A – per-model with eager-load on TagAlbum) | 2026-06-28 | 2026-06-28 |
 | Q-040-01 | 040 – Disable Request Caching | Medium | Analysis Gate never formally signed off: plan.md gate checklist has unchecked boxes yet I1–I4 tasks are marked complete; gate must be ticked before implementation is considered verified | Open | 2026-05-31 | 2026-05-31 |
 | ~~Q-045-13~~ | 045 – NSFW Moderation | High | Photo-Album is many-to-many — spec assumes `album_id` FK on photos but photos use a `photo_album` pivot table. "Direct parent album" is ambiguous when a photo is in multiple albums. | Resolved (A – mark all associated albums) | 2026-06-22 | 2026-06-22 |
 | ~~Q-045-14~~ | 045 – NSFW Moderation | High | Block action hard-delete mechanism — spec says "permanently removed" but doesn't specify whether to reuse the existing `Delete` action (handles pivot cleanup, purchasable cleanup, events) or use a simpler raw delete. | Resolved (A – reuse Delete with dedicated force-delete method) | 2026-06-22 | 2026-06-22 |
@@ -3530,3 +3533,37 @@ Default value: `skip`. This gives the admin explicit control over the trade-off 
 
 ---
 
+
+### ~~Q-046-01~~ · Move cover_id to base_albums vs add to tag_albums only ✅ RESOLVED
+
+**Status:** Resolved — **Option B** (add to `tag_albums` only)
+**Feature:** F-046 – Tag Album Custom Cover
+**Priority:** High
+**Opened:** 2026-06-28
+**Resolved:** 2026-06-28
+
+**Resolution:** Option B chosen. `cover_id` is added to `tag_albums` only; `albums.cover_id` remains untouched. This avoids touching `HasAlbumThumb` which is tightly coupled to `Album` with its precomputed cover fields (`auto_cover_id_max_privilege`, `auto_cover_id_least_privilege`). Each model manages its own `cover()` relationship independently. Encoded in FR-046-01, FR-046-02.
+
+---
+
+### ~~Q-046-02~~ · Front-end guard mechanism for cover support ✅ RESOLVED
+
+**Status:** Resolved — **Option B** (check `is_model_album || tagAlbum` in context menu)
+**Feature:** F-046 – Tag Album Custom Cover
+**Priority:** Medium
+**Opened:** 2026-06-28
+**Resolved:** 2026-06-28
+
+**Resolution:** Option B chosen. No new `AlbumConfig` flag. The context menu guard block at `contextMenu.ts:126–148` is split: "Set as cover" uses `is_model_album || albumStore.tagAlbum !== undefined`; "Set as header" keeps the `is_model_album`-only guard. Encoded in FR-046-07, UI-046-03.
+
+---
+
+### ~~Q-046-03~~ · cover() relationship location and eager-loading strategy ✅ RESOLVED
+
+**Status:** Resolved — N/A (per-model with eager-load on TagAlbum)
+**Feature:** F-046 – Tag Album Custom Cover
+**Priority:** Medium
+**Opened:** 2026-06-28
+**Resolved:** 2026-06-28
+
+**Resolution:** Question no longer applies since `cover_id` stays per-model (Q-046-01 → B). `TagAlbum` defines its own `cover()` HasOne relationship and eager-loads it via `$with`. `Album` is unchanged. Encoded in FR-046-02, NFR-046-04.

--- a/docs/specs/4-architecture/roadmap.md
+++ b/docs/specs/4-architecture/roadmap.md
@@ -7,6 +7,7 @@ High-level planning document for Lychee features and architectural initiatives.
 | Feature ID | Name | Status | Priority | Assignee | Started | Updated | Progress |
 |------------|------|--------|----------|----------|---------|---------|----------|
 | 045 | NSFW Detection & Moderation | Implementation | P1 | LycheeOrg | 2026-06-21 | 2026-06-22 | All 7 increments implemented (I1–I7). Backend: 7 enums, 3 migrations (12 config keys, 2 photo columns, nsfw_detections table), NsfwDetection model, NsfwDetectionService + NsfwActionService, DispatchNsfwScanJob + ApplyNsfwAlbumSensitivityJob, AutoScanNsfwOnUpload pipe, NsfwDetectionController + NsfwConfigController, callback/bulk-scan/config-proxy routes, CSRF exemption, ModerationController NSFW approval logic, Delete::forceDeletePhoto(). Frontend: NsfwConfig.vue admin page, MaintenanceBulkScanNsfw component, nsfw-detection-service.ts + nsfw-config-service.ts, Moderation NSFW badge, admin dashboard tile, translation keys. PHPStan 0, vue-tsc clean, php-cs-fixer clean. |
+| 046 | Tag Album Custom Cover | Spec | P2 | ildyria | 2026-06-28 | 2026-06-28 | Spec, plan, tasks drafted. All 3 questions resolved (Q-046-01 B, Q-046-02 B, Q-046-03 N/A). Add `cover_id` to `tag_albums` table (not `base_albums`). 5 increments planned (I1 migration, I2 models, I3 API, I4 frontend, I5 tests), 14 tasks. Includes `PhotosToBeDeletedDTO` cover nullification (FR-046-10). Ready for implementation. |
 
 ## Paused Features
 

--- a/resources/js/components/gallery/albumModule/AlbumPanel.vue
+++ b/resources/js/components/gallery/albumModule/AlbumPanel.vue
@@ -345,6 +345,9 @@ const photoCallbacks = {
 		if (albumStore.modelAlbum !== undefined) {
 			albumStore.modelAlbum.cover_id = albumStore.modelAlbum.cover_id === selectedPhoto.value!.id ? null : selectedPhoto.value!.id;
 		}
+		if (albumStore.tagAlbum !== undefined) {
+			albumStore.tagAlbum.cover_id = albumStore.tagAlbum.cover_id === selectedPhoto.value!.id ? null : selectedPhoto.value!.id;
+		}
 		AlbumService.clearCache(albumStore.album.id);
 	},
 	setAsHeader: () => {

--- a/resources/js/components/gallery/albumModule/PhotoListView.vue
+++ b/resources/js/components/gallery/albumModule/PhotoListView.vue
@@ -5,7 +5,7 @@
 			:key="photo.id"
 			:photo="photo"
 			:is-selected="props.selectedPhotos.includes(photo.id)"
-			:is-cover-id="albumStore.modelAlbum?.cover_id === photo.id"
+			:is-cover-id="albumStore.coverId === photo.id"
 			:is-header-id="albumStore.modelAlbum?.header_id === photo.id"
 			@clicked="handleClicked"
 			@contexted="handleContexted"

--- a/resources/js/components/gallery/albumModule/PhotoThumbPanelList.vue
+++ b/resources/js/components/gallery/albumModule/PhotoThumbPanelList.vue
@@ -15,7 +15,7 @@
 			<PhotoThumb
 				:photo="photo"
 				:is-selected="props.selectedPhotos.includes(photo.id)"
-				:is-cover-id="albumStore.modelAlbum?.cover_id === photo.id"
+				:is-cover-id="albumStore.coverId === photo.id"
 				:is-header-id="albumStore.modelAlbum?.header_id === photo.id"
 				@click="(e: MouseEvent) => maySelect(photo.id, e)"
 				@contextmenu.prevent="(e: MouseEvent) => menuOpen(photo.id, e)"

--- a/resources/js/composables/contextMenus/contextMenu.ts
+++ b/resources/js/composables/contextMenus/contextMenu.ts
@@ -123,14 +123,17 @@ export function useContextMenu(selectors: Selectors, photoCallbacks: PhotoCallba
 			});
 		}
 
-		if (selectors.config?.value?.is_model_album === true && selectors.album !== undefined) {
-			const parent_album = selectors.album.value as App.Http.Resources.Models.HeadAlbumResource;
+		if (selectors.album !== undefined && (selectors.config?.value?.is_model_album === true || albumStore.tagAlbum !== undefined)) {
 			menuItems.push({
 				label: "gallery.menus.set_cover",
 				icon: "pi pi-id-card",
 				callback: photoCallbacks.setAsCover,
-				access: parent_album.rights.can_edit ?? false,
+				access: selectors.album.value?.rights.can_edit ?? false,
 			});
+		}
+
+		if (selectors.config?.value?.is_model_album === true && selectors.album !== undefined) {
+			const parent_album = selectors.album.value as App.Http.Resources.Models.HeadAlbumResource;
 			if (parent_album.header_id === selectedPhoto.id) {
 				menuItems.push({
 					label: "gallery.menus.remove_header",

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -880,6 +880,7 @@ declare namespace App.Http.Resources.Models {
 		slug: string | null;
 		owner_name: string | null;
 		copyright: string | null;
+		cover_id: string | null;
 		is_tag_album: boolean;
 		show_tags: Array<string>;
 		policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;

--- a/resources/js/stores/AlbumState.ts
+++ b/resources/js/stores/AlbumState.ts
@@ -546,6 +546,9 @@ export const useAlbumStore = defineStore("album-store", {
 			| undefined {
 			return state.modelAlbum || state.tagAlbum || state.smartAlbum;
 		},
+		coverId(state): string | undefined {
+			return (state.modelAlbum || state.tagAlbum)?.cover_id ?? undefined;
+		},
 		tagOrModelAlbum(state): App.Http.Resources.Models.HeadAlbumResource | App.Http.Resources.Models.HeadTagAlbumResource | undefined {
 			return state.modelAlbum || state.tagAlbum;
 		},

--- a/tests/Feature_v2/Album/TagAlbumSetCoverTest.php
+++ b/tests/Feature_v2/Album/TagAlbumSetCoverTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\Album;
+
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+
+class TagAlbumSetCoverTest extends BaseApiWithDataTest
+{
+	public function testSetCoverTagAlbumUnauthorizedForbidden(): void
+	{
+		$response = $this->postJson('Album::cover', []);
+		$this->assertUnprocessable($response);
+
+		$response = $this->postJson('Album::cover', [
+			'album_id' => $this->tagAlbum1->id,
+			'photo_id' => $this->photo1->id,
+		]);
+		$this->assertUnauthorized($response);
+
+		$response = $this->actingAs($this->userNoUpload)->postJson('Album::cover', [
+			'album_id' => $this->tagAlbum1->id,
+			'photo_id' => $this->photo1->id,
+		]);
+		$this->assertForbidden($response);
+	}
+
+	public function testSetCoverTagAlbumAllowed(): void
+	{
+		$response = $this->actingAs($this->userMayUpload1)->postJson('Album::cover', []);
+		$this->assertUnprocessable($response);
+
+		// Set the cover ID
+		$response = $this->postJson('Album::cover', [
+			'album_id' => $this->tagAlbum1->id,
+			'photo_id' => $this->photo1->id,
+		]);
+		$this->assertNoContent($response);
+
+		$this->tagAlbum1->refresh();
+		$this->assertEquals($this->photo1->id, $this->tagAlbum1->cover_id);
+
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->tagAlbum1->id]);
+		$this->assertOk($response);
+		$response->assertJson([
+			'config' => [
+				'is_base_album' => true,
+				'is_model_album' => false,
+			],
+			'resource' => [
+				'id' => $this->tagAlbum1->id,
+				'cover_id' => $this->photo1->id,
+			],
+		]);
+
+		// Unset the cover_id by toggling (same photo ID)
+		$response = $this->postJson('Album::cover', [
+			'album_id' => $this->tagAlbum1->id,
+			'photo_id' => $this->photo1->id,
+		]);
+		$this->assertNoContent($response);
+
+		$this->tagAlbum1->refresh();
+		$this->assertNull($this->tagAlbum1->cover_id);
+
+		$response = $this->getJsonWithData('Album::head', ['album_id' => $this->tagAlbum1->id]);
+		$this->assertOk($response);
+		$response->assertJson([
+			'config' => [
+				'is_base_album' => true,
+				'is_model_album' => false,
+			],
+			'resource' => [
+				'id' => $this->tagAlbum1->id,
+				'cover_id' => null,
+			],
+		]);
+	}
+
+	public function testDeleteCoverPhotoNullifiesCoverId(): void
+	{
+		$this->actingAs($this->userMayUpload1);
+
+		// Set the cover
+		$response = $this->postJson('Album::cover', [
+			'album_id' => $this->tagAlbum1->id,
+			'photo_id' => $this->photo1->id,
+		]);
+		$this->assertNoContent($response);
+
+		$this->tagAlbum1->refresh();
+		$this->assertEquals($this->photo1->id, $this->tagAlbum1->cover_id);
+
+		// Delete the photo (from_id is required by DeletePhotosRequest)
+		$response = $this->deleteJson('Photo', [
+			'photo_ids' => [$this->photo1->id],
+			'from_id' => $this->album1->id,
+		]);
+		$this->assertNoContent($response);
+
+		$this->tagAlbum1->refresh();
+		$this->assertNull($this->tagAlbum1->cover_id);
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tag albums can now use a custom cover photo.
  * The photo context menu now shows **Set as cover** for eligible tag albums.
  * Tag album cover selection is reflected in album views and thumbnails.
* **Bug Fixes**
  * Deleting a cover photo now clears the cover selection for tag albums.
  * Switching the same photo on and off correctly updates the cover setting.
* **Tests**
  * Added coverage for permissions, cover selection and toggle behavior, and cover cleanup on photo deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->