### PR TITLE
Add bread-crubs navigation on albums

### DIFF
--- a/app/Actions/Album/Breadcrumb.php
+++ b/app/Actions/Album/Breadcrumb.php
@@ -42,40 +42,28 @@ class Breadcrumb
 
 		$accessible_ids = $this->getAccessibleAncestorIds($ancestors->pluck('id')->all());
 
-		$is_supporter = request()->verify()->is_supporter();
-		$masked = false;
-		$breadcrumb = [];
-
-		foreach ($ancestors as $ancestor) {
-			if (!$masked && in_array($ancestor->id, $accessible_ids, true)) {
-				$breadcrumb[] = new BreadcrumbItemResource(
-					$ancestor->id,
-					$ancestor->title,
-					$is_supporter ? $ancestor->slug : null,
-				);
-			} else {
-				$masked = true;
-				$breadcrumb[] = new BreadcrumbItemResource(null, '...', null);
-			}
-		}
-
-		$breadcrumb = array_reverse($breadcrumb);
-
-		$result = [];
-		$prev_masked = false;
-		foreach ($breadcrumb as $item) {
-			if ($item->id === null) {
-				if (!$prev_masked) {
-					$result[] = $item;
-					$prev_masked = true;
+		/** @var BreadcrumbItemResource[] $batch */
+		[, $batch] = $ancestors->reduceSpread(
+			function (bool $mask, array $batch, object $ancestor) use ($accessible_ids): array {
+				if ($mask) {
+					return [true, $batch];
 				}
-			} else {
-				$result[] = $item;
-				$prev_masked = false;
-			}
-		}
 
-		return $result;
+				if (in_array($ancestor->id, $accessible_ids, true)) {
+					$batch[] = new BreadcrumbItemResource(
+						$ancestor->id,
+						$ancestor->title,
+						$ancestor->slug,
+					);
+				} else {
+					$batch[] = new BreadcrumbItemResource(null, '...', null);
+					$mask = true;
+				}
+
+				return [$mask, $batch];
+			}, false, []);
+
+		return array_reverse($batch);
 	}
 
 	/**

--- a/app/Actions/Album/Breadcrumb.php
+++ b/app/Actions/Album/Breadcrumb.php
@@ -28,6 +28,11 @@ class Breadcrumb
 	 */
 	public function do(Album $album): array
 	{
+		// Disable if v8 is disabled, as the breadcrumb feature is only available in v8.
+		if (config('features.v8') === false) {
+			return [];
+		}
+
 		$ancestors = DB::table('albums')
 			->join('base_albums', 'base_albums.id', '=', 'albums.id')
 			->where('albums._lft', '<', $album->_lft)

--- a/app/Actions/Album/Breadcrumb.php
+++ b/app/Actions/Album/Breadcrumb.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Actions\Album;
+
+use App\Http\Resources\Models\BreadcrumbItemResource;
+use App\Models\Album;
+use App\Policies\AlbumPolicy;
+use App\Policies\AlbumQueryPolicy;
+use Illuminate\Database\Query\Builder as BaseBuilder;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class Breadcrumb
+{
+	public function __construct(
+		protected readonly AlbumQueryPolicy $album_query_policy,
+	) {
+	}
+
+	/**
+	 * @return BreadcrumbItemResource[]
+	 */
+	public function do(Album $album): array
+	{
+		$ancestors = DB::table('albums')
+			->join('base_albums', 'base_albums.id', '=', 'albums.id')
+			->where('albums._lft', '<', $album->_lft)
+			->where('albums._rgt', '>', $album->_rgt)
+			->select(['albums.id', 'base_albums.title', 'base_albums.slug'])
+			->orderByDesc('albums._lft')
+			->get();
+
+		if ($ancestors->isEmpty()) {
+			return [];
+		}
+
+		$accessible_ids = $this->getAccessibleAncestorIds($ancestors->pluck('id')->all());
+
+		$is_supporter = request()->verify()->is_supporter();
+		$masked = false;
+		$breadcrumb = [];
+
+		foreach ($ancestors as $ancestor) {
+			if (!$masked && in_array($ancestor->id, $accessible_ids, true)) {
+				$breadcrumb[] = new BreadcrumbItemResource(
+					$ancestor->id,
+					$ancestor->title,
+					$is_supporter ? $ancestor->slug : null,
+				);
+			} else {
+				$masked = true;
+				$breadcrumb[] = new BreadcrumbItemResource(null, '...', null);
+			}
+		}
+
+		$breadcrumb = array_reverse($breadcrumb);
+
+		$result = [];
+		$prev_masked = false;
+		foreach ($breadcrumb as $item) {
+			if ($item->id === null) {
+				if (!$prev_masked) {
+					$result[] = $item;
+					$prev_masked = true;
+				}
+			} else {
+				$result[] = $item;
+				$prev_masked = false;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @param string[] $ancestor_ids
+	 *
+	 * @return string[]
+	 */
+	private function getAccessibleAncestorIds(array $ancestor_ids): array
+	{
+		$user = Auth::user();
+
+		if ($user?->may_administrate === true) {
+			return $ancestor_ids;
+		}
+
+		$unlocked_album_ids = AlbumPolicy::getUnlockedAlbumIDs();
+
+		$query = DB::table('base_albums')
+			->whereIn('base_albums.id', $ancestor_ids)
+			->select('base_albums.id');
+
+		$this->album_query_policy->joinSubComputedAccessPermissions(
+			$query, 'base_albums.id', 'left', '', false, $user
+		);
+
+		$query->where(fn (BaseBuilder $q) => $this->album_query_policy->appendAccessibilityConditions($q, $user, $unlocked_album_ids));
+
+		return $query->pluck('id')->all();
+	}
+}

--- a/app/Actions/Album/Breadcrumb.php
+++ b/app/Actions/Album/Breadcrumb.php
@@ -42,28 +42,16 @@ class Breadcrumb
 
 		$accessible_ids = $this->getAccessibleAncestorIds($ancestors->pluck('id')->all());
 
-		/** @var BreadcrumbItemResource[] $batch */
-		[, $batch] = $ancestors->reduceSpread(
-			function (bool $mask, array $batch, object $ancestor) use ($accessible_ids): array {
-				if ($mask) {
-					return [true, $batch];
-				}
+		$result = [];
+		foreach ($ancestors as $ancestor) {
+			if (!in_array($ancestor->id, $accessible_ids, true)) {
+				$result[] = new BreadcrumbItemResource(null, '...', null);
+				break;
+			}
+			$result[] = new BreadcrumbItemResource($ancestor->id, $ancestor->title, $ancestor->slug);
+		}
 
-				if (in_array($ancestor->id, $accessible_ids, true)) {
-					$batch[] = new BreadcrumbItemResource(
-						$ancestor->id,
-						$ancestor->title,
-						$ancestor->slug,
-					);
-				} else {
-					$batch[] = new BreadcrumbItemResource(null, '...', null);
-					$mask = true;
-				}
-
-				return [$mask, $batch];
-			}, false, []);
-
-		return array_reverse($batch);
+		return array_reverse($result);
 	}
 
 	/**

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -34,6 +34,7 @@ class SettingsController extends Controller
 		'site_logo',
 		'landing_logo',
 		'landing_header_logo',
+		'breadcrumb_enabled',
 	];
 
 	/**

--- a/app/Http/Controllers/Gallery/AlbumHeadController.php
+++ b/app/Http/Controllers/Gallery/AlbumHeadController.php
@@ -8,6 +8,7 @@
 
 namespace App\Http\Controllers\Gallery;
 
+use App\Actions\Album\Breadcrumb;
 use App\Events\Metrics\AlbumVisit;
 use App\Exceptions\Internal\LycheeLogicException;
 use App\Http\Controllers\MetricsController;
@@ -33,6 +34,11 @@ class AlbumHeadController extends Controller
 {
 	use HasVisitorIdTrait;
 
+	public function __construct(
+		private readonly Breadcrumb $breadcrumb,
+	) {
+	}
+
 	/**
 	 * Provided an albumID, returns the album metadata without children/photos collections.
 	 *
@@ -48,7 +54,7 @@ class AlbumHeadController extends Controller
 		$album_resource = match (true) {
 			$request->album() instanceof BaseSmartAlbum => new HeadSmartAlbumResource($request->album()),
 			$request->album() instanceof TagAlbum => new HeadTagAlbumResource($request->album()),
-			$request->album() instanceof Album => new HeadAlbumResource($request->album()),
+			$request->album() instanceof Album => new HeadAlbumResource($request->album(), $this->breadcrumb->do($request->album())),
 			// @codeCoverageIgnoreStart
 			default => throw new LycheeLogicException('This should not happen'),
 			// @codeCoverageIgnoreEnd

--- a/app/Http/Controllers/Gallery/AlbumHeadController.php
+++ b/app/Http/Controllers/Gallery/AlbumHeadController.php
@@ -54,7 +54,7 @@ class AlbumHeadController extends Controller
 		$album_resource = match (true) {
 			$request->album() instanceof BaseSmartAlbum => new HeadSmartAlbumResource($request->album()),
 			$request->album() instanceof TagAlbum => new HeadTagAlbumResource($request->album()),
-			$request->album() instanceof Album => new HeadAlbumResource($request->album(), $this->breadcrumb->do($request->album())),
+			$request->album() instanceof Album => new HeadAlbumResource($request->album(), $config->is_breadcrumb_enabled ? $this->breadcrumb->do($request->album()) : []),
 			// @codeCoverageIgnoreStart
 			default => throw new LycheeLogicException('This should not happen'),
 			// @codeCoverageIgnoreEnd

--- a/app/Http/Resources/GalleryConfigs/AlbumConfig.php
+++ b/app/Http/Resources/GalleryConfigs/AlbumConfig.php
@@ -36,6 +36,7 @@ class AlbumConfig extends Data
 	public bool $is_mod_frame_enabled;
 	public bool $is_search_accessible;
 	public bool $is_nsfw_warning_visible;
+	public bool $is_breadcrumb_enabled;
 	public AspectRatioCSSType $album_thumb_css_aspect_ratio;
 	public PhotoLayoutType $photo_layout;
 	public bool $is_album_timeline_enabled = false;
@@ -49,6 +50,7 @@ class AlbumConfig extends Data
 
 		$this->is_base_album = $album instanceof BaseAlbum;
 		$this->is_model_album = $album instanceof Album;
+		$this->is_breadcrumb_enabled = $this->is_model_album && $config_manager->getValueAsBool('breadcrumb_enabled');
 		$this->is_password_protected = !$is_accessible && $public_perm?->password !== null;
 		$this->is_nsfw_warning_visible =
 			$album instanceof BaseAlbum &&

--- a/app/Http/Resources/Models/BreadcrumbItemResource.php
+++ b/app/Http/Resources/Models/BreadcrumbItemResource.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Http\Resources\Models;
+
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript()]
+class BreadcrumbItemResource extends Data
+{
+	public function __construct(
+		public ?string $id,
+		public string $title,
+		public ?string $slug,
+	) {
+	}
+}

--- a/app/Http/Resources/Models/HeadAlbumResource.php
+++ b/app/Http/Resources/Models/HeadAlbumResource.php
@@ -18,6 +18,7 @@ use App\Policies\AlbumPolicy;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
 #[TypeScript()]
@@ -55,7 +56,14 @@ class HeadAlbumResource extends Data
 
 	public ?AlbumStatisticsResource $statistics = null;
 
-	public function __construct(Album $album)
+	/** @var BreadcrumbItemResource[] */
+	#[LiteralTypeScriptType('App.Http.Resources.Models.BreadcrumbItemResource[]')]
+	public array $breadcrumb;
+
+	/**
+	 * @param BreadcrumbItemResource[] $breadcrumb
+	 */
+	public function __construct(Album $album, array $breadcrumb = [])
 	{
 		$this->id = $album->id;
 		$this->title = $album->title;
@@ -85,6 +93,7 @@ class HeadAlbumResource extends Data
 		$url = $this->getHeaderUrl($album);
 		$this->preFormattedData = new PreFormattedAlbumData($album, $url);
 		$this->is_pinned = $album->is_pinned;
+		$this->breadcrumb = $breadcrumb;
 
 		if ($this->rights->can_edit) {
 			$this->editable = EditableBaseAlbumResource::fromModel($album);
@@ -95,8 +104,11 @@ class HeadAlbumResource extends Data
 		}
 	}
 
-	public static function fromModel(Album $album): HeadAlbumResource
+	/**
+	 * @param BreadcrumbItemResource[] $breadcrumb
+	 */
+	public static function fromModel(Album $album, array $breadcrumb = []): HeadAlbumResource
 	{
-		return new self($album);
+		return new self($album, $breadcrumb);
 	}
 }

--- a/database/migrations/2026_06_30_140000_add_breadcrumb_config_setting.php
+++ b/database/migrations/2026_06_30_140000_add_breadcrumb_config_setting.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const CAT = 'Gallery';
+
+	public function getConfigs(): array
+	{
+		return [
+			[
+				'key' => 'breadcrumb_enabled',
+				'value' => '1',
+				'cat' => self::CAT,
+				'type_range' => self::BOOL,
+				'is_secret' => false,
+				'description' => 'Enable breadcrumb navigation in the album header',
+				'details' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
+				'level' => 0,
+				'order' => 85,
+				'is_expert' => false,
+			],
+		];
+	}
+};

--- a/lang/ar/all_settings.php
+++ b/lang/ar/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/bg/all_settings.php
+++ b/lang/bg/all_settings.php
@@ -366,6 +366,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -728,6 +729,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
     'category_name' => [
         'config' => 'Основни',

--- a/lang/cz/all_settings.php
+++ b/lang/cz/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/de/all_settings.php
+++ b/lang/de/all_settings.php
@@ -366,6 +366,7 @@ return [
         'album_header_landing_title_enabled' => 'Landingpage-Titel im Album-Header anzeigen',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -728,6 +729,7 @@ return [
         'album_header_landing_title_enabled' => 'Zeigt den Landingpage-Titel am unteren Rand des Album-Headers an. Der Titel kann in den Landingpage-Einstellungen konfiguriert werden.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
     'category_name' => [
         'config' => 'Grundeinstellungen',

--- a/lang/el/all_settings.php
+++ b/lang/el/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/en/all_settings.php
+++ b/lang/en/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/es/all_settings.php
+++ b/lang/es/all_settings.php
@@ -366,6 +366,7 @@ return [
         'album_header_landing_title_enabled' => 'Mostrar el título de la página de destino en el encabezado del álbum',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -728,6 +729,7 @@ return [
         'album_header_landing_title_enabled' => 'Muestra el título de la página de destino en la parte inferior del encabezado del álbum. Puedes configurar el título de la página de destino en el módulo «Página de destino».',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
     'category_name' => [
         'config' => 'Conceptos básicos',

--- a/lang/fa/all_settings.php
+++ b/lang/fa/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/fr/all_settings.php
+++ b/lang/fr/all_settings.php
@@ -366,6 +366,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'documentation' => [
         'version' => 'Version actuelle de Lychee',
@@ -728,6 +729,7 @@ return [
         'album_header_landing_title_enabled' => 'Afficher le titre de la page d\'accueil dans l\'en-tête de l\'album',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
     'category_name' => [
         'config' => 'Les bases',

--- a/lang/hu/all_settings.php
+++ b/lang/hu/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/it/all_settings.php
+++ b/lang/it/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/ja/all_settings.php
+++ b/lang/ja/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/nl/all_settings.php
+++ b/lang/nl/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/no/all_settings.php
+++ b/lang/no/all_settings.php
@@ -366,6 +366,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -728,6 +729,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
     'category_name' => [
         'config' => 'Basics',

--- a/lang/pl/all_settings.php
+++ b/lang/pl/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/pt/all_settings.php
+++ b/lang/pt/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/ru/all_settings.php
+++ b/lang/ru/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/sk/all_settings.php
+++ b/lang/sk/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/sv/all_settings.php
+++ b/lang/sv/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/tr/all_settings.php
+++ b/lang/tr/all_settings.php
@@ -367,6 +367,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -729,6 +730,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
     'category_name' => [
         'config' => 'Basics',

--- a/lang/vi/all_settings.php
+++ b/lang/vi/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/zh_CN/all_settings.php
+++ b/lang/zh_CN/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/lang/zh_TW/all_settings.php
+++ b/lang/zh_TW/all_settings.php
@@ -368,6 +368,7 @@ return [
         'album_header_landing_title_enabled' => 'Display landing title on album header',
         'sm_card_album_source' => 'Album photo source for social media cards',
         'sm_card_image_url' => 'Fallback image URL or photo ID for social media cards',
+        'breadcrumb_enabled' => 'Enable breadcrumb navigation in the album header',
     ],
     'details' => [
         'version' => '',
@@ -730,6 +731,7 @@ return [
         'album_header_landing_title_enabled' => 'Display the landing title at the bottom of the Album header. You can configure the landing title in the Landing page module.',
         'sm_card_album_source' => 'Select whether the header or cover photo of an album is used as the Open Graph image when sharing links on social media.',
         'sm_card_image_url' => 'URL or photo ID used as the Open Graph image when no album-specific image is available. If empty, the landing page background is used.',
+        'breadcrumb_enabled' => 'Display the album ancestry as breadcrumbs in the header bar instead of the back button and title.',
     ],
 
     'category_name' => [

--- a/resources/js/components/headers/AlbumHeader.vue
+++ b/resources/js/components/headers/AlbumHeader.vue
@@ -9,7 +9,7 @@
 	>
 		<template #start>
 			<template v-if="showBreadcrumb">
-				<Breadcrumb :model="breadcrumbModel" class="hidden @min-[28rem]:block max-w-[45vw] border-none bg-transparent p-0" />
+				<LycheeBreadcrumb :items="albumStore.modelAlbum?.breadcrumb ?? []" :current-title="albumStore.album?.title ?? ''" />
 				<div class="flex @min-[28rem]:hidden">
 					<GoBack @go-back="emits('goBack')" />
 				</div>
@@ -105,8 +105,7 @@
 <script setup lang="ts">
 import Button from "primevue/button";
 import Toolbar from "primevue/toolbar";
-import Breadcrumb from "primevue/breadcrumb";
-import { type MenuItem, type MenuItemCommandEvent } from "primevue/menuitem";
+import LycheeBreadcrumb from "./LycheeBreadcrumb.vue";
 import ContextMenu from "primevue/contextmenu";
 import { useContextMenuAlbumAdd } from "@/composables/contextMenus/contextMenuAlbumAdd";
 import Divider from "primevue/divider";
@@ -118,13 +117,11 @@ import { useTogglablesStateStore } from "@/stores/ModalsState";
 import { useFavouriteStore } from "@/stores/FavouriteState";
 import GoBack from "./GoBack.vue";
 import { computed, onMounted } from "vue";
-import { useRouter } from "vue-router";
 import { useAlbumStore } from "@/stores/AlbumState";
 import { useOrderManagementStore } from "@/stores/OrderManagement";
 import { isTouchDevice } from "@/utils/keybindings-utils";
 import { useAlbumActions } from "@/composables/album/albumActions";
 
-const router = useRouter();
 const togglableStore = useTogglablesStateStore();
 const lycheeStore = useLycheeStateStore();
 const favourites = useFavouriteStore();
@@ -148,27 +145,6 @@ const emits = defineEmits<{
 }>();
 
 const showBreadcrumb = computed(() => (albumStore.config?.is_breadcrumb_enabled ?? false) && (albumStore.modelAlbum?.breadcrumb.length ?? 0) > 0);
-
-const breadcrumbModel = computed<MenuItem[]>(() => {
-	const items: MenuItem[] = (albumStore.modelAlbum?.breadcrumb ?? []).map((ancestor) => {
-		const albumId = ancestor.id;
-		return {
-			label: ancestor.title,
-			disabled: albumId === null,
-			command:
-				albumId === null
-					? undefined
-					: (event: MenuItemCommandEvent) => {
-							event.originalEvent.preventDefault();
-							router.push({ name: "album", params: { albumId } });
-						},
-		};
-	});
-
-	items.push({ label: albumStore.album?.title ?? "", disabled: true });
-
-	return items;
-});
 
 function toggleUploadTrack() {
 	document.getElementById("upload_track_file")?.click();

--- a/resources/js/components/headers/AlbumHeader.vue
+++ b/resources/js/components/headers/AlbumHeader.vue
@@ -1,18 +1,24 @@
 <template>
 	<Toolbar
 		v-if="albumStore.album"
-		class="w-full border-0 transition-all duration-100 ease-in-out rounded-none"
+		class="w-full border-0 transition-all duration-100 ease-in-out rounded-none @container"
 		:class="{
 			'max-h-14': !is_full_screen,
 			'max-h-0': is_full_screen,
 		}"
 	>
 		<template #start>
-			<GoBack @go-back="emits('goBack')" />
+			<template v-if="showBreadcrumb">
+				<Breadcrumb :model="breadcrumbModel" class="hidden @min-[28rem]:block max-w-[45vw] border-none bg-transparent p-0" />
+				<div class="flex @min-[28rem]:hidden">
+					<GoBack @go-back="emits('goBack')" />
+				</div>
+			</template>
+			<GoBack v-else @go-back="emits('goBack')" />
 		</template>
 
 		<template #center>
-			{{ albumStore.album.title }}
+			<span :class="{ '@min-[28rem]:hidden': showBreadcrumb }">{{ albumStore.album.title }}</span>
 		</template>
 
 		<template #end>
@@ -99,6 +105,8 @@
 <script setup lang="ts">
 import Button from "primevue/button";
 import Toolbar from "primevue/toolbar";
+import Breadcrumb from "primevue/breadcrumb";
+import { type MenuItem, type MenuItemCommandEvent } from "primevue/menuitem";
 import ContextMenu from "primevue/contextmenu";
 import { useContextMenuAlbumAdd } from "@/composables/contextMenus/contextMenuAlbumAdd";
 import Divider from "primevue/divider";
@@ -109,12 +117,14 @@ import AlbumService from "@/services/album-service";
 import { useTogglablesStateStore } from "@/stores/ModalsState";
 import { useFavouriteStore } from "@/stores/FavouriteState";
 import GoBack from "./GoBack.vue";
-import { onMounted } from "vue";
+import { computed, onMounted } from "vue";
+import { useRouter } from "vue-router";
 import { useAlbumStore } from "@/stores/AlbumState";
 import { useOrderManagementStore } from "@/stores/OrderManagement";
 import { isTouchDevice } from "@/utils/keybindings-utils";
 import { useAlbumActions } from "@/composables/album/albumActions";
 
+const router = useRouter();
 const togglableStore = useTogglablesStateStore();
 const lycheeStore = useLycheeStateStore();
 const favourites = useFavouriteStore();
@@ -136,6 +146,29 @@ const emits = defineEmits<{
 	showSelected: [];
 	openContextMenu: [event: MouseEvent];
 }>();
+
+const showBreadcrumb = computed(() => (albumStore.config?.is_breadcrumb_enabled ?? false) && (albumStore.modelAlbum?.breadcrumb.length ?? 0) > 0);
+
+const breadcrumbModel = computed<MenuItem[]>(() => {
+	const items: MenuItem[] = (albumStore.modelAlbum?.breadcrumb ?? []).map((ancestor) => {
+		const albumId = ancestor.id;
+		return {
+			label: ancestor.title,
+			disabled: albumId === null,
+			command:
+				albumId === null
+					? undefined
+					: (event: MenuItemCommandEvent) => {
+							event.originalEvent.preventDefault();
+							router.push({ name: "album", params: { albumId } });
+						},
+		};
+	});
+
+	items.push({ label: albumStore.album?.title ?? "", disabled: true });
+
+	return items;
+});
 
 function toggleUploadTrack() {
 	document.getElementById("upload_track_file")?.click();

--- a/resources/js/components/headers/LycheeBreadcrumb.vue
+++ b/resources/js/components/headers/LycheeBreadcrumb.vue
@@ -1,6 +1,17 @@
 <template>
-	<nav id="header-breadcrumb" class="hidden @min-[28rem]:flex max-w-[45vw] items-center overflow-hidden whitespace-nowrap h-12">
-		<template v-for="(item, index) in items" :key="item.id ?? index">
+	<!--
+		Rendered right-to-left (flex-row-reverse) over a reversed item list so that, when the
+		chain overflows max-w-[45vw], the container's overflow-hidden clips the oldest/least
+		relevant ancestors first and currentTitle - anchored at the start of the reversed flex
+		flow - always stays visible. The double reversal keeps the visual reading order intact.
+	-->
+	<nav
+		id="header-breadcrumb"
+		class="hidden @min-[28rem]:flex flex-row-reverse justify-end max-w-[45vw] items-center overflow-hidden whitespace-nowrap h-12"
+	>
+		<span class="text-base truncate max-w-32 shrink-0">{{ currentTitle }}</span>
+		<template v-for="(item, index) in reversedItems" :key="item.id ?? index">
+			<i :class="isLTR() ? 'pi-angle-right' : 'pi-angle-left'" class="pi text-sm mx-1 text-muted-color shrink-0" />
 			<RouterLink
 				v-if="item.id !== null"
 				:to="{ name: 'album', params: { albumId: item.id } }"
@@ -9,18 +20,19 @@
 				{{ item.title }}
 			</RouterLink>
 			<span v-else class="text-base truncate max-w-32 text-muted-color">{{ item.title }}</span>
-			<i :class="isLTR() ? 'pi-angle-right' : 'pi-angle-left'" class="pi text-sm mx-1 text-muted-color shrink-0" />
 		</template>
-		<span class="text-base truncate max-w-32">{{ currentTitle }}</span>
 	</nav>
 </template>
 <script setup lang="ts">
+import { computed } from "vue";
 import { useLtRorRtL } from "@/utils/Helpers";
 
-defineProps<{
+const props = defineProps<{
 	items: App.Http.Resources.Models.BreadcrumbItemResource[];
 	currentTitle: string;
 }>();
 
 const { isLTR } = useLtRorRtL();
+
+const reversedItems = computed(() => [...props.items].reverse());
 </script>

--- a/resources/js/components/headers/LycheeBreadcrumb.vue
+++ b/resources/js/components/headers/LycheeBreadcrumb.vue
@@ -1,0 +1,26 @@
+<template>
+	<nav id="header-breadcrumb" class="hidden @min-[28rem]:flex max-w-[45vw] items-center overflow-hidden whitespace-nowrap h-12">
+		<template v-for="(item, index) in items" :key="item.id ?? index">
+			<RouterLink
+				v-if="item.id !== null"
+				:to="{ name: 'album', params: { albumId: item.id } }"
+				class="text-base truncate max-w-32 text-muted-color hover:text-color transition"
+			>
+				{{ item.title }}
+			</RouterLink>
+			<span v-else class="text-base truncate max-w-32 opacity-60">{{ item.title }}</span>
+			<i :class="isLTR() ? 'pi pi-angle-right' : 'pi pi-angle-left'" class="text-sm mx-1 text-muted-color shrink-0" />
+		</template>
+		<span class="text-base truncate max-w-32">{{ currentTitle }}</span>
+	</nav>
+</template>
+<script setup lang="ts">
+import { useLtRorRtL } from "@/utils/Helpers";
+
+defineProps<{
+	items: App.Http.Resources.Models.BreadcrumbItemResource[];
+	currentTitle: string;
+}>();
+
+const { isLTR } = useLtRorRtL();
+</script>

--- a/resources/js/components/headers/LycheeBreadcrumb.vue
+++ b/resources/js/components/headers/LycheeBreadcrumb.vue
@@ -8,8 +8,8 @@
 			>
 				{{ item.title }}
 			</RouterLink>
-			<span v-else class="text-base truncate max-w-32 opacity-60">{{ item.title }}</span>
-			<i :class="isLTR() ? 'pi pi-angle-right' : 'pi pi-angle-left'" class="text-sm mx-1 text-muted-color shrink-0" />
+			<span v-else class="text-base truncate max-w-32 text-muted-color">{{ item.title }}</span>
+			<i :class="isLTR() ? 'pi-angle-right' : 'pi-angle-left'" class="pi text-sm mx-1 text-muted-color shrink-0" />
 		</template>
 		<span class="text-base truncate max-w-32">{{ currentTitle }}</span>
 	</nav>

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -1,1553 +1,1439 @@
 declare namespace App.DTO {
-	export type AlbumSortingCriterion = {
-		column: App.Enum.ColumnSortingType;
-		order: App.Enum.OrderSortingType;
-	};
-	export type PhotoSortingCriterion = {
-		column: App.Enum.ColumnSortingType;
-		order: App.Enum.OrderSortingType;
-	};
-	export type SortingCriterion = {
-		column: App.Enum.ColumnSortingType;
-		order: App.Enum.OrderSortingType;
-	};
+export type AlbumSortingCriterion = {
+column: App.Enum.ColumnSortingType;
+order: App.Enum.OrderSortingType;
+};
+export type PhotoSortingCriterion = {
+column: App.Enum.ColumnSortingType;
+order: App.Enum.OrderSortingType;
+};
+export type SortingCriterion = {
+column: App.Enum.ColumnSortingType;
+order: App.Enum.OrderSortingType;
+};
 }
 declare namespace App.DTO.Nsfw {
-	export type NsfwBboxData = {
-		x: number;
-		y: number;
-		width: number;
-		height: number;
-	};
-	export type NsfwDetectionItemData = {
-		label: App.Enum.NsfwDetectionLabel;
-		confidence: number;
-		bbox: App.DTO.Nsfw.NsfwBboxData;
-		area_pixels: number;
-		area_ratio: number;
-	};
-	export type NsfwDetectionResultsData = {
-		photo_id: string;
-		status: string;
-		should_block: boolean;
-		should_review: boolean;
-		is_sensitive: boolean;
-		all_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
-		block_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
-		review_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
-		sensitive_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
-		error_code: string | null;
-		message: string | null;
-	};
+export type NsfwBboxData = {
+x: number;
+y: number;
+width: number;
+height: number;
+};
+export type NsfwDetectionItemData = {
+label: App.Enum.NsfwDetectionLabel;
+confidence: number;
+bbox: App.DTO.Nsfw.NsfwBboxData;
+area_pixels: number;
+area_ratio: number;
+};
+export type NsfwDetectionResultsData = {
+photo_id: string;
+status: string;
+should_block: boolean;
+should_review: boolean;
+is_sensitive: boolean;
+all_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
+block_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
+review_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
+sensitive_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
+error_code: string | null;
+message: string | null;
+};
 }
 declare namespace App.Enum {
-	export type AlbumDecorationOrientation = "row" | "row-reverse" | "column" | "column-reverse";
-	export type AlbumDecorationType = "none" | "layers" | "album" | "photo" | "all";
-	export type AlbumHeaderSize = "half_screen" | "full_screen";
-	export type AlbumLayoutType = "list" | "grid";
-	export type AlbumTitleColor = "white" | "black" | "colour_1" | "colour_2" | "colour_3" | "colour_4" | "colour_5";
-	export type AlbumTitlePosition = "top_left" | "top_right" | "bottom_left" | "bottom_right" | "center";
-	export type AspectRatioCSSType = "aspect-5x4" | "aspect-4x5" | "aspect-3x2" | "aspect-square" | "aspect-2x3" | "aspect-video";
-	export type AspectRatioType = "5/4" | "3/2" | "1/1" | "2/3" | "4/5" | "16/9";
-	export type CacheTag = "gallery" | "auth" | "user" | "settings" | "statistics" | "users";
-	export type ColumnSortingAlbumType =
-		| "owner_id"
-		| "created_at"
-		| "title"
-		| "description"
-		| "title_strict"
-		| "description_strict"
-		| "min_taken_at"
-		| "max_taken_at";
-	export type ColumnSortingPhotoType =
-		| "owner_id"
-		| "created_at"
-		| "title"
-		| "description"
-		| "title_strict"
-		| "description_strict"
-		| "taken_at"
-		| "is_highlighted"
-		| "type"
-		| "rating_avg";
-	export type ColumnSortingType =
-		| "owner_id"
-		| "created_at"
-		| "title"
-		| "description"
-		| "title_strict"
-		| "description_strict"
-		| "min_taken_at"
-		| "max_taken_at"
-		| "taken_at"
-		| "is_highlighted"
-		| "type"
-		| "rating_avg";
-	export type ConfigType =
-		| "int"
-		| "positive"
-		| "string"
-		| "string_required"
-		| "0|1"
-		| "0|1|2"
-		| ""
-		| "admin_user"
-		| "license"
-		| "map_provider"
-		| "currency";
-	export type CountType = "taken_at" | "created_at";
-	export type CoverFitType = "cover" | "fit";
-	export type DateOrderingType = "older_younger" | "younger_older";
-	export type DbDriverType = "mysql" | "pgsql" | "sqlite";
-	export type DefaultAlbumProtectionType = "private" | "public" | "inherit" | "public_hidden";
-	export type DownloadVariantType = "RAW" | "LIVEPHOTOVIDEO" | "ORIGINAL" | "MEDIUM2X" | "MEDIUM" | "SMALL2X" | "SMALL" | "THUMB2X" | "THUMB";
-	export type FacePermissionMode = "public" | "private" | "privacy-preserving" | "restricted";
-	export type FaceScanStatus = "pending" | "completed" | "failed";
-	export type FileStatus = "uploading" | "processing" | "ready" | "skipped" | "done" | "error";
-	export type FlowStrategy = "auto" | "opt-in";
-	export type ImageOverlayType = "none" | "desc" | "date" | "exif";
-	export type JobStatus = 0 | 1 | 2 | 3;
-	export type LandingBackgroundModeType = "static" | "photo_id" | "random" | "latest_album_cover" | "random_from_album";
-	export type LicenseType =
-		| "none"
-		| "reserved"
-		| "CC0"
-		| "CC-BY-1.0"
-		| "CC-BY-2.0"
-		| "CC-BY-2.5"
-		| "CC-BY-3.0"
-		| "CC-BY-4.0"
-		| "CC-BY-ND-1.0"
-		| "CC-BY-ND-2.0"
-		| "CC-BY-ND-2.5"
-		| "CC-BY-ND-3.0"
-		| "CC-BY-ND-4.0"
-		| "CC-BY-SA-1.0"
-		| "CC-BY-SA-2.0"
-		| "CC-BY-SA-2.5"
-		| "CC-BY-SA-3.0"
-		| "CC-BY-SA-4.0"
-		| "CC-BY-NC-1.0"
-		| "CC-BY-NC-2.0"
-		| "CC-BY-NC-2.5"
-		| "CC-BY-NC-3.0"
-		| "CC-BY-NC-4.0"
-		| "CC-BY-NC-ND-1.0"
-		| "CC-BY-NC-ND-2.0"
-		| "CC-BY-NC-ND-2.5"
-		| "CC-BY-NC-ND-3.0"
-		| "CC-BY-NC-ND-4.0"
-		| "CC-BY-NC-SA-1.0"
-		| "CC-BY-NC-SA-2.0"
-		| "CC-BY-NC-SA-2.5"
-		| "CC-BY-NC-SA-3.0"
-		| "CC-BY-NC-SA-4.0";
-	export type LiveMetricsAccess = "logged-in users" | "admin";
-	export type MapProviders = "OpenStreetMap.org" | "OpenStreetMap.de" | "OpenStreetMap.fr" | "RRZE";
-	export type MessageType = "info" | "warning" | "error";
-	export type MetricsAccess = "public" | "logged-in users" | "owner" | "admin";
-	export type MetricsAction = "visit" | "favourite" | "download" | "shared";
-	export type NsfwBlockFindingAction = "block" | "moderate" | "approve";
-	export type NsfwDetectionLabel =
-		| "FEMALE_GENITALIA_COVERED"
-		| "FACE_FEMALE"
-		| "BUTTOCKS_EXPOSED"
-		| "FEMALE_BREAST_EXPOSED"
-		| "FEMALE_GENITALIA_EXPOSED"
-		| "MALE_BREAST_EXPOSED"
-		| "ANUS_EXPOSED"
-		| "FEET_EXPOSED"
-		| "BELLY_COVERED"
-		| "FEET_COVERED"
-		| "ARMPITS_COVERED"
-		| "ARMPITS_EXPOSED"
-		| "FACE_MALE"
-		| "BELLY_EXPOSED"
-		| "MALE_GENITALIA_EXPOSED"
-		| "ANUS_COVERED"
-		| "FEMALE_BREAST_COVERED"
-		| "BUTTOCKS_COVERED";
-	export type NsfwPreset = "default" | "strict" | "moderation" | "nude_female" | "permissive" | "social_media";
-	export type NsfwSensitiveAlbumAction = "mark_album" | "nothing";
-	export type NsfwSensitiveNoAlbumAction = "skip" | "moderate";
-	export type NsfwStatus = "pending" | "failed" | "review" | "visible";
-	export type OauthProvidersType =
-		| "amazon"
-		| "apple"
-		| "authelia"
-		| "authentik"
-		| "facebook"
-		| "github"
-		| "google"
-		| "mastodon"
-		| "microsoft"
-		| "nextcloud"
-		| "keycloak";
-	export type OgImageAlbumSourceType = "header" | "cover";
-	export type OmnipayProviderType = "Dummy" | "Mollie" | "PayPal" | "Stripe";
-	export type OrderSortingType = "ASC" | "DESC";
-	export type PaginationMode = "infinite_scroll" | "load_more_button" | "page_navigation";
-	export type PaymentStatusType = "pending" | "cancelled" | "failed" | "refunded" | "processing" | "offline" | "completed" | "closed";
-	export type PhotoHighlightVisibilityType = "anonymous" | "authenticated" | "editor";
-	export type PhotoLayoutType = "square" | "justified" | "masonry" | "grid";
-	export type PhotoThumbInfoType = "title" | "description";
-	export type PhotoWebhookEvent = "photo.add" | "photo.move" | "photo.delete";
-	export type PurchasableLicenseType = "personal" | "commercial" | "extended" | "print";
-	export type PurchasableSizeVariantType = "medium" | "medium2x" | "original" | "full";
-	export type RenamerModeType = "first" | "all" | "regex" | "trim" | "strtolower" | "strtoupper" | "ucwords" | "ucfirst";
-	export type SeverityType = "emergency" | "alert" | "critical" | "error" | "warning" | "notice" | "info" | "debug";
-	export type SharedAlbumsVisibility = "show" | "separate" | "separate_shared_only" | "hide";
-	export type ShiftType = "relative" | "absolute";
-	export type ShiftX = "left" | "right";
-	export type ShiftY = "up" | "down";
-	export type SizeVariantType = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
-	export type SmallLargeType = "small" | "large";
-	export type SmartAlbumType =
-		| "unsorted"
-		| "highlighted"
-		| "recent"
-		| "on_this_day"
-		| "untagged"
-		| "unrated"
-		| "one_star"
-		| "two_stars"
-		| "three_stars"
-		| "four_stars"
-		| "five_stars"
-		| "best_pictures"
-		| "my_rated_pictures"
-		| "my_best_pictures";
-	export type StorageDiskType = "images" | "s3";
-	export type ThumbAlbumSubtitleType = "description" | "takedate" | "creation" | "oldstyle" | "num_photos" | "num_albums" | "num_photos_albums";
-	export type TimelineAlbumGranularity = "default" | "disabled" | "year" | "month" | "day";
-	export type TimelinePhotoGranularity = "default" | "disabled" | "year" | "month" | "day" | "hour";
-	export type UpdateStatus = 0 | 1 | 2 | 3;
-	export type UserGroupRole = "member" | "admin";
-	export type UserSharedAlbumsVisibility = "default" | "show" | "separate" | "separate_shared_only" | "hide";
-	export type UserUploadTrustLevel = "check" | "monitor" | "trust_but_verify" | "trusted";
-	export type VersionChannelType = "release" | "git" | "tag";
-	export type VisibilityType = "never" | "always" | "hover";
-	export type WatermarkPosition = "top-left" | "top" | "top-right" | "left" | "center" | "right" | "bottom-left" | "bottom" | "bottom-right";
-	export type WebhookMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
-	export type WebhookPayloadFormat = "json" | "query_string";
+export type AlbumDecorationOrientation = 'row' | 'row-reverse' | 'column' | 'column-reverse';
+export type AlbumDecorationType = 'none' | 'layers' | 'album' | 'photo' | 'all';
+export type AlbumHeaderSize = 'half_screen' | 'full_screen';
+export type AlbumLayoutType = 'list' | 'grid';
+export type AlbumTitleColor = 'white' | 'black' | 'colour_1' | 'colour_2' | 'colour_3' | 'colour_4' | 'colour_5';
+export type AlbumTitlePosition = 'top_left' | 'top_right' | 'bottom_left' | 'bottom_right' | 'center';
+export type AspectRatioCSSType = 'aspect-5x4' | 'aspect-4x5' | 'aspect-3x2' | 'aspect-square' | 'aspect-2x3' | 'aspect-video';
+export type AspectRatioType = '5/4' | '3/2' | '1/1' | '2/3' | '4/5' | '16/9';
+export type CacheTag = 'gallery' | 'auth' | 'user' | 'settings' | 'statistics' | 'users';
+export type ColumnSortingAlbumType = 'owner_id' | 'created_at' | 'title' | 'description' | 'title_strict' | 'description_strict' | 'min_taken_at' | 'max_taken_at';
+export type ColumnSortingPhotoType = 'owner_id' | 'created_at' | 'title' | 'description' | 'title_strict' | 'description_strict' | 'taken_at' | 'is_highlighted' | 'type' | 'rating_avg';
+export type ColumnSortingType = 'owner_id' | 'created_at' | 'title' | 'description' | 'title_strict' | 'description_strict' | 'min_taken_at' | 'max_taken_at' | 'taken_at' | 'is_highlighted' | 'type' | 'rating_avg';
+export type ConfigType = 'int' | 'positive' | 'string' | 'string_required' | '0|1' | '0|1|2' | '' | 'admin_user' | 'license' | 'map_provider' | 'currency';
+export type CountType = 'taken_at' | 'created_at';
+export type CoverFitType = 'cover' | 'fit';
+export type DateOrderingType = 'older_younger' | 'younger_older';
+export type DbDriverType = 'mysql' | 'pgsql' | 'sqlite';
+export type DefaultAlbumProtectionType = 'private' | 'public' | 'inherit' | 'public_hidden';
+export type DownloadVariantType = 'RAW' | 'LIVEPHOTOVIDEO' | 'ORIGINAL' | 'MEDIUM2X' | 'MEDIUM' | 'SMALL2X' | 'SMALL' | 'THUMB2X' | 'THUMB';
+export type FacePermissionMode = 'public' | 'private' | 'privacy-preserving' | 'restricted';
+export type FaceScanStatus = 'pending' | 'completed' | 'failed';
+export type FileStatus = 'uploading' | 'processing' | 'ready' | 'skipped' | 'done' | 'error';
+export type FlowStrategy = 'auto' | 'opt-in';
+export type ImageOverlayType = 'none' | 'desc' | 'date' | 'exif';
+export type JobStatus = 0 | 1 | 2 | 3;
+export type LandingBackgroundModeType = 'static' | 'photo_id' | 'random' | 'latest_album_cover' | 'random_from_album';
+export type LicenseType = 'none' | 'reserved' | 'CC0' | 'CC-BY-1.0' | 'CC-BY-2.0' | 'CC-BY-2.5' | 'CC-BY-3.0' | 'CC-BY-4.0' | 'CC-BY-ND-1.0' | 'CC-BY-ND-2.0' | 'CC-BY-ND-2.5' | 'CC-BY-ND-3.0' | 'CC-BY-ND-4.0' | 'CC-BY-SA-1.0' | 'CC-BY-SA-2.0' | 'CC-BY-SA-2.5' | 'CC-BY-SA-3.0' | 'CC-BY-SA-4.0' | 'CC-BY-NC-1.0' | 'CC-BY-NC-2.0' | 'CC-BY-NC-2.5' | 'CC-BY-NC-3.0' | 'CC-BY-NC-4.0' | 'CC-BY-NC-ND-1.0' | 'CC-BY-NC-ND-2.0' | 'CC-BY-NC-ND-2.5' | 'CC-BY-NC-ND-3.0' | 'CC-BY-NC-ND-4.0' | 'CC-BY-NC-SA-1.0' | 'CC-BY-NC-SA-2.0' | 'CC-BY-NC-SA-2.5' | 'CC-BY-NC-SA-3.0' | 'CC-BY-NC-SA-4.0';
+export type LiveMetricsAccess = 'logged-in users' | 'admin';
+export type MapProviders = 'OpenStreetMap.org' | 'OpenStreetMap.de' | 'OpenStreetMap.fr' | 'RRZE';
+export type MessageType = 'info' | 'warning' | 'error';
+export type MetricsAccess = 'public' | 'logged-in users' | 'owner' | 'admin';
+export type MetricsAction = 'visit' | 'favourite' | 'download' | 'shared';
+export type NsfwBlockFindingAction = 'block' | 'moderate' | 'approve';
+export type NsfwDetectionLabel = 'FEMALE_GENITALIA_COVERED' | 'FACE_FEMALE' | 'BUTTOCKS_EXPOSED' | 'FEMALE_BREAST_EXPOSED' | 'FEMALE_GENITALIA_EXPOSED' | 'MALE_BREAST_EXPOSED' | 'ANUS_EXPOSED' | 'FEET_EXPOSED' | 'BELLY_COVERED' | 'FEET_COVERED' | 'ARMPITS_COVERED' | 'ARMPITS_EXPOSED' | 'FACE_MALE' | 'BELLY_EXPOSED' | 'MALE_GENITALIA_EXPOSED' | 'ANUS_COVERED' | 'FEMALE_BREAST_COVERED' | 'BUTTOCKS_COVERED';
+export type NsfwPreset = 'default' | 'strict' | 'moderation' | 'nude_female' | 'permissive' | 'social_media';
+export type NsfwSensitiveAlbumAction = 'mark_album' | 'nothing';
+export type NsfwSensitiveNoAlbumAction = 'skip' | 'moderate';
+export type NsfwStatus = 'pending' | 'failed' | 'review' | 'visible';
+export type OauthProvidersType = 'amazon' | 'apple' | 'authelia' | 'authentik' | 'facebook' | 'github' | 'google' | 'mastodon' | 'microsoft' | 'nextcloud' | 'keycloak';
+export type OgImageAlbumSourceType = 'header' | 'cover';
+export type OmnipayProviderType = 'Dummy' | 'Mollie' | 'PayPal' | 'Stripe';
+export type OrderSortingType = 'ASC' | 'DESC';
+export type PaginationMode = 'infinite_scroll' | 'load_more_button' | 'page_navigation';
+export type PaymentStatusType = 'pending' | 'cancelled' | 'failed' | 'refunded' | 'processing' | 'offline' | 'completed' | 'closed';
+export type PhotoHighlightVisibilityType = 'anonymous' | 'authenticated' | 'editor';
+export type PhotoLayoutType = 'square' | 'justified' | 'masonry' | 'grid';
+export type PhotoThumbInfoType = 'title' | 'description';
+export type PhotoWebhookEvent = 'photo.add' | 'photo.move' | 'photo.delete';
+export type PurchasableLicenseType = 'personal' | 'commercial' | 'extended' | 'print';
+export type PurchasableSizeVariantType = 'medium' | 'medium2x' | 'original' | 'full';
+export type RenamerModeType = 'first' | 'all' | 'regex' | 'trim' | 'strtolower' | 'strtoupper' | 'ucwords' | 'ucfirst';
+export type SeverityType = 'emergency' | 'alert' | 'critical' | 'error' | 'warning' | 'notice' | 'info' | 'debug';
+export type SharedAlbumsVisibility = 'show' | 'separate' | 'separate_shared_only' | 'hide';
+export type ShiftType = 'relative' | 'absolute';
+export type ShiftX = 'left' | 'right';
+export type ShiftY = 'up' | 'down';
+export type SizeVariantType = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+export type SmallLargeType = 'small' | 'large';
+export type SmartAlbumType = 'unsorted' | 'highlighted' | 'recent' | 'on_this_day' | 'untagged' | 'unrated' | 'one_star' | 'two_stars' | 'three_stars' | 'four_stars' | 'five_stars' | 'best_pictures' | 'my_rated_pictures' | 'my_best_pictures';
+export type StorageDiskType = 'images' | 's3';
+export type ThumbAlbumSubtitleType = 'description' | 'takedate' | 'creation' | 'oldstyle' | 'num_photos' | 'num_albums' | 'num_photos_albums';
+export type TimelineAlbumGranularity = 'default' | 'disabled' | 'year' | 'month' | 'day';
+export type TimelinePhotoGranularity = 'default' | 'disabled' | 'year' | 'month' | 'day' | 'hour';
+export type UpdateStatus = 0 | 1 | 2 | 3;
+export type UserGroupRole = 'member' | 'admin';
+export type UserSharedAlbumsVisibility = 'default' | 'show' | 'separate' | 'separate_shared_only' | 'hide';
+export type UserUploadTrustLevel = 'check' | 'monitor' | 'trust_but_verify' | 'trusted';
+export type VersionChannelType = 'release' | 'git' | 'tag';
+export type VisibilityType = 'never' | 'always' | 'hover';
+export type WatermarkPosition = 'top-left' | 'top' | 'top-right' | 'left' | 'center' | 'right' | 'bottom-left' | 'bottom' | 'bottom-right';
+export type WebhookMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+export type WebhookPayloadFormat = 'json' | 'query_string';
 }
 declare namespace App.Http.Resources.Admin {
-	export type BulkAlbumIdsResource = {
-		ids: Array<string>;
-		capped: boolean;
-	};
-	export type BulkAlbumResource = {
-		id: string;
-		title: string;
-		owner_id: number;
-		owner_name: string;
-		description: string | null;
-		copyright: string | null;
-		license: App.Enum.LicenseType;
-		photo_layout: App.Enum.PhotoLayoutType | null;
-		photo_sorting_col: App.Enum.ColumnSortingPhotoType | null;
-		photo_sorting_order: App.Enum.OrderSortingType | null;
-		album_sorting_col: App.Enum.ColumnSortingAlbumType | null;
-		album_sorting_order: App.Enum.OrderSortingType | null;
-		album_thumb_aspect_ratio: App.Enum.AspectRatioType | null;
-		album_timeline: App.Enum.TimelineAlbumGranularity | null;
-		photo_timeline: App.Enum.TimelinePhotoGranularity | null;
-		is_nsfw: boolean;
-		_lft: number;
-		_rgt: number;
-		is_public: boolean;
-		is_link_required: boolean;
-		grants_full_photo_access: boolean;
-		grants_download: boolean;
-		grants_upload: boolean;
-		created_at: string;
-	};
-	export type ImportDirectoryResource = {
-		directory: string;
-		status: boolean;
-		message: string | null;
-		jobs_count: number | null;
-	};
-	export type ImportFromServerOptionsResource = {
-		delete_imported: boolean;
-		import_via_symlink: boolean;
-		skip_duplicates: boolean;
-		resync_metadata: boolean;
-		delete_missing_photos: boolean;
-		delete_missing_albums: boolean;
-		directory: string;
-	};
-	export type ImportFromServerResource = {
-		status: boolean;
-		message: string;
-		results: App.Http.Resources.Admin.ImportDirectoryResource[];
-		job_count: number;
-	};
-	export type PaginatedBulkAlbumResource = {
-		data: App.Http.Resources.Admin.BulkAlbumResource[];
-		current_page: number;
-		last_page: number;
-		per_page: number;
-		total: number;
-	};
+export type BulkAlbumIdsResource = {
+ids: Array<string>;
+capped: boolean;
+};
+export type BulkAlbumResource = {
+id: string;
+title: string;
+owner_id: number;
+owner_name: string;
+description: string | null;
+copyright: string | null;
+license: App.Enum.LicenseType;
+photo_layout: App.Enum.PhotoLayoutType | null;
+photo_sorting_col: App.Enum.ColumnSortingPhotoType | null;
+photo_sorting_order: App.Enum.OrderSortingType | null;
+album_sorting_col: App.Enum.ColumnSortingAlbumType | null;
+album_sorting_order: App.Enum.OrderSortingType | null;
+album_thumb_aspect_ratio: App.Enum.AspectRatioType | null;
+album_timeline: App.Enum.TimelineAlbumGranularity | null;
+photo_timeline: App.Enum.TimelinePhotoGranularity | null;
+is_nsfw: boolean;
+_lft: number;
+_rgt: number;
+is_public: boolean;
+is_link_required: boolean;
+grants_full_photo_access: boolean;
+grants_download: boolean;
+grants_upload: boolean;
+created_at: string;
+};
+export type ImportDirectoryResource = {
+directory: string;
+status: boolean;
+message: string | null;
+jobs_count: number | null;
+};
+export type ImportFromServerOptionsResource = {
+delete_imported: boolean;
+import_via_symlink: boolean;
+skip_duplicates: boolean;
+resync_metadata: boolean;
+delete_missing_photos: boolean;
+delete_missing_albums: boolean;
+directory: string;
+};
+export type ImportFromServerResource = {
+status: boolean;
+message: string;
+results: App.Http.Resources.Admin.ImportDirectoryResource[];
+job_count: number;
+};
+export type PaginatedBulkAlbumResource = {
+data: App.Http.Resources.Admin.BulkAlbumResource[];
+current_page: number;
+last_page: number;
+per_page: number;
+total: number;
+};
 }
 declare namespace App.Http.Resources.Collections {
-	export type ContactMessageCollectionResource = {
-		data: App.Http.Resources.Models.ContactMessageResource[];
-		current_page: number;
-		per_page: number;
-		total: number;
-	};
-	export type PaginatedAlbumsResource = {
-		data: App.Http.Resources.Models.ThumbAlbumResource[];
-		current_page: number;
-		last_page: number;
-		per_page: number;
-		total: number;
-	};
-	export type PaginatedClustersResource = {
-		data: App.Http.Resources.Models.ClusterPreviewResource[];
-		current_page: number;
-		last_page: number;
-		per_page: number;
-		total: number;
-	};
-	export type PaginatedFaceResource = {
-		data: App.Http.Resources.Models.FaceResource[];
-		current_page: number;
-		last_page: number;
-		per_page: number;
-		total: number;
-	};
-	export type PaginatedModerationResource = {
-		photos: App.Http.Resources.Models.ModerationResource[];
-		current_page: number;
-		last_page: number;
-		per_page: number;
-		total: number;
-	};
-	export type PaginatedPersonsResource = {
-		data: App.Http.Resources.Models.PersonResource[];
-		current_page: number;
-		last_page: number;
-		per_page: number;
-		total: number;
-	};
-	export type PaginatedPhotosResource = {
-		photos: App.Http.Resources.Models.PhotoResource[];
-		current_page: number;
-		last_page: number;
-		per_page: number;
-		total: number;
-	};
-	export type PaginatedWebhookResource = {
-		webhooks: App.Http.Resources.Models.WebhookResource[];
-		current_page: number;
-		last_page: number;
-		per_page: number;
-		total: number;
-	};
-	export type PositionDataResource = {
-		id: string | null;
-		title: string | null;
-		track_url: string | null;
-		photos: App.Http.Resources.Models.PhotoResource[];
-	};
-	export type RootAlbumResource = {
-		smart_albums: App.Http.Resources.Models.ThumbAlbumResource[];
-		tag_albums: App.Http.Resources.Models.ThumbAlbumResource[];
-		pinned_albums: App.Http.Resources.Models.ThumbAlbumResource[];
-		albums: App.Http.Resources.Models.ThumbAlbumResource[];
-		shared_albums: App.Http.Resources.Models.ThumbAlbumResource[];
-		config: App.Http.Resources.GalleryConfigs.RootConfig;
-		rights: App.Http.Resources.Rights.RootAlbumRightsResource;
-	};
-	export type UserGroupDataResource = {
-		user_groups: App.Http.Resources.Models.UserGroupResource[];
-		can_create_delete_user_groups: boolean;
-	};
+export type ContactMessageCollectionResource = {
+data: App.Http.Resources.Models.ContactMessageResource[];
+current_page: number;
+per_page: number;
+total: number;
+};
+export type PaginatedAlbumsResource = {
+data: App.Http.Resources.Models.ThumbAlbumResource[];
+current_page: number;
+last_page: number;
+per_page: number;
+total: number;
+};
+export type PaginatedClustersResource = {
+data: App.Http.Resources.Models.ClusterPreviewResource[];
+current_page: number;
+last_page: number;
+per_page: number;
+total: number;
+};
+export type PaginatedFaceResource = {
+data: App.Http.Resources.Models.FaceResource[];
+current_page: number;
+last_page: number;
+per_page: number;
+total: number;
+};
+export type PaginatedModerationResource = {
+photos: App.Http.Resources.Models.ModerationResource[];
+current_page: number;
+last_page: number;
+per_page: number;
+total: number;
+};
+export type PaginatedPersonsResource = {
+data: App.Http.Resources.Models.PersonResource[];
+current_page: number;
+last_page: number;
+per_page: number;
+total: number;
+};
+export type PaginatedPhotosResource = {
+photos: App.Http.Resources.Models.PhotoResource[];
+current_page: number;
+last_page: number;
+per_page: number;
+total: number;
+};
+export type PaginatedWebhookResource = {
+webhooks: App.Http.Resources.Models.WebhookResource[];
+current_page: number;
+last_page: number;
+per_page: number;
+total: number;
+};
+export type PositionDataResource = {
+id: string | null;
+title: string | null;
+track_url: string | null;
+photos: App.Http.Resources.Models.PhotoResource[];
+};
+export type RootAlbumResource = {
+smart_albums: App.Http.Resources.Models.ThumbAlbumResource[];
+tag_albums: App.Http.Resources.Models.ThumbAlbumResource[];
+pinned_albums: App.Http.Resources.Models.ThumbAlbumResource[];
+albums: App.Http.Resources.Models.ThumbAlbumResource[];
+shared_albums: App.Http.Resources.Models.ThumbAlbumResource[];
+config: App.Http.Resources.GalleryConfigs.RootConfig;
+rights: App.Http.Resources.Rights.RootAlbumRightsResource;
+};
+export type UserGroupDataResource = {
+user_groups: App.Http.Resources.Models.UserGroupResource[];
+can_create_delete_user_groups: boolean;
+};
 }
 declare namespace App.Http.Resources.Diagnostics {
-	export type AlbumTree = {
-		id: string;
-		title: string;
-		parent_id: string | null;
-		_lft: number;
-		_rgt: number;
-	};
-	export type ChangeLogInfo = {
-		version: string;
-		date: string;
-		changes: string;
-	};
-	export type CleaningState = {
-		path: string;
-		base: string;
-		is_not_empty: boolean;
-	};
-	export type ErrorLine = {
-		type: App.Enum.MessageType;
-		message: string;
-		from: string;
-		details: string[];
-	};
-	export type Errors = {
-		_note: string;
-		errors: App.Http.Resources.Diagnostics.ErrorLine[];
-	};
-	export type Permissions = {
-		left: string;
-		right: string;
-	};
-	export type StatisticsCheckResource = {
-		missing_photos: number;
-		missing_albums: number;
-	};
-	export type TreeState = {
-		oddness: number;
-		duplicates: number;
-		wrong_parent: number;
-		missing_parent: number;
-	};
-	export type UpdateCheckInfo = {
-		extra: string;
-		can_update: boolean;
-	};
-	export type UpdateInfo = {
-		info: string;
-		extra: string;
-		channel_name: App.Enum.VersionChannelType;
-		is_docker: boolean;
-	};
+export type AlbumTree = {
+id: string;
+title: string;
+parent_id: string | null;
+_lft: number;
+_rgt: number;
+};
+export type ChangeLogInfo = {
+version: string;
+date: string;
+changes: string;
+};
+export type CleaningState = {
+path: string;
+base: string;
+is_not_empty: boolean;
+};
+export type ErrorLine = {
+type: App.Enum.MessageType;
+message: string;
+from: string;
+details: string[];
+};
+export type Errors = {
+_note: string;
+errors: App.Http.Resources.Diagnostics.ErrorLine[];
+};
+export type Permissions = {
+left: string;
+right: string;
+};
+export type StatisticsCheckResource = {
+missing_photos: number;
+missing_albums: number;
+};
+export type TreeState = {
+oddness: number;
+duplicates: number;
+wrong_parent: number;
+missing_parent: number;
+};
+export type UpdateCheckInfo = {
+extra: string;
+can_update: boolean;
+};
+export type UpdateInfo = {
+info: string;
+extra: string;
+channel_name: App.Enum.VersionChannelType;
+is_docker: boolean;
+};
 }
 declare namespace App.Http.Resources.Editable {
-	export type EditableBaseAlbumResource = {
-		id: string;
-		title: string;
-		slug: string | null;
-		description: string | null;
-		copyright: string | null;
-		license: App.Enum.LicenseType | null;
-		photo_sorting: App.DTO.PhotoSortingCriterion | null;
-		album_sorting: App.DTO.AlbumSortingCriterion | null;
-		aspect_ratio: App.Enum.AspectRatioType | null;
-		photo_layout: App.Enum.PhotoLayoutType | null;
-		header_id: string | null;
-		cover_id: string | null;
-		album_timeline: App.Enum.TimelineAlbumGranularity | null;
-		photo_timeline: App.Enum.TimelinePhotoGranularity | null;
-		tags: Array<string>;
-		is_and: boolean;
-		is_model_album: boolean;
-		is_pinned: boolean;
-	};
-	export type EditableConfigResource = {
-		key: string;
-		value: string | null;
-	};
-	export type UploadMetaResource = {
-		file_name: string;
-		extension: string | null;
-		uuid_name: string | null;
-		stage: App.Enum.FileStatus;
-		chunk_number: number;
-		total_chunks: number;
-		expected_id: string | null;
-		title: string | null;
-		description: string | null;
-	};
+export type EditableBaseAlbumResource = {
+id: string;
+title: string;
+slug: string | null;
+description: string | null;
+copyright: string | null;
+license: App.Enum.LicenseType | null;
+photo_sorting: App.DTO.PhotoSortingCriterion | null;
+album_sorting: App.DTO.AlbumSortingCriterion | null;
+aspect_ratio: App.Enum.AspectRatioType | null;
+photo_layout: App.Enum.PhotoLayoutType | null;
+header_id: string | null;
+cover_id: string | null;
+album_timeline: App.Enum.TimelineAlbumGranularity | null;
+photo_timeline: App.Enum.TimelinePhotoGranularity | null;
+tags: Array<string>;
+is_and: boolean;
+is_model_album: boolean;
+is_pinned: boolean;
+};
+export type EditableConfigResource = {
+key: string;
+value: string | null;
+};
+export type UploadMetaResource = {
+file_name: string;
+extension: string | null;
+uuid_name: string | null;
+stage: App.Enum.FileStatus;
+chunk_number: number;
+total_chunks: number;
+expected_id: string | null;
+title: string | null;
+description: string | null;
+};
 }
 declare namespace App.Http.Resources.Embed {
-	export type EmbedAlbumInfo = {
-		id: string;
-		title: string;
-		description: string | null;
-		photo_count: number;
-		copyright: string | null;
-		license: string | null;
-	};
-	export type EmbedAlbumResource = {
-		album: App.Http.Resources.Embed.EmbedAlbumInfo;
-		photos: App.Http.Resources.Embed.EmbedPhotoResource[];
-	};
-	export type EmbedPhotoResource = {
-		id: string;
-		title: string | null;
-		description: string | null;
-		is_video: boolean;
-		duration: string | null;
-		size_variants: App.Http.Resources.Models.SizeVariantsResouce;
-		exif: { [key: string]: string | null };
-	};
-	export type EmbedStreamResource = {
-		site_title: string;
-		photos: App.Http.Resources.Embed.EmbedPhotoResource[];
-	};
+export type EmbedAlbumInfo = {
+id: string;
+title: string;
+description: string | null;
+photo_count: number;
+copyright: string | null;
+license: string | null;
+};
+export type EmbedAlbumResource = {
+album: App.Http.Resources.Embed.EmbedAlbumInfo;
+photos: App.Http.Resources.Embed.EmbedPhotoResource[];
+};
+export type EmbedPhotoResource = {
+id: string;
+title: string | null;
+description: string | null;
+is_video: boolean;
+duration: string | null;
+size_variants: App.Http.Resources.Models.SizeVariantsResouce;
+exif: { [key: string]: string | null };
+};
+export type EmbedStreamResource = {
+site_title: string;
+photos: App.Http.Resources.Embed.EmbedPhotoResource[];
+};
 }
 declare namespace App.Http.Resources.Flow {
-	export type FlowItemResource = {
-		id: string;
-		title: string;
-		description: string | null;
-		min_max_text: string | null;
-		published_created_at: string;
-		diff_published_created_at: string;
-		owner_name: string | null;
-		is_nsfw: boolean;
-		num_photos: number;
-		num_children: number;
-		cover: App.Http.Resources.Models.SizeVariantsResouce | null;
-		photos: App.Http.Resources.Models.PhotoResource[];
-		statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
-	};
-	export type FlowResource = {
-		albums: App.Http.Resources.Flow.FlowItemResource[];
-		current_page: number;
-		from: number;
-		last_page: number;
-		per_page: number;
-		to: number;
-		total: number;
-	};
-	export type InitResource = {
-		is_mod_flow_enabled: boolean;
-		is_open_album_on_click: boolean;
-		is_display_open_album_button: boolean;
-		is_highlight_first_picture: boolean;
-		is_image_header_enabled: boolean;
-		image_header_cover: App.Enum.CoverFitType;
-		image_header_height: number;
-		is_carousel_enabled: boolean;
-		carousel_height: number;
-		is_blur_nsfw_enabled: boolean;
-		is_compact_mode_enabled: boolean;
-	};
+export type FlowItemResource = {
+id: string;
+title: string;
+description: string | null;
+min_max_text: string | null;
+published_created_at: string;
+diff_published_created_at: string;
+owner_name: string | null;
+is_nsfw: boolean;
+num_photos: number;
+num_children: number;
+cover: App.Http.Resources.Models.SizeVariantsResouce | null;
+photos: App.Http.Resources.Models.PhotoResource[];
+statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
+};
+export type FlowResource = {
+albums: App.Http.Resources.Flow.FlowItemResource[];
+current_page: number;
+from: number;
+last_page: number;
+per_page: number;
+to: number;
+total: number;
+};
+export type InitResource = {
+is_mod_flow_enabled: boolean;
+is_open_album_on_click: boolean;
+is_display_open_album_button: boolean;
+is_highlight_first_picture: boolean;
+is_image_header_enabled: boolean;
+image_header_cover: App.Enum.CoverFitType;
+image_header_height: number;
+is_carousel_enabled: boolean;
+carousel_height: number;
+is_blur_nsfw_enabled: boolean;
+is_compact_mode_enabled: boolean;
+};
 }
 declare namespace App.Http.Resources.Frame {
-	export type FrameData = {
-		timeout: number;
-		src: string;
-		srcset: string;
-	};
+export type FrameData = {
+timeout: number;
+src: string;
+srcset: string;
+};
 }
 declare namespace App.Http.Resources.GalleryConfigs {
-	export type AlbumConfig = {
-		is_base_album: boolean;
-		is_model_album: boolean;
-		is_password_protected: boolean;
-		is_map_accessible: boolean;
-		is_mod_frame_enabled: boolean;
-		is_search_accessible: boolean;
-		is_nsfw_warning_visible: boolean;
-		album_thumb_css_aspect_ratio: App.Enum.AspectRatioCSSType;
-		photo_layout: App.Enum.PhotoLayoutType;
-		is_album_timeline_enabled: boolean;
-		is_photo_timeline_enabled: boolean;
-	};
-	export type ContactConfig = {
-		is_contact_form_enabled: boolean;
-		security_question: string;
-		is_consent_required: boolean;
-		header: string;
-		headline: string;
-		consent_text: string;
-		privacy_policy_url: string;
-		submit_button_text: string;
-		contact_method: string;
-		message_label: string;
-		message_answer: string;
-		thank_you_message: string;
-	};
-	export type FooterConfig = {
-		footer_additional_text: string;
-		footer_show_copyright: boolean;
-		footer_show_social_media: boolean;
-		copyright: string;
-		sm_facebook_url: string;
-		sm_flickr_url: string;
-		sm_instagram_url: string;
-		sm_twitter_url: string;
-		sm_youtube_url: string;
-		is_contact_form_enabled: boolean;
-		contact_header: string;
-	};
-	export type InitConfig = {
-		is_debug_enabled: boolean;
-		are_nsfw_visible: boolean;
-		is_nsfw_background_blurred: boolean;
-		nsfw_banner_override: string;
-		is_nsfw_banner_backdrop_blurred: boolean;
-		show_keybinding_help_popup: boolean;
-		image_overlay_type: App.Enum.ImageOverlayType;
-		can_rotate: boolean;
-		can_autoplay: boolean;
-		is_exif_disabled: boolean;
-		is_favourite_enabled: boolean;
-		photo_previous_next_size: App.Enum.SmallLargeType;
-		is_details_links_enabled: boolean;
-		is_desktop_dock_full_transparency_enabled: boolean;
-		is_mobile_dock_full_transparency_enabled: boolean;
-		is_photo_details_always_open: boolean;
-		is_face_overlay_visible: boolean;
-		is_face_recognition_enabled: boolean;
-		is_nsfw_classifier_enabled: boolean;
-		display_thumb_album_overlay: App.Enum.VisibilityType;
-		display_thumb_photo_overlay: App.Enum.VisibilityType;
-		album_subtitle_type: App.Enum.ThumbAlbumSubtitleType;
-		album_decoration: App.Enum.AlbumDecorationType;
-		album_decoration_orientation: App.Enum.AlbumDecorationOrientation;
-		number_albums_per_row_mobile: 1 | 2 | 3;
-		photo_thumb_info: App.Enum.PhotoThumbInfoType;
-		is_photo_thumb_tags_enabled: boolean;
-		album_layout: App.Enum.AlbumLayoutType;
-		is_raw_download_enabled: boolean;
-		is_thumb_download_enabled: boolean;
-		is_thum2x_download_enabled: boolean;
-		is_small_download_enabled: boolean;
-		is_small2x_download_enabled: boolean;
-		is_medium_download_enabled: boolean;
-		is_medium2x_download_enabled: boolean;
-		is_download_archive_chunked: boolean;
-		clockwork_url: string | null;
-		slideshow_timeout: number;
-		is_slideshow_enabled: boolean;
-		is_timeline_left_border_visible: boolean;
-		title: string;
-		site_logo: string;
-		dropbox_api_key: string;
-		is_se_enabled: boolean;
-		is_pro_enabled: boolean;
-		is_se_preview_enabled: boolean;
-		is_se_info_hidden: boolean;
-		is_se_expired: boolean;
-		is_live_metrics_enabled: boolean;
-		is_white_label_enabled: boolean;
-		is_basic_auth_enabled: boolean;
-		is_webauthn_enabled: boolean;
-		is_registration_enabled: boolean;
-		is_scroll_to_navigate_photos_enabled: boolean;
-		is_swipe_vertically_to_go_back_enabled: boolean;
-		disable_swipe_effect: boolean;
-		is_rating_show_avg_in_details_enabled: boolean;
-		is_rating_show_avg_in_photo_view_enabled: boolean;
-		rating_photo_view_mode: App.Enum.VisibilityType;
-		is_rating_show_avg_in_album_view_enabled: boolean;
-		rating_album_view_mode: App.Enum.VisibilityType;
-		is_embed_enabled: boolean;
-		default_homepage: string;
-		is_timeline_page_enabled: boolean;
-		is_contact_form_enabled: boolean;
-		photos_pagination_mode: App.Enum.PaginationMode;
-		albums_pagination_mode: App.Enum.PaginationMode;
-		photos_per_page: number;
-		albums_per_page: number;
-		photos_infinite_scroll_threshold: number;
-		albums_infinite_scroll_threshold: number;
-		default_album_protection: App.Enum.DefaultAlbumProtectionType;
-		photos_star_visibility: App.Enum.PhotoHighlightVisibilityType;
-		is_album_enhanced_display_enabled: boolean;
-		album_header_size: App.Enum.AlbumHeaderSize;
-		is_album_header_landing_title_enabled: boolean;
-		use_admin_dashboard: boolean;
-	};
-	export type LandingPageResource = {
-		landing_page_enable: boolean;
-		landing_background_landscape: string;
-		landing_background_portrait: string;
-		landing_subtitle: string;
-		landing_title: string;
-		site_owner: string;
-		site_title: string;
-		landing_logo: string;
-		landing_header_logo: string;
-		footer: App.Http.Resources.GalleryConfigs.FooterConfig;
-	};
-	export type MapProviderData = {
-		layer: string;
-		attribution: string;
-	};
-	export type PhotoLayoutConfig = {
-		photo_layout_justified_row_height: number;
-		photo_layout_masonry_column_width: number;
-		photo_layout_grid_column_width: number;
-		photo_layout_square_column_width: number;
-		photo_layout_gap: number;
-	};
-	export type RegisterData = {
-		success: boolean;
-	};
-	export type RootConfig = {
-		is_album_timeline_enabled: boolean;
-		is_search_accessible: boolean;
-		show_keybinding_help_button: boolean;
-		album_thumb_css_aspect_ratio: App.Enum.AspectRatioType;
-		back_button_enabled: boolean;
-		back_button_text: string;
-		back_button_url: string;
-		timeline_album_granularity: App.Enum.TimelineAlbumGranularity;
-		header_image_url: string;
-		is_header_bar_transparent: boolean;
-		is_header_bar_gradient: boolean;
-		shared_albums_visibility_mode: App.Enum.SharedAlbumsVisibility;
-	};
-	export type SettingsConfig = {
-		default_old_settings: boolean;
-		default_expert_settings: boolean;
-		default_all_settings: boolean;
-	};
-	export type UploadConfig = {
-		upload_processing_limit: number;
-		upload_chunk_size: number;
-		can_watermark_optout: boolean;
-		close_upload_on_success: boolean;
-		folder_upload_enabled: boolean;
-		folder_upload_max_depth: number;
-	};
-	export type ZipChunkData = {
-		total_chunks: number;
-		total_photos: number;
-	};
+export type AlbumConfig = {
+is_base_album: boolean;
+is_model_album: boolean;
+is_password_protected: boolean;
+is_map_accessible: boolean;
+is_mod_frame_enabled: boolean;
+is_search_accessible: boolean;
+is_nsfw_warning_visible: boolean;
+album_thumb_css_aspect_ratio: App.Enum.AspectRatioCSSType;
+photo_layout: App.Enum.PhotoLayoutType;
+is_album_timeline_enabled: boolean;
+is_photo_timeline_enabled: boolean;
+};
+export type ContactConfig = {
+is_contact_form_enabled: boolean;
+security_question: string;
+is_consent_required: boolean;
+header: string;
+headline: string;
+consent_text: string;
+privacy_policy_url: string;
+submit_button_text: string;
+contact_method: string;
+message_label: string;
+message_answer: string;
+thank_you_message: string;
+};
+export type FooterConfig = {
+footer_additional_text: string;
+footer_show_copyright: boolean;
+footer_show_social_media: boolean;
+copyright: string;
+sm_facebook_url: string;
+sm_flickr_url: string;
+sm_instagram_url: string;
+sm_twitter_url: string;
+sm_youtube_url: string;
+is_contact_form_enabled: boolean;
+contact_header: string;
+};
+export type InitConfig = {
+is_debug_enabled: boolean;
+are_nsfw_visible: boolean;
+is_nsfw_background_blurred: boolean;
+nsfw_banner_override: string;
+is_nsfw_banner_backdrop_blurred: boolean;
+show_keybinding_help_popup: boolean;
+image_overlay_type: App.Enum.ImageOverlayType;
+can_rotate: boolean;
+can_autoplay: boolean;
+is_exif_disabled: boolean;
+is_favourite_enabled: boolean;
+photo_previous_next_size: App.Enum.SmallLargeType;
+is_details_links_enabled: boolean;
+is_desktop_dock_full_transparency_enabled: boolean;
+is_mobile_dock_full_transparency_enabled: boolean;
+is_photo_details_always_open: boolean;
+is_face_overlay_visible: boolean;
+is_face_recognition_enabled: boolean;
+is_nsfw_classifier_enabled: boolean;
+display_thumb_album_overlay: App.Enum.VisibilityType;
+display_thumb_photo_overlay: App.Enum.VisibilityType;
+album_subtitle_type: App.Enum.ThumbAlbumSubtitleType;
+album_decoration: App.Enum.AlbumDecorationType;
+album_decoration_orientation: App.Enum.AlbumDecorationOrientation;
+number_albums_per_row_mobile: 1|2|3;
+photo_thumb_info: App.Enum.PhotoThumbInfoType;
+is_photo_thumb_tags_enabled: boolean;
+album_layout: App.Enum.AlbumLayoutType;
+is_raw_download_enabled: boolean;
+is_thumb_download_enabled: boolean;
+is_thum2x_download_enabled: boolean;
+is_small_download_enabled: boolean;
+is_small2x_download_enabled: boolean;
+is_medium_download_enabled: boolean;
+is_medium2x_download_enabled: boolean;
+is_download_archive_chunked: boolean;
+clockwork_url: string | null;
+slideshow_timeout: number;
+is_slideshow_enabled: boolean;
+is_timeline_left_border_visible: boolean;
+title: string;
+site_logo: string;
+dropbox_api_key: string;
+is_se_enabled: boolean;
+is_pro_enabled: boolean;
+is_se_preview_enabled: boolean;
+is_se_info_hidden: boolean;
+is_se_expired: boolean;
+is_live_metrics_enabled: boolean;
+is_white_label_enabled: boolean;
+is_basic_auth_enabled: boolean;
+is_webauthn_enabled: boolean;
+is_registration_enabled: boolean;
+is_scroll_to_navigate_photos_enabled: boolean;
+is_swipe_vertically_to_go_back_enabled: boolean;
+disable_swipe_effect: boolean;
+is_rating_show_avg_in_details_enabled: boolean;
+is_rating_show_avg_in_photo_view_enabled: boolean;
+rating_photo_view_mode: App.Enum.VisibilityType;
+is_rating_show_avg_in_album_view_enabled: boolean;
+rating_album_view_mode: App.Enum.VisibilityType;
+is_embed_enabled: boolean;
+default_homepage: string;
+is_timeline_page_enabled: boolean;
+is_contact_form_enabled: boolean;
+photos_pagination_mode: App.Enum.PaginationMode;
+albums_pagination_mode: App.Enum.PaginationMode;
+photos_per_page: number;
+albums_per_page: number;
+photos_infinite_scroll_threshold: number;
+albums_infinite_scroll_threshold: number;
+default_album_protection: App.Enum.DefaultAlbumProtectionType;
+photos_star_visibility: App.Enum.PhotoHighlightVisibilityType;
+is_album_enhanced_display_enabled: boolean;
+album_header_size: App.Enum.AlbumHeaderSize;
+is_album_header_landing_title_enabled: boolean;
+use_admin_dashboard: boolean;
+};
+export type LandingPageResource = {
+landing_page_enable: boolean;
+landing_background_landscape: string;
+landing_background_portrait: string;
+landing_subtitle: string;
+landing_title: string;
+site_owner: string;
+site_title: string;
+landing_logo: string;
+landing_header_logo: string;
+footer: App.Http.Resources.GalleryConfigs.FooterConfig;
+};
+export type MapProviderData = {
+layer: string;
+attribution: string;
+};
+export type PhotoLayoutConfig = {
+photo_layout_justified_row_height: number;
+photo_layout_masonry_column_width: number;
+photo_layout_grid_column_width: number;
+photo_layout_square_column_width: number;
+photo_layout_gap: number;
+};
+export type RegisterData = {
+success: boolean;
+};
+export type RootConfig = {
+is_album_timeline_enabled: boolean;
+is_search_accessible: boolean;
+show_keybinding_help_button: boolean;
+album_thumb_css_aspect_ratio: App.Enum.AspectRatioType;
+back_button_enabled: boolean;
+back_button_text: string;
+back_button_url: string;
+timeline_album_granularity: App.Enum.TimelineAlbumGranularity;
+header_image_url: string;
+is_header_bar_transparent: boolean;
+is_header_bar_gradient: boolean;
+shared_albums_visibility_mode: App.Enum.SharedAlbumsVisibility;
+};
+export type SettingsConfig = {
+default_old_settings: boolean;
+default_expert_settings: boolean;
+default_all_settings: boolean;
+};
+export type UploadConfig = {
+upload_processing_limit: number;
+upload_chunk_size: number;
+can_watermark_optout: boolean;
+close_upload_on_success: boolean;
+folder_upload_enabled: boolean;
+folder_upload_max_depth: number;
+};
+export type ZipChunkData = {
+total_chunks: number;
+total_photos: number;
+};
 }
 declare namespace App.Http.Resources.GalleryConfigs.Nsfw {
-	export type NsfwActionCategoryResource = {
-		labels: App.Enum.NsfwDetectionLabel[];
-		confidence: number | null;
-		area_ratio: number | null;
-		label_thresholds: number[];
-	};
-	export type NsfwConfigPresetResource = {
-		name: App.Enum.NsfwPreset;
-		description: string;
-		block: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
-		review: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
-		sensitive: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
-	};
-	export type NsfwConfigResource = {
-		config: App.Http.Resources.GalleryConfigs.Nsfw.NsfwConfigSettingsResource;
-		presets: App.Http.Resources.GalleryConfigs.Nsfw.NsfwConfigPresetResource[];
-	};
-	export type NsfwConfigSettingsResource = {
-		confidence_threshold: string;
-		area_ratio_threshold: string;
-		debug_detect_threshold: string;
-		block: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
-		review: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
-		sensitive: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
-		queue_backend: string;
-		queue_max_size: string;
-		thread_pool_size: string;
-		verify_ssl: string;
-		workers: string;
-	};
+export type NsfwActionCategoryResource = {
+labels: App.Enum.NsfwDetectionLabel[];
+confidence: number | null;
+area_ratio: number | null;
+label_thresholds: number[];
+};
+export type NsfwConfigPresetResource = {
+name: App.Enum.NsfwPreset;
+description: string;
+block: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
+review: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
+sensitive: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
+};
+export type NsfwConfigResource = {
+config: App.Http.Resources.GalleryConfigs.Nsfw.NsfwConfigSettingsResource;
+presets: App.Http.Resources.GalleryConfigs.Nsfw.NsfwConfigPresetResource[];
+};
+export type NsfwConfigSettingsResource = {
+confidence_threshold: string;
+area_ratio_threshold: string;
+debug_detect_threshold: string;
+block: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
+review: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
+sensitive: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
+queue_backend: string;
+queue_max_size: string;
+thread_pool_size: string;
+verify_ssl: string;
+workers: string;
+};
 }
 declare namespace App.Http.Resources.Models {
-	export type AccessPermissionResource = {
-		id: number | null;
-		user_id: number | null;
-		user_group_id: number | null;
-		username: string | null;
-		user_group_name: string | null;
-		album_title: string | null;
-		album_id: string | null;
-		grants_full_photo_access: boolean;
-		grants_download: boolean;
-		grants_upload: boolean;
-		grants_edit: boolean;
-		grants_delete: boolean;
-	};
-	export type AdminStatsResource = {
-		photos_count: number;
-		albums_count: number;
-		users_count: number;
-		storage_bytes: number;
-		queued_jobs: number;
-		failed_jobs_24h: number;
-		last_successful_job_at: string | null;
-		cached_at: string;
-		errors: Array<string>;
-	};
-	export type AdminUpdateStatusResource = {
-		enabled: boolean;
-		update_status: number | null;
-		has_update: boolean;
-		current_version: string | null;
-		latest_version: string | null;
-	};
-	export type AlbumStatisticsResource = {
-		visit_count: number;
-		download_count: number;
-		shared_count: number;
-	};
-	export type ClusterPreviewResource = {
-		cluster_label: number;
-		face_count: number;
-		sample_crop_urls: string[];
-	};
-	export type ColourPaletteResource = {
-		colour_1: string;
-		colour_2: string;
-		colour_3: string;
-		colour_4: string;
-		colour_5: string;
-	};
-	export type ConfigCategoryResource = {
-		cat: string;
-		name: string;
-		description: string;
-		configs: App.Http.Resources.Models.ConfigResource[];
-		priority: number;
-	};
-	export type ConfigResource = {
-		key: string;
-		type: App.Enum.ConfigType | string;
-		value: string;
-		documentation: string;
-		details: string;
-		is_expert: boolean;
-		require_se: boolean;
-		order: number | null;
-	};
-	export type ContactMessageResource = {
-		id: number;
-		name: string;
-		email: string;
-		message: string;
-		is_read: boolean;
-		created_at: string;
-	};
-	export type FaceResource = {
-		id: string;
-		photo_id: string;
-		person_id: string | null;
-		x: number;
-		y: number;
-		width: number;
-		height: number;
-		confidence: number;
-		laplacian_variance: number;
-		is_dismissed: boolean;
-		cluster_label: number | null;
-		crop_url: string | null;
-		person_name: string | null;
-		suggestions: Array<App.Http.Resources.Models.FaceSuggestionResource>;
-	};
-	export type FaceSuggestionResource = {
-		suggested_face_id: string;
-		crop_url: string | null;
-		person_name: string | null;
-		confidence: number;
-	};
-	export type HeadAbstractAlbumResource = {
-		config: App.Http.Resources.GalleryConfigs.AlbumConfig;
-		resource:
-			| App.Http.Resources.Models.HeadAlbumResource
-			| App.Http.Resources.Models.HeadSmartAlbumResource
-			| App.Http.Resources.Models.HeadTagAlbumResource;
-	};
-	export type HeadAlbumResource = {
-		id: string;
-		title: string;
-		slug: string | null;
-		owner_name: string | null;
-		description: string | null;
-		copyright: string | null;
-		track_url: string | null;
-		license: string;
-		header_id: string | null;
-		parent_id: string | null;
-		has_albums: boolean;
-		num_children: number;
-		num_photos: number;
-		cover_id: string | null;
-		policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
-		rights: App.Http.Resources.Rights.AlbumRightsResource;
-		preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
-		editable: App.Http.Resources.Editable.EditableBaseAlbumResource | null;
-		is_pinned: boolean;
-		statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
-	};
-	export type HeadSmartAlbumResource = {
-		id: string;
-		title: string;
-		policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
-		rights: App.Http.Resources.Rights.AlbumRightsResource;
-		preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
-		statistics: null | null;
-	};
-	export type HeadTagAlbumResource = {
-		id: string;
-		title: string;
-		slug: string | null;
-		owner_name: string | null;
-		copyright: string | null;
-		is_tag_album: boolean;
-		show_tags: Array<string>;
-		policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
-		rights: App.Http.Resources.Rights.AlbumRightsResource;
-		preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
-		editable: App.Http.Resources.Editable.EditableBaseAlbumResource | null;
-		statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
-	};
-	export type JobHistoryResource = {
-		username: string;
-		status: "ready" | "success" | "failure" | "started";
-		created_at: string;
-		updated_at: string;
-		job: string;
-	};
-	export type LightUserResource = {
-		id: number;
-		username: string;
-	};
-	export type LiveMetricsResource = {
-		created_at: string;
-		visitor_id: string;
-		action: App.Enum.MetricsAction;
-		photo_id: string | null;
-		album_id: string;
-		title: string;
-		url: string | null;
-	};
-	export type ModerationResource = {
-		photo_id: string;
-		title: string;
-		thumb_url: string | null;
-		owner_username: string;
-		album_id: string | null;
-		album_title: string | null;
-		created_at: string;
-		nsfw_status: string | null;
-	};
-	export type NsfwDetectionResource = {
-		id: number;
-		photo_id: string;
-		label: string;
-		confidence: number;
-		bbox_x: number;
-		bbox_y: number;
-		bbox_width: number;
-		bbox_height: number;
-		is_block: boolean;
-		is_review: boolean;
-		is_sensitive: boolean;
-	};
-	export type PersonResource = {
-		id: string;
-		name: string;
-		user_id: number | null;
-		is_searchable: boolean;
-		representative_face_id: string | null;
-		face_count: number;
-		photo_count: number;
-		representative_crop_url: string | null;
-	};
-	export type PhotoAlbumResource = {
-		id: string;
-		title: string;
-	};
-	export type PhotoFacesResource = {
-		faces: App.Http.Resources.Models.FaceResource[];
-		hidden_face_count: number;
-		rights: App.Http.Resources.Rights.PhotoRightsResource;
-	};
-	export type PhotoNsfwDetectionsResource = {
-		detections: App.Http.Resources.Models.NsfwDetectionResource[];
-		image_width: number;
-		image_height: number;
-	};
-	export type PhotoRatingResource = {
-		rating_user: number;
-		rating_count: number;
-		rating_avg: number;
-	};
-	export type PhotoResource = {
-		id: string;
-		album_id: string | null;
-		checksum: string;
-		created_at: string;
-		description: string;
-		is_highlighted: boolean;
-		license: App.Enum.LicenseType;
-		live_photo_checksum: string | null;
-		live_photo_content_id: string | null;
-		live_photo_url: string | null;
-		original_checksum: string;
-		size_variants: App.Http.Resources.Models.SizeVariantsResouce;
-		tags: Array<string>;
-		taken_at: string | null;
-		taken_at_orig_tz: string | null;
-		title: string;
-		type: string;
-		updated_at: string;
-		next_photo_id: string | null;
-		previous_photo_id: string | null;
-		preformatted: App.Http.Resources.Models.Utils.PreformattedPhotoData;
-		precomputed: App.Http.Resources.Models.Utils.PreComputedPhotoData;
-		timeline: App.Http.Resources.Models.Utils.TimelineData | null;
-		palette: App.Http.Resources.Models.ColourPaletteResource | null;
-		statistics: App.Http.Resources.Models.PhotoStatisticsResource | null;
-		rating: App.Http.Resources.Models.PhotoRatingResource | null;
-		face_count: number;
-		is_validated: boolean;
-	};
-	export type PhotoStatisticsResource = {
-		visit_count: number;
-		download_count: number;
-		favourite_count: number;
-		shared_count: number;
-		rating_count: number;
-		rating_avg: number | null;
-	};
-	export type RenamerPreviewResource = {
-		id: string;
-		original: string;
-		new: string;
-	};
-	export type RenamerRuleResource = {
-		id: number;
-		order: number;
-		owner_id: number;
-		rule: string;
-		description: string;
-		needle: string;
-		replacement: string;
-		mode: App.Enum.RenamerModeType;
-		is_enabled: boolean;
-		is_photo_rule: boolean;
-		is_album_rule: boolean;
-	};
-	export type SecurityAdvisoryResource = {
-		cve_id: string | null;
-		ghsa_id: string;
-		summary: string;
-		cvss_score: number | null;
-		cvss_vector: string | null;
-	};
-	export type SizeVariantResource = {
-		type: App.Enum.SizeVariantType;
-		locale: string;
-		filesize: string;
-		height: number;
-		width: number;
-		url: string | null;
-		is_watermarked: boolean;
-	};
-	export type SizeVariantsResouce = {
-		raw: App.Http.Resources.Models.SizeVariantResource | null;
-		original: App.Http.Resources.Models.SizeVariantResource | null;
-		medium2x: App.Http.Resources.Models.SizeVariantResource | null;
-		medium: App.Http.Resources.Models.SizeVariantResource | null;
-		small2x: App.Http.Resources.Models.SizeVariantResource | null;
-		small: App.Http.Resources.Models.SizeVariantResource | null;
-		thumb2x: App.Http.Resources.Models.SizeVariantResource | null;
-		thumb: App.Http.Resources.Models.SizeVariantResource | null;
-		placeholder: App.Http.Resources.Models.SizeVariantResource | null;
-	};
-	export type TargetAlbumResource = {
-		id: string | null;
-		title: string;
-		original: string;
-		short_title: string;
-		thumb: string;
-	};
-	export type ThumbAlbumResource = {
-		id: string;
-		title: string;
-		description: string | null;
-		thumb: App.Http.Resources.Models.ThumbResource | null;
-		is_nsfw: boolean;
-		is_pinned: boolean;
-		is_public: boolean;
-		is_link_required: boolean;
-		is_password_required: boolean;
-		is_tag_album: boolean;
-		has_subalbum: boolean;
-		num_subalbums: number;
-		num_photos: number;
-		created_at: string;
-		formatted_min_max: string | null;
-		owner: string | null;
-		rights: App.Http.Resources.Rights.AlbumRightsResource;
-		timeline: App.Http.Resources.Models.Utils.TimelineData | null;
-	};
-	export type ThumbResource = {
-		id: string;
-		type: string;
-		thumb: string | null;
-		thumb2x: string | null;
-		placeholder: string | null;
-	};
-	export type UserGroupResource = {
-		id: number;
-		name: string;
-		description: string;
-		members: App.Http.Resources.Models.UserMemberGroupResource[];
-		rights: App.Http.Resources.Rights.UserGroupRightResource;
-	};
-	export type UserManagementResource = {
-		id: number;
-		username: string;
-		may_administrate: boolean;
-		may_upload: boolean;
-		may_edit_own_settings: boolean;
-		is_owner: boolean;
-		upload_trust_level: App.Enum.UserUploadTrustLevel;
-		quota_kb: number | null;
-		description: string | null;
-		note: string | null;
-		space: number | null;
-	};
-	export type UserMemberGroupResource = {
-		id: number;
-		username: string;
-		role: App.Enum.UserGroupRole;
-	};
-	export type UserResource = {
-		id: number | null;
-		has_token: boolean | null;
-		username: string | null;
-		email: string | null;
-		is_ldap: boolean;
-		may_administrate: boolean;
-		shared_albums_visibility: App.Enum.UserSharedAlbumsVisibility;
-	};
-	export type WebAuthnResource = {
-		id: string;
-		alias: string | null;
-		created_at: string;
-	};
-	export type WebhookResource = {
-		id: string;
-		name: string;
-		event: App.Enum.PhotoWebhookEvent;
-		method: App.Enum.WebhookMethod;
-		url: string;
-		payload_format: App.Enum.WebhookPayloadFormat;
-		has_secret: boolean;
-		secret_header: string | null;
-		enabled: boolean;
-		send_photo_id: boolean;
-		send_album_id: boolean;
-		send_title: boolean;
-		send_size_variants: boolean;
-		size_variant_types: Array<number> | null;
-		created_at: string;
-		updated_at: string;
-	};
+export type AccessPermissionResource = {
+id: number | null;
+user_id: number | null;
+user_group_id: number | null;
+username: string | null;
+user_group_name: string | null;
+album_title: string | null;
+album_id: string | null;
+grants_full_photo_access: boolean;
+grants_download: boolean;
+grants_upload: boolean;
+grants_edit: boolean;
+grants_delete: boolean;
+};
+export type AdminStatsResource = {
+photos_count: number;
+albums_count: number;
+users_count: number;
+storage_bytes: number;
+queued_jobs: number;
+failed_jobs_24h: number;
+last_successful_job_at: string | null;
+cached_at: string;
+errors: Array<string>;
+};
+export type AdminUpdateStatusResource = {
+enabled: boolean;
+update_status: number | null;
+has_update: boolean;
+current_version: string | null;
+latest_version: string | null;
+};
+export type AlbumStatisticsResource = {
+visit_count: number;
+download_count: number;
+shared_count: number;
+};
+export type BreadcrumbItemResource = {
+id: string | null;
+title: string;
+slug: string | null;
+};
+export type ClusterPreviewResource = {
+cluster_label: number;
+face_count: number;
+sample_crop_urls: string[];
+};
+export type ColourPaletteResource = {
+colour_1: string;
+colour_2: string;
+colour_3: string;
+colour_4: string;
+colour_5: string;
+};
+export type ConfigCategoryResource = {
+cat: string;
+name: string;
+description: string;
+configs: App.Http.Resources.Models.ConfigResource[];
+priority: number;
+};
+export type ConfigResource = {
+key: string;
+type: App.Enum.ConfigType | string;
+value: string;
+documentation: string;
+details: string;
+is_expert: boolean;
+require_se: boolean;
+order: number | null;
+};
+export type ContactMessageResource = {
+id: number;
+name: string;
+email: string;
+message: string;
+is_read: boolean;
+created_at: string;
+};
+export type FaceResource = {
+id: string;
+photo_id: string;
+person_id: string | null;
+x: number;
+y: number;
+width: number;
+height: number;
+confidence: number;
+laplacian_variance: number;
+is_dismissed: boolean;
+cluster_label: number | null;
+crop_url: string | null;
+person_name: string | null;
+suggestions: Array<App.Http.Resources.Models.FaceSuggestionResource>;
+};
+export type FaceSuggestionResource = {
+suggested_face_id: string;
+crop_url: string | null;
+person_name: string | null;
+confidence: number;
+};
+export type HeadAbstractAlbumResource = {
+config: App.Http.Resources.GalleryConfigs.AlbumConfig;
+resource: App.Http.Resources.Models.HeadAlbumResource | App.Http.Resources.Models.HeadSmartAlbumResource | App.Http.Resources.Models.HeadTagAlbumResource;
+};
+export type HeadAlbumResource = {
+id: string;
+title: string;
+slug: string | null;
+owner_name: string | null;
+description: string | null;
+copyright: string | null;
+track_url: string | null;
+license: string;
+header_id: string | null;
+parent_id: string | null;
+has_albums: boolean;
+num_children: number;
+num_photos: number;
+cover_id: string | null;
+policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
+rights: App.Http.Resources.Rights.AlbumRightsResource;
+preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
+editable: App.Http.Resources.Editable.EditableBaseAlbumResource | null;
+is_pinned: boolean;
+statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
+breadcrumb: App.Http.Resources.Models.BreadcrumbItemResource[];
+};
+export type HeadSmartAlbumResource = {
+id: string;
+title: string;
+policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
+rights: App.Http.Resources.Rights.AlbumRightsResource;
+preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
+statistics: null | null;
+};
+export type HeadTagAlbumResource = {
+id: string;
+title: string;
+slug: string | null;
+owner_name: string | null;
+copyright: string | null;
+is_tag_album: boolean;
+show_tags: Array<string>;
+policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
+rights: App.Http.Resources.Rights.AlbumRightsResource;
+preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
+editable: App.Http.Resources.Editable.EditableBaseAlbumResource | null;
+statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
+};
+export type JobHistoryResource = {
+username: string;
+status: 'ready'|'success'|'failure'|'started';
+created_at: string;
+updated_at: string;
+job: string;
+};
+export type LightUserResource = {
+id: number;
+username: string;
+};
+export type LiveMetricsResource = {
+created_at: string;
+visitor_id: string;
+action: App.Enum.MetricsAction;
+photo_id: string | null;
+album_id: string;
+title: string;
+url: string | null;
+};
+export type ModerationResource = {
+photo_id: string;
+title: string;
+thumb_url: string | null;
+owner_username: string;
+album_id: string | null;
+album_title: string | null;
+created_at: string;
+nsfw_status: string | null;
+};
+export type NsfwDetectionResource = {
+id: number;
+photo_id: string;
+label: string;
+confidence: number;
+bbox_x: number;
+bbox_y: number;
+bbox_width: number;
+bbox_height: number;
+is_block: boolean;
+is_review: boolean;
+is_sensitive: boolean;
+};
+export type PersonResource = {
+id: string;
+name: string;
+user_id: number | null;
+is_searchable: boolean;
+representative_face_id: string | null;
+face_count: number;
+photo_count: number;
+representative_crop_url: string | null;
+};
+export type PhotoAlbumResource = {
+id: string;
+title: string;
+};
+export type PhotoFacesResource = {
+faces: App.Http.Resources.Models.FaceResource[];
+hidden_face_count: number;
+rights: App.Http.Resources.Rights.PhotoRightsResource;
+};
+export type PhotoNsfwDetectionsResource = {
+detections: App.Http.Resources.Models.NsfwDetectionResource[];
+image_width: number;
+image_height: number;
+};
+export type PhotoRatingResource = {
+rating_user: number;
+rating_count: number;
+rating_avg: number;
+};
+export type PhotoResource = {
+id: string;
+album_id: string | null;
+checksum: string;
+created_at: string;
+description: string;
+is_highlighted: boolean;
+license: App.Enum.LicenseType;
+live_photo_checksum: string | null;
+live_photo_content_id: string | null;
+live_photo_url: string | null;
+original_checksum: string;
+size_variants: App.Http.Resources.Models.SizeVariantsResouce;
+tags: Array<string>;
+taken_at: string | null;
+taken_at_orig_tz: string | null;
+title: string;
+type: string;
+updated_at: string;
+next_photo_id: string | null;
+previous_photo_id: string | null;
+preformatted: App.Http.Resources.Models.Utils.PreformattedPhotoData;
+precomputed: App.Http.Resources.Models.Utils.PreComputedPhotoData;
+timeline: App.Http.Resources.Models.Utils.TimelineData | null;
+palette: App.Http.Resources.Models.ColourPaletteResource | null;
+statistics: App.Http.Resources.Models.PhotoStatisticsResource | null;
+rating: App.Http.Resources.Models.PhotoRatingResource | null;
+face_count: number;
+is_validated: boolean;
+};
+export type PhotoStatisticsResource = {
+visit_count: number;
+download_count: number;
+favourite_count: number;
+shared_count: number;
+rating_count: number;
+rating_avg: number | null;
+};
+export type RenamerPreviewResource = {
+id: string;
+original: string;
+new: string;
+};
+export type RenamerRuleResource = {
+id: number;
+order: number;
+owner_id: number;
+rule: string;
+description: string;
+needle: string;
+replacement: string;
+mode: App.Enum.RenamerModeType;
+is_enabled: boolean;
+is_photo_rule: boolean;
+is_album_rule: boolean;
+};
+export type SecurityAdvisoryResource = {
+cve_id: string | null;
+ghsa_id: string;
+summary: string;
+cvss_score: number | null;
+cvss_vector: string | null;
+};
+export type SizeVariantResource = {
+type: App.Enum.SizeVariantType;
+locale: string;
+filesize: string;
+height: number;
+width: number;
+url: string | null;
+is_watermarked: boolean;
+};
+export type SizeVariantsResouce = {
+raw: App.Http.Resources.Models.SizeVariantResource | null;
+original: App.Http.Resources.Models.SizeVariantResource | null;
+medium2x: App.Http.Resources.Models.SizeVariantResource | null;
+medium: App.Http.Resources.Models.SizeVariantResource | null;
+small2x: App.Http.Resources.Models.SizeVariantResource | null;
+small: App.Http.Resources.Models.SizeVariantResource | null;
+thumb2x: App.Http.Resources.Models.SizeVariantResource | null;
+thumb: App.Http.Resources.Models.SizeVariantResource | null;
+placeholder: App.Http.Resources.Models.SizeVariantResource | null;
+};
+export type TargetAlbumResource = {
+id: string | null;
+title: string;
+original: string;
+short_title: string;
+thumb: string;
+};
+export type ThumbAlbumResource = {
+id: string;
+title: string;
+description: string | null;
+thumb: App.Http.Resources.Models.ThumbResource | null;
+is_nsfw: boolean;
+is_pinned: boolean;
+is_public: boolean;
+is_link_required: boolean;
+is_password_required: boolean;
+is_tag_album: boolean;
+has_subalbum: boolean;
+num_subalbums: number;
+num_photos: number;
+created_at: string;
+formatted_min_max: string | null;
+owner: string | null;
+rights: App.Http.Resources.Rights.AlbumRightsResource;
+timeline: App.Http.Resources.Models.Utils.TimelineData | null;
+};
+export type ThumbResource = {
+id: string;
+type: string;
+thumb: string | null;
+thumb2x: string | null;
+placeholder: string | null;
+};
+export type UserGroupResource = {
+id: number;
+name: string;
+description: string;
+members: App.Http.Resources.Models.UserMemberGroupResource[];
+rights: App.Http.Resources.Rights.UserGroupRightResource;
+};
+export type UserManagementResource = {
+id: number;
+username: string;
+may_administrate: boolean;
+may_upload: boolean;
+may_edit_own_settings: boolean;
+is_owner: boolean;
+upload_trust_level: App.Enum.UserUploadTrustLevel;
+quota_kb: number | null;
+description: string | null;
+note: string | null;
+space: number | null;
+};
+export type UserMemberGroupResource = {
+id: number;
+username: string;
+role: App.Enum.UserGroupRole;
+};
+export type UserResource = {
+id: number | null;
+has_token: boolean | null;
+username: string | null;
+email: string | null;
+is_ldap: boolean;
+may_administrate: boolean;
+shared_albums_visibility: App.Enum.UserSharedAlbumsVisibility;
+};
+export type WebAuthnResource = {
+id: string;
+alias: string | null;
+created_at: string;
+};
+export type WebhookResource = {
+id: string;
+name: string;
+event: App.Enum.PhotoWebhookEvent;
+method: App.Enum.WebhookMethod;
+url: string;
+payload_format: App.Enum.WebhookPayloadFormat;
+has_secret: boolean;
+secret_header: string | null;
+enabled: boolean;
+send_photo_id: boolean;
+send_album_id: boolean;
+send_title: boolean;
+send_size_variants: boolean;
+size_variant_types: Array<number> | null;
+created_at: string;
+updated_at: string;
+};
 }
 declare namespace App.Http.Resources.Models.Duplicates {
-	export type Duplicate = {
-		album_id: string;
-		album_title: string;
-		photo_id: string;
-		photo_title: string;
-		checksum: string;
-		url: string | null;
-	};
-	export type DuplicateCount = {
-		pure_duplicates: number;
-		title_duplicates: number;
-		duplicates_within_album: number;
-	};
+export type Duplicate = {
+album_id: string;
+album_title: string;
+photo_id: string;
+photo_title: string;
+checksum: string;
+url: string | null;
+};
+export type DuplicateCount = {
+pure_duplicates: number;
+title_duplicates: number;
+duplicates_within_album: number;
+};
 }
 declare namespace App.Http.Resources.Models.Utils {
-	export type AlbumProtectionPolicy = {
-		is_public: boolean;
-		is_link_required: boolean;
-		is_nsfw: boolean;
-		grants_full_photo_access: boolean;
-		grants_download: boolean;
-		grants_upload: boolean;
-		is_password_required: boolean;
-	};
-	export type HeaderFocusData = {
-		x: number;
-		y: number;
-	};
-	export type PreComputedPhotoData = {
-		is_video: boolean;
-		is_raw: boolean;
-		is_livephoto: boolean;
-		is_camera_date: boolean;
-		has_exif: boolean;
-		has_location: boolean;
-		is_taken_at_modified: boolean;
-		latitude: number | null;
-		longitude: number | null;
-		altitude: number | null;
-	};
-	export type PreFormattedAlbumData = {
-		url: string | null;
-		title: string;
-		min_max_text: string | null;
-		album_id: string;
-		license: string;
-		num_children: number;
-		num_photos: number;
-		created_at: string | null;
-		description: string | null;
-		copyright: string | null;
-		palette: App.Http.Resources.Models.ColourPaletteResource | null;
-		title_color: App.Enum.AlbumTitleColor | null;
-		title_position: App.Enum.AlbumTitlePosition | null;
-		header_photo_focus: App.Http.Resources.Models.Utils.HeaderFocusData | null;
-	};
-	export type PreformattedPhotoData = {
-		created_at: string;
-		taken_at: string | null;
-		date_overlay: string;
-		make: string | null;
-		model: string | null;
-		shutter: string;
-		aperture: string;
-		iso: string;
-		lens: string;
-		focal: string | null;
-		duration: string;
-		fps: string;
-		filesize: string;
-		resolution: string;
-		latitude: string | null;
-		longitude: string | null;
-		altitude: string | null;
-		location: string | null;
-		license: string;
-		description: string;
-	};
-	export type TimelineData = {
-		time_date: string;
-		format: string;
-	};
-	export type UserToken = {
-		token: string;
-	};
+export type AlbumProtectionPolicy = {
+is_public: boolean;
+is_link_required: boolean;
+is_nsfw: boolean;
+grants_full_photo_access: boolean;
+grants_download: boolean;
+grants_upload: boolean;
+is_password_required: boolean;
+};
+export type HeaderFocusData = {
+x: number;
+y: number;
+};
+export type PreComputedPhotoData = {
+is_video: boolean;
+is_raw: boolean;
+is_livephoto: boolean;
+is_camera_date: boolean;
+has_exif: boolean;
+has_location: boolean;
+is_taken_at_modified: boolean;
+latitude: number | null;
+longitude: number | null;
+altitude: number | null;
+};
+export type PreFormattedAlbumData = {
+url: string | null;
+title: string;
+min_max_text: string | null;
+album_id: string;
+license: string;
+num_children: number;
+num_photos: number;
+created_at: string | null;
+description: string | null;
+copyright: string | null;
+palette: App.Http.Resources.Models.ColourPaletteResource | null;
+title_color: App.Enum.AlbumTitleColor | null;
+title_position: App.Enum.AlbumTitlePosition | null;
+header_photo_focus: App.Http.Resources.Models.Utils.HeaderFocusData | null;
+};
+export type PreformattedPhotoData = {
+created_at: string;
+taken_at: string | null;
+date_overlay: string;
+make: string | null;
+model: string | null;
+shutter: string;
+aperture: string;
+iso: string;
+lens: string;
+focal: string | null;
+duration: string;
+fps: string;
+filesize: string;
+resolution: string;
+latitude: string | null;
+longitude: string | null;
+altitude: string | null;
+location: string | null;
+license: string;
+description: string;
+};
+export type TimelineData = {
+time_date: string;
+format: string;
+};
+export type UserToken = {
+token: string;
+};
 }
 declare namespace App.Http.Resources.Oauth {
-	export type OauthRegistrationData = {
-		provider_type: App.Enum.OauthProvidersType;
-		is_enabled: boolean;
-		registration_route: string;
-	};
+export type OauthRegistrationData = {
+provider_type: App.Enum.OauthProvidersType;
+is_enabled: boolean;
+registration_route: string;
+};
 }
 declare namespace App.Http.Resources.Rights {
-	export type AlbumRightsResource = {
-		can_edit: boolean;
-		can_share: boolean;
-		can_share_with_users: boolean;
-		can_download: boolean;
-		can_upload: boolean;
-		can_move: boolean;
-		can_delete: boolean;
-		can_transfer: boolean;
-		can_access_original: boolean;
-		can_pasword_protect: boolean;
-		can_import_from_server: boolean;
-		can_make_purchasable: boolean;
-		can_view_album_people: boolean;
-		can_trigger_scan: boolean;
-		can_assign_face: boolean;
-		can_batch_face_ops: boolean;
-	};
-	export type GlobalRightsResource = {
-		root_album: App.Http.Resources.Rights.RootAlbumRightsResource;
-		settings: App.Http.Resources.Rights.SettingsRightsResource;
-		user_management: App.Http.Resources.Rights.UserManagementRightsResource;
-		user: App.Http.Resources.Rights.UserRightsResource;
-		modules: App.Http.Resources.Rights.ModulesRightsResource;
-	};
-	export type ModulesRightsResource = {
-		is_map_enabled: boolean;
-		is_mod_frame_enabled: boolean;
-		is_mod_flow_enabled: boolean;
-		is_watermarker_enabled: boolean;
-		is_photo_timeline_enabled: boolean;
-		is_mod_renamer_enabled: boolean;
-		is_mod_webshop_enabled: boolean;
-		is_mod_webhook_enabled: boolean;
-		is_face_recognition_enabled: boolean;
-		is_nsfw_classifier_enabled: boolean;
-		is_face_overlay_enabled: boolean;
-		is_face_recognition_warning_enabled: boolean;
-		is_contact_enabled: boolean;
-		messages_count: number;
-	};
-	export type PhotoRightsResource = {
-		can_edit: boolean;
-		can_download: boolean;
-		can_access_full_photo: boolean;
-		can_view_face_overlays: boolean;
-		can_dismiss_face: boolean;
-		can_assign_face: boolean;
-		can_trigger_scan: boolean;
-	};
-	export type RootAlbumRightsResource = {
-		can_edit: boolean;
-		can_upload: boolean;
-		can_see_live_metrics: boolean;
-		can_import_from_server: boolean;
-		can_highlight: boolean;
-	};
-	export type SettingsRightsResource = {
-		can_edit: boolean;
-		can_see_logs: boolean;
-		can_see_diagnostics: boolean;
-		can_update: boolean;
-		can_access_dev_tools: boolean;
-		can_acess_user_groups: boolean;
-	};
-	export type UserGroupRightResource = {
-		can_edit: boolean;
-		can_manage: boolean;
-	};
-	export type UserManagementRightsResource = {
-		can_create: boolean;
-		can_list: boolean;
-		can_edit: boolean;
-		can_delete: boolean;
-	};
-	export type UserRightsResource = {
-		can_edit: boolean;
-	};
+export type AlbumRightsResource = {
+can_edit: boolean;
+can_share: boolean;
+can_share_with_users: boolean;
+can_download: boolean;
+can_upload: boolean;
+can_move: boolean;
+can_delete: boolean;
+can_transfer: boolean;
+can_access_original: boolean;
+can_pasword_protect: boolean;
+can_import_from_server: boolean;
+can_make_purchasable: boolean;
+can_view_album_people: boolean;
+can_trigger_scan: boolean;
+can_assign_face: boolean;
+can_batch_face_ops: boolean;
+};
+export type GlobalRightsResource = {
+root_album: App.Http.Resources.Rights.RootAlbumRightsResource;
+settings: App.Http.Resources.Rights.SettingsRightsResource;
+user_management: App.Http.Resources.Rights.UserManagementRightsResource;
+user: App.Http.Resources.Rights.UserRightsResource;
+modules: App.Http.Resources.Rights.ModulesRightsResource;
+};
+export type ModulesRightsResource = {
+is_map_enabled: boolean;
+is_mod_frame_enabled: boolean;
+is_mod_flow_enabled: boolean;
+is_watermarker_enabled: boolean;
+is_photo_timeline_enabled: boolean;
+is_mod_renamer_enabled: boolean;
+is_mod_webshop_enabled: boolean;
+is_mod_webhook_enabled: boolean;
+is_face_recognition_enabled: boolean;
+is_nsfw_classifier_enabled: boolean;
+is_face_overlay_enabled: boolean;
+is_face_recognition_warning_enabled: boolean;
+is_contact_enabled: boolean;
+messages_count: number;
+};
+export type PhotoRightsResource = {
+can_edit: boolean;
+can_download: boolean;
+can_access_full_photo: boolean;
+can_view_face_overlays: boolean;
+can_dismiss_face: boolean;
+can_assign_face: boolean;
+can_trigger_scan: boolean;
+};
+export type RootAlbumRightsResource = {
+can_edit: boolean;
+can_upload: boolean;
+can_see_live_metrics: boolean;
+can_import_from_server: boolean;
+can_highlight: boolean;
+};
+export type SettingsRightsResource = {
+can_edit: boolean;
+can_see_logs: boolean;
+can_see_diagnostics: boolean;
+can_update: boolean;
+can_access_dev_tools: boolean;
+can_acess_user_groups: boolean;
+};
+export type UserGroupRightResource = {
+can_edit: boolean;
+can_manage: boolean;
+};
+export type UserManagementRightsResource = {
+can_create: boolean;
+can_list: boolean;
+can_edit: boolean;
+can_delete: boolean;
+};
+export type UserRightsResource = {
+can_edit: boolean;
+};
 }
 declare namespace App.Http.Resources.Root {
-	export type AuthConfig = {
-		oauthProviders: { [key: number]: App.Enum.OauthProvidersType };
-		u2f_enabled: boolean;
-	};
-	export type VersionResource = {
-		version: string | null;
-		is_new_release_available: boolean;
-		is_git_update_available: boolean;
-	};
+export type AuthConfig = {
+oauthProviders: { [key: number]: App.Enum.OauthProvidersType };
+u2f_enabled: boolean;
+};
+export type VersionResource = {
+version: string | null;
+is_new_release_available: boolean;
+is_git_update_available: boolean;
+};
 }
 declare namespace App.Http.Resources.Search {
-	export type InitResource = {
-		search_minimum_length: number;
-		photo_layout: App.Enum.PhotoLayoutType;
-	};
-	export type ResultsResource = {
-		albums: App.Http.Resources.Models.ThumbAlbumResource[];
-		photos: App.Http.Resources.Models.PhotoResource[];
-		current_page: number;
-		from: number;
-		last_page: number;
-		per_page: number;
-		to: number;
-		total: number;
-	};
+export type InitResource = {
+search_minimum_length: number;
+photo_layout: App.Enum.PhotoLayoutType;
+};
+export type ResultsResource = {
+albums: App.Http.Resources.Models.ThumbAlbumResource[];
+photos: App.Http.Resources.Models.PhotoResource[];
+current_page: number;
+from: number;
+last_page: number;
+per_page: number;
+to: number;
+total: number;
+};
 }
 declare namespace App.Http.Resources.Shop {
-	export type CatalogResource = {
-		album_purchasable: App.Http.Resources.Shop.PurchasableResource | null;
-		children_purchasables: App.Http.Resources.Shop.PurchasableResource[];
-		photo_purchasables: App.Http.Resources.Shop.PurchasableResource[];
-	};
-	export type CatalogueSizesResource = {
-		print_sizes: Array<App.Http.Resources.Shop.PurchasablePrintSizeResource>;
-		pixel_sizes: Array<App.Http.Resources.Shop.PurchasablePixelSizeResource>;
-	};
-	export type CheckoutOptionResource = {
-		currency: string;
-		allow_guest_checkout: boolean;
-		is_offline: boolean;
-		terms_url: string;
-		privacy_url: string;
-		payment_providers: App.Enum.OmnipayProviderType[];
-		mollie_profile_id: string;
-		stripe_public_key: string;
-		paypal_client_id: string;
-		is_test_mode: boolean;
-		is_lycheeorg_disclaimer_enabled: boolean;
-	};
-	export type CheckoutResource = {
-		is_success: boolean;
-		is_redirect: boolean;
-		redirect_url: string | null;
-		complete_url: string | null;
-		message: string;
-		order: App.Http.Resources.Shop.OrderResource | null;
-	};
-	export type ConfigOptionResource = {
-		currency: string;
-		default_price_cents: number;
-		default_license: App.Enum.PurchasableLicenseType;
-		default_size: App.Enum.PurchasableSizeVariantType;
-	};
-	export type EditablePurchasableResource = {
-		purchasable_id: number;
-		album_id: string | null;
-		album_title: string | null;
-		photo_id: string | null;
-		photo_title: string | null;
-		photo_url: string | null;
-		prices: App.Http.Resources.Shop.PriceResource[] | null;
-		print_sizes: App.Http.Resources.Shop.PurchasablePrintSizeResource[];
-		pixel_sizes: App.Http.Resources.Shop.PurchasablePixelSizeResource[];
-		owner_notes: string | null;
-		description: string | null;
-		is_active: boolean;
-	};
-	export type OrderItemResource = {
-		id: number;
-		order_id: number;
-		purchasable_id: number | null;
-		album_id: string | null;
-		photo_id: string | null;
-		title: string;
-		license_type: App.Enum.PurchasableLicenseType;
-		price: string;
-		size_variant_type: App.Enum.PurchasableSizeVariantType;
-		item_notes: string | null;
-		content_url: string | null;
-		is_print: boolean;
-		print_size_id: number | null;
-		print_width: number | null;
-		print_height: number | null;
-		print_unit: string | null;
-		print_paper_type: string | null;
-		pixel_size_id: number | null;
-		pixel_width: number | null;
-		pixel_height: number | null;
-		album_title: string | null;
-		thumb_url: string | null;
-	};
-	export type OrderResource = {
-		id: number;
-		provider: App.Enum.OmnipayProviderType | null;
-		transaction_id: string;
-		username: string | null;
-		email: string | null;
-		status: App.Enum.PaymentStatusType;
-		amount: string;
-		paid_at: string | null;
-		created_at: string | null;
-		updated_at: string | null;
-		comment: string | null;
-		items: App.Http.Resources.Shop.OrderItemResource[] | null;
-		can_process_payment: boolean;
-		shipping_street_name: string | null;
-		shipping_street_number: string | null;
-		shipping_additional_info: string | null;
-		shipping_city: string | null;
-		shipping_post_code: string | null;
-		shipping_country: string | null;
-	};
-	export type PixelSizeResource = {
-		id: number;
-		label: string;
-		width: number;
-		height: number;
-		is_active: boolean;
-	};
-	export type PriceResource = {
-		size_variant: App.Enum.PurchasableSizeVariantType;
-		license_type: App.Enum.PurchasableLicenseType;
-		price: string;
-		price_cents: number;
-	};
-	export type PrintSizeResource = {
-		id: number;
-		label: string;
-		width: number;
-		height: number;
-		unit: string;
-		paper_type: string | null;
-		is_active: boolean;
-	};
-	export type PurchasablePixelSizeResource = {
-		id: number;
-		pixel_size_id: number;
-		label: string;
-		width: number;
-		height: number;
-		price: string;
-		price_cents: number;
-		license_type: App.Enum.PurchasableLicenseType;
-	};
-	export type PurchasablePrintSizeResource = {
-		id: number;
-		print_size_id: number;
-		label: string;
-		width: number;
-		height: number;
-		unit: string;
-		paper_type: string | null;
-		price: string;
-		price_cents: number;
-	};
-	export type PurchasableResource = {
-		purchasable_id: number;
-		album_id: string | null;
-		photo_id: string | null;
-		prices: App.Http.Resources.Shop.PriceResource[] | null;
-		description: string;
-		is_active: boolean;
-	};
+export type CatalogResource = {
+album_purchasable: App.Http.Resources.Shop.PurchasableResource | null;
+children_purchasables: App.Http.Resources.Shop.PurchasableResource[];
+photo_purchasables: App.Http.Resources.Shop.PurchasableResource[];
+};
+export type CatalogueSizesResource = {
+print_sizes: Array<App.Http.Resources.Shop.PurchasablePrintSizeResource>;
+pixel_sizes: Array<App.Http.Resources.Shop.PurchasablePixelSizeResource>;
+};
+export type CheckoutOptionResource = {
+currency: string;
+allow_guest_checkout: boolean;
+is_offline: boolean;
+terms_url: string;
+privacy_url: string;
+payment_providers: App.Enum.OmnipayProviderType[];
+mollie_profile_id: string;
+stripe_public_key: string;
+paypal_client_id: string;
+is_test_mode: boolean;
+is_lycheeorg_disclaimer_enabled: boolean;
+};
+export type CheckoutResource = {
+is_success: boolean;
+is_redirect: boolean;
+redirect_url: string | null;
+complete_url: string | null;
+message: string;
+order: App.Http.Resources.Shop.OrderResource | null;
+};
+export type ConfigOptionResource = {
+currency: string;
+default_price_cents: number;
+default_license: App.Enum.PurchasableLicenseType;
+default_size: App.Enum.PurchasableSizeVariantType;
+};
+export type EditablePurchasableResource = {
+purchasable_id: number;
+album_id: string | null;
+album_title: string | null;
+photo_id: string | null;
+photo_title: string | null;
+photo_url: string | null;
+prices: App.Http.Resources.Shop.PriceResource[]|null;
+print_sizes: App.Http.Resources.Shop.PurchasablePrintSizeResource[];
+pixel_sizes: App.Http.Resources.Shop.PurchasablePixelSizeResource[];
+owner_notes: string | null;
+description: string | null;
+is_active: boolean;
+};
+export type OrderItemResource = {
+id: number;
+order_id: number;
+purchasable_id: number | null;
+album_id: string | null;
+photo_id: string | null;
+title: string;
+license_type: App.Enum.PurchasableLicenseType;
+price: string;
+size_variant_type: App.Enum.PurchasableSizeVariantType;
+item_notes: string | null;
+content_url: string | null;
+is_print: boolean;
+print_size_id: number | null;
+print_width: number | null;
+print_height: number | null;
+print_unit: string | null;
+print_paper_type: string | null;
+pixel_size_id: number | null;
+pixel_width: number | null;
+pixel_height: number | null;
+album_title: string | null;
+thumb_url: string | null;
+};
+export type OrderResource = {
+id: number;
+provider: App.Enum.OmnipayProviderType | null;
+transaction_id: string;
+username: string | null;
+email: string | null;
+status: App.Enum.PaymentStatusType;
+amount: string;
+paid_at: string | null;
+created_at: string | null;
+updated_at: string | null;
+comment: string | null;
+items: App.Http.Resources.Shop.OrderItemResource[]|null;
+can_process_payment: boolean;
+shipping_street_name: string | null;
+shipping_street_number: string | null;
+shipping_additional_info: string | null;
+shipping_city: string | null;
+shipping_post_code: string | null;
+shipping_country: string | null;
+};
+export type PixelSizeResource = {
+id: number;
+label: string;
+width: number;
+height: number;
+is_active: boolean;
+};
+export type PriceResource = {
+size_variant: App.Enum.PurchasableSizeVariantType;
+license_type: App.Enum.PurchasableLicenseType;
+price: string;
+price_cents: number;
+};
+export type PrintSizeResource = {
+id: number;
+label: string;
+width: number;
+height: number;
+unit: string;
+paper_type: string | null;
+is_active: boolean;
+};
+export type PurchasablePixelSizeResource = {
+id: number;
+pixel_size_id: number;
+label: string;
+width: number;
+height: number;
+price: string;
+price_cents: number;
+license_type: App.Enum.PurchasableLicenseType;
+};
+export type PurchasablePrintSizeResource = {
+id: number;
+print_size_id: number;
+label: string;
+width: number;
+height: number;
+unit: string;
+paper_type: string | null;
+price: string;
+price_cents: number;
+};
+export type PurchasableResource = {
+purchasable_id: number;
+album_id: string | null;
+photo_id: string | null;
+prices: App.Http.Resources.Shop.PriceResource[]|null;
+description: string;
+is_active: boolean;
+};
 }
 declare namespace App.Http.Resources.Statistics {
-	export type Album = {
-		username: string;
-		title: string;
-		is_nsfw: boolean;
-		left: number;
-		right: number;
-		num_photos: number;
-		num_descendants: number;
-		size: number;
-	};
-	export type CountsData = {
-		data: Array<App.Http.Resources.Statistics.DayCount>;
-		low_number_of_shoots_per_day: number;
-		medium_number_of_shoots_per_day: number;
-		high_number_of_shoots_per_day: number;
-		min_created_at: string;
-		min_taken_at: string;
-	};
-	export type DayCount = {
-		date: string;
-		count: number;
-	};
-	export type Sizes = {
-		type: App.Enum.SizeVariantType;
-		label: string;
-		size: number;
-	};
-	export type UserSpace = {
-		id: number;
-		username: string;
-		size: number;
-	};
+export type Album = {
+username: string;
+title: string;
+is_nsfw: boolean;
+left: number;
+right: number;
+num_photos: number;
+num_descendants: number;
+size: number;
+};
+export type CountsData = {
+data: Array<App.Http.Resources.Statistics.DayCount>;
+low_number_of_shoots_per_day: number;
+medium_number_of_shoots_per_day: number;
+high_number_of_shoots_per_day: number;
+min_created_at: string;
+min_taken_at: string;
+};
+export type DayCount = {
+date: string;
+count: number;
+};
+export type Sizes = {
+type: App.Enum.SizeVariantType;
+label: string;
+size: number;
+};
+export type UserSpace = {
+id: number;
+username: string;
+size: number;
+};
 }
 declare namespace App.Http.Resources.Tags {
-	export type TagResource = {
-		id: number;
-		name: string;
-		num: number;
-	};
-	export type TagWithPhotosResource = {
-		id: number;
-		name: string;
-		photos: App.Http.Resources.Models.PhotoResource[];
-	};
-	export type TagsResource = {
-		can_edit: boolean;
-		tags: App.Http.Resources.Tags.TagResource[];
-	};
+export type TagResource = {
+id: number;
+name: string;
+num: number;
+};
+export type TagWithPhotosResource = {
+id: number;
+name: string;
+photos: App.Http.Resources.Models.PhotoResource[];
+};
+export type TagsResource = {
+can_edit: boolean;
+tags: App.Http.Resources.Tags.TagResource[];
+};
 }
 declare namespace App.Http.Resources.Timeline {
-	export type InitResource = {
-		photo_layout: App.Enum.PhotoLayoutType;
-		is_timeline_page_enabled: boolean;
-		config: App.Http.Resources.GalleryConfigs.RootConfig;
-		rights: App.Http.Resources.Rights.RootAlbumRightsResource;
-	};
-	export type TimelineResource = {
-		photos: App.Http.Resources.Models.PhotoResource[];
-		current_page: number;
-		from: number;
-		last_page: number;
-		per_page: number;
-		to: number;
-		total: number;
-	};
+export type InitResource = {
+photo_layout: App.Enum.PhotoLayoutType;
+is_timeline_page_enabled: boolean;
+config: App.Http.Resources.GalleryConfigs.RootConfig;
+rights: App.Http.Resources.Rights.RootAlbumRightsResource;
+};
+export type TimelineResource = {
+photos: App.Http.Resources.Models.PhotoResource[];
+current_page: number;
+from: number;
+last_page: number;
+per_page: number;
+to: number;
+total: number;
+};
 }

--- a/resources/js/lychee.d.ts
+++ b/resources/js/lychee.d.ts
@@ -1,1439 +1,1560 @@
 declare namespace App.DTO {
-export type AlbumSortingCriterion = {
-column: App.Enum.ColumnSortingType;
-order: App.Enum.OrderSortingType;
-};
-export type PhotoSortingCriterion = {
-column: App.Enum.ColumnSortingType;
-order: App.Enum.OrderSortingType;
-};
-export type SortingCriterion = {
-column: App.Enum.ColumnSortingType;
-order: App.Enum.OrderSortingType;
-};
+	export type AlbumSortingCriterion = {
+		column: App.Enum.ColumnSortingType;
+		order: App.Enum.OrderSortingType;
+	};
+	export type PhotoSortingCriterion = {
+		column: App.Enum.ColumnSortingType;
+		order: App.Enum.OrderSortingType;
+	};
+	export type SortingCriterion = {
+		column: App.Enum.ColumnSortingType;
+		order: App.Enum.OrderSortingType;
+	};
 }
 declare namespace App.DTO.Nsfw {
-export type NsfwBboxData = {
-x: number;
-y: number;
-width: number;
-height: number;
-};
-export type NsfwDetectionItemData = {
-label: App.Enum.NsfwDetectionLabel;
-confidence: number;
-bbox: App.DTO.Nsfw.NsfwBboxData;
-area_pixels: number;
-area_ratio: number;
-};
-export type NsfwDetectionResultsData = {
-photo_id: string;
-status: string;
-should_block: boolean;
-should_review: boolean;
-is_sensitive: boolean;
-all_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
-block_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
-review_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
-sensitive_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
-error_code: string | null;
-message: string | null;
-};
+	export type NsfwBboxData = {
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+	};
+	export type NsfwDetectionItemData = {
+		label: App.Enum.NsfwDetectionLabel;
+		confidence: number;
+		bbox: App.DTO.Nsfw.NsfwBboxData;
+		area_pixels: number;
+		area_ratio: number;
+	};
+	export type NsfwDetectionResultsData = {
+		photo_id: string;
+		status: string;
+		should_block: boolean;
+		should_review: boolean;
+		is_sensitive: boolean;
+		all_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
+		block_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
+		review_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
+		sensitive_detected: App.DTO.Nsfw.NsfwDetectionItemData[];
+		error_code: string | null;
+		message: string | null;
+	};
 }
 declare namespace App.Enum {
-export type AlbumDecorationOrientation = 'row' | 'row-reverse' | 'column' | 'column-reverse';
-export type AlbumDecorationType = 'none' | 'layers' | 'album' | 'photo' | 'all';
-export type AlbumHeaderSize = 'half_screen' | 'full_screen';
-export type AlbumLayoutType = 'list' | 'grid';
-export type AlbumTitleColor = 'white' | 'black' | 'colour_1' | 'colour_2' | 'colour_3' | 'colour_4' | 'colour_5';
-export type AlbumTitlePosition = 'top_left' | 'top_right' | 'bottom_left' | 'bottom_right' | 'center';
-export type AspectRatioCSSType = 'aspect-5x4' | 'aspect-4x5' | 'aspect-3x2' | 'aspect-square' | 'aspect-2x3' | 'aspect-video';
-export type AspectRatioType = '5/4' | '3/2' | '1/1' | '2/3' | '4/5' | '16/9';
-export type CacheTag = 'gallery' | 'auth' | 'user' | 'settings' | 'statistics' | 'users';
-export type ColumnSortingAlbumType = 'owner_id' | 'created_at' | 'title' | 'description' | 'title_strict' | 'description_strict' | 'min_taken_at' | 'max_taken_at';
-export type ColumnSortingPhotoType = 'owner_id' | 'created_at' | 'title' | 'description' | 'title_strict' | 'description_strict' | 'taken_at' | 'is_highlighted' | 'type' | 'rating_avg';
-export type ColumnSortingType = 'owner_id' | 'created_at' | 'title' | 'description' | 'title_strict' | 'description_strict' | 'min_taken_at' | 'max_taken_at' | 'taken_at' | 'is_highlighted' | 'type' | 'rating_avg';
-export type ConfigType = 'int' | 'positive' | 'string' | 'string_required' | '0|1' | '0|1|2' | '' | 'admin_user' | 'license' | 'map_provider' | 'currency';
-export type CountType = 'taken_at' | 'created_at';
-export type CoverFitType = 'cover' | 'fit';
-export type DateOrderingType = 'older_younger' | 'younger_older';
-export type DbDriverType = 'mysql' | 'pgsql' | 'sqlite';
-export type DefaultAlbumProtectionType = 'private' | 'public' | 'inherit' | 'public_hidden';
-export type DownloadVariantType = 'RAW' | 'LIVEPHOTOVIDEO' | 'ORIGINAL' | 'MEDIUM2X' | 'MEDIUM' | 'SMALL2X' | 'SMALL' | 'THUMB2X' | 'THUMB';
-export type FacePermissionMode = 'public' | 'private' | 'privacy-preserving' | 'restricted';
-export type FaceScanStatus = 'pending' | 'completed' | 'failed';
-export type FileStatus = 'uploading' | 'processing' | 'ready' | 'skipped' | 'done' | 'error';
-export type FlowStrategy = 'auto' | 'opt-in';
-export type ImageOverlayType = 'none' | 'desc' | 'date' | 'exif';
-export type JobStatus = 0 | 1 | 2 | 3;
-export type LandingBackgroundModeType = 'static' | 'photo_id' | 'random' | 'latest_album_cover' | 'random_from_album';
-export type LicenseType = 'none' | 'reserved' | 'CC0' | 'CC-BY-1.0' | 'CC-BY-2.0' | 'CC-BY-2.5' | 'CC-BY-3.0' | 'CC-BY-4.0' | 'CC-BY-ND-1.0' | 'CC-BY-ND-2.0' | 'CC-BY-ND-2.5' | 'CC-BY-ND-3.0' | 'CC-BY-ND-4.0' | 'CC-BY-SA-1.0' | 'CC-BY-SA-2.0' | 'CC-BY-SA-2.5' | 'CC-BY-SA-3.0' | 'CC-BY-SA-4.0' | 'CC-BY-NC-1.0' | 'CC-BY-NC-2.0' | 'CC-BY-NC-2.5' | 'CC-BY-NC-3.0' | 'CC-BY-NC-4.0' | 'CC-BY-NC-ND-1.0' | 'CC-BY-NC-ND-2.0' | 'CC-BY-NC-ND-2.5' | 'CC-BY-NC-ND-3.0' | 'CC-BY-NC-ND-4.0' | 'CC-BY-NC-SA-1.0' | 'CC-BY-NC-SA-2.0' | 'CC-BY-NC-SA-2.5' | 'CC-BY-NC-SA-3.0' | 'CC-BY-NC-SA-4.0';
-export type LiveMetricsAccess = 'logged-in users' | 'admin';
-export type MapProviders = 'OpenStreetMap.org' | 'OpenStreetMap.de' | 'OpenStreetMap.fr' | 'RRZE';
-export type MessageType = 'info' | 'warning' | 'error';
-export type MetricsAccess = 'public' | 'logged-in users' | 'owner' | 'admin';
-export type MetricsAction = 'visit' | 'favourite' | 'download' | 'shared';
-export type NsfwBlockFindingAction = 'block' | 'moderate' | 'approve';
-export type NsfwDetectionLabel = 'FEMALE_GENITALIA_COVERED' | 'FACE_FEMALE' | 'BUTTOCKS_EXPOSED' | 'FEMALE_BREAST_EXPOSED' | 'FEMALE_GENITALIA_EXPOSED' | 'MALE_BREAST_EXPOSED' | 'ANUS_EXPOSED' | 'FEET_EXPOSED' | 'BELLY_COVERED' | 'FEET_COVERED' | 'ARMPITS_COVERED' | 'ARMPITS_EXPOSED' | 'FACE_MALE' | 'BELLY_EXPOSED' | 'MALE_GENITALIA_EXPOSED' | 'ANUS_COVERED' | 'FEMALE_BREAST_COVERED' | 'BUTTOCKS_COVERED';
-export type NsfwPreset = 'default' | 'strict' | 'moderation' | 'nude_female' | 'permissive' | 'social_media';
-export type NsfwSensitiveAlbumAction = 'mark_album' | 'nothing';
-export type NsfwSensitiveNoAlbumAction = 'skip' | 'moderate';
-export type NsfwStatus = 'pending' | 'failed' | 'review' | 'visible';
-export type OauthProvidersType = 'amazon' | 'apple' | 'authelia' | 'authentik' | 'facebook' | 'github' | 'google' | 'mastodon' | 'microsoft' | 'nextcloud' | 'keycloak';
-export type OgImageAlbumSourceType = 'header' | 'cover';
-export type OmnipayProviderType = 'Dummy' | 'Mollie' | 'PayPal' | 'Stripe';
-export type OrderSortingType = 'ASC' | 'DESC';
-export type PaginationMode = 'infinite_scroll' | 'load_more_button' | 'page_navigation';
-export type PaymentStatusType = 'pending' | 'cancelled' | 'failed' | 'refunded' | 'processing' | 'offline' | 'completed' | 'closed';
-export type PhotoHighlightVisibilityType = 'anonymous' | 'authenticated' | 'editor';
-export type PhotoLayoutType = 'square' | 'justified' | 'masonry' | 'grid';
-export type PhotoThumbInfoType = 'title' | 'description';
-export type PhotoWebhookEvent = 'photo.add' | 'photo.move' | 'photo.delete';
-export type PurchasableLicenseType = 'personal' | 'commercial' | 'extended' | 'print';
-export type PurchasableSizeVariantType = 'medium' | 'medium2x' | 'original' | 'full';
-export type RenamerModeType = 'first' | 'all' | 'regex' | 'trim' | 'strtolower' | 'strtoupper' | 'ucwords' | 'ucfirst';
-export type SeverityType = 'emergency' | 'alert' | 'critical' | 'error' | 'warning' | 'notice' | 'info' | 'debug';
-export type SharedAlbumsVisibility = 'show' | 'separate' | 'separate_shared_only' | 'hide';
-export type ShiftType = 'relative' | 'absolute';
-export type ShiftX = 'left' | 'right';
-export type ShiftY = 'up' | 'down';
-export type SizeVariantType = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
-export type SmallLargeType = 'small' | 'large';
-export type SmartAlbumType = 'unsorted' | 'highlighted' | 'recent' | 'on_this_day' | 'untagged' | 'unrated' | 'one_star' | 'two_stars' | 'three_stars' | 'four_stars' | 'five_stars' | 'best_pictures' | 'my_rated_pictures' | 'my_best_pictures';
-export type StorageDiskType = 'images' | 's3';
-export type ThumbAlbumSubtitleType = 'description' | 'takedate' | 'creation' | 'oldstyle' | 'num_photos' | 'num_albums' | 'num_photos_albums';
-export type TimelineAlbumGranularity = 'default' | 'disabled' | 'year' | 'month' | 'day';
-export type TimelinePhotoGranularity = 'default' | 'disabled' | 'year' | 'month' | 'day' | 'hour';
-export type UpdateStatus = 0 | 1 | 2 | 3;
-export type UserGroupRole = 'member' | 'admin';
-export type UserSharedAlbumsVisibility = 'default' | 'show' | 'separate' | 'separate_shared_only' | 'hide';
-export type UserUploadTrustLevel = 'check' | 'monitor' | 'trust_but_verify' | 'trusted';
-export type VersionChannelType = 'release' | 'git' | 'tag';
-export type VisibilityType = 'never' | 'always' | 'hover';
-export type WatermarkPosition = 'top-left' | 'top' | 'top-right' | 'left' | 'center' | 'right' | 'bottom-left' | 'bottom' | 'bottom-right';
-export type WebhookMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
-export type WebhookPayloadFormat = 'json' | 'query_string';
+	export type AlbumDecorationOrientation = "row" | "row-reverse" | "column" | "column-reverse";
+	export type AlbumDecorationType = "none" | "layers" | "album" | "photo" | "all";
+	export type AlbumHeaderSize = "half_screen" | "full_screen";
+	export type AlbumLayoutType = "list" | "grid";
+	export type AlbumTitleColor = "white" | "black" | "colour_1" | "colour_2" | "colour_3" | "colour_4" | "colour_5";
+	export type AlbumTitlePosition = "top_left" | "top_right" | "bottom_left" | "bottom_right" | "center";
+	export type AspectRatioCSSType = "aspect-5x4" | "aspect-4x5" | "aspect-3x2" | "aspect-square" | "aspect-2x3" | "aspect-video";
+	export type AspectRatioType = "5/4" | "3/2" | "1/1" | "2/3" | "4/5" | "16/9";
+	export type CacheTag = "gallery" | "auth" | "user" | "settings" | "statistics" | "users";
+	export type ColumnSortingAlbumType =
+		| "owner_id"
+		| "created_at"
+		| "title"
+		| "description"
+		| "title_strict"
+		| "description_strict"
+		| "min_taken_at"
+		| "max_taken_at";
+	export type ColumnSortingPhotoType =
+		| "owner_id"
+		| "created_at"
+		| "title"
+		| "description"
+		| "title_strict"
+		| "description_strict"
+		| "taken_at"
+		| "is_highlighted"
+		| "type"
+		| "rating_avg";
+	export type ColumnSortingType =
+		| "owner_id"
+		| "created_at"
+		| "title"
+		| "description"
+		| "title_strict"
+		| "description_strict"
+		| "min_taken_at"
+		| "max_taken_at"
+		| "taken_at"
+		| "is_highlighted"
+		| "type"
+		| "rating_avg";
+	export type ConfigType =
+		| "int"
+		| "positive"
+		| "string"
+		| "string_required"
+		| "0|1"
+		| "0|1|2"
+		| ""
+		| "admin_user"
+		| "license"
+		| "map_provider"
+		| "currency";
+	export type CountType = "taken_at" | "created_at";
+	export type CoverFitType = "cover" | "fit";
+	export type DateOrderingType = "older_younger" | "younger_older";
+	export type DbDriverType = "mysql" | "pgsql" | "sqlite";
+	export type DefaultAlbumProtectionType = "private" | "public" | "inherit" | "public_hidden";
+	export type DownloadVariantType = "RAW" | "LIVEPHOTOVIDEO" | "ORIGINAL" | "MEDIUM2X" | "MEDIUM" | "SMALL2X" | "SMALL" | "THUMB2X" | "THUMB";
+	export type FacePermissionMode = "public" | "private" | "privacy-preserving" | "restricted";
+	export type FaceScanStatus = "pending" | "completed" | "failed";
+	export type FileStatus = "uploading" | "processing" | "ready" | "skipped" | "done" | "error";
+	export type FlowStrategy = "auto" | "opt-in";
+	export type ImageOverlayType = "none" | "desc" | "date" | "exif";
+	export type JobStatus = 0 | 1 | 2 | 3;
+	export type LandingBackgroundModeType = "static" | "photo_id" | "random" | "latest_album_cover" | "random_from_album";
+	export type LicenseType =
+		| "none"
+		| "reserved"
+		| "CC0"
+		| "CC-BY-1.0"
+		| "CC-BY-2.0"
+		| "CC-BY-2.5"
+		| "CC-BY-3.0"
+		| "CC-BY-4.0"
+		| "CC-BY-ND-1.0"
+		| "CC-BY-ND-2.0"
+		| "CC-BY-ND-2.5"
+		| "CC-BY-ND-3.0"
+		| "CC-BY-ND-4.0"
+		| "CC-BY-SA-1.0"
+		| "CC-BY-SA-2.0"
+		| "CC-BY-SA-2.5"
+		| "CC-BY-SA-3.0"
+		| "CC-BY-SA-4.0"
+		| "CC-BY-NC-1.0"
+		| "CC-BY-NC-2.0"
+		| "CC-BY-NC-2.5"
+		| "CC-BY-NC-3.0"
+		| "CC-BY-NC-4.0"
+		| "CC-BY-NC-ND-1.0"
+		| "CC-BY-NC-ND-2.0"
+		| "CC-BY-NC-ND-2.5"
+		| "CC-BY-NC-ND-3.0"
+		| "CC-BY-NC-ND-4.0"
+		| "CC-BY-NC-SA-1.0"
+		| "CC-BY-NC-SA-2.0"
+		| "CC-BY-NC-SA-2.5"
+		| "CC-BY-NC-SA-3.0"
+		| "CC-BY-NC-SA-4.0";
+	export type LiveMetricsAccess = "logged-in users" | "admin";
+	export type MapProviders = "OpenStreetMap.org" | "OpenStreetMap.de" | "OpenStreetMap.fr" | "RRZE";
+	export type MessageType = "info" | "warning" | "error";
+	export type MetricsAccess = "public" | "logged-in users" | "owner" | "admin";
+	export type MetricsAction = "visit" | "favourite" | "download" | "shared";
+	export type NsfwBlockFindingAction = "block" | "moderate" | "approve";
+	export type NsfwDetectionLabel =
+		| "FEMALE_GENITALIA_COVERED"
+		| "FACE_FEMALE"
+		| "BUTTOCKS_EXPOSED"
+		| "FEMALE_BREAST_EXPOSED"
+		| "FEMALE_GENITALIA_EXPOSED"
+		| "MALE_BREAST_EXPOSED"
+		| "ANUS_EXPOSED"
+		| "FEET_EXPOSED"
+		| "BELLY_COVERED"
+		| "FEET_COVERED"
+		| "ARMPITS_COVERED"
+		| "ARMPITS_EXPOSED"
+		| "FACE_MALE"
+		| "BELLY_EXPOSED"
+		| "MALE_GENITALIA_EXPOSED"
+		| "ANUS_COVERED"
+		| "FEMALE_BREAST_COVERED"
+		| "BUTTOCKS_COVERED";
+	export type NsfwPreset = "default" | "strict" | "moderation" | "nude_female" | "permissive" | "social_media";
+	export type NsfwSensitiveAlbumAction = "mark_album" | "nothing";
+	export type NsfwSensitiveNoAlbumAction = "skip" | "moderate";
+	export type NsfwStatus = "pending" | "failed" | "review" | "visible";
+	export type OauthProvidersType =
+		| "amazon"
+		| "apple"
+		| "authelia"
+		| "authentik"
+		| "facebook"
+		| "github"
+		| "google"
+		| "mastodon"
+		| "microsoft"
+		| "nextcloud"
+		| "keycloak";
+	export type OgImageAlbumSourceType = "header" | "cover";
+	export type OmnipayProviderType = "Dummy" | "Mollie" | "PayPal" | "Stripe";
+	export type OrderSortingType = "ASC" | "DESC";
+	export type PaginationMode = "infinite_scroll" | "load_more_button" | "page_navigation";
+	export type PaymentStatusType = "pending" | "cancelled" | "failed" | "refunded" | "processing" | "offline" | "completed" | "closed";
+	export type PhotoHighlightVisibilityType = "anonymous" | "authenticated" | "editor";
+	export type PhotoLayoutType = "square" | "justified" | "masonry" | "grid";
+	export type PhotoThumbInfoType = "title" | "description";
+	export type PhotoWebhookEvent = "photo.add" | "photo.move" | "photo.delete";
+	export type PurchasableLicenseType = "personal" | "commercial" | "extended" | "print";
+	export type PurchasableSizeVariantType = "medium" | "medium2x" | "original" | "full";
+	export type RenamerModeType = "first" | "all" | "regex" | "trim" | "strtolower" | "strtoupper" | "ucwords" | "ucfirst";
+	export type SeverityType = "emergency" | "alert" | "critical" | "error" | "warning" | "notice" | "info" | "debug";
+	export type SharedAlbumsVisibility = "show" | "separate" | "separate_shared_only" | "hide";
+	export type ShiftType = "relative" | "absolute";
+	export type ShiftX = "left" | "right";
+	export type ShiftY = "up" | "down";
+	export type SizeVariantType = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+	export type SmallLargeType = "small" | "large";
+	export type SmartAlbumType =
+		| "unsorted"
+		| "highlighted"
+		| "recent"
+		| "on_this_day"
+		| "untagged"
+		| "unrated"
+		| "one_star"
+		| "two_stars"
+		| "three_stars"
+		| "four_stars"
+		| "five_stars"
+		| "best_pictures"
+		| "my_rated_pictures"
+		| "my_best_pictures";
+	export type StorageDiskType = "images" | "s3";
+	export type ThumbAlbumSubtitleType = "description" | "takedate" | "creation" | "oldstyle" | "num_photos" | "num_albums" | "num_photos_albums";
+	export type TimelineAlbumGranularity = "default" | "disabled" | "year" | "month" | "day";
+	export type TimelinePhotoGranularity = "default" | "disabled" | "year" | "month" | "day" | "hour";
+	export type UpdateStatus = 0 | 1 | 2 | 3;
+	export type UserGroupRole = "member" | "admin";
+	export type UserSharedAlbumsVisibility = "default" | "show" | "separate" | "separate_shared_only" | "hide";
+	export type UserUploadTrustLevel = "check" | "monitor" | "trust_but_verify" | "trusted";
+	export type VersionChannelType = "release" | "git" | "tag";
+	export type VisibilityType = "never" | "always" | "hover";
+	export type WatermarkPosition = "top-left" | "top" | "top-right" | "left" | "center" | "right" | "bottom-left" | "bottom" | "bottom-right";
+	export type WebhookMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+	export type WebhookPayloadFormat = "json" | "query_string";
 }
 declare namespace App.Http.Resources.Admin {
-export type BulkAlbumIdsResource = {
-ids: Array<string>;
-capped: boolean;
-};
-export type BulkAlbumResource = {
-id: string;
-title: string;
-owner_id: number;
-owner_name: string;
-description: string | null;
-copyright: string | null;
-license: App.Enum.LicenseType;
-photo_layout: App.Enum.PhotoLayoutType | null;
-photo_sorting_col: App.Enum.ColumnSortingPhotoType | null;
-photo_sorting_order: App.Enum.OrderSortingType | null;
-album_sorting_col: App.Enum.ColumnSortingAlbumType | null;
-album_sorting_order: App.Enum.OrderSortingType | null;
-album_thumb_aspect_ratio: App.Enum.AspectRatioType | null;
-album_timeline: App.Enum.TimelineAlbumGranularity | null;
-photo_timeline: App.Enum.TimelinePhotoGranularity | null;
-is_nsfw: boolean;
-_lft: number;
-_rgt: number;
-is_public: boolean;
-is_link_required: boolean;
-grants_full_photo_access: boolean;
-grants_download: boolean;
-grants_upload: boolean;
-created_at: string;
-};
-export type ImportDirectoryResource = {
-directory: string;
-status: boolean;
-message: string | null;
-jobs_count: number | null;
-};
-export type ImportFromServerOptionsResource = {
-delete_imported: boolean;
-import_via_symlink: boolean;
-skip_duplicates: boolean;
-resync_metadata: boolean;
-delete_missing_photos: boolean;
-delete_missing_albums: boolean;
-directory: string;
-};
-export type ImportFromServerResource = {
-status: boolean;
-message: string;
-results: App.Http.Resources.Admin.ImportDirectoryResource[];
-job_count: number;
-};
-export type PaginatedBulkAlbumResource = {
-data: App.Http.Resources.Admin.BulkAlbumResource[];
-current_page: number;
-last_page: number;
-per_page: number;
-total: number;
-};
+	export type BulkAlbumIdsResource = {
+		ids: Array<string>;
+		capped: boolean;
+	};
+	export type BulkAlbumResource = {
+		id: string;
+		title: string;
+		owner_id: number;
+		owner_name: string;
+		description: string | null;
+		copyright: string | null;
+		license: App.Enum.LicenseType;
+		photo_layout: App.Enum.PhotoLayoutType | null;
+		photo_sorting_col: App.Enum.ColumnSortingPhotoType | null;
+		photo_sorting_order: App.Enum.OrderSortingType | null;
+		album_sorting_col: App.Enum.ColumnSortingAlbumType | null;
+		album_sorting_order: App.Enum.OrderSortingType | null;
+		album_thumb_aspect_ratio: App.Enum.AspectRatioType | null;
+		album_timeline: App.Enum.TimelineAlbumGranularity | null;
+		photo_timeline: App.Enum.TimelinePhotoGranularity | null;
+		is_nsfw: boolean;
+		_lft: number;
+		_rgt: number;
+		is_public: boolean;
+		is_link_required: boolean;
+		grants_full_photo_access: boolean;
+		grants_download: boolean;
+		grants_upload: boolean;
+		created_at: string;
+	};
+	export type ImportDirectoryResource = {
+		directory: string;
+		status: boolean;
+		message: string | null;
+		jobs_count: number | null;
+	};
+	export type ImportFromServerOptionsResource = {
+		delete_imported: boolean;
+		import_via_symlink: boolean;
+		skip_duplicates: boolean;
+		resync_metadata: boolean;
+		delete_missing_photos: boolean;
+		delete_missing_albums: boolean;
+		directory: string;
+	};
+	export type ImportFromServerResource = {
+		status: boolean;
+		message: string;
+		results: App.Http.Resources.Admin.ImportDirectoryResource[];
+		job_count: number;
+	};
+	export type PaginatedBulkAlbumResource = {
+		data: App.Http.Resources.Admin.BulkAlbumResource[];
+		current_page: number;
+		last_page: number;
+		per_page: number;
+		total: number;
+	};
 }
 declare namespace App.Http.Resources.Collections {
-export type ContactMessageCollectionResource = {
-data: App.Http.Resources.Models.ContactMessageResource[];
-current_page: number;
-per_page: number;
-total: number;
-};
-export type PaginatedAlbumsResource = {
-data: App.Http.Resources.Models.ThumbAlbumResource[];
-current_page: number;
-last_page: number;
-per_page: number;
-total: number;
-};
-export type PaginatedClustersResource = {
-data: App.Http.Resources.Models.ClusterPreviewResource[];
-current_page: number;
-last_page: number;
-per_page: number;
-total: number;
-};
-export type PaginatedFaceResource = {
-data: App.Http.Resources.Models.FaceResource[];
-current_page: number;
-last_page: number;
-per_page: number;
-total: number;
-};
-export type PaginatedModerationResource = {
-photos: App.Http.Resources.Models.ModerationResource[];
-current_page: number;
-last_page: number;
-per_page: number;
-total: number;
-};
-export type PaginatedPersonsResource = {
-data: App.Http.Resources.Models.PersonResource[];
-current_page: number;
-last_page: number;
-per_page: number;
-total: number;
-};
-export type PaginatedPhotosResource = {
-photos: App.Http.Resources.Models.PhotoResource[];
-current_page: number;
-last_page: number;
-per_page: number;
-total: number;
-};
-export type PaginatedWebhookResource = {
-webhooks: App.Http.Resources.Models.WebhookResource[];
-current_page: number;
-last_page: number;
-per_page: number;
-total: number;
-};
-export type PositionDataResource = {
-id: string | null;
-title: string | null;
-track_url: string | null;
-photos: App.Http.Resources.Models.PhotoResource[];
-};
-export type RootAlbumResource = {
-smart_albums: App.Http.Resources.Models.ThumbAlbumResource[];
-tag_albums: App.Http.Resources.Models.ThumbAlbumResource[];
-pinned_albums: App.Http.Resources.Models.ThumbAlbumResource[];
-albums: App.Http.Resources.Models.ThumbAlbumResource[];
-shared_albums: App.Http.Resources.Models.ThumbAlbumResource[];
-config: App.Http.Resources.GalleryConfigs.RootConfig;
-rights: App.Http.Resources.Rights.RootAlbumRightsResource;
-};
-export type UserGroupDataResource = {
-user_groups: App.Http.Resources.Models.UserGroupResource[];
-can_create_delete_user_groups: boolean;
-};
+	export type ContactMessageCollectionResource = {
+		data: App.Http.Resources.Models.ContactMessageResource[];
+		current_page: number;
+		per_page: number;
+		total: number;
+	};
+	export type PaginatedAlbumsResource = {
+		data: App.Http.Resources.Models.ThumbAlbumResource[];
+		current_page: number;
+		last_page: number;
+		per_page: number;
+		total: number;
+	};
+	export type PaginatedClustersResource = {
+		data: App.Http.Resources.Models.ClusterPreviewResource[];
+		current_page: number;
+		last_page: number;
+		per_page: number;
+		total: number;
+	};
+	export type PaginatedFaceResource = {
+		data: App.Http.Resources.Models.FaceResource[];
+		current_page: number;
+		last_page: number;
+		per_page: number;
+		total: number;
+	};
+	export type PaginatedModerationResource = {
+		photos: App.Http.Resources.Models.ModerationResource[];
+		current_page: number;
+		last_page: number;
+		per_page: number;
+		total: number;
+	};
+	export type PaginatedPersonsResource = {
+		data: App.Http.Resources.Models.PersonResource[];
+		current_page: number;
+		last_page: number;
+		per_page: number;
+		total: number;
+	};
+	export type PaginatedPhotosResource = {
+		photos: App.Http.Resources.Models.PhotoResource[];
+		current_page: number;
+		last_page: number;
+		per_page: number;
+		total: number;
+	};
+	export type PaginatedWebhookResource = {
+		webhooks: App.Http.Resources.Models.WebhookResource[];
+		current_page: number;
+		last_page: number;
+		per_page: number;
+		total: number;
+	};
+	export type PositionDataResource = {
+		id: string | null;
+		title: string | null;
+		track_url: string | null;
+		photos: App.Http.Resources.Models.PhotoResource[];
+	};
+	export type RootAlbumResource = {
+		smart_albums: App.Http.Resources.Models.ThumbAlbumResource[];
+		tag_albums: App.Http.Resources.Models.ThumbAlbumResource[];
+		pinned_albums: App.Http.Resources.Models.ThumbAlbumResource[];
+		albums: App.Http.Resources.Models.ThumbAlbumResource[];
+		shared_albums: App.Http.Resources.Models.ThumbAlbumResource[];
+		config: App.Http.Resources.GalleryConfigs.RootConfig;
+		rights: App.Http.Resources.Rights.RootAlbumRightsResource;
+	};
+	export type UserGroupDataResource = {
+		user_groups: App.Http.Resources.Models.UserGroupResource[];
+		can_create_delete_user_groups: boolean;
+	};
 }
 declare namespace App.Http.Resources.Diagnostics {
-export type AlbumTree = {
-id: string;
-title: string;
-parent_id: string | null;
-_lft: number;
-_rgt: number;
-};
-export type ChangeLogInfo = {
-version: string;
-date: string;
-changes: string;
-};
-export type CleaningState = {
-path: string;
-base: string;
-is_not_empty: boolean;
-};
-export type ErrorLine = {
-type: App.Enum.MessageType;
-message: string;
-from: string;
-details: string[];
-};
-export type Errors = {
-_note: string;
-errors: App.Http.Resources.Diagnostics.ErrorLine[];
-};
-export type Permissions = {
-left: string;
-right: string;
-};
-export type StatisticsCheckResource = {
-missing_photos: number;
-missing_albums: number;
-};
-export type TreeState = {
-oddness: number;
-duplicates: number;
-wrong_parent: number;
-missing_parent: number;
-};
-export type UpdateCheckInfo = {
-extra: string;
-can_update: boolean;
-};
-export type UpdateInfo = {
-info: string;
-extra: string;
-channel_name: App.Enum.VersionChannelType;
-is_docker: boolean;
-};
+	export type AlbumTree = {
+		id: string;
+		title: string;
+		parent_id: string | null;
+		_lft: number;
+		_rgt: number;
+	};
+	export type ChangeLogInfo = {
+		version: string;
+		date: string;
+		changes: string;
+	};
+	export type CleaningState = {
+		path: string;
+		base: string;
+		is_not_empty: boolean;
+	};
+	export type ErrorLine = {
+		type: App.Enum.MessageType;
+		message: string;
+		from: string;
+		details: string[];
+	};
+	export type Errors = {
+		_note: string;
+		errors: App.Http.Resources.Diagnostics.ErrorLine[];
+	};
+	export type Permissions = {
+		left: string;
+		right: string;
+	};
+	export type StatisticsCheckResource = {
+		missing_photos: number;
+		missing_albums: number;
+	};
+	export type TreeState = {
+		oddness: number;
+		duplicates: number;
+		wrong_parent: number;
+		missing_parent: number;
+	};
+	export type UpdateCheckInfo = {
+		extra: string;
+		can_update: boolean;
+	};
+	export type UpdateInfo = {
+		info: string;
+		extra: string;
+		channel_name: App.Enum.VersionChannelType;
+		is_docker: boolean;
+	};
 }
 declare namespace App.Http.Resources.Editable {
-export type EditableBaseAlbumResource = {
-id: string;
-title: string;
-slug: string | null;
-description: string | null;
-copyright: string | null;
-license: App.Enum.LicenseType | null;
-photo_sorting: App.DTO.PhotoSortingCriterion | null;
-album_sorting: App.DTO.AlbumSortingCriterion | null;
-aspect_ratio: App.Enum.AspectRatioType | null;
-photo_layout: App.Enum.PhotoLayoutType | null;
-header_id: string | null;
-cover_id: string | null;
-album_timeline: App.Enum.TimelineAlbumGranularity | null;
-photo_timeline: App.Enum.TimelinePhotoGranularity | null;
-tags: Array<string>;
-is_and: boolean;
-is_model_album: boolean;
-is_pinned: boolean;
-};
-export type EditableConfigResource = {
-key: string;
-value: string | null;
-};
-export type UploadMetaResource = {
-file_name: string;
-extension: string | null;
-uuid_name: string | null;
-stage: App.Enum.FileStatus;
-chunk_number: number;
-total_chunks: number;
-expected_id: string | null;
-title: string | null;
-description: string | null;
-};
+	export type EditableBaseAlbumResource = {
+		id: string;
+		title: string;
+		slug: string | null;
+		description: string | null;
+		copyright: string | null;
+		license: App.Enum.LicenseType | null;
+		photo_sorting: App.DTO.PhotoSortingCriterion | null;
+		album_sorting: App.DTO.AlbumSortingCriterion | null;
+		aspect_ratio: App.Enum.AspectRatioType | null;
+		photo_layout: App.Enum.PhotoLayoutType | null;
+		header_id: string | null;
+		cover_id: string | null;
+		album_timeline: App.Enum.TimelineAlbumGranularity | null;
+		photo_timeline: App.Enum.TimelinePhotoGranularity | null;
+		tags: Array<string>;
+		is_and: boolean;
+		is_model_album: boolean;
+		is_pinned: boolean;
+	};
+	export type EditableConfigResource = {
+		key: string;
+		value: string | null;
+	};
+	export type UploadMetaResource = {
+		file_name: string;
+		extension: string | null;
+		uuid_name: string | null;
+		stage: App.Enum.FileStatus;
+		chunk_number: number;
+		total_chunks: number;
+		expected_id: string | null;
+		title: string | null;
+		description: string | null;
+	};
 }
 declare namespace App.Http.Resources.Embed {
-export type EmbedAlbumInfo = {
-id: string;
-title: string;
-description: string | null;
-photo_count: number;
-copyright: string | null;
-license: string | null;
-};
-export type EmbedAlbumResource = {
-album: App.Http.Resources.Embed.EmbedAlbumInfo;
-photos: App.Http.Resources.Embed.EmbedPhotoResource[];
-};
-export type EmbedPhotoResource = {
-id: string;
-title: string | null;
-description: string | null;
-is_video: boolean;
-duration: string | null;
-size_variants: App.Http.Resources.Models.SizeVariantsResouce;
-exif: { [key: string]: string | null };
-};
-export type EmbedStreamResource = {
-site_title: string;
-photos: App.Http.Resources.Embed.EmbedPhotoResource[];
-};
+	export type EmbedAlbumInfo = {
+		id: string;
+		title: string;
+		description: string | null;
+		photo_count: number;
+		copyright: string | null;
+		license: string | null;
+	};
+	export type EmbedAlbumResource = {
+		album: App.Http.Resources.Embed.EmbedAlbumInfo;
+		photos: App.Http.Resources.Embed.EmbedPhotoResource[];
+	};
+	export type EmbedPhotoResource = {
+		id: string;
+		title: string | null;
+		description: string | null;
+		is_video: boolean;
+		duration: string | null;
+		size_variants: App.Http.Resources.Models.SizeVariantsResouce;
+		exif: { [key: string]: string | null };
+	};
+	export type EmbedStreamResource = {
+		site_title: string;
+		photos: App.Http.Resources.Embed.EmbedPhotoResource[];
+	};
 }
 declare namespace App.Http.Resources.Flow {
-export type FlowItemResource = {
-id: string;
-title: string;
-description: string | null;
-min_max_text: string | null;
-published_created_at: string;
-diff_published_created_at: string;
-owner_name: string | null;
-is_nsfw: boolean;
-num_photos: number;
-num_children: number;
-cover: App.Http.Resources.Models.SizeVariantsResouce | null;
-photos: App.Http.Resources.Models.PhotoResource[];
-statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
-};
-export type FlowResource = {
-albums: App.Http.Resources.Flow.FlowItemResource[];
-current_page: number;
-from: number;
-last_page: number;
-per_page: number;
-to: number;
-total: number;
-};
-export type InitResource = {
-is_mod_flow_enabled: boolean;
-is_open_album_on_click: boolean;
-is_display_open_album_button: boolean;
-is_highlight_first_picture: boolean;
-is_image_header_enabled: boolean;
-image_header_cover: App.Enum.CoverFitType;
-image_header_height: number;
-is_carousel_enabled: boolean;
-carousel_height: number;
-is_blur_nsfw_enabled: boolean;
-is_compact_mode_enabled: boolean;
-};
+	export type FlowItemResource = {
+		id: string;
+		title: string;
+		description: string | null;
+		min_max_text: string | null;
+		published_created_at: string;
+		diff_published_created_at: string;
+		owner_name: string | null;
+		is_nsfw: boolean;
+		num_photos: number;
+		num_children: number;
+		cover: App.Http.Resources.Models.SizeVariantsResouce | null;
+		photos: App.Http.Resources.Models.PhotoResource[];
+		statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
+	};
+	export type FlowResource = {
+		albums: App.Http.Resources.Flow.FlowItemResource[];
+		current_page: number;
+		from: number;
+		last_page: number;
+		per_page: number;
+		to: number;
+		total: number;
+	};
+	export type InitResource = {
+		is_mod_flow_enabled: boolean;
+		is_open_album_on_click: boolean;
+		is_display_open_album_button: boolean;
+		is_highlight_first_picture: boolean;
+		is_image_header_enabled: boolean;
+		image_header_cover: App.Enum.CoverFitType;
+		image_header_height: number;
+		is_carousel_enabled: boolean;
+		carousel_height: number;
+		is_blur_nsfw_enabled: boolean;
+		is_compact_mode_enabled: boolean;
+	};
 }
 declare namespace App.Http.Resources.Frame {
-export type FrameData = {
-timeout: number;
-src: string;
-srcset: string;
-};
+	export type FrameData = {
+		timeout: number;
+		src: string;
+		srcset: string;
+	};
 }
 declare namespace App.Http.Resources.GalleryConfigs {
-export type AlbumConfig = {
-is_base_album: boolean;
-is_model_album: boolean;
-is_password_protected: boolean;
-is_map_accessible: boolean;
-is_mod_frame_enabled: boolean;
-is_search_accessible: boolean;
-is_nsfw_warning_visible: boolean;
-album_thumb_css_aspect_ratio: App.Enum.AspectRatioCSSType;
-photo_layout: App.Enum.PhotoLayoutType;
-is_album_timeline_enabled: boolean;
-is_photo_timeline_enabled: boolean;
-};
-export type ContactConfig = {
-is_contact_form_enabled: boolean;
-security_question: string;
-is_consent_required: boolean;
-header: string;
-headline: string;
-consent_text: string;
-privacy_policy_url: string;
-submit_button_text: string;
-contact_method: string;
-message_label: string;
-message_answer: string;
-thank_you_message: string;
-};
-export type FooterConfig = {
-footer_additional_text: string;
-footer_show_copyright: boolean;
-footer_show_social_media: boolean;
-copyright: string;
-sm_facebook_url: string;
-sm_flickr_url: string;
-sm_instagram_url: string;
-sm_twitter_url: string;
-sm_youtube_url: string;
-is_contact_form_enabled: boolean;
-contact_header: string;
-};
-export type InitConfig = {
-is_debug_enabled: boolean;
-are_nsfw_visible: boolean;
-is_nsfw_background_blurred: boolean;
-nsfw_banner_override: string;
-is_nsfw_banner_backdrop_blurred: boolean;
-show_keybinding_help_popup: boolean;
-image_overlay_type: App.Enum.ImageOverlayType;
-can_rotate: boolean;
-can_autoplay: boolean;
-is_exif_disabled: boolean;
-is_favourite_enabled: boolean;
-photo_previous_next_size: App.Enum.SmallLargeType;
-is_details_links_enabled: boolean;
-is_desktop_dock_full_transparency_enabled: boolean;
-is_mobile_dock_full_transparency_enabled: boolean;
-is_photo_details_always_open: boolean;
-is_face_overlay_visible: boolean;
-is_face_recognition_enabled: boolean;
-is_nsfw_classifier_enabled: boolean;
-display_thumb_album_overlay: App.Enum.VisibilityType;
-display_thumb_photo_overlay: App.Enum.VisibilityType;
-album_subtitle_type: App.Enum.ThumbAlbumSubtitleType;
-album_decoration: App.Enum.AlbumDecorationType;
-album_decoration_orientation: App.Enum.AlbumDecorationOrientation;
-number_albums_per_row_mobile: 1|2|3;
-photo_thumb_info: App.Enum.PhotoThumbInfoType;
-is_photo_thumb_tags_enabled: boolean;
-album_layout: App.Enum.AlbumLayoutType;
-is_raw_download_enabled: boolean;
-is_thumb_download_enabled: boolean;
-is_thum2x_download_enabled: boolean;
-is_small_download_enabled: boolean;
-is_small2x_download_enabled: boolean;
-is_medium_download_enabled: boolean;
-is_medium2x_download_enabled: boolean;
-is_download_archive_chunked: boolean;
-clockwork_url: string | null;
-slideshow_timeout: number;
-is_slideshow_enabled: boolean;
-is_timeline_left_border_visible: boolean;
-title: string;
-site_logo: string;
-dropbox_api_key: string;
-is_se_enabled: boolean;
-is_pro_enabled: boolean;
-is_se_preview_enabled: boolean;
-is_se_info_hidden: boolean;
-is_se_expired: boolean;
-is_live_metrics_enabled: boolean;
-is_white_label_enabled: boolean;
-is_basic_auth_enabled: boolean;
-is_webauthn_enabled: boolean;
-is_registration_enabled: boolean;
-is_scroll_to_navigate_photos_enabled: boolean;
-is_swipe_vertically_to_go_back_enabled: boolean;
-disable_swipe_effect: boolean;
-is_rating_show_avg_in_details_enabled: boolean;
-is_rating_show_avg_in_photo_view_enabled: boolean;
-rating_photo_view_mode: App.Enum.VisibilityType;
-is_rating_show_avg_in_album_view_enabled: boolean;
-rating_album_view_mode: App.Enum.VisibilityType;
-is_embed_enabled: boolean;
-default_homepage: string;
-is_timeline_page_enabled: boolean;
-is_contact_form_enabled: boolean;
-photos_pagination_mode: App.Enum.PaginationMode;
-albums_pagination_mode: App.Enum.PaginationMode;
-photos_per_page: number;
-albums_per_page: number;
-photos_infinite_scroll_threshold: number;
-albums_infinite_scroll_threshold: number;
-default_album_protection: App.Enum.DefaultAlbumProtectionType;
-photos_star_visibility: App.Enum.PhotoHighlightVisibilityType;
-is_album_enhanced_display_enabled: boolean;
-album_header_size: App.Enum.AlbumHeaderSize;
-is_album_header_landing_title_enabled: boolean;
-use_admin_dashboard: boolean;
-};
-export type LandingPageResource = {
-landing_page_enable: boolean;
-landing_background_landscape: string;
-landing_background_portrait: string;
-landing_subtitle: string;
-landing_title: string;
-site_owner: string;
-site_title: string;
-landing_logo: string;
-landing_header_logo: string;
-footer: App.Http.Resources.GalleryConfigs.FooterConfig;
-};
-export type MapProviderData = {
-layer: string;
-attribution: string;
-};
-export type PhotoLayoutConfig = {
-photo_layout_justified_row_height: number;
-photo_layout_masonry_column_width: number;
-photo_layout_grid_column_width: number;
-photo_layout_square_column_width: number;
-photo_layout_gap: number;
-};
-export type RegisterData = {
-success: boolean;
-};
-export type RootConfig = {
-is_album_timeline_enabled: boolean;
-is_search_accessible: boolean;
-show_keybinding_help_button: boolean;
-album_thumb_css_aspect_ratio: App.Enum.AspectRatioType;
-back_button_enabled: boolean;
-back_button_text: string;
-back_button_url: string;
-timeline_album_granularity: App.Enum.TimelineAlbumGranularity;
-header_image_url: string;
-is_header_bar_transparent: boolean;
-is_header_bar_gradient: boolean;
-shared_albums_visibility_mode: App.Enum.SharedAlbumsVisibility;
-};
-export type SettingsConfig = {
-default_old_settings: boolean;
-default_expert_settings: boolean;
-default_all_settings: boolean;
-};
-export type UploadConfig = {
-upload_processing_limit: number;
-upload_chunk_size: number;
-can_watermark_optout: boolean;
-close_upload_on_success: boolean;
-folder_upload_enabled: boolean;
-folder_upload_max_depth: number;
-};
-export type ZipChunkData = {
-total_chunks: number;
-total_photos: number;
-};
+	export type AlbumConfig = {
+		is_base_album: boolean;
+		is_model_album: boolean;
+		is_password_protected: boolean;
+		is_map_accessible: boolean;
+		is_mod_frame_enabled: boolean;
+		is_search_accessible: boolean;
+		is_nsfw_warning_visible: boolean;
+		is_breadcrumb_enabled: boolean;
+		album_thumb_css_aspect_ratio: App.Enum.AspectRatioCSSType;
+		photo_layout: App.Enum.PhotoLayoutType;
+		is_album_timeline_enabled: boolean;
+		is_photo_timeline_enabled: boolean;
+	};
+	export type ContactConfig = {
+		is_contact_form_enabled: boolean;
+		security_question: string;
+		is_consent_required: boolean;
+		header: string;
+		headline: string;
+		consent_text: string;
+		privacy_policy_url: string;
+		submit_button_text: string;
+		contact_method: string;
+		message_label: string;
+		message_answer: string;
+		thank_you_message: string;
+	};
+	export type FooterConfig = {
+		footer_additional_text: string;
+		footer_show_copyright: boolean;
+		footer_show_social_media: boolean;
+		copyright: string;
+		sm_facebook_url: string;
+		sm_flickr_url: string;
+		sm_instagram_url: string;
+		sm_twitter_url: string;
+		sm_youtube_url: string;
+		is_contact_form_enabled: boolean;
+		contact_header: string;
+	};
+	export type InitConfig = {
+		is_debug_enabled: boolean;
+		are_nsfw_visible: boolean;
+		is_nsfw_background_blurred: boolean;
+		nsfw_banner_override: string;
+		is_nsfw_banner_backdrop_blurred: boolean;
+		show_keybinding_help_popup: boolean;
+		image_overlay_type: App.Enum.ImageOverlayType;
+		can_rotate: boolean;
+		can_autoplay: boolean;
+		is_exif_disabled: boolean;
+		is_favourite_enabled: boolean;
+		photo_previous_next_size: App.Enum.SmallLargeType;
+		is_details_links_enabled: boolean;
+		is_desktop_dock_full_transparency_enabled: boolean;
+		is_mobile_dock_full_transparency_enabled: boolean;
+		is_photo_details_always_open: boolean;
+		is_face_overlay_visible: boolean;
+		is_face_recognition_enabled: boolean;
+		is_nsfw_classifier_enabled: boolean;
+		display_thumb_album_overlay: App.Enum.VisibilityType;
+		display_thumb_photo_overlay: App.Enum.VisibilityType;
+		album_subtitle_type: App.Enum.ThumbAlbumSubtitleType;
+		album_decoration: App.Enum.AlbumDecorationType;
+		album_decoration_orientation: App.Enum.AlbumDecorationOrientation;
+		number_albums_per_row_mobile: 1 | 2 | 3;
+		photo_thumb_info: App.Enum.PhotoThumbInfoType;
+		is_photo_thumb_tags_enabled: boolean;
+		album_layout: App.Enum.AlbumLayoutType;
+		is_raw_download_enabled: boolean;
+		is_thumb_download_enabled: boolean;
+		is_thum2x_download_enabled: boolean;
+		is_small_download_enabled: boolean;
+		is_small2x_download_enabled: boolean;
+		is_medium_download_enabled: boolean;
+		is_medium2x_download_enabled: boolean;
+		is_download_archive_chunked: boolean;
+		clockwork_url: string | null;
+		slideshow_timeout: number;
+		is_slideshow_enabled: boolean;
+		is_timeline_left_border_visible: boolean;
+		title: string;
+		site_logo: string;
+		dropbox_api_key: string;
+		is_se_enabled: boolean;
+		is_pro_enabled: boolean;
+		is_se_preview_enabled: boolean;
+		is_se_info_hidden: boolean;
+		is_se_expired: boolean;
+		is_live_metrics_enabled: boolean;
+		is_white_label_enabled: boolean;
+		is_basic_auth_enabled: boolean;
+		is_webauthn_enabled: boolean;
+		is_registration_enabled: boolean;
+		is_scroll_to_navigate_photos_enabled: boolean;
+		is_swipe_vertically_to_go_back_enabled: boolean;
+		disable_swipe_effect: boolean;
+		is_rating_show_avg_in_details_enabled: boolean;
+		is_rating_show_avg_in_photo_view_enabled: boolean;
+		rating_photo_view_mode: App.Enum.VisibilityType;
+		is_rating_show_avg_in_album_view_enabled: boolean;
+		rating_album_view_mode: App.Enum.VisibilityType;
+		is_embed_enabled: boolean;
+		default_homepage: string;
+		is_timeline_page_enabled: boolean;
+		is_contact_form_enabled: boolean;
+		photos_pagination_mode: App.Enum.PaginationMode;
+		albums_pagination_mode: App.Enum.PaginationMode;
+		photos_per_page: number;
+		albums_per_page: number;
+		photos_infinite_scroll_threshold: number;
+		albums_infinite_scroll_threshold: number;
+		default_album_protection: App.Enum.DefaultAlbumProtectionType;
+		photos_star_visibility: App.Enum.PhotoHighlightVisibilityType;
+		is_album_enhanced_display_enabled: boolean;
+		album_header_size: App.Enum.AlbumHeaderSize;
+		is_album_header_landing_title_enabled: boolean;
+		use_admin_dashboard: boolean;
+	};
+	export type LandingPageResource = {
+		landing_page_enable: boolean;
+		landing_background_landscape: string;
+		landing_background_portrait: string;
+		landing_subtitle: string;
+		landing_title: string;
+		site_owner: string;
+		site_title: string;
+		landing_logo: string;
+		landing_header_logo: string;
+		footer: App.Http.Resources.GalleryConfigs.FooterConfig;
+	};
+	export type MapProviderData = {
+		layer: string;
+		attribution: string;
+	};
+	export type PhotoLayoutConfig = {
+		photo_layout_justified_row_height: number;
+		photo_layout_masonry_column_width: number;
+		photo_layout_grid_column_width: number;
+		photo_layout_square_column_width: number;
+		photo_layout_gap: number;
+	};
+	export type RegisterData = {
+		success: boolean;
+	};
+	export type RootConfig = {
+		is_album_timeline_enabled: boolean;
+		is_search_accessible: boolean;
+		show_keybinding_help_button: boolean;
+		album_thumb_css_aspect_ratio: App.Enum.AspectRatioType;
+		back_button_enabled: boolean;
+		back_button_text: string;
+		back_button_url: string;
+		timeline_album_granularity: App.Enum.TimelineAlbumGranularity;
+		header_image_url: string;
+		is_header_bar_transparent: boolean;
+		is_header_bar_gradient: boolean;
+		shared_albums_visibility_mode: App.Enum.SharedAlbumsVisibility;
+	};
+	export type SettingsConfig = {
+		default_old_settings: boolean;
+		default_expert_settings: boolean;
+		default_all_settings: boolean;
+	};
+	export type UploadConfig = {
+		upload_processing_limit: number;
+		upload_chunk_size: number;
+		can_watermark_optout: boolean;
+		close_upload_on_success: boolean;
+		folder_upload_enabled: boolean;
+		folder_upload_max_depth: number;
+	};
+	export type ZipChunkData = {
+		total_chunks: number;
+		total_photos: number;
+	};
 }
 declare namespace App.Http.Resources.GalleryConfigs.Nsfw {
-export type NsfwActionCategoryResource = {
-labels: App.Enum.NsfwDetectionLabel[];
-confidence: number | null;
-area_ratio: number | null;
-label_thresholds: number[];
-};
-export type NsfwConfigPresetResource = {
-name: App.Enum.NsfwPreset;
-description: string;
-block: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
-review: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
-sensitive: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
-};
-export type NsfwConfigResource = {
-config: App.Http.Resources.GalleryConfigs.Nsfw.NsfwConfigSettingsResource;
-presets: App.Http.Resources.GalleryConfigs.Nsfw.NsfwConfigPresetResource[];
-};
-export type NsfwConfigSettingsResource = {
-confidence_threshold: string;
-area_ratio_threshold: string;
-debug_detect_threshold: string;
-block: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
-review: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
-sensitive: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
-queue_backend: string;
-queue_max_size: string;
-thread_pool_size: string;
-verify_ssl: string;
-workers: string;
-};
+	export type NsfwActionCategoryResource = {
+		labels: App.Enum.NsfwDetectionLabel[];
+		confidence: number | null;
+		area_ratio: number | null;
+		label_thresholds: number[];
+	};
+	export type NsfwConfigPresetResource = {
+		name: App.Enum.NsfwPreset;
+		description: string;
+		block: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
+		review: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
+		sensitive: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
+	};
+	export type NsfwConfigResource = {
+		config: App.Http.Resources.GalleryConfigs.Nsfw.NsfwConfigSettingsResource;
+		presets: App.Http.Resources.GalleryConfigs.Nsfw.NsfwConfigPresetResource[];
+	};
+	export type NsfwConfigSettingsResource = {
+		confidence_threshold: string;
+		area_ratio_threshold: string;
+		debug_detect_threshold: string;
+		block: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
+		review: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
+		sensitive: App.Http.Resources.GalleryConfigs.Nsfw.NsfwActionCategoryResource;
+		queue_backend: string;
+		queue_max_size: string;
+		thread_pool_size: string;
+		verify_ssl: string;
+		workers: string;
+	};
 }
 declare namespace App.Http.Resources.Models {
-export type AccessPermissionResource = {
-id: number | null;
-user_id: number | null;
-user_group_id: number | null;
-username: string | null;
-user_group_name: string | null;
-album_title: string | null;
-album_id: string | null;
-grants_full_photo_access: boolean;
-grants_download: boolean;
-grants_upload: boolean;
-grants_edit: boolean;
-grants_delete: boolean;
-};
-export type AdminStatsResource = {
-photos_count: number;
-albums_count: number;
-users_count: number;
-storage_bytes: number;
-queued_jobs: number;
-failed_jobs_24h: number;
-last_successful_job_at: string | null;
-cached_at: string;
-errors: Array<string>;
-};
-export type AdminUpdateStatusResource = {
-enabled: boolean;
-update_status: number | null;
-has_update: boolean;
-current_version: string | null;
-latest_version: string | null;
-};
-export type AlbumStatisticsResource = {
-visit_count: number;
-download_count: number;
-shared_count: number;
-};
-export type BreadcrumbItemResource = {
-id: string | null;
-title: string;
-slug: string | null;
-};
-export type ClusterPreviewResource = {
-cluster_label: number;
-face_count: number;
-sample_crop_urls: string[];
-};
-export type ColourPaletteResource = {
-colour_1: string;
-colour_2: string;
-colour_3: string;
-colour_4: string;
-colour_5: string;
-};
-export type ConfigCategoryResource = {
-cat: string;
-name: string;
-description: string;
-configs: App.Http.Resources.Models.ConfigResource[];
-priority: number;
-};
-export type ConfigResource = {
-key: string;
-type: App.Enum.ConfigType | string;
-value: string;
-documentation: string;
-details: string;
-is_expert: boolean;
-require_se: boolean;
-order: number | null;
-};
-export type ContactMessageResource = {
-id: number;
-name: string;
-email: string;
-message: string;
-is_read: boolean;
-created_at: string;
-};
-export type FaceResource = {
-id: string;
-photo_id: string;
-person_id: string | null;
-x: number;
-y: number;
-width: number;
-height: number;
-confidence: number;
-laplacian_variance: number;
-is_dismissed: boolean;
-cluster_label: number | null;
-crop_url: string | null;
-person_name: string | null;
-suggestions: Array<App.Http.Resources.Models.FaceSuggestionResource>;
-};
-export type FaceSuggestionResource = {
-suggested_face_id: string;
-crop_url: string | null;
-person_name: string | null;
-confidence: number;
-};
-export type HeadAbstractAlbumResource = {
-config: App.Http.Resources.GalleryConfigs.AlbumConfig;
-resource: App.Http.Resources.Models.HeadAlbumResource | App.Http.Resources.Models.HeadSmartAlbumResource | App.Http.Resources.Models.HeadTagAlbumResource;
-};
-export type HeadAlbumResource = {
-id: string;
-title: string;
-slug: string | null;
-owner_name: string | null;
-description: string | null;
-copyright: string | null;
-track_url: string | null;
-license: string;
-header_id: string | null;
-parent_id: string | null;
-has_albums: boolean;
-num_children: number;
-num_photos: number;
-cover_id: string | null;
-policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
-rights: App.Http.Resources.Rights.AlbumRightsResource;
-preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
-editable: App.Http.Resources.Editable.EditableBaseAlbumResource | null;
-is_pinned: boolean;
-statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
-breadcrumb: App.Http.Resources.Models.BreadcrumbItemResource[];
-};
-export type HeadSmartAlbumResource = {
-id: string;
-title: string;
-policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
-rights: App.Http.Resources.Rights.AlbumRightsResource;
-preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
-statistics: null | null;
-};
-export type HeadTagAlbumResource = {
-id: string;
-title: string;
-slug: string | null;
-owner_name: string | null;
-copyright: string | null;
-is_tag_album: boolean;
-show_tags: Array<string>;
-policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
-rights: App.Http.Resources.Rights.AlbumRightsResource;
-preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
-editable: App.Http.Resources.Editable.EditableBaseAlbumResource | null;
-statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
-};
-export type JobHistoryResource = {
-username: string;
-status: 'ready'|'success'|'failure'|'started';
-created_at: string;
-updated_at: string;
-job: string;
-};
-export type LightUserResource = {
-id: number;
-username: string;
-};
-export type LiveMetricsResource = {
-created_at: string;
-visitor_id: string;
-action: App.Enum.MetricsAction;
-photo_id: string | null;
-album_id: string;
-title: string;
-url: string | null;
-};
-export type ModerationResource = {
-photo_id: string;
-title: string;
-thumb_url: string | null;
-owner_username: string;
-album_id: string | null;
-album_title: string | null;
-created_at: string;
-nsfw_status: string | null;
-};
-export type NsfwDetectionResource = {
-id: number;
-photo_id: string;
-label: string;
-confidence: number;
-bbox_x: number;
-bbox_y: number;
-bbox_width: number;
-bbox_height: number;
-is_block: boolean;
-is_review: boolean;
-is_sensitive: boolean;
-};
-export type PersonResource = {
-id: string;
-name: string;
-user_id: number | null;
-is_searchable: boolean;
-representative_face_id: string | null;
-face_count: number;
-photo_count: number;
-representative_crop_url: string | null;
-};
-export type PhotoAlbumResource = {
-id: string;
-title: string;
-};
-export type PhotoFacesResource = {
-faces: App.Http.Resources.Models.FaceResource[];
-hidden_face_count: number;
-rights: App.Http.Resources.Rights.PhotoRightsResource;
-};
-export type PhotoNsfwDetectionsResource = {
-detections: App.Http.Resources.Models.NsfwDetectionResource[];
-image_width: number;
-image_height: number;
-};
-export type PhotoRatingResource = {
-rating_user: number;
-rating_count: number;
-rating_avg: number;
-};
-export type PhotoResource = {
-id: string;
-album_id: string | null;
-checksum: string;
-created_at: string;
-description: string;
-is_highlighted: boolean;
-license: App.Enum.LicenseType;
-live_photo_checksum: string | null;
-live_photo_content_id: string | null;
-live_photo_url: string | null;
-original_checksum: string;
-size_variants: App.Http.Resources.Models.SizeVariantsResouce;
-tags: Array<string>;
-taken_at: string | null;
-taken_at_orig_tz: string | null;
-title: string;
-type: string;
-updated_at: string;
-next_photo_id: string | null;
-previous_photo_id: string | null;
-preformatted: App.Http.Resources.Models.Utils.PreformattedPhotoData;
-precomputed: App.Http.Resources.Models.Utils.PreComputedPhotoData;
-timeline: App.Http.Resources.Models.Utils.TimelineData | null;
-palette: App.Http.Resources.Models.ColourPaletteResource | null;
-statistics: App.Http.Resources.Models.PhotoStatisticsResource | null;
-rating: App.Http.Resources.Models.PhotoRatingResource | null;
-face_count: number;
-is_validated: boolean;
-};
-export type PhotoStatisticsResource = {
-visit_count: number;
-download_count: number;
-favourite_count: number;
-shared_count: number;
-rating_count: number;
-rating_avg: number | null;
-};
-export type RenamerPreviewResource = {
-id: string;
-original: string;
-new: string;
-};
-export type RenamerRuleResource = {
-id: number;
-order: number;
-owner_id: number;
-rule: string;
-description: string;
-needle: string;
-replacement: string;
-mode: App.Enum.RenamerModeType;
-is_enabled: boolean;
-is_photo_rule: boolean;
-is_album_rule: boolean;
-};
-export type SecurityAdvisoryResource = {
-cve_id: string | null;
-ghsa_id: string;
-summary: string;
-cvss_score: number | null;
-cvss_vector: string | null;
-};
-export type SizeVariantResource = {
-type: App.Enum.SizeVariantType;
-locale: string;
-filesize: string;
-height: number;
-width: number;
-url: string | null;
-is_watermarked: boolean;
-};
-export type SizeVariantsResouce = {
-raw: App.Http.Resources.Models.SizeVariantResource | null;
-original: App.Http.Resources.Models.SizeVariantResource | null;
-medium2x: App.Http.Resources.Models.SizeVariantResource | null;
-medium: App.Http.Resources.Models.SizeVariantResource | null;
-small2x: App.Http.Resources.Models.SizeVariantResource | null;
-small: App.Http.Resources.Models.SizeVariantResource | null;
-thumb2x: App.Http.Resources.Models.SizeVariantResource | null;
-thumb: App.Http.Resources.Models.SizeVariantResource | null;
-placeholder: App.Http.Resources.Models.SizeVariantResource | null;
-};
-export type TargetAlbumResource = {
-id: string | null;
-title: string;
-original: string;
-short_title: string;
-thumb: string;
-};
-export type ThumbAlbumResource = {
-id: string;
-title: string;
-description: string | null;
-thumb: App.Http.Resources.Models.ThumbResource | null;
-is_nsfw: boolean;
-is_pinned: boolean;
-is_public: boolean;
-is_link_required: boolean;
-is_password_required: boolean;
-is_tag_album: boolean;
-has_subalbum: boolean;
-num_subalbums: number;
-num_photos: number;
-created_at: string;
-formatted_min_max: string | null;
-owner: string | null;
-rights: App.Http.Resources.Rights.AlbumRightsResource;
-timeline: App.Http.Resources.Models.Utils.TimelineData | null;
-};
-export type ThumbResource = {
-id: string;
-type: string;
-thumb: string | null;
-thumb2x: string | null;
-placeholder: string | null;
-};
-export type UserGroupResource = {
-id: number;
-name: string;
-description: string;
-members: App.Http.Resources.Models.UserMemberGroupResource[];
-rights: App.Http.Resources.Rights.UserGroupRightResource;
-};
-export type UserManagementResource = {
-id: number;
-username: string;
-may_administrate: boolean;
-may_upload: boolean;
-may_edit_own_settings: boolean;
-is_owner: boolean;
-upload_trust_level: App.Enum.UserUploadTrustLevel;
-quota_kb: number | null;
-description: string | null;
-note: string | null;
-space: number | null;
-};
-export type UserMemberGroupResource = {
-id: number;
-username: string;
-role: App.Enum.UserGroupRole;
-};
-export type UserResource = {
-id: number | null;
-has_token: boolean | null;
-username: string | null;
-email: string | null;
-is_ldap: boolean;
-may_administrate: boolean;
-shared_albums_visibility: App.Enum.UserSharedAlbumsVisibility;
-};
-export type WebAuthnResource = {
-id: string;
-alias: string | null;
-created_at: string;
-};
-export type WebhookResource = {
-id: string;
-name: string;
-event: App.Enum.PhotoWebhookEvent;
-method: App.Enum.WebhookMethod;
-url: string;
-payload_format: App.Enum.WebhookPayloadFormat;
-has_secret: boolean;
-secret_header: string | null;
-enabled: boolean;
-send_photo_id: boolean;
-send_album_id: boolean;
-send_title: boolean;
-send_size_variants: boolean;
-size_variant_types: Array<number> | null;
-created_at: string;
-updated_at: string;
-};
+	export type AccessPermissionResource = {
+		id: number | null;
+		user_id: number | null;
+		user_group_id: number | null;
+		username: string | null;
+		user_group_name: string | null;
+		album_title: string | null;
+		album_id: string | null;
+		grants_full_photo_access: boolean;
+		grants_download: boolean;
+		grants_upload: boolean;
+		grants_edit: boolean;
+		grants_delete: boolean;
+	};
+	export type AdminStatsResource = {
+		photos_count: number;
+		albums_count: number;
+		users_count: number;
+		storage_bytes: number;
+		queued_jobs: number;
+		failed_jobs_24h: number;
+		last_successful_job_at: string | null;
+		cached_at: string;
+		errors: Array<string>;
+	};
+	export type AdminUpdateStatusResource = {
+		enabled: boolean;
+		update_status: number | null;
+		has_update: boolean;
+		current_version: string | null;
+		latest_version: string | null;
+	};
+	export type AlbumStatisticsResource = {
+		visit_count: number;
+		download_count: number;
+		shared_count: number;
+	};
+	export type BreadcrumbItemResource = {
+		id: string | null;
+		title: string;
+		slug: string | null;
+	};
+	export type ClusterPreviewResource = {
+		cluster_label: number;
+		face_count: number;
+		sample_crop_urls: string[];
+	};
+	export type ColourPaletteResource = {
+		colour_1: string;
+		colour_2: string;
+		colour_3: string;
+		colour_4: string;
+		colour_5: string;
+	};
+	export type ConfigCategoryResource = {
+		cat: string;
+		name: string;
+		description: string;
+		configs: App.Http.Resources.Models.ConfigResource[];
+		priority: number;
+	};
+	export type ConfigResource = {
+		key: string;
+		type: App.Enum.ConfigType | string;
+		value: string;
+		documentation: string;
+		details: string;
+		is_expert: boolean;
+		require_se: boolean;
+		order: number | null;
+	};
+	export type ContactMessageResource = {
+		id: number;
+		name: string;
+		email: string;
+		message: string;
+		is_read: boolean;
+		created_at: string;
+	};
+	export type FaceResource = {
+		id: string;
+		photo_id: string;
+		person_id: string | null;
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+		confidence: number;
+		laplacian_variance: number;
+		is_dismissed: boolean;
+		cluster_label: number | null;
+		crop_url: string | null;
+		person_name: string | null;
+		suggestions: Array<App.Http.Resources.Models.FaceSuggestionResource>;
+	};
+	export type FaceSuggestionResource = {
+		suggested_face_id: string;
+		crop_url: string | null;
+		person_name: string | null;
+		confidence: number;
+	};
+	export type HeadAbstractAlbumResource = {
+		config: App.Http.Resources.GalleryConfigs.AlbumConfig;
+		resource:
+			| App.Http.Resources.Models.HeadAlbumResource
+			| App.Http.Resources.Models.HeadSmartAlbumResource
+			| App.Http.Resources.Models.HeadTagAlbumResource;
+	};
+	export type HeadAlbumResource = {
+		id: string;
+		title: string;
+		slug: string | null;
+		owner_name: string | null;
+		description: string | null;
+		copyright: string | null;
+		track_url: string | null;
+		license: string;
+		header_id: string | null;
+		parent_id: string | null;
+		has_albums: boolean;
+		num_children: number;
+		num_photos: number;
+		cover_id: string | null;
+		policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
+		rights: App.Http.Resources.Rights.AlbumRightsResource;
+		preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
+		editable: App.Http.Resources.Editable.EditableBaseAlbumResource | null;
+		is_pinned: boolean;
+		statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
+		breadcrumb: App.Http.Resources.Models.BreadcrumbItemResource[];
+	};
+	export type HeadSmartAlbumResource = {
+		id: string;
+		title: string;
+		policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
+		rights: App.Http.Resources.Rights.AlbumRightsResource;
+		preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
+		statistics: null | null;
+	};
+	export type HeadTagAlbumResource = {
+		id: string;
+		title: string;
+		slug: string | null;
+		owner_name: string | null;
+		copyright: string | null;
+		is_tag_album: boolean;
+		show_tags: Array<string>;
+		policy: App.Http.Resources.Models.Utils.AlbumProtectionPolicy;
+		rights: App.Http.Resources.Rights.AlbumRightsResource;
+		preFormattedData: App.Http.Resources.Models.Utils.PreFormattedAlbumData;
+		editable: App.Http.Resources.Editable.EditableBaseAlbumResource | null;
+		statistics: App.Http.Resources.Models.AlbumStatisticsResource | null;
+	};
+	export type JobHistoryResource = {
+		username: string;
+		status: "ready" | "success" | "failure" | "started";
+		created_at: string;
+		updated_at: string;
+		job: string;
+	};
+	export type LightUserResource = {
+		id: number;
+		username: string;
+	};
+	export type LiveMetricsResource = {
+		created_at: string;
+		visitor_id: string;
+		action: App.Enum.MetricsAction;
+		photo_id: string | null;
+		album_id: string;
+		title: string;
+		url: string | null;
+	};
+	export type ModerationResource = {
+		photo_id: string;
+		title: string;
+		thumb_url: string | null;
+		owner_username: string;
+		album_id: string | null;
+		album_title: string | null;
+		created_at: string;
+		nsfw_status: string | null;
+	};
+	export type NsfwDetectionResource = {
+		id: number;
+		photo_id: string;
+		label: string;
+		confidence: number;
+		bbox_x: number;
+		bbox_y: number;
+		bbox_width: number;
+		bbox_height: number;
+		is_block: boolean;
+		is_review: boolean;
+		is_sensitive: boolean;
+	};
+	export type PersonResource = {
+		id: string;
+		name: string;
+		user_id: number | null;
+		is_searchable: boolean;
+		representative_face_id: string | null;
+		face_count: number;
+		photo_count: number;
+		representative_crop_url: string | null;
+	};
+	export type PhotoAlbumResource = {
+		id: string;
+		title: string;
+	};
+	export type PhotoFacesResource = {
+		faces: App.Http.Resources.Models.FaceResource[];
+		hidden_face_count: number;
+		rights: App.Http.Resources.Rights.PhotoRightsResource;
+	};
+	export type PhotoNsfwDetectionsResource = {
+		detections: App.Http.Resources.Models.NsfwDetectionResource[];
+		image_width: number;
+		image_height: number;
+	};
+	export type PhotoRatingResource = {
+		rating_user: number;
+		rating_count: number;
+		rating_avg: number;
+	};
+	export type PhotoResource = {
+		id: string;
+		album_id: string | null;
+		checksum: string;
+		created_at: string;
+		description: string;
+		is_highlighted: boolean;
+		license: App.Enum.LicenseType;
+		live_photo_checksum: string | null;
+		live_photo_content_id: string | null;
+		live_photo_url: string | null;
+		original_checksum: string;
+		size_variants: App.Http.Resources.Models.SizeVariantsResouce;
+		tags: Array<string>;
+		taken_at: string | null;
+		taken_at_orig_tz: string | null;
+		title: string;
+		type: string;
+		updated_at: string;
+		next_photo_id: string | null;
+		previous_photo_id: string | null;
+		preformatted: App.Http.Resources.Models.Utils.PreformattedPhotoData;
+		precomputed: App.Http.Resources.Models.Utils.PreComputedPhotoData;
+		timeline: App.Http.Resources.Models.Utils.TimelineData | null;
+		palette: App.Http.Resources.Models.ColourPaletteResource | null;
+		statistics: App.Http.Resources.Models.PhotoStatisticsResource | null;
+		rating: App.Http.Resources.Models.PhotoRatingResource | null;
+		face_count: number;
+		is_validated: boolean;
+	};
+	export type PhotoStatisticsResource = {
+		visit_count: number;
+		download_count: number;
+		favourite_count: number;
+		shared_count: number;
+		rating_count: number;
+		rating_avg: number | null;
+	};
+	export type RenamerPreviewResource = {
+		id: string;
+		original: string;
+		new: string;
+	};
+	export type RenamerRuleResource = {
+		id: number;
+		order: number;
+		owner_id: number;
+		rule: string;
+		description: string;
+		needle: string;
+		replacement: string;
+		mode: App.Enum.RenamerModeType;
+		is_enabled: boolean;
+		is_photo_rule: boolean;
+		is_album_rule: boolean;
+	};
+	export type SecurityAdvisoryResource = {
+		cve_id: string | null;
+		ghsa_id: string;
+		summary: string;
+		cvss_score: number | null;
+		cvss_vector: string | null;
+	};
+	export type SizeVariantResource = {
+		type: App.Enum.SizeVariantType;
+		locale: string;
+		filesize: string;
+		height: number;
+		width: number;
+		url: string | null;
+		is_watermarked: boolean;
+	};
+	export type SizeVariantsResouce = {
+		raw: App.Http.Resources.Models.SizeVariantResource | null;
+		original: App.Http.Resources.Models.SizeVariantResource | null;
+		medium2x: App.Http.Resources.Models.SizeVariantResource | null;
+		medium: App.Http.Resources.Models.SizeVariantResource | null;
+		small2x: App.Http.Resources.Models.SizeVariantResource | null;
+		small: App.Http.Resources.Models.SizeVariantResource | null;
+		thumb2x: App.Http.Resources.Models.SizeVariantResource | null;
+		thumb: App.Http.Resources.Models.SizeVariantResource | null;
+		placeholder: App.Http.Resources.Models.SizeVariantResource | null;
+	};
+	export type TargetAlbumResource = {
+		id: string | null;
+		title: string;
+		original: string;
+		short_title: string;
+		thumb: string;
+	};
+	export type ThumbAlbumResource = {
+		id: string;
+		title: string;
+		description: string | null;
+		thumb: App.Http.Resources.Models.ThumbResource | null;
+		is_nsfw: boolean;
+		is_pinned: boolean;
+		is_public: boolean;
+		is_link_required: boolean;
+		is_password_required: boolean;
+		is_tag_album: boolean;
+		has_subalbum: boolean;
+		num_subalbums: number;
+		num_photos: number;
+		created_at: string;
+		formatted_min_max: string | null;
+		owner: string | null;
+		rights: App.Http.Resources.Rights.AlbumRightsResource;
+		timeline: App.Http.Resources.Models.Utils.TimelineData | null;
+	};
+	export type ThumbResource = {
+		id: string;
+		type: string;
+		thumb: string | null;
+		thumb2x: string | null;
+		placeholder: string | null;
+	};
+	export type UserGroupResource = {
+		id: number;
+		name: string;
+		description: string;
+		members: App.Http.Resources.Models.UserMemberGroupResource[];
+		rights: App.Http.Resources.Rights.UserGroupRightResource;
+	};
+	export type UserManagementResource = {
+		id: number;
+		username: string;
+		may_administrate: boolean;
+		may_upload: boolean;
+		may_edit_own_settings: boolean;
+		is_owner: boolean;
+		upload_trust_level: App.Enum.UserUploadTrustLevel;
+		quota_kb: number | null;
+		description: string | null;
+		note: string | null;
+		space: number | null;
+	};
+	export type UserMemberGroupResource = {
+		id: number;
+		username: string;
+		role: App.Enum.UserGroupRole;
+	};
+	export type UserResource = {
+		id: number | null;
+		has_token: boolean | null;
+		username: string | null;
+		email: string | null;
+		is_ldap: boolean;
+		may_administrate: boolean;
+		shared_albums_visibility: App.Enum.UserSharedAlbumsVisibility;
+	};
+	export type WebAuthnResource = {
+		id: string;
+		alias: string | null;
+		created_at: string;
+	};
+	export type WebhookResource = {
+		id: string;
+		name: string;
+		event: App.Enum.PhotoWebhookEvent;
+		method: App.Enum.WebhookMethod;
+		url: string;
+		payload_format: App.Enum.WebhookPayloadFormat;
+		has_secret: boolean;
+		secret_header: string | null;
+		enabled: boolean;
+		send_photo_id: boolean;
+		send_album_id: boolean;
+		send_title: boolean;
+		send_size_variants: boolean;
+		size_variant_types: Array<number> | null;
+		created_at: string;
+		updated_at: string;
+	};
 }
 declare namespace App.Http.Resources.Models.Duplicates {
-export type Duplicate = {
-album_id: string;
-album_title: string;
-photo_id: string;
-photo_title: string;
-checksum: string;
-url: string | null;
-};
-export type DuplicateCount = {
-pure_duplicates: number;
-title_duplicates: number;
-duplicates_within_album: number;
-};
+	export type Duplicate = {
+		album_id: string;
+		album_title: string;
+		photo_id: string;
+		photo_title: string;
+		checksum: string;
+		url: string | null;
+	};
+	export type DuplicateCount = {
+		pure_duplicates: number;
+		title_duplicates: number;
+		duplicates_within_album: number;
+	};
 }
 declare namespace App.Http.Resources.Models.Utils {
-export type AlbumProtectionPolicy = {
-is_public: boolean;
-is_link_required: boolean;
-is_nsfw: boolean;
-grants_full_photo_access: boolean;
-grants_download: boolean;
-grants_upload: boolean;
-is_password_required: boolean;
-};
-export type HeaderFocusData = {
-x: number;
-y: number;
-};
-export type PreComputedPhotoData = {
-is_video: boolean;
-is_raw: boolean;
-is_livephoto: boolean;
-is_camera_date: boolean;
-has_exif: boolean;
-has_location: boolean;
-is_taken_at_modified: boolean;
-latitude: number | null;
-longitude: number | null;
-altitude: number | null;
-};
-export type PreFormattedAlbumData = {
-url: string | null;
-title: string;
-min_max_text: string | null;
-album_id: string;
-license: string;
-num_children: number;
-num_photos: number;
-created_at: string | null;
-description: string | null;
-copyright: string | null;
-palette: App.Http.Resources.Models.ColourPaletteResource | null;
-title_color: App.Enum.AlbumTitleColor | null;
-title_position: App.Enum.AlbumTitlePosition | null;
-header_photo_focus: App.Http.Resources.Models.Utils.HeaderFocusData | null;
-};
-export type PreformattedPhotoData = {
-created_at: string;
-taken_at: string | null;
-date_overlay: string;
-make: string | null;
-model: string | null;
-shutter: string;
-aperture: string;
-iso: string;
-lens: string;
-focal: string | null;
-duration: string;
-fps: string;
-filesize: string;
-resolution: string;
-latitude: string | null;
-longitude: string | null;
-altitude: string | null;
-location: string | null;
-license: string;
-description: string;
-};
-export type TimelineData = {
-time_date: string;
-format: string;
-};
-export type UserToken = {
-token: string;
-};
+	export type AlbumProtectionPolicy = {
+		is_public: boolean;
+		is_link_required: boolean;
+		is_nsfw: boolean;
+		grants_full_photo_access: boolean;
+		grants_download: boolean;
+		grants_upload: boolean;
+		is_password_required: boolean;
+	};
+	export type HeaderFocusData = {
+		x: number;
+		y: number;
+	};
+	export type PreComputedPhotoData = {
+		is_video: boolean;
+		is_raw: boolean;
+		is_livephoto: boolean;
+		is_camera_date: boolean;
+		has_exif: boolean;
+		has_location: boolean;
+		is_taken_at_modified: boolean;
+		latitude: number | null;
+		longitude: number | null;
+		altitude: number | null;
+	};
+	export type PreFormattedAlbumData = {
+		url: string | null;
+		title: string;
+		min_max_text: string | null;
+		album_id: string;
+		license: string;
+		num_children: number;
+		num_photos: number;
+		created_at: string | null;
+		description: string | null;
+		copyright: string | null;
+		palette: App.Http.Resources.Models.ColourPaletteResource | null;
+		title_color: App.Enum.AlbumTitleColor | null;
+		title_position: App.Enum.AlbumTitlePosition | null;
+		header_photo_focus: App.Http.Resources.Models.Utils.HeaderFocusData | null;
+	};
+	export type PreformattedPhotoData = {
+		created_at: string;
+		taken_at: string | null;
+		date_overlay: string;
+		make: string | null;
+		model: string | null;
+		shutter: string;
+		aperture: string;
+		iso: string;
+		lens: string;
+		focal: string | null;
+		duration: string;
+		fps: string;
+		filesize: string;
+		resolution: string;
+		latitude: string | null;
+		longitude: string | null;
+		altitude: string | null;
+		location: string | null;
+		license: string;
+		description: string;
+	};
+	export type TimelineData = {
+		time_date: string;
+		format: string;
+	};
+	export type UserToken = {
+		token: string;
+	};
 }
 declare namespace App.Http.Resources.Oauth {
-export type OauthRegistrationData = {
-provider_type: App.Enum.OauthProvidersType;
-is_enabled: boolean;
-registration_route: string;
-};
+	export type OauthRegistrationData = {
+		provider_type: App.Enum.OauthProvidersType;
+		is_enabled: boolean;
+		registration_route: string;
+	};
 }
 declare namespace App.Http.Resources.Rights {
-export type AlbumRightsResource = {
-can_edit: boolean;
-can_share: boolean;
-can_share_with_users: boolean;
-can_download: boolean;
-can_upload: boolean;
-can_move: boolean;
-can_delete: boolean;
-can_transfer: boolean;
-can_access_original: boolean;
-can_pasword_protect: boolean;
-can_import_from_server: boolean;
-can_make_purchasable: boolean;
-can_view_album_people: boolean;
-can_trigger_scan: boolean;
-can_assign_face: boolean;
-can_batch_face_ops: boolean;
-};
-export type GlobalRightsResource = {
-root_album: App.Http.Resources.Rights.RootAlbumRightsResource;
-settings: App.Http.Resources.Rights.SettingsRightsResource;
-user_management: App.Http.Resources.Rights.UserManagementRightsResource;
-user: App.Http.Resources.Rights.UserRightsResource;
-modules: App.Http.Resources.Rights.ModulesRightsResource;
-};
-export type ModulesRightsResource = {
-is_map_enabled: boolean;
-is_mod_frame_enabled: boolean;
-is_mod_flow_enabled: boolean;
-is_watermarker_enabled: boolean;
-is_photo_timeline_enabled: boolean;
-is_mod_renamer_enabled: boolean;
-is_mod_webshop_enabled: boolean;
-is_mod_webhook_enabled: boolean;
-is_face_recognition_enabled: boolean;
-is_nsfw_classifier_enabled: boolean;
-is_face_overlay_enabled: boolean;
-is_face_recognition_warning_enabled: boolean;
-is_contact_enabled: boolean;
-messages_count: number;
-};
-export type PhotoRightsResource = {
-can_edit: boolean;
-can_download: boolean;
-can_access_full_photo: boolean;
-can_view_face_overlays: boolean;
-can_dismiss_face: boolean;
-can_assign_face: boolean;
-can_trigger_scan: boolean;
-};
-export type RootAlbumRightsResource = {
-can_edit: boolean;
-can_upload: boolean;
-can_see_live_metrics: boolean;
-can_import_from_server: boolean;
-can_highlight: boolean;
-};
-export type SettingsRightsResource = {
-can_edit: boolean;
-can_see_logs: boolean;
-can_see_diagnostics: boolean;
-can_update: boolean;
-can_access_dev_tools: boolean;
-can_acess_user_groups: boolean;
-};
-export type UserGroupRightResource = {
-can_edit: boolean;
-can_manage: boolean;
-};
-export type UserManagementRightsResource = {
-can_create: boolean;
-can_list: boolean;
-can_edit: boolean;
-can_delete: boolean;
-};
-export type UserRightsResource = {
-can_edit: boolean;
-};
+	export type AlbumRightsResource = {
+		can_edit: boolean;
+		can_share: boolean;
+		can_share_with_users: boolean;
+		can_download: boolean;
+		can_upload: boolean;
+		can_move: boolean;
+		can_delete: boolean;
+		can_transfer: boolean;
+		can_access_original: boolean;
+		can_pasword_protect: boolean;
+		can_import_from_server: boolean;
+		can_make_purchasable: boolean;
+		can_view_album_people: boolean;
+		can_trigger_scan: boolean;
+		can_assign_face: boolean;
+		can_batch_face_ops: boolean;
+	};
+	export type GlobalRightsResource = {
+		root_album: App.Http.Resources.Rights.RootAlbumRightsResource;
+		settings: App.Http.Resources.Rights.SettingsRightsResource;
+		user_management: App.Http.Resources.Rights.UserManagementRightsResource;
+		user: App.Http.Resources.Rights.UserRightsResource;
+		modules: App.Http.Resources.Rights.ModulesRightsResource;
+	};
+	export type ModulesRightsResource = {
+		is_map_enabled: boolean;
+		is_mod_frame_enabled: boolean;
+		is_mod_flow_enabled: boolean;
+		is_watermarker_enabled: boolean;
+		is_photo_timeline_enabled: boolean;
+		is_mod_renamer_enabled: boolean;
+		is_mod_webshop_enabled: boolean;
+		is_mod_webhook_enabled: boolean;
+		is_face_recognition_enabled: boolean;
+		is_nsfw_classifier_enabled: boolean;
+		is_face_overlay_enabled: boolean;
+		is_face_recognition_warning_enabled: boolean;
+		is_contact_enabled: boolean;
+		messages_count: number;
+	};
+	export type PhotoRightsResource = {
+		can_edit: boolean;
+		can_download: boolean;
+		can_access_full_photo: boolean;
+		can_view_face_overlays: boolean;
+		can_dismiss_face: boolean;
+		can_assign_face: boolean;
+		can_trigger_scan: boolean;
+	};
+	export type RootAlbumRightsResource = {
+		can_edit: boolean;
+		can_upload: boolean;
+		can_see_live_metrics: boolean;
+		can_import_from_server: boolean;
+		can_highlight: boolean;
+	};
+	export type SettingsRightsResource = {
+		can_edit: boolean;
+		can_see_logs: boolean;
+		can_see_diagnostics: boolean;
+		can_update: boolean;
+		can_access_dev_tools: boolean;
+		can_acess_user_groups: boolean;
+	};
+	export type UserGroupRightResource = {
+		can_edit: boolean;
+		can_manage: boolean;
+	};
+	export type UserManagementRightsResource = {
+		can_create: boolean;
+		can_list: boolean;
+		can_edit: boolean;
+		can_delete: boolean;
+	};
+	export type UserRightsResource = {
+		can_edit: boolean;
+	};
 }
 declare namespace App.Http.Resources.Root {
-export type AuthConfig = {
-oauthProviders: { [key: number]: App.Enum.OauthProvidersType };
-u2f_enabled: boolean;
-};
-export type VersionResource = {
-version: string | null;
-is_new_release_available: boolean;
-is_git_update_available: boolean;
-};
+	export type AuthConfig = {
+		oauthProviders: { [key: number]: App.Enum.OauthProvidersType };
+		u2f_enabled: boolean;
+	};
+	export type VersionResource = {
+		version: string | null;
+		is_new_release_available: boolean;
+		is_git_update_available: boolean;
+	};
 }
 declare namespace App.Http.Resources.Search {
-export type InitResource = {
-search_minimum_length: number;
-photo_layout: App.Enum.PhotoLayoutType;
-};
-export type ResultsResource = {
-albums: App.Http.Resources.Models.ThumbAlbumResource[];
-photos: App.Http.Resources.Models.PhotoResource[];
-current_page: number;
-from: number;
-last_page: number;
-per_page: number;
-to: number;
-total: number;
-};
+	export type InitResource = {
+		search_minimum_length: number;
+		photo_layout: App.Enum.PhotoLayoutType;
+	};
+	export type ResultsResource = {
+		albums: App.Http.Resources.Models.ThumbAlbumResource[];
+		photos: App.Http.Resources.Models.PhotoResource[];
+		current_page: number;
+		from: number;
+		last_page: number;
+		per_page: number;
+		to: number;
+		total: number;
+	};
 }
 declare namespace App.Http.Resources.Shop {
-export type CatalogResource = {
-album_purchasable: App.Http.Resources.Shop.PurchasableResource | null;
-children_purchasables: App.Http.Resources.Shop.PurchasableResource[];
-photo_purchasables: App.Http.Resources.Shop.PurchasableResource[];
-};
-export type CatalogueSizesResource = {
-print_sizes: Array<App.Http.Resources.Shop.PurchasablePrintSizeResource>;
-pixel_sizes: Array<App.Http.Resources.Shop.PurchasablePixelSizeResource>;
-};
-export type CheckoutOptionResource = {
-currency: string;
-allow_guest_checkout: boolean;
-is_offline: boolean;
-terms_url: string;
-privacy_url: string;
-payment_providers: App.Enum.OmnipayProviderType[];
-mollie_profile_id: string;
-stripe_public_key: string;
-paypal_client_id: string;
-is_test_mode: boolean;
-is_lycheeorg_disclaimer_enabled: boolean;
-};
-export type CheckoutResource = {
-is_success: boolean;
-is_redirect: boolean;
-redirect_url: string | null;
-complete_url: string | null;
-message: string;
-order: App.Http.Resources.Shop.OrderResource | null;
-};
-export type ConfigOptionResource = {
-currency: string;
-default_price_cents: number;
-default_license: App.Enum.PurchasableLicenseType;
-default_size: App.Enum.PurchasableSizeVariantType;
-};
-export type EditablePurchasableResource = {
-purchasable_id: number;
-album_id: string | null;
-album_title: string | null;
-photo_id: string | null;
-photo_title: string | null;
-photo_url: string | null;
-prices: App.Http.Resources.Shop.PriceResource[]|null;
-print_sizes: App.Http.Resources.Shop.PurchasablePrintSizeResource[];
-pixel_sizes: App.Http.Resources.Shop.PurchasablePixelSizeResource[];
-owner_notes: string | null;
-description: string | null;
-is_active: boolean;
-};
-export type OrderItemResource = {
-id: number;
-order_id: number;
-purchasable_id: number | null;
-album_id: string | null;
-photo_id: string | null;
-title: string;
-license_type: App.Enum.PurchasableLicenseType;
-price: string;
-size_variant_type: App.Enum.PurchasableSizeVariantType;
-item_notes: string | null;
-content_url: string | null;
-is_print: boolean;
-print_size_id: number | null;
-print_width: number | null;
-print_height: number | null;
-print_unit: string | null;
-print_paper_type: string | null;
-pixel_size_id: number | null;
-pixel_width: number | null;
-pixel_height: number | null;
-album_title: string | null;
-thumb_url: string | null;
-};
-export type OrderResource = {
-id: number;
-provider: App.Enum.OmnipayProviderType | null;
-transaction_id: string;
-username: string | null;
-email: string | null;
-status: App.Enum.PaymentStatusType;
-amount: string;
-paid_at: string | null;
-created_at: string | null;
-updated_at: string | null;
-comment: string | null;
-items: App.Http.Resources.Shop.OrderItemResource[]|null;
-can_process_payment: boolean;
-shipping_street_name: string | null;
-shipping_street_number: string | null;
-shipping_additional_info: string | null;
-shipping_city: string | null;
-shipping_post_code: string | null;
-shipping_country: string | null;
-};
-export type PixelSizeResource = {
-id: number;
-label: string;
-width: number;
-height: number;
-is_active: boolean;
-};
-export type PriceResource = {
-size_variant: App.Enum.PurchasableSizeVariantType;
-license_type: App.Enum.PurchasableLicenseType;
-price: string;
-price_cents: number;
-};
-export type PrintSizeResource = {
-id: number;
-label: string;
-width: number;
-height: number;
-unit: string;
-paper_type: string | null;
-is_active: boolean;
-};
-export type PurchasablePixelSizeResource = {
-id: number;
-pixel_size_id: number;
-label: string;
-width: number;
-height: number;
-price: string;
-price_cents: number;
-license_type: App.Enum.PurchasableLicenseType;
-};
-export type PurchasablePrintSizeResource = {
-id: number;
-print_size_id: number;
-label: string;
-width: number;
-height: number;
-unit: string;
-paper_type: string | null;
-price: string;
-price_cents: number;
-};
-export type PurchasableResource = {
-purchasable_id: number;
-album_id: string | null;
-photo_id: string | null;
-prices: App.Http.Resources.Shop.PriceResource[]|null;
-description: string;
-is_active: boolean;
-};
+	export type CatalogResource = {
+		album_purchasable: App.Http.Resources.Shop.PurchasableResource | null;
+		children_purchasables: App.Http.Resources.Shop.PurchasableResource[];
+		photo_purchasables: App.Http.Resources.Shop.PurchasableResource[];
+	};
+	export type CatalogueSizesResource = {
+		print_sizes: Array<App.Http.Resources.Shop.PurchasablePrintSizeResource>;
+		pixel_sizes: Array<App.Http.Resources.Shop.PurchasablePixelSizeResource>;
+	};
+	export type CheckoutOptionResource = {
+		currency: string;
+		allow_guest_checkout: boolean;
+		is_offline: boolean;
+		terms_url: string;
+		privacy_url: string;
+		payment_providers: App.Enum.OmnipayProviderType[];
+		mollie_profile_id: string;
+		stripe_public_key: string;
+		paypal_client_id: string;
+		is_test_mode: boolean;
+		is_lycheeorg_disclaimer_enabled: boolean;
+	};
+	export type CheckoutResource = {
+		is_success: boolean;
+		is_redirect: boolean;
+		redirect_url: string | null;
+		complete_url: string | null;
+		message: string;
+		order: App.Http.Resources.Shop.OrderResource | null;
+	};
+	export type ConfigOptionResource = {
+		currency: string;
+		default_price_cents: number;
+		default_license: App.Enum.PurchasableLicenseType;
+		default_size: App.Enum.PurchasableSizeVariantType;
+	};
+	export type EditablePurchasableResource = {
+		purchasable_id: number;
+		album_id: string | null;
+		album_title: string | null;
+		photo_id: string | null;
+		photo_title: string | null;
+		photo_url: string | null;
+		prices: App.Http.Resources.Shop.PriceResource[] | null;
+		print_sizes: App.Http.Resources.Shop.PurchasablePrintSizeResource[];
+		pixel_sizes: App.Http.Resources.Shop.PurchasablePixelSizeResource[];
+		owner_notes: string | null;
+		description: string | null;
+		is_active: boolean;
+	};
+	export type OrderItemResource = {
+		id: number;
+		order_id: number;
+		purchasable_id: number | null;
+		album_id: string | null;
+		photo_id: string | null;
+		title: string;
+		license_type: App.Enum.PurchasableLicenseType;
+		price: string;
+		size_variant_type: App.Enum.PurchasableSizeVariantType;
+		item_notes: string | null;
+		content_url: string | null;
+		is_print: boolean;
+		print_size_id: number | null;
+		print_width: number | null;
+		print_height: number | null;
+		print_unit: string | null;
+		print_paper_type: string | null;
+		pixel_size_id: number | null;
+		pixel_width: number | null;
+		pixel_height: number | null;
+		album_title: string | null;
+		thumb_url: string | null;
+	};
+	export type OrderResource = {
+		id: number;
+		provider: App.Enum.OmnipayProviderType | null;
+		transaction_id: string;
+		username: string | null;
+		email: string | null;
+		status: App.Enum.PaymentStatusType;
+		amount: string;
+		paid_at: string | null;
+		created_at: string | null;
+		updated_at: string | null;
+		comment: string | null;
+		items: App.Http.Resources.Shop.OrderItemResource[] | null;
+		can_process_payment: boolean;
+		shipping_street_name: string | null;
+		shipping_street_number: string | null;
+		shipping_additional_info: string | null;
+		shipping_city: string | null;
+		shipping_post_code: string | null;
+		shipping_country: string | null;
+	};
+	export type PixelSizeResource = {
+		id: number;
+		label: string;
+		width: number;
+		height: number;
+		is_active: boolean;
+	};
+	export type PriceResource = {
+		size_variant: App.Enum.PurchasableSizeVariantType;
+		license_type: App.Enum.PurchasableLicenseType;
+		price: string;
+		price_cents: number;
+	};
+	export type PrintSizeResource = {
+		id: number;
+		label: string;
+		width: number;
+		height: number;
+		unit: string;
+		paper_type: string | null;
+		is_active: boolean;
+	};
+	export type PurchasablePixelSizeResource = {
+		id: number;
+		pixel_size_id: number;
+		label: string;
+		width: number;
+		height: number;
+		price: string;
+		price_cents: number;
+		license_type: App.Enum.PurchasableLicenseType;
+	};
+	export type PurchasablePrintSizeResource = {
+		id: number;
+		print_size_id: number;
+		label: string;
+		width: number;
+		height: number;
+		unit: string;
+		paper_type: string | null;
+		price: string;
+		price_cents: number;
+	};
+	export type PurchasableResource = {
+		purchasable_id: number;
+		album_id: string | null;
+		photo_id: string | null;
+		prices: App.Http.Resources.Shop.PriceResource[] | null;
+		description: string;
+		is_active: boolean;
+	};
 }
 declare namespace App.Http.Resources.Statistics {
-export type Album = {
-username: string;
-title: string;
-is_nsfw: boolean;
-left: number;
-right: number;
-num_photos: number;
-num_descendants: number;
-size: number;
-};
-export type CountsData = {
-data: Array<App.Http.Resources.Statistics.DayCount>;
-low_number_of_shoots_per_day: number;
-medium_number_of_shoots_per_day: number;
-high_number_of_shoots_per_day: number;
-min_created_at: string;
-min_taken_at: string;
-};
-export type DayCount = {
-date: string;
-count: number;
-};
-export type Sizes = {
-type: App.Enum.SizeVariantType;
-label: string;
-size: number;
-};
-export type UserSpace = {
-id: number;
-username: string;
-size: number;
-};
+	export type Album = {
+		username: string;
+		title: string;
+		is_nsfw: boolean;
+		left: number;
+		right: number;
+		num_photos: number;
+		num_descendants: number;
+		size: number;
+	};
+	export type CountsData = {
+		data: Array<App.Http.Resources.Statistics.DayCount>;
+		low_number_of_shoots_per_day: number;
+		medium_number_of_shoots_per_day: number;
+		high_number_of_shoots_per_day: number;
+		min_created_at: string;
+		min_taken_at: string;
+	};
+	export type DayCount = {
+		date: string;
+		count: number;
+	};
+	export type Sizes = {
+		type: App.Enum.SizeVariantType;
+		label: string;
+		size: number;
+	};
+	export type UserSpace = {
+		id: number;
+		username: string;
+		size: number;
+	};
 }
 declare namespace App.Http.Resources.Tags {
-export type TagResource = {
-id: number;
-name: string;
-num: number;
-};
-export type TagWithPhotosResource = {
-id: number;
-name: string;
-photos: App.Http.Resources.Models.PhotoResource[];
-};
-export type TagsResource = {
-can_edit: boolean;
-tags: App.Http.Resources.Tags.TagResource[];
-};
+	export type TagResource = {
+		id: number;
+		name: string;
+		num: number;
+	};
+	export type TagWithPhotosResource = {
+		id: number;
+		name: string;
+		photos: App.Http.Resources.Models.PhotoResource[];
+	};
+	export type TagsResource = {
+		can_edit: boolean;
+		tags: App.Http.Resources.Tags.TagResource[];
+	};
 }
 declare namespace App.Http.Resources.Timeline {
-export type InitResource = {
-photo_layout: App.Enum.PhotoLayoutType;
-is_timeline_page_enabled: boolean;
-config: App.Http.Resources.GalleryConfigs.RootConfig;
-rights: App.Http.Resources.Rights.RootAlbumRightsResource;
-};
-export type TimelineResource = {
-photos: App.Http.Resources.Models.PhotoResource[];
-current_page: number;
-from: number;
-last_page: number;
-per_page: number;
-to: number;
-total: number;
-};
+	export type InitResource = {
+		photo_layout: App.Enum.PhotoLayoutType;
+		is_timeline_page_enabled: boolean;
+		config: App.Http.Resources.GalleryConfigs.RootConfig;
+		rights: App.Http.Resources.Rights.RootAlbumRightsResource;
+	};
+	export type TimelineResource = {
+		photos: App.Http.Resources.Models.PhotoResource[];
+		current_page: number;
+		from: number;
+		last_page: number;
+		per_page: number;
+		to: number;
+		total: number;
+	};
 }

--- a/resources/js/views/gallery-panels/Search.vue
+++ b/resources/js/views/gallery-panels/Search.vue
@@ -255,6 +255,7 @@ const configForMenu = computed<App.Http.Resources.GalleryConfigs.AlbumConfig>(()
 		is_mod_frame_enabled: false,
 		is_search_accessible: false,
 		is_nsfw_warning_visible: false,
+		is_breadcrumb_enabled: false,
 		album_thumb_css_aspect_ratio: "aspect-square",
 		photo_layout: "justified",
 		is_album_timeline_enabled: false,

--- a/tests/Unit/Actions/Album/BreadcrumbTest.php
+++ b/tests/Unit/Actions/Album/BreadcrumbTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Unit\Actions\Album;
+
+use App\Actions\Album\Breadcrumb;
+use App\Models\Album;
+use App\Models\User;
+use App\Policies\AlbumQueryPolicy;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Tests\AbstractTestCase;
+
+class BreadcrumbTest extends AbstractTestCase
+{
+	use DatabaseTransactions;
+
+	private function breadcrumb(): Breadcrumb
+	{
+		return new Breadcrumb(new AlbumQueryPolicy());
+	}
+
+	/**
+	 * Sets the owner of an album directly in the database.
+	 *
+	 * Album::fixOwnershipOfChildren() (triggered by AlbumFactory::children_of())
+	 * propagates a parent's owner down to its whole subtree as soon as another
+	 * child is appended anywhere in the chain. To build a tree with mixed
+	 * ownership for these tests, ownership is therefore fixed up directly in
+	 * the database only after the whole tree has been created.
+	 */
+	private function setOwner(Album $album, User $user): void
+	{
+		DB::table('base_albums')->where('id', $album->id)->update(['owner_id' => $user->id]);
+	}
+
+	public function testNoAncestorsReturnsEmptyArray(): void
+	{
+		$user = User::factory()->create();
+		$root = Album::factory()->as_root()->owned_by($user)->create(['title' => 'Root']);
+
+		$this->actingAs($user);
+
+		$result = $this->breadcrumb()->do($root);
+
+		$this->assertSame([], $result);
+	}
+
+	public function testReturnsFullBreadcrumbInRootToLeafOrderWhenAllAccessible(): void
+	{
+		$user = User::factory()->create();
+		$root = Album::factory()->as_root()->owned_by($user)->create(['title' => 'Root', 'slug' => 'root-slug']);
+		$mid = Album::factory()->children_of($root)->owned_by($user)->create(['title' => 'Middle', 'slug' => 'mid-slug']);
+		$leaf = Album::factory()->children_of($mid)->owned_by($user)->create(['title' => 'Leaf']);
+		$leaf->refresh();
+
+		$this->actingAs($user);
+
+		$result = $this->breadcrumb()->do($leaf);
+
+		$this->assertCount(2, $result);
+		$this->assertSame($root->id, $result[0]->id);
+		$this->assertSame('Root', $result[0]->title);
+		$this->assertSame('root-slug', $result[0]->slug);
+		$this->assertSame($mid->id, $result[1]->id);
+		$this->assertSame('Middle', $result[1]->title);
+		$this->assertSame('mid-slug', $result[1]->slug);
+	}
+
+	public function testAdminSeesFullBreadcrumbRegardlessOfOwnership(): void
+	{
+		$owner = User::factory()->create();
+		$other = User::factory()->create();
+		$admin = User::factory()->may_administrate()->create();
+
+		// Build the chain with a valid owner throughout (the factory's default
+		// owner_id does not reference an existing user and would violate the
+		// foreign key), then reassign the middle album to someone else entirely.
+		$root = Album::factory()->as_root()->owned_by($owner)->create(['title' => 'Root']);
+		$mid = Album::factory()->children_of($root)->owned_by($owner)->create(['title' => 'Middle']);
+		$leaf = Album::factory()->children_of($mid)->owned_by($owner)->create(['title' => 'Leaf']);
+		$leaf->refresh();
+
+		$this->setOwner($mid, $other);
+
+		$this->actingAs($admin);
+
+		$result = $this->breadcrumb()->do($leaf);
+
+		$this->assertCount(2, $result);
+		$this->assertSame($root->id, $result[0]->id);
+		$this->assertSame($mid->id, $result[1]->id);
+	}
+
+	public function testInaccessibleAncestorAndEverythingAboveItIsMaskedAndCollapsed(): void
+	{
+		$user = User::factory()->create();
+		$other = User::factory()->create();
+
+		// Build the chain with a valid owner throughout (the factory's default
+		// owner_id does not reference an existing user and would violate the
+		// foreign key), then reassign just the middle album: root (owned by
+		// $user, would be accessible on its own) -> private (owned by $other,
+		// NOT shared) -> accessible (owned by $user) -> leaf.
+		$root = Album::factory()->as_root()->owned_by($user)->create(['title' => 'Root']);
+		$private = Album::factory()->children_of($root)->owned_by($user)->create(['title' => 'Private']);
+		$accessible = Album::factory()->children_of($private)->owned_by($user)->create(['title' => 'Accessible']);
+		$leaf = Album::factory()->children_of($accessible)->owned_by($user)->create(['title' => 'Leaf']);
+		$leaf->refresh();
+
+		$this->setOwner($private, $other);
+
+		$this->actingAs($user);
+
+		$result = $this->breadcrumb()->do($leaf);
+
+		// Even though `root` is independently accessible to $user, the broken
+		// link at `private` masks everything from that point up to the root,
+		// and consecutive masked entries collapse into a single placeholder.
+		$this->assertCount(2, $result);
+		$this->assertNull($result[0]->id);
+		$this->assertSame('...', $result[0]->title);
+		$this->assertNull($result[0]->slug);
+		$this->assertSame($accessible->id, $result[1]->id);
+		$this->assertSame('Accessible', $result[1]->title);
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `breadcrumb_enabled` setting to display album ancestry breadcrumbs in the album header for eligible album types.
  * Updated the album header to render a breadcrumb trail (and associated typed UI/API models) when breadcrumbs are enabled and available.
* **Bug Fixes**
  * Breadcrumbs now respect access permissions: when an ancestor is not accessible, the trail is collapsed into an ellipsis while accessible descendants remain visible (admins can view the full trail).
* **Chores**
  * Introduced the setting with database migration support and added translations for multiple languages.
* **Tests**
  * Added unit tests validating breadcrumb ordering and permission-based masking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->