### PR TITLE
Fix propagation error

### DIFF
--- a/app/Actions/Sharing/Propagate.php
+++ b/app/Actions/Sharing/Propagate.php
@@ -49,7 +49,10 @@ final class Propagate
 		// for each descendant, create a new permission if it does not exist.
 		// or update the existing permission.
 		$descendants = $album->descendants()->getQuery()->select('id')->pluck('id');
-		$permissions = $album->access_permissions()->whereNotNull(APC::USER_ID)->orWhereNotNull(APC::USER_GROUP_ID)->get();
+		$permissions = $album->access_permissions()->where(fn ($q) => $q
+			->whereNotNull(APC::USER_ID)
+			->orWhereNotNull(APC::USER_GROUP_ID)
+		)->get();
 
 		// This is super inefficient.
 		// It would be better to do it in a single query...
@@ -126,7 +129,10 @@ final class Propagate
 			->where('_rgt', '<', $album->_rgt)
 			->pluck('id');
 
-		$access_permissions = $album->access_permissions()->whereNotNull('user_id')->orWhereNotNull('user_group_id')->get();
+		$access_permissions = $album->access_permissions()->where(fn ($q) => $q
+			->whereNotNull(APC::USER_ID)
+			->orWhereNotNull(APC::USER_GROUP_ID)
+		)->get();
 
 		$new_perm = $access_permissions->reduce(
 			fn (?array $acc, AccessPermission $permission) => array_merge(

--- a/database/migrations/2026_07_01_120000_deduplicate_and_constrain_access_permissions.php
+++ b/database/migrations/2026_07_01_120000_deduplicate_and_constrain_access_permissions.php
@@ -28,6 +28,10 @@ return new class() extends Migration {
 	private const USER_ID_UNIQUE_KEY = 'user_id_unique_key';
 	private const USER_GROUP_ID_UNIQUE_KEY = 'user_group_id_unique_key';
 
+	// Explicit name because Laravel's auto-generated name (concatenating all
+	// four column names) exceeds MySQL's 64-character identifier limit.
+	private const UNIQUE_INDEX_NAME = 'access_permissions_dedup_unique';
+
 	/**
 	 * Run the migrations.
 	 */
@@ -42,13 +46,26 @@ return new class() extends Migration {
 		}
 
 		Schema::table(self::TABLE_NAME, function (Blueprint $table) {
+			// MySQL/MariaDB refuses to add a STORED generated column to a table
+			// that still has an active foreign key: doing so requires an
+			// in-place table rebuild, which InnoDB rejects with error 1215
+			// ("Cannot add foreign key constraint"). Drop it here and
+			// recreate it once the new columns are in place.
+			$table->dropForeign([self::USER_ID]);
 			$table->dropUnique([self::BASE_ALBUM_ID, self::USER_ID]);
 			$table->unsignedInteger(self::USER_ID_UNIQUE_KEY)->nullable(false)->storedAs('COALESCE(' . self::USER_ID . ', 0)');
 			$table->unsignedInteger(self::USER_GROUP_ID_UNIQUE_KEY)->nullable(false)->storedAs('COALESCE(' . self::USER_GROUP_ID . ', 0)');
 		});
 
 		Schema::table(self::TABLE_NAME, function (Blueprint $table) {
-			$table->unique([self::BASE_ALBUM_ID, self::USER_ID_UNIQUE_KEY, self::USER_GROUP_ID_UNIQUE_KEY]);
+			$table->unique([self::BASE_ALBUM_ID, self::USER_ID_UNIQUE_KEY, self::USER_GROUP_ID_UNIQUE_KEY], self::UNIQUE_INDEX_NAME);
+			// MySQL prohibits CASCADE/SET NULL referential actions on a column
+			// that is a base column of a generated column (user_id_unique_key
+			// depends on user_id here), so this can no longer cascade at the
+			// DB level. This is not a behavior change in practice: User::delete()
+			// already deletes the user's AccessPermission rows explicitly before
+			// removing the user.
+			$table->foreign(self::USER_ID)->references('id')->on('users')->restrictOnUpdate()->restrictOnDelete();
 		});
 	}
 
@@ -58,9 +75,16 @@ return new class() extends Migration {
 	public function down(): void
 	{
 		Schema::table(self::TABLE_NAME, function (Blueprint $table) {
-			$table->dropUnique([self::BASE_ALBUM_ID, self::USER_ID_UNIQUE_KEY, self::USER_GROUP_ID_UNIQUE_KEY]);
+			$table->dropForeign([self::USER_ID]);
+			$table->dropUnique(self::UNIQUE_INDEX_NAME);
 			$table->dropColumn([self::USER_ID_UNIQUE_KEY, self::USER_GROUP_ID_UNIQUE_KEY]);
+		});
+
+		Schema::table(self::TABLE_NAME, function (Blueprint $table) {
 			$table->unique([self::BASE_ALBUM_ID, self::USER_ID]);
+			// The generated columns are already gone at this point, so the
+			// original CASCADE actions are legal again here.
+			$table->foreign(self::USER_ID)->references('id')->on('users')->cascadeOnUpdate()->cascadeOnDelete();
 		});
 	}
 

--- a/database/migrations/2026_07_01_120000_deduplicate_and_constrain_access_permissions.php
+++ b/database/migrations/2026_07_01_120000_deduplicate_and_constrain_access_permissions.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+	private const TABLE_NAME = 'access_permissions';
+
+	private const BASE_ALBUM_ID = 'base_album_id';
+	private const USER_ID = 'user_id';
+	private const USER_GROUP_ID = 'user_group_id';
+
+	// Generated columns coalescing the nullable USER_ID / USER_GROUP_ID so that
+	// a plain unique index can actually enforce uniqueness for both of them.
+	// (A unique index ignores NULL, so [base_album_id, user_id, user_group_id]
+	// alone would never catch duplicate group permissions, since user_id is
+	// always NULL for those rows.)
+	private const USER_ID_UNIQUE_KEY = 'user_id_unique_key';
+	private const USER_GROUP_ID_UNIQUE_KEY = 'user_group_id_unique_key';
+
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		if (!App::runningUnitTests()) {
+			// @codeCoverageIgnoreStart
+			DB::transaction(fn () => $this->deduplicate());
+		// @codeCoverageIgnoreEnd
+		} else {
+			$this->deduplicate();
+		}
+
+		Schema::table(self::TABLE_NAME, function (Blueprint $table) {
+			$table->dropUnique([self::BASE_ALBUM_ID, self::USER_ID]);
+			$table->unsignedInteger(self::USER_ID_UNIQUE_KEY)->nullable(false)->storedAs('COALESCE(' . self::USER_ID . ', 0)');
+			$table->unsignedInteger(self::USER_GROUP_ID_UNIQUE_KEY)->nullable(false)->storedAs('COALESCE(' . self::USER_GROUP_ID . ', 0)');
+		});
+
+		Schema::table(self::TABLE_NAME, function (Blueprint $table) {
+			$table->unique([self::BASE_ALBUM_ID, self::USER_ID_UNIQUE_KEY, self::USER_GROUP_ID_UNIQUE_KEY]);
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		Schema::table(self::TABLE_NAME, function (Blueprint $table) {
+			$table->dropUnique([self::BASE_ALBUM_ID, self::USER_ID_UNIQUE_KEY, self::USER_GROUP_ID_UNIQUE_KEY]);
+			$table->dropColumn([self::USER_ID_UNIQUE_KEY, self::USER_GROUP_ID_UNIQUE_KEY]);
+			$table->unique([self::BASE_ALBUM_ID, self::USER_ID]);
+		});
+	}
+
+	/**
+	 * Remove duplicate (base_album_id, user_id, user_group_id) rows, e.g. those
+	 * created by the Propagate action bug where an unscoped query leaked
+	 * unrelated albums' group permissions and re-inserted them for every
+	 * descendant on every click. One row per group is kept, the rest deleted.
+	 */
+	private function deduplicate(): void
+	{
+		$duplicate_groups = DB::table(self::TABLE_NAME)
+			->select(self::BASE_ALBUM_ID, self::USER_ID, self::USER_GROUP_ID)
+			->groupBy(self::BASE_ALBUM_ID, self::USER_ID, self::USER_GROUP_ID)
+			->havingRaw('count(*) > 1')
+			->get();
+
+		foreach ($duplicate_groups as $group) {
+			$scoped = $this->matchNullable(
+				$this->matchNullable(
+					$this->matchNullable(
+						DB::table(self::TABLE_NAME),
+						self::BASE_ALBUM_ID,
+						$group->base_album_id
+					),
+					self::USER_ID,
+					$group->user_id
+				),
+				self::USER_GROUP_ID,
+				$group->user_group_id
+			);
+
+			// Keep the most recently written row: if duplicates ended up with
+			// different grants (e.g. leaked from different source albums),
+			// the newest one best reflects the last-applied intended state.
+			$keep_id = $scoped->max('id');
+			$scoped->where('id', '!=', $keep_id)->delete();
+		}
+	}
+
+	/**
+	 * Constrain a query builder on a column that may legitimately be NULL.
+	 */
+	private function matchNullable(Builder $query, string $column, string|int|null $value): Builder
+	{
+		return $value === null ? $query->whereNull($column) : $query->where($column, '=', $value);
+	}
+};

--- a/tests/Feature_v2/Album/SharingTest.php
+++ b/tests/Feature_v2/Album/SharingTest.php
@@ -182,6 +182,40 @@ class SharingTest extends BaseApiWithDataTest
 		self::assertTrue($perm->grants_upload);
 	}
 
+	public function testUpdateDoesNotLeakUnrelatedAlbumGroupPermissions(): void
+	{
+		// Give an *unrelated* album (not in album1's tree) a group permission.
+		// A buggy query scoping in Propagate::applyUpdate would leak this into
+		// album1's descendants because it is not actually restricted to album1.
+		$response = $this->actingAs($this->userMayUpload2)->postJson('Sharing', [
+			'user_ids' => [],
+			'group_ids' => [$this->group2->id],
+			'album_ids' => [$this->album2->id],
+			'grants_edit' => true,
+			'grants_delete' => true,
+			'grants_download' => true,
+			'grants_full_photo_access' => true,
+			'grants_upload' => true,
+		]);
+		$this->assertOk($response);
+
+		// Propagate album1 (unrelated to album2) to its descendants.
+		$response = $this->actingAs($this->userMayUpload1)->putJson('Sharing', [
+			'album_id' => $this->album1->id,
+			'shall_override' => false,
+		]);
+		$this->assertNoContent($response);
+
+		// subAlbum1 should only inherit album1's own permissions (perm1, perm11),
+		// not the unrelated group2 permission that lives on album2.
+		self::assertEquals(2, AccessPermission::where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)->count());
+		self::assertEquals(0,
+			AccessPermission::query()
+				->where(APC::BASE_ALBUM_ID, '=', $this->subAlbum1->id)
+				->where(APC::USER_GROUP_ID, '=', $this->group2->id)
+				->count());
+	}
+
 	public function testOverride(): void
 	{
 		// Set up the permission in subSlbum

--- a/tests/Unit/Http/Requests/Album/GetAlbumPhotosRequestTest.php
+++ b/tests/Unit/Http/Requests/Album/GetAlbumPhotosRequestTest.php
@@ -15,12 +15,15 @@ use App\Contracts\Models\AbstractAlbum;
 use App\Http\Requests\Album\GetAlbumPhotosRequest;
 use App\Models\Tag;
 use App\Policies\AlbumPolicy;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\ValidationException;
 use Tests\Unit\Http\Requests\Base\BaseRequestTest;
 
 class GetAlbumPhotosRequestTest extends BaseRequestTest
 {
+	use DatabaseTransactions;
+
 	public function testAuthorization(): void
 	{
 		Gate::shouldReceive('check')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sharing permission updates so unrelated group permissions no longer propagate across other albums or subalbums.
  * Improved permission propagation logic to more reliably handle group vs. user inheritance during sharing updates.
* **Chores**
  * Added a database update to deduplicate access permission records and enforce a stronger uniqueness rule going forward.
* **Tests**
  * Added coverage to prevent permission leakage during sharing updates.
  * Updated request test setup to run within database transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->