### PR TITLE
Fixes access rights with multiple groups

### DIFF
--- a/app/DTO/EffectiveAccessPermission.php
+++ b/app/DTO/EffectiveAccessPermission.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\DTO;
+
+use App\Models\AccessPermission;
+use Illuminate\Support\Collection;
+
+/**
+ * Read-only, non-persistable capability snapshot for the current user on an
+ * album: the union (logical OR) of every applicable AccessPermission row's
+ * grant flags, independent of row order or source (direct-user vs. group).
+ */
+final readonly class EffectiveAccessPermission
+{
+	public function __construct(
+		public bool $grants_full_photo_access = false,
+		public bool $grants_download = false,
+		public bool $grants_upload = false,
+		public bool $grants_edit = false,
+		public bool $grants_delete = false,
+	) {
+	}
+
+	/**
+	 * Merge every given AccessPermission row into a single snapshot: each
+	 * grant flag is true if it is true on at least one row.
+	 *
+	 * @param Collection<int,AccessPermission> $permissions
+	 */
+	public static function merge(Collection $permissions): self
+	{
+		return new self(
+			grants_full_photo_access: $permissions->contains(fn (AccessPermission $p) => $p->grants_full_photo_access),
+			grants_download: $permissions->contains(fn (AccessPermission $p) => $p->grants_download),
+			grants_upload: $permissions->contains(fn (AccessPermission $p) => $p->grants_upload),
+			grants_edit: $permissions->contains(fn (AccessPermission $p) => $p->grants_edit),
+			grants_delete: $permissions->contains(fn (AccessPermission $p) => $p->grants_delete),
+		);
+	}
+}

--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -10,6 +10,7 @@ namespace App\Models;
 
 use App\Actions\Album\Delete;
 use App\DTO\AlbumSortingCriterion;
+use App\DTO\EffectiveAccessPermission;
 use App\Enum\AlbumTitleColor;
 use App\Enum\AlbumTitlePosition;
 use App\Enum\AspectRatioType;
@@ -84,7 +85,7 @@ use Kalnoy\Nestedset\NodeTrait;
  *
  * @property Collection<int,AccessPermission> $access_permissions
  * @property int|null                         $access_permissions_count
- * @property AccessPermission|null            $current_user_permissions
+ * @property EffectiveAccessPermission|null   $current_user_permissions
  * @property AccessPermission|null            $public_permissions
  * @property Collection<int,User>             $shared_with
  * @property int|null                         $shared_with_count

--- a/app/Models/BaseAlbumImpl.php
+++ b/app/Models/BaseAlbumImpl.php
@@ -11,6 +11,7 @@ namespace App\Models;
 use App\Constants\AccessPermissionConstants as APC;
 use App\Constants\RandomID;
 use App\Contracts\Models\HasRandomID;
+use App\DTO\EffectiveAccessPermission;
 use App\DTO\PhotoSortingCriterion;
 use App\Enum\ColumnSortingType;
 use App\Enum\OrderSortingType;
@@ -256,18 +257,27 @@ class BaseAlbumImpl extends Model implements HasRandomID
 	}
 
 	/**
-	 * Returns the relationship between an album and its associated current user permissions.
+	 * Returns the merged, effective permissions of the current user on this album.
+	 *
+	 * Combines the direct-user AccessPermission row (if any) with every row for
+	 * a group the user belongs to: each grant flag is the logical OR across all
+	 * matching rows, independent of row order (there is no precedence between
+	 * a direct-user row and a group row — the most permissive grant wins).
 	 */
-	public function current_user_permissions(): AccessPermission|null
+	public function current_user_permissions(): EffectiveAccessPermission|null
 	{
 		if (Auth::guest()) {
 			return null; // No permissions for guests
 		}
 
 		$user = Auth::user();
+		$group_ids = $user->user_groups->map(fn ($g) => $g->id)->all();
 
-		return $this->access_permissions->first(fn (AccessPermission $p) => $p->user_id === $user->id)
-			?? $this->access_permissions->first(fn (AccessPermission $p) => in_array($p->user_group_id, $user->user_groups->map(fn ($g) => $g->id)->all(), true));
+		$matching = $this->access_permissions->filter(
+			fn (AccessPermission $p) => $p->user_id === $user->id || in_array($p->user_group_id, $group_ids, true)
+		);
+
+		return $matching->isEmpty() ? null : EffectiveAccessPermission::merge($matching);
 	}
 
 	/**

--- a/app/Models/Extensions/BaseAlbum.php
+++ b/app/Models/Extensions/BaseAlbum.php
@@ -11,6 +11,7 @@ namespace App\Models\Extensions;
 use App\Constants\RandomID;
 use App\Contracts\Models\AbstractAlbum;
 use App\Contracts\Models\HasRandomID;
+use App\DTO\EffectiveAccessPermission;
 use App\DTO\PhotoSortingCriterion;
 use App\Enum\PhotoLayoutType;
 use App\Enum\TimelinePhotoGranularity;
@@ -115,7 +116,7 @@ abstract class BaseAlbum extends Model implements AbstractAlbum, HasRandomID
 	/**
 	 * Returns the relationship between an album and its associated current user permissions.
 	 */
-	public function current_user_permissions(): AccessPermission|null
+	public function current_user_permissions(): EffectiveAccessPermission|null
 	{
 		return $this->base_class->current_user_permissions();
 	}

--- a/app/Models/PersonAlbum.php
+++ b/app/Models/PersonAlbum.php
@@ -9,6 +9,7 @@
 namespace App\Models;
 
 use App\Constants\PersonAlbumPersons;
+use App\DTO\EffectiveAccessPermission;
 use App\Exceptions\InvalidPropertyException;
 use App\ModelFunctions\HasAbstractAlbumProperties;
 use App\Models\Builders\PersonAlbumBuilder;
@@ -38,7 +39,7 @@ use Illuminate\Support\Facades\Auth;
  * @property int|null                          $shared_with_count
  * @property Collection<int, AccessPermission> $access_permissions
  * @property int|null                          $access_permissions_count
- * @property AccessPermission|null             $current_user_permissions
+ * @property EffectiveAccessPermission|null    $current_user_permissions
  * @property AccessPermission|null             $public_permissions
  *
  * @method static PersonAlbumBuilder|PersonAlbum addSelect($column)

--- a/app/Models/TagAlbum.php
+++ b/app/Models/TagAlbum.php
@@ -8,6 +8,7 @@
 
 namespace App\Models;
 
+use App\DTO\EffectiveAccessPermission;
 use App\Exceptions\InvalidPropertyException;
 use App\ModelFunctions\HasAbstractAlbumProperties;
 use App\Models\Builders\TagAlbumBuilder;
@@ -39,7 +40,7 @@ use Illuminate\Database\Query\Builder as BaseBuilder;
  * @property int|null                          $shared_with_count
  * @property Collection<int, AccessPermission> $access_permissions
  * @property int|null                          $access_permissions_count
- * @property AccessPermission|null             $current_user_permissions
+ * @property EffectiveAccessPermission|null    $current_user_permissions
  * @property AccessPermission|null             $public_permissions
  * @property Collection<int, User>             $shared_with
  *

--- a/docs/specs/4-architecture/features/048-fix-multi-group-permissions/plan.md
+++ b/docs/specs/4-architecture/features/048-fix-multi-group-permissions/plan.md
@@ -1,0 +1,145 @@
+# Feature Plan 048 – Fix Multi-Group Permissions
+
+_Linked specification:_ `docs/specs/4-architecture/features/048-fix-multi-group-permissions/spec.md`
+_Status:_ Draft
+_Last updated:_ 2026-07-01
+
+> Guardrail: Keep this plan traceable back to the governing spec. Reference FR/NFR/Scenario IDs from `spec.md` where relevant, log any new high- or medium-impact questions in [docs/specs/4-architecture/open-questions.md](../../open-questions.md), and assume clarifications are resolved only when the spec's normative sections and, where applicable, ADRs under `docs/specs/6-decisions/` have been updated.
+
+## Vision & Success Criteria
+A user who belongs to multiple groups (with or without an additional direct per-user share) on the same album always receives the union of every applicable grant, regardless of the order the shares were created in. Success signals:
+- The exact bug-report scenario (group "All" View-only created before group "Support_VIP" View+Access+Download) now grants Download.
+- Reversing the creation order produces the identical result (order-independence).
+- No new SQL query is introduced by the fix (NFR-048-01).
+- `php artisan test`, `make phpstan`, and `php-cs-fixer` stay clean.
+
+## Scope Alignment
+- **In scope:** new `App\DTO\EffectiveAccessPermission` DTO + its `merge()` factory; `app/Models/BaseAlbumImpl.php::current_user_permissions()`; the `BaseAlbum` extension trait's forwarding method; `@property` docblock updates on `Album`/`TagAlbum`/`PersonAlbum`; unit tests for both the DTO and the model method; a Feature_v2 regression test extending `AlbumSharingTest.php`'s fixtures; an ADR documenting the merge policy.
+- **Out of scope:** `public_permissions()` (still returns `App\Models\AccessPermission` — it resolves a genuinely persisted, schema-unique row, not a computed merge), the `access_permissions` DB schema/migrations, `AlbumPolicy::canDelete/canEditById/canDeleteById` (already correct), any REST/UI contract changes, admin UI for configuring merge precedence.
+
+## Dependencies & Interfaces
+- **New:** `App\DTO\EffectiveAccessPermission` (`app/DTO/EffectiveAccessPermission.php`) — `final readonly class` with 5 boolean constructor-promoted properties (`grants_full_photo_access`, `grants_download`, `grants_upload`, `grants_edit`, `grants_delete`, all default `false`) and a static `merge(Collection<int,AccessPermission> $permissions): self` factory. Mirrors the existing `App\DTO\CheckoutDTO`/`App\DTO\PixelSizeAssignment` style already used in this codebase. Deliberately **not** a subclass of `App\Models\AccessPermission` and **not** an Eloquent model, so it cannot be mass-assigned, `save()`d, or otherwise persisted (NFR-048-03).
+- `App\Models\AccessPermission` (`app/Models/AccessPermission.php`) — unchanged; still the source rows read (never constructed as a synthetic instance) by the merge.
+- `App\Constants\AccessPermissionConstants` (`app/Constants/AccessPermissionConstants.php`) — reused only to name the flags consistently in tests/docs; the DTO itself uses plain typed properties, not the string constants (no array-based construction to mass-assign against).
+- `App\Models\User::user_groups()` (`app/Models/User.php:277`) — already lazy-loaded relation, unchanged.
+- `BaseAlbumImpl::$with` (`app/Models/BaseAlbumImpl.php:215`) — already eager-loads `access_permissions`; no change needed.
+- `App\Models\Extensions\BaseAlbum::current_user_permissions()` (`app/Models/Extensions/BaseAlbum.php:118-121`) — pure forwarding method; return type updated to match `BaseAlbumImpl`.
+- `@property` docblocks on `App\Models\Album`, `App\Models\TagAlbum`, `App\Models\PersonAlbum` — updated from `AccessPermission|null` to a nullable `EffectiveAccessPermission`.
+- Consumers (unchanged code, only benefit from stricter typing): `App\Policies\AlbumPolicy` (`app/Policies/AlbumPolicy.php:134,205,227,264,351`), `App\Http\Controllers\Gallery\PhotoController::index` (`app/Http/Controllers/Gallery/PhotoController.php:349`).
+- Test fixtures in `tests/Feature_v2/Album/AlbumSharingTest.php` and `tests/Feature_v2/Base/BaseApiWithDataTest.php` (`group1`, `group2`, `userWithGroup1`, `AccessPermission::factory()->for_user_group()/for_user()`).
+
+## Assumptions & Risks
+- **Assumptions:**
+  - The `access_permissions` dedup migration (`2026_07_01_120000_deduplicate_and_constrain_access_permissions.php`) is already applied, so at most one row exists per `(album, user)` and per `(album, group)` pair — the merge only ever combines a bounded, small set of rows (1 direct + N groups).
+  - No caller of `current_user_permissions()` reads anything off the returned object besides existence (`!== null`) and the 5 boolean grant flags (verified via `grep` across `app/`) — this assumption is now enforced at compile time by PHPStan once the return type changes to `EffectiveAccessPermission`, rather than relying solely on the grep sweep.
+- **Risks / Mitigations:**
+  - _Risk:_ A hidden caller relies on `id`/`user_id`/`password`/`save()` from the returned value. _Mitigation:_ switching the return type to a DTO that structurally lacks those members turns this risk into a build-time PHPStan/type error instead of a silent runtime bug — strictly safer than the original synthetic-`AccessPermission` approach. T-048-01 still runs the repo-wide grep first as a sanity check before the type change.
+  - _Risk:_ Extra boilerplate (constructing a new class, updating 5 call sites' docblocks) increases the diff size for what started as a one-method fix. _Mitigation:_ kept as a single small, focused DTO with no extra behaviour; the wiring change in `BaseAlbumImpl` is a signature/type swap, not a logic rewrite (the merge algorithm itself is unchanged, just relocated into the DTO's static factory).
+
+## Implementation Drift Gate
+Before starting I2, re-run the `grep -rn "current_user_permissions()"` sweep across `app/` and `resources/js/` to confirm the caller list in the spec's DO-048-01 note is still exhaustive. Record the command output in this plan's Analysis Gate section. No traceability matrix beyond the Scenario Tracking table below is needed for a fix this small.
+
+## Increment Map
+
+1. **I1 – Unit tests: reproduce the bug and pin the target DTO API**
+   - _Goal:_ Add failing tests at two levels: (a) `EffectiveAccessPermission::merge()` pure algorithm tests, and (b) `BaseAlbumImpl::current_user_permissions()` filter/delegate tests — both proving the order-dependent bug (S-048-01/S-048-02) and the direct-user-vs-group merge (S-048-03).
+   - _Preconditions:_ None — uses existing `AccessPermission`/`UserGroup`/`User` factories; the DTO class doesn't need to exist yet for its test file to be written (red).
+   - _Steps:_
+     - Re-run the caller grep from the Drift Gate to confirm scope.
+     - Add `tests/Unit/DTO/EffectiveAccessPermissionTest.php`: build plain `Collection<AccessPermission>` instances (via `new AccessPermission([...])`, no DB) and assert `EffectiveAccessPermission::merge()` OR-combines each flag correctly, independent of collection order (S-048-01, S-048-02, S-048-03).
+     - Add `tests/Unit/Models/BaseAlbumImplCurrentUserPermissionsTest.php`: inject an in-memory `access_permissions` collection via `setRelation()` and assert `current_user_permissions()` filters correctly and returns `null` when nothing matches (S-048-04 through S-048-07).
+     - Confirm both new test files fail to run/compile against the current code (the DTO class and the new filter logic don't exist yet — this is the expected red state).
+   - _Commands:_ `php artisan test --filter=EffectiveAccessPermissionTest`, `php artisan test --filter=BaseAlbumImplCurrentUserPermissionsTest`
+   - _Exit:_ Both new test files exist and fail for the expected reason (missing class / wrong merge result, not an unrelated error).
+
+2. **I2 – Implement `App\DTO\EffectiveAccessPermission`**
+   - _Goal:_ Create the DTO (FR-048-01, NFR-048-03) so the I1 DTO-level tests go green.
+   - _Preconditions:_ I1 tests exist and are red.
+   - _Steps:_
+     - Add `app/DTO/EffectiveAccessPermission.php`: `final readonly class` with 5 boolean constructor-promoted properties (all default `false`) and a static `merge(Collection<int,AccessPermission> $permissions): self` factory using `$permissions->contains(fn ($p) => $p->grants_x)` per flag — no branching, no mutation of the input collection (NFR-048-02).
+     - Include the standard SPDX/copyright header used across `app/DTO/*.php`.
+   - _Commands:_ `php artisan test --filter=EffectiveAccessPermissionTest`, `make phpstan`
+   - _Exit:_ `EffectiveAccessPermissionTest` passes; `BaseAlbumImplCurrentUserPermissionsTest` still red (not wired up yet).
+
+3. **I3 – Wire the DTO into `current_user_permissions()` and update consumer types**
+   - _Goal:_ Rewrite `BaseAlbumImpl::current_user_permissions()` (FR-048-01, FR-048-04) to collect every matching row (direct-user + all matching groups) via a single `->filter(...)`, short-circuit to `null` when empty, and delegate to `EffectiveAccessPermission::merge()`; propagate the new nullable return type to the `BaseAlbum` trait and the `@property` docblocks on `Album`/`TagAlbum`/`PersonAlbum`.
+   - _Preconditions:_ I2 complete (DTO exists).
+   - _Steps:_
+     - Replace the two `->first(...)` calls in `BaseAlbumImpl::current_user_permissions()` with one `->filter(...)` + empty-check + `EffectiveAccessPermission::merge($matching)`.
+     - Update `App\Models\Extensions\BaseAlbum::current_user_permissions()` return type to match.
+     - Update the `@property` docblock in `Album.php`, `TagAlbum.php`, `PersonAlbum.php` from `AccessPermission|null` to the nullable `EffectiveAccessPermission`.
+     - Do not touch `public_permissions()`.
+   - _Commands:_ `php artisan test --filter=BaseAlbumImplCurrentUserPermissionsTest`, `make phpstan`
+   - _Exit:_ Both I1 test files pass (green); `make phpstan` clean (confirms no consumer relied on an `AccessPermission`-only member per FR-048-04's validation path); no other existing test regresses.
+
+4. **I4 – Feature-level regression test (exact bug report reproduction)**
+   - _Goal:_ Prove the fix end-to-end through the HTTP/API layer, matching how the bug was actually observed (Download button visibility).
+   - _Preconditions:_ I3 merged.
+   - _Steps:_
+     - Extend `tests/Feature_v2/Album/AlbumSharingTest.php` (or a new `MultiGroupPermissionMergeTest.php` in the same namespace, reusing its `BaseApiWithDataTest` fixtures) with a test that: creates an album, shares it with `group1` (View-only, i.e. all `grants_*` false) then `group2` (`grants_download=true` + others), puts a user in both groups, calls `GET Albums/{album_id}` (or the equivalent album-head endpoint already covered by existing tests) as that user, and asserts `rights.can_download === true`.
+     - Add a mirrored test with the two `AccessPermission::factory()` calls swapped in order, asserting the identical result (S-048-02).
+   - _Commands:_ `php artisan test --filter=AlbumSharingTest`
+   - _Exit:_ Both order variants pass; existing `AlbumSharingTest` tests (listing-once behaviour) still pass unmodified.
+
+5. **I5 – Query-count guard (NFR-048-01)**
+   - _Goal:_ Add an explicit assertion that the fix does not introduce a new SQL query.
+   - _Preconditions:_ I3/I4 complete.
+   - _Steps:_
+     - In the Feature test from I4 (or a dedicated unit test), wrap the `current_user_permissions()` call (or the full `GET Albums/{id}` request) with `DB::enableQueryLog()`/`DB::getQueryLog()` before/after, and assert the query count is unchanged from a single-group baseline captured in the same test.
+   - _Commands:_ `php artisan test --filter=AlbumSharingTest`
+   - _Exit:_ Query-count assertion passes; documents NFR-048-01 compliance directly in the test suite (self-verifying, no manual query-log inspection needed for future changes).
+
+6. **I6 – ADR + documentation**
+   - _Goal:_ Record the "most-permissive-wins, order-independent merge, expressed as a non-persistable DTO" as the canonical policy for combining `AccessPermission` sources (Documentation Deliverables in spec.md).
+   - _Preconditions:_ I2–I5 green.
+   - _Steps:_
+     - Add `docs/specs/6-decisions/ADR-0004-multi-group-permission-merge.md` using the ADR template, referencing FR-048-01/FR-048-04/NFR-048-01/NFR-048-03/Q-048-01 and the precedent citations already gathered in spec.md's Appendix, including the rationale for introducing `EffectiveAccessPermission` as a DTO instead of a synthetic `AccessPermission` instance.
+     - Update `docs/specs/4-architecture/roadmap.md` Active Features table with Feature 048.
+     - Update `docs/specs/_current-session.md`.
+   - _Commands:_ None (docs only).
+   - _Exit:_ ADR merged; roadmap and session snapshot reflect Feature 048.
+
+7. **I7 – Quality gates**
+   - _Goal:_ Full PHP quality gate per AGENTS.md (PHP-only change; no `.vue`/`.ts`/`.js`/`.css` touched).
+   - _Preconditions:_ I1–I6 complete.
+   - _Steps:_ Run the PHP quality gate.
+   - _Commands:_
+     - `vendor/bin/php-cs-fixer fix`
+     - `php artisan test`
+     - `make phpstan`
+   - _Exit:_ All three commands clean; ready for commit per AGENTS.md commit protocol.
+
+## Scenario Tracking
+
+| Scenario ID | Increment / Task reference | Notes |
+|-------------|---------------------------|-------|
+| S-048-01 | I1 / T-048-01, I2 / T-048-03, I3 / T-048-05, I4 / T-048-07 | Core bug reproduction, DTO + model unit level + feature level. |
+| S-048-02 | I1 / T-048-01, I4 / T-048-08 | Order-reversal proves order-independence. |
+| S-048-03 | I1 / T-048-01 | Direct-user + group merge (Q-048-01 Option A). |
+| S-048-04 | I1 / T-048-02 | Single-group-only regression. |
+| S-048-05 | I1 / T-048-02 | Direct-share-only regression. |
+| S-048-06 | I1 / T-048-02 | No-access-returns-null regression. |
+| S-048-07 | I1 / T-048-02 | Guest-returns-null regression. |
+| S-048-08 | Covered by existing `AlbumPolicy` owner short-circuit; no new test needed. | Owner path bypasses `current_user_permissions()` entirely. |
+
+## Analysis Gate
+**Reviewed:** 2026-07-01, by the authoring agent (spec/plan/tasks drafted in the same session), per [docs/specs/5-operations/analysis-gate-checklist.md](../../../5-operations/analysis-gate-checklist.md). Re-reviewed 2026-07-01 after adopting the `EffectiveAccessPermission` DTO (user follow-up request) in place of a synthetic `AccessPermission` instance.
+
+1. **Specification completeness** — ✅ FR/NFR tables populated (FR-048-01…04, NFR-048-01…03). ✅ Q-048-01 resolved directly in spec.md (Non-Goals + Appendix precedent). ✅ No UI mock-up needed — spec Overview states this is a backend-only fix with no REST/UI contract change (existing `AlbumRightsResource.can_download` field is unaffected in shape, only in value); the new DTO is an internal type, never serialized to a resource.
+2. **Open questions review** — ✅ No `Open` entries remain for Feature 048 in open-questions.md (Q-048-01 resolved 2026-07-01). ✅ Architecturally significant (security-relevant merge policy + non-persistable-by-design DTO) → ADR-0004 planned in I6/T-048-10, referenced from spec.md Documentation Deliverables.
+3. **Plan alignment** — ✅ This plan references `spec.md` and `tasks.md` in the same directory; dependencies/success criteria match spec wording (order-independence, zero new queries, non-persistable DTO).
+4. **Tasks coverage** — ✅ FR-048-01 → T-048-01/02/03/04/05/07; FR-048-02 → T-048-05/08; FR-048-03 → T-048-02/09; FR-048-04 → T-048-05/06; NFR-048-01 → T-048-08; NFR-048-02 → T-048-04; NFR-048-03 → T-048-04. ✅ Tests (T-048-01/02) precede implementation (T-048-03/04/05). ✅ Success (merge correctness), validation (regression on existing single-source scenarios), and failure (null-return for no-access/guest) branches all enumerated in S-048-01…08 with tests queued in T-048-01/02/07 before T-048-03/04/05 implementation.
+5. **Constitution compliance** — ✅ No new dependencies (DTO uses only existing `Illuminate\Support\Collection`). ✅ I2/T-048-03 and I3/T-048-05 keep both the DTO and `current_user_permissions()` straight-line (NFR-048-02). ✅ No existing ADRs reference Feature 048 module boundaries yet (first ADR for this area is the one this feature adds).
+6. **Tooling readiness** — ✅ Commands documented per increment/task (`php artisan test --filter=...`, `make phpstan`, `vendor/bin/php-cs-fixer fix`).
+
+**Outcome:** Pass — no blocking findings. Cleared to begin I1.
+
+## Exit Criteria
+- All Increment Map items (I1–I7) complete and checked off in `tasks.md`.
+- `php artisan test`, `make phpstan`, `vendor/bin/php-cs-fixer fix` all clean.
+- ADR-0004 merged and linked from this spec/plan.
+- Roadmap and `_current-session.md` updated.
+- Q-048-01 remains resolved with no new high/medium open questions outstanding for Feature 048.
+
+## Follow-ups / Backlog
+- Consider whether `Propagate.php` (the sharing-propagation action touched by `adc58943`) should reuse the same merge helper if it ever needs to compute an "effective" permission rather than per-row propagation — out of scope for this fix, noted for future reference only.

--- a/docs/specs/4-architecture/features/048-fix-multi-group-permissions/spec.md
+++ b/docs/specs/4-architecture/features/048-fix-multi-group-permissions/spec.md
@@ -1,0 +1,197 @@
+# Feature 048 – Fix Multi-Group Permissions
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Last updated | 2026-07-01 |
+| Owners | LycheeOrg |
+| Linked plan | `docs/specs/4-architecture/features/048-fix-multi-group-permissions/plan.md` |
+| Linked tasks | `docs/specs/4-architecture/features/048-fix-multi-group-permissions/tasks.md` |
+| Roadmap entry | #048 |
+
+> Guardrail: This specification is the single normative source of truth for the feature. Track high- and medium-impact questions in [docs/specs/4-architecture/open-questions.md](../../open-questions.md), encode resolved answers directly in the Requirements/NFR/Behaviour/UI/Telemetry sections below (no per-feature `## Clarifications` sections), and use ADRs under `docs/specs/6-decisions/` for architecturally significant clarifications (referencing their IDs from the relevant spec sections).
+
+## Overview
+`BaseAlbumImpl::current_user_permissions()` (`app/Models/BaseAlbumImpl.php:261-271`) resolves the effective `AccessPermission` for the current user on an album by calling `Collection::first()` twice: once for a direct user-level row, and once — only if the first lookup fails — for a matching user-group row. Because `first()` returns the earliest-matching element of an already in-memory `Collection` (ordered by DB fetch order, effectively insertion/id order), a user who belongs to **two or more groups** with different grants on the same album only ever receives the grants of whichever group's `AccessPermission` row happens to sort first. The other group's grants (e.g. Download) are silently dropped, and simply re-creating the sharing rows in a different order changes the outcome — this is the bug reported against the "All" + "Support_VIP" group scenario.
+
+This is a backend-only authorization fix (modules: `app/Models`, `app/DTO`, consumed by `app/Policies/AlbumPolicy.php`). It has no REST contract or UI changes: the existing `AlbumRightsResource`/`can_download` field (and the other Gate-derived rights) simply start reflecting the correct value once the underlying permission resolution is fixed.
+
+The merged result is returned as a new dedicated DTO, `App\DTO\EffectiveAccessPermission`, rather than a synthetic `App\Models\AccessPermission` Eloquent model instance. An `AccessPermission` model is inherently persistable (mass-assignable, `->save()`-able); a computed, request-scoped "effective grants for this user on this album" snapshot must never be written back to the database, and a plain readonly DTO makes that a type-level guarantee instead of a convention every future caller has to remember. This mirrors the existing `App\DTO\CheckoutDTO`/`App\DTO\PixelSizeAssignment` pattern (`final readonly class` with promoted constructor properties) already used in this codebase for similar read-only value objects.
+
+## Goals
+- A user who belongs to multiple groups (and/or has a direct per-user share) on the same album receives the **union** (logical OR) of every applicable grant flag, regardless of the order in which the `AccessPermission` rows were created.
+- The fix must not add any new database queries beyond what `current_user_permissions()` already triggers today (the `access_permissions` relation is already eager-loaded via `BaseAlbumImpl::$with`, and `$user->user_groups` is already read by the current implementation).
+- The merged/effective permission is represented by a type that cannot be accidentally persisted (no mass assignment, no `save()`), separating "a persistable share record" from "a computed capability snapshot" at the type level.
+- Existing single-group / single-share / guest / no-permission behaviour is unchanged.
+
+## Non-Goals
+- Changing the DB schema, unique constraints, or the `access_permissions` table (the July 2026 dedup migration already guarantees at most one row per `(base_album_id, user_id)` and per `(base_album_id, user_group_id)` pair — this feature only changes how multiple *distinct* rows for the same user are combined in memory).
+- Changing `public_permissions()` — it looks up the single, schema-guaranteed-unique `(user_id IS NULL, user_group_id IS NULL)` row and is not affected by this bug.
+- Changing the already-correct SQL-level group aggregation in `AlbumPolicy::canDelete()`, `canEditById()`, `canDeleteById()` (these already `orWhereIn(user_group_id, ...)` across every group and are not affected by this bug).
+- Adding any admin UI to manage merge precedence — the merge rule (most-permissive-wins) is fixed and not configurable (see Q-048-01 resolution below).
+
+## Functional Requirements
+
+| ID | Requirement | Success path | Validation path | Failure path | Telemetry & traces | Source |
+|----|-------------|--------------|-----------------|--------------|--------------------|--------|
+| FR-048-01 | `BaseAlbumImpl::current_user_permissions()` returns a nullable `App\DTO\EffectiveAccessPermission` (or `null`) whose boolean grant flags (`grants_full_photo_access`, `grants_download`, `grants_upload`, `grants_edit`, `grants_delete`) are the logical OR of every `AccessPermission` row matching the current user — the direct `user_id` row (if any) plus every row whose `user_group_id` is one of the user's group ids. | Any grant flag `true` on **any** matching row makes that flag `true` on the merged result, independent of row insertion order. | If no row matches (no direct share, member of no group with access), the method returns `null` exactly as today. | Guests (`Auth::guest()`) continue to receive `null` with no matching attempted. | None (no new telemetry). | Bug report: user in "All" (View only) + "Support_VIP" (View, Access, Download) only received "All"'s grants; reordering the shares flipped the outcome. |
+| FR-048-02 | The merge in FR-048-01 introduces zero additional database queries compared to the current implementation. | `access_permissions` (already eager-loaded per-album via `BaseAlbumImpl::$with`) and `$user->user_groups` (already read by the current code) are the only data sources; the merge itself is an in-memory `Collection` operation. | N/A (implementation constraint, not user input). | N/A. | None. | User requirement: "Propose a solution which is the least heavy on database queries." |
+| FR-048-03 | All existing single-source scenarios (single direct share only, single group share only, public-only, owner, guest, no access) resolve to the exact same effective permissions as before this fix. | Regression coverage via existing and new tests (see Test Strategy). | N/A. | N/A. | None. | Backward compatibility — no behaviour change intended outside the multi-row-merge case. |
+| FR-048-04 | `current_user_permissions()`'s return type (and every consumer's type expectations) change from a nullable `App\Models\AccessPermission` to a nullable `App\DTO\EffectiveAccessPermission` across `BaseAlbumImpl`, the `BaseAlbum` extension trait, and the `@property` docblocks on `Album`, `TagAlbum`, `PersonAlbum`. | PHPStan level 6 passes with the new type end-to-end; every consumer (`AlbumPolicy`, `PhotoController::index`) continues to compile because they only ever read `!== null` or `?->grants_*` boolean properties, which `EffectiveAccessPermission` also exposes. | A consumer that reads any `AccessPermission`-only member (`id`, `user_id`, `password`, `is_link_required`, `save()`, …) off the return value fails static analysis, surfacing any hidden dependency the spec's caller sweep (T-048-02) might have missed. | N/A. | None. | Follow-up from user request: "create a proper DTO for this to make sure it is not persisted by error." |
+
+## Non-Functional Requirements
+
+| ID | Requirement | Driver | Measurement | Dependencies | Source |
+|----|-------------|--------|-------------|--------------|--------|
+| NFR-048-01 | Fixing the bug must not add any SQL query to `current_user_permissions()` (query count for a given album+user pair stays identical before/after the fix). | User's explicit constraint: "least heavy on database queries." | Feature/unit test asserts identical query count via `DB::listen()` or `assertQueryCount`-style assertion, or a code-review confirmation that only already-loaded relations (`access_permissions`, `user_groups`) are touched (no `::query()`/`whereIn` added). | `BaseAlbumImpl::$with` continuing to eager-load `access_permissions`; `User::user_groups()` relation. | User directive. |
+| NFR-048-02 | The merge algorithm must be a small, pure, order-independent helper (no branching on collection order) so future readers cannot reintroduce order-dependence. | AGENTS.md "Straight-line increments" guidance; this is exactly the bug class being fixed. | Code review / PHPStan level 6 clean. | None. | AGENTS.md coding conventions. |
+| NFR-048-03 | The value returned by `current_user_permissions()` must be structurally non-persistable: not an Eloquent model, no mass-assignment/`save()`/`fill()` capability. | Prevent a future accidental `->save()` or mass-assignment on a computed, request-scoped permission snapshot from writing a bogus row into `access_permissions`. | `App\DTO\EffectiveAccessPermission` is a `final readonly class` (plain PHP object, not extending `Illuminate\Database\Eloquent\Model`) — verified by code review / class hierarchy, not by a runtime test. | New `App\DTO\EffectiveAccessPermission` class. | User directive: "create a proper DTO for this to make sure it is not persisted by error." |
+
+## Branch & Scenario Matrix
+
+| Scenario ID | Description / Expected outcome |
+|-------------|--------------------------------|
+| S-048-01 | User is in two groups sharing the same album with different grants, group with fewer grants created first → user receives the union of both groups' grants (reproduces the bug report; must now pass). |
+| S-048-02 | Same as S-048-01 but with insertion order reversed → identical merged result as S-048-01 (order-independence). |
+| S-048-03 | User has a direct per-user `AccessPermission` on an album (e.g. `grants_download=false`) **and** belongs to a group with `grants_download=true` on the same album → merged result has `grants_download=true` (Q-048-01, Option A). |
+| S-048-04 | User belongs to a single group only (no direct share) → behaviour unchanged from before the fix. |
+| S-048-05 | User has a direct share only (no group share) → behaviour unchanged from before the fix. |
+| S-048-06 | User belongs to no group and has no direct share, album is not public → `current_user_permissions()` returns `null`, `canAccess` falls through to `public_permissions()`/owner checks exactly as today. |
+| S-048-07 | Guest (unauthenticated) → `current_user_permissions()` returns `null` without evaluating any permission row. |
+| S-048-08 | Album owner → unaffected; `isOwner()` short-circuits before `current_user_permissions()` is consulted in `AlbumPolicy`. |
+
+## Test Strategy
+- **Core (Unit):** Two layers of unit coverage:
+  1. Pure DTO tests for `App\DTO\EffectiveAccessPermission::merge()` — construct a plain `Collection<AccessPermission>` in memory (no DB, no Auth faking needed) and assert the OR-merge logic directly (covers S-048-01, S-048-02, S-048-03 at the algorithm level, independent of how `BaseAlbumImpl` builds the input collection).
+  2. `BaseAlbumImpl::current_user_permissions()` tests covering the filter/delegate/null-short-circuit logic (S-048-04 through S-048-07), using `setRelation()` to inject an in-memory `access_permissions` collection without touching the DB.
+- **Application/REST (Feature):** New Feature_v2 test extending the existing `tests/Feature_v2/Album/AlbumSharingTest.php` pattern (reuses `BaseApiWithDataTest` fixtures: `group1`, `group2`, users, `AccessPermission::factory()`) that reproduces the exact bug report — create the album, share with a low-grant group then a high-grant group (and the reverse order), log in as a user in both groups, and assert `GET Albums/{id}` (or the album head/list response) exposes `rights.can_download === true` in both orders.
+- **No CLI, UI (JS/Selenium), or Docs/Contracts impact** — no new routes, REST-facing DTOs, or frontend fields are introduced; `App\DTO\EffectiveAccessPermission` is an internal backend type, not exposed via any resource; the existing `AlbumRightsResource.can_download` field simply reflects the corrected value.
+
+## Interface & Contract Catalogue
+
+### Domain Objects
+| ID | Description | Modules |
+|----|-------------|---------|
+| DO-048-01 | `App\DTO\EffectiveAccessPermission` — new `final readonly class` in `app/DTO/`. Constructor-promoted public properties for the 5 boolean grant flags (`grants_full_photo_access`, `grants_download`, `grants_upload`, `grants_edit`, `grants_delete`), each defaulting to `false`. Static factory `merge(Collection<int,AccessPermission> $permissions): self` builds an instance via boolean OR across the given rows. Not an Eloquent model — no `id`, `password`, `is_link_required`, `save()`, or mass-assignment; deliberately cannot represent (or persist) anything beyond the 5 grant flags. | core (`app/DTO`) |
+| DO-048-02 | `current_user_permissions()` signature change: `BaseAlbumImpl::current_user_permissions()` and the matching `BaseAlbum::current_user_permissions()` forwarding method (`app/Models/Extensions/BaseAlbum.php:118-121`) now both return a nullable `EffectiveAccessPermission`; `@property` docblocks on `Album`, `TagAlbum`, `PersonAlbum` updated to `EffectiveAccessPermission` (nullable) accordingly. | core (Models) |
+
+### Fixtures & Sample Data
+| ID | Path | Purpose |
+|----|------|---------|
+| FX-048-01 | `tests/Feature_v2/Album/AlbumSharingTest.php` fixtures (`group1`, `group2`, `userWithGroup1`, `BaseApiWithDataTest`) | Reused for the new multi-group-merge regression test instead of creating a parallel fixture set. |
+
+## Telemetry & Observability
+No new telemetry. No new verbose-trace fields.
+
+## Documentation Deliverables
+- Update `docs/specs/6-decisions/` with an ADR recording the "most-permissive-wins, order-independent merge" policy for `current_user_permissions()`, since this establishes the canonical multi-source permission-merge rule for the album authorization module (security-relevant, cross-cutting: `AlbumPolicy` + `PhotoController`).
+- Close Q-048-01 in `docs/specs/4-architecture/open-questions.md` (done).
+
+## Fixtures & Sample Data
+See FX-048-01 above — no new fixture files are required.
+
+## Spec DSL
+```
+domain_objects:
+  - id: DO-048-01
+    name: EffectiveAccessPermission
+    path: app/DTO/EffectiveAccessPermission.php
+    kind: "final readonly class (plain DTO, not an Eloquent model)"
+    fields:
+      - name: grants_full_photo_access
+        type: boolean
+        constraints: "OR of all matching rows; default false"
+      - name: grants_download
+        type: boolean
+        constraints: "OR of all matching rows; default false"
+      - name: grants_upload
+        type: boolean
+        constraints: "OR of all matching rows; default false"
+      - name: grants_edit
+        type: boolean
+        constraints: "OR of all matching rows; default false"
+      - name: grants_delete
+        type: boolean
+        constraints: "OR of all matching rows; default false"
+    static_factory: "merge(Collection<int,AccessPermission> $permissions): self"
+  - id: DO-048-02
+    name: current_user_permissions signature change
+    affected:
+      - app/Models/BaseAlbumImpl.php
+      - app/Models/Extensions/BaseAlbum.php
+      - app/Models/Album.php (docblock)
+      - app/Models/TagAlbum.php (docblock)
+      - app/Models/PersonAlbum.php (docblock)
+fixtures:
+  - id: FX-048-01
+    path: tests/Feature_v2/Album/AlbumSharingTest.php
+    purpose: Reused fixtures for multi-group merge regression test
+```
+
+## Appendix (Optional)
+
+### Root cause (for implementers)
+```php
+// app/Models/BaseAlbumImpl.php:261-271 (current, buggy)
+public function current_user_permissions(): AccessPermission|null
+{
+    if (Auth::guest()) {
+        return null;
+    }
+    $user = Auth::user();
+    return $this->access_permissions->first(fn (AccessPermission $p) => $p->user_id === $user->id)
+        ?? $this->access_permissions->first(fn (AccessPermission $p) => in_array($p->user_group_id, $user->user_groups->map(fn ($g) => $g->id)->all(), true));
+}
+```
+`Collection::first()` short-circuits on the first element satisfying the predicate. When two group rows both satisfy the second predicate, only the first (by collection/DB order) is ever considered — the second group's grants are discarded even if they are strictly more permissive.
+
+### Target design (for implementers)
+```php
+// app/DTO/EffectiveAccessPermission.php (new)
+final readonly class EffectiveAccessPermission
+{
+    public function __construct(
+        public bool $grants_full_photo_access = false,
+        public bool $grants_download = false,
+        public bool $grants_upload = false,
+        public bool $grants_edit = false,
+        public bool $grants_delete = false,
+    ) {
+    }
+
+    /** @param Collection<int,AccessPermission> $permissions */
+    public static function merge(Collection $permissions): self
+    {
+        return new self(
+            grants_full_photo_access: $permissions->contains(fn (AccessPermission $p) => $p->grants_full_photo_access),
+            grants_download: $permissions->contains(fn (AccessPermission $p) => $p->grants_download),
+            grants_upload: $permissions->contains(fn (AccessPermission $p) => $p->grants_upload),
+            grants_edit: $permissions->contains(fn (AccessPermission $p) => $p->grants_edit),
+            grants_delete: $permissions->contains(fn (AccessPermission $p) => $p->grants_delete),
+        );
+    }
+}
+
+// app/Models/BaseAlbumImpl.php (rewritten)
+public function current_user_permissions(): EffectiveAccessPermission|null
+{
+    if (Auth::guest()) {
+        return null;
+    }
+    $user = Auth::user();
+    $group_ids = $user->user_groups->map(fn ($g) => $g->id)->all();
+    $matching = $this->access_permissions->filter(
+        fn (AccessPermission $p) => $p->user_id === $user->id || in_array($p->user_group_id, $group_ids, true)
+    );
+    return $matching->isEmpty() ? null : EffectiveAccessPermission::merge($matching);
+}
+```
+This keeps `current_user_permissions()` straight-line (filter → empty-check → delegate) and makes the merge algorithm itself independently unit-testable via `EffectiveAccessPermission::merge()` without any `Auth`/relation setup.
+
+### Precedent for the "most permissive wins" merge rule (used to resolve Q-048-01 without a schema change)
+- `app/Policies/AlbumPolicy.php:205,227,264,351` already OR `current_user_permissions()?->grants_*` with `public_permissions()?->grants_*`.
+- `app/Policies/AlbumPolicy.php:296-305,392-404,447-459` (`canDelete`, `canEditById`, `canDeleteById`) already OR across every matching group row directly in SQL via `orWhereIn(APC::USER_GROUP_ID, $user->user_groups->pluck('id'))`.
+- `tests/Feature_v2/Album/AlbumSharingTest.php:30` docblock: "Expected behavior is that the access for that album via group are taken as max."
+
+### Related prior work
+- `database/migrations/2026_07_01_120000_deduplicate_and_constrain_access_permissions.php` (merged 2026-07-01 in `adc58943`, "Fix propagation error") already guarantees at most one `AccessPermission` row per `(base_album_id, user_id)` pair and per `(base_album_id, user_group_id)` pair, so the merge in FR-048-01 operates over a bounded set: at most 1 direct-user row + at most 1 row per group the user belongs to.

--- a/docs/specs/4-architecture/features/048-fix-multi-group-permissions/tasks.md
+++ b/docs/specs/4-architecture/features/048-fix-multi-group-permissions/tasks.md
@@ -1,0 +1,87 @@
+# Feature 048 Tasks – Fix Multi-Group Permissions
+
+_Status: Draft_
+_Last updated: 2026-07-01_
+
+> Keep this checklist aligned with the feature plan increments. Stage tests before implementation, record verification commands beside each task, and prefer bite-sized entries (≤90 minutes).
+> **Mark tasks `[x]` immediately** after each one passes verification—do not batch completions. Update the roadmap status when all tasks are done.
+> When referencing requirements, keep feature IDs (`F-`), non-goal IDs (`N-`), and scenario IDs (`S-048-`) inside the same parentheses immediately after the task title.
+
+## Checklist
+
+- [ ] T-048-01 – Repo-wide caller sweep for `current_user_permissions()` (Implementation Drift Gate).
+  _Intent:_ Re-run `grep -rn "current_user_permissions()" app/ resources/js/` and confirm every caller only checks `!== null` or reads a `grants_*` boolean, matching DO-048-01/DO-048-02's assumption. Record the (unchanged) result inline in this task's notes.
+  _Verification commands:_
+  - `grep -rn "current_user_permissions()" app resources/js`
+  _Notes:_ Must complete before T-048-04/T-048-05 (plan I1/I3 Drift Gate).
+
+- [ ] T-048-02 – Unit tests: `EffectiveAccessPermission::merge()` pure algorithm (F-048-01, S-048-01, S-048-02, S-048-03).
+  _Intent:_ Add `tests/Unit/DTO/EffectiveAccessPermissionTest.php`. Build plain `Illuminate\Support\Collection` instances of `new AccessPermission([...])` rows (no DB) and assert `EffectiveAccessPermission::merge()`: (a) OR-combines a low-grant + high-grant row correctly (S-048-01); (b) produces the identical result with the two rows swapped (S-048-02, order-independence); (c) OR-combines a direct-user row with a group row (S-048-03); (d) returns all-`false` flags when given an empty collection (edge case feeding into T-048-03's null-short-circuit).
+  _Verification commands:_
+  - `php artisan test --filter=EffectiveAccessPermissionTest`
+  _Notes:_ Expected to fail (class doesn't exist yet) until T-048-04. Spec: FR-048-01.
+
+- [ ] T-048-03 – Unit tests: `BaseAlbumImpl::current_user_permissions()` filter/delegate/null logic (F-048-01, F-048-03, S-048-04, S-048-05, S-048-06, S-048-07).
+  _Intent:_ Add `tests/Unit/Models/BaseAlbumImplCurrentUserPermissionsTest.php`. Build a `BaseAlbumImpl` instance and inject synthetic `AccessPermission` rows via `setRelation(APC::ACCESS_PERMISSIONS, collect([...]))` (no DB); build a `User` instance with `setRelation('user_groups', collect([...]))`; authenticate via `Auth::shouldReceive('guest')->andReturn(false)` + `Auth::shouldReceive('user')->andReturn($user)` (Mockery) or `$this->actingAs($user)` if that proves simpler against in-memory models. Cover: single group only, unaffected (S-048-04); direct share only, unaffected (S-048-05); no matching row → `null` (S-048-06); guest → `null` without evaluating any row (S-048-07).
+  _Verification commands:_
+  - `php artisan test --filter=BaseAlbumImplCurrentUserPermissionsTest`
+  _Notes:_ Expected to fail until T-048-05 rewires the method. Spec: FR-048-01, FR-048-03.
+
+- [ ] T-048-04 – Implement `App\DTO\EffectiveAccessPermission` (F-048-01, NFR-048-02, NFR-048-03).
+  _Intent:_ Add `app/DTO/EffectiveAccessPermission.php`: `final readonly class` (SPDX/copyright header matching other `app/DTO/*.php` files) with 5 boolean constructor-promoted properties (`grants_full_photo_access`, `grants_download`, `grants_upload`, `grants_edit`, `grants_delete`, each default `false`) and a static `merge(Collection<int,AccessPermission> $permissions): self` factory that sets each flag via `$permissions->contains(fn (AccessPermission $p) => $p->{flag} === true)`. No mutation of `$permissions`; no branching beyond the 5 independent flag computations (straight-line).
+  _Verification commands:_
+  - `php artisan test --filter=EffectiveAccessPermissionTest`
+  - `make phpstan`
+  _Notes:_ T-048-02 must go green. Spec: FR-048-01, NFR-048-02, NFR-048-03.
+
+- [ ] T-048-05 – Wire the DTO into `current_user_permissions()` and propagate the type change (F-048-01, F-048-04).
+  _Intent:_ In `app/Models/BaseAlbumImpl.php:261-271`, replace the two `->first(...)` calls with a single `->filter(fn (AccessPermission $p) => $p->user_id === $user->id || in_array($p->user_group_id, $group_ids, true))`, return `null` if the filtered collection is empty, otherwise `return EffectiveAccessPermission::merge($matching);`. Update `App\Models\Extensions\BaseAlbum::current_user_permissions()` (`app/Models/Extensions/BaseAlbum.php:118-121`) return type to match. Update the `@property` docblock in `app/Models/Album.php`, `app/Models/TagAlbum.php`, `app/Models/PersonAlbum.php` from `AccessPermission|null` to the nullable `EffectiveAccessPermission` (and drop the now-unused `AccessPermission` import in those files if PHPStan/php-cs-fixer flags it). Do not touch `public_permissions()`.
+  _Verification commands:_
+  - `php artisan test --filter=BaseAlbumImplCurrentUserPermissionsTest`
+  - `make phpstan`
+  _Notes:_ T-048-01 (grep sweep) must be re-confirmed clean first. T-048-03 must go green; a `make phpstan` failure here on any consumer would indicate the caller-sweep assumption was wrong (see plan Risks). Spec: FR-048-01, FR-048-04.
+
+- [ ] T-048-06 – Feature regression test reproducing the exact bug report, both share orders (F-048-01, S-048-01, S-048-02).
+  _Intent:_ In `tests/Feature_v2/Album/AlbumSharingTest.php` (reusing its `BaseApiWithDataTest` fixtures) or a new sibling test class in the same namespace, add a test that: creates an album, shares it with `group1` (all `grants_*` false, i.e. "View only") then `group2` (`grants_download` + others true), puts a user in both groups via `user_groups()->attach(...)`, calls the album endpoint the user would use to see the Download button (`GET Albums/{album_id}` or equivalent already-covered endpoint), and asserts `rights.can_download === true`. Add a second test with the two `AccessPermission::factory()->create()` calls swapped in order, asserting the same result.
+  _Verification commands:_
+  - `php artisan test --filter=AlbumSharingTest`
+  _Notes:_ Confirms FR-048-01 through the real HTTP → `AlbumPolicy::canDownload` → `AlbumRightsResource.can_download` path, matching how the bug was actually observed (missing Download button). Spec: FR-048-01, S-048-01, S-048-02.
+
+- [ ] T-048-07 – Query-count guard for NFR-048-01 (F-048-02).
+  _Intent:_ In the T-048-06 feature test (or a dedicated test), capture the SQL query count for the `GET Albums/{album_id}` call with a single-group baseline, then repeat with the two-group multi-permission scenario and assert the query count is identical (e.g. via `DB::enableQueryLog()`/`count(DB::getQueryLog())` before/after, or `assertQueryCount` if the project already has that helper — check `tests/Traits` first).
+  _Verification commands:_
+  - `php artisan test --filter=AlbumSharingTest`
+  _Notes:_ This is the executable proof of "least heavy on database queries." Spec: NFR-048-01.
+
+- [ ] T-048-08 – Regression pass on existing permission/sharing tests (F-048-03).
+  _Intent:_ Run the full existing test suites touching `AccessPermission`/`AlbumPolicy`/sharing to confirm zero regressions from the merge-rule change and the type swap (especially `AlbumSharingTest`, `PasswordDownloadBypassTest`, `BulkAlbumEdit` tests, `UserGroupTest`, `AccessPermissionTest`).
+  _Verification commands:_
+  - `php artisan test --filter=AlbumSharingTest`
+  - `php artisan test --filter=PasswordDownloadBypassTest`
+  - `php artisan test --filter=UserGroupTest`
+  - `php artisan test --filter=AccessPermissionTest`
+  - `php artisan test`
+  _Notes:_ Spec: FR-048-03.
+
+- [ ] T-048-09 – ADR-0004: multi-group permission merge policy (Documentation Deliverables).
+  _Intent:_ Add `docs/specs/6-decisions/ADR-0004-multi-group-permission-merge.md` using `docs/specs/templates/adr-template.md`, documenting: (1) the "collect all matching rows (direct-user + every group), OR each boolean grant flag, no precedence between sources" merge policy, citing the precedent in spec.md's Appendix (`AlbumPolicy` public+current OR pattern, `canDeleteById`/`canEditById` group-OR-in-SQL, `AlbumSharingTest.php` docblock); and (2) the decision to represent the merged result as the new `App\DTO\EffectiveAccessPermission` (a plain, non-persistable DTO) rather than a synthetic `App\Models\AccessPermission` instance, so the result cannot be mass-assigned or `save()`d by accident. Reference Q-048-01, FR-048-01, FR-048-04, NFR-048-01, NFR-048-03.
+  _Verification commands:_ None (docs only).
+  _Notes:_ Link the ADR ID back into spec.md's Documentation Deliverables section once created.
+
+- [ ] T-048-10 – Update roadmap and session snapshot (Documentation Deliverables).
+  _Intent:_ Move Feature 048 from "Active Features" to "Completed Features" in `docs/specs/4-architecture/roadmap.md` with a completion date and summary once all tasks are done, and refresh `docs/specs/_current-session.md` accordingly.
+  _Verification commands:_ None (docs only).
+  _Notes:_ Per AGENTS.md "Sync context to disk."
+
+- [ ] T-048-11 – Full PHP quality gate (per AGENTS.md "After Completing Work").
+  _Intent:_ Run the complete PHP quality gate since only `.php` files are touched by this feature.
+  _Verification commands:_
+  - `vendor/bin/php-cs-fixer fix`
+  - `php artisan test`
+  - `make phpstan`
+  _Notes:_ Must be clean before handing off the commit per AGENTS.md commit protocol (staged summary + commit message prepared for the operator, not executed automatically).
+
+## Notes / TODOs
+- If `tests/Traits` already has a query-count-assertion helper (check before writing a new one in T-048-07), reuse it instead of hand-rolling `DB::enableQueryLog()`.
+- T-048-05's docblock updates may leave `use App\Models\AccessPermission;` unused in `Album.php`/`TagAlbum.php`/`PersonAlbum.php` if that import existed only for the old `@property` type — check `php-cs-fixer`/PHPStan output and remove if flagged, but keep it if the file still uses `AccessPermission` elsewhere (e.g. `access_permissions` collection typing).
+- `EffectiveAccessPermission` lives in `app/DTO/` (flat, no subfolder) matching `CheckoutDTO.php`/`PixelSizeAssignment.php` — do not create a new `app/DTO/Sharing/` subfolder for a single class.

--- a/docs/specs/4-architecture/open-questions.md
+++ b/docs/specs/4-architecture/open-questions.md
@@ -22,6 +22,7 @@ Track unresolved high- and medium-impact questions here. Remove each row as soon
 | ~~Q-046-02~~ | 046 – Tag Album Cover | Medium | Front-end guard: replace `is_model_album` with `has_cover_support` flag, or widen check to include tag albums? | Resolved (B – check `is_model_album \|\| tagAlbum` in context menu) | 2026-06-28 | 2026-06-28 |
 | ~~Q-046-03~~ | 046 – Tag Album Cover | Medium | Should `cover()` relationship and eager-loading live on `BaseAlbumImpl` or remain per-model? | Resolved (N/A – per-model with eager-load on TagAlbum) | 2026-06-28 | 2026-06-28 |
 | Q-040-01 | 040 – Disable Request Caching | Medium | Analysis Gate never formally signed off: plan.md gate checklist has unchecked boxes yet I1–I4 tasks are marked complete; gate must be ticked before implementation is considered verified | Open | 2026-05-31 | 2026-05-31 |
+| ~~Q-048-01~~ | 048 – Fix Multi-Group Permissions | High | Should a direct user-level `AccessPermission` override group permissions, or merge with them, once group-vs-group merging is fixed? | Resolved (A – merge everything via boolean OR) | 2026-07-01 | 2026-07-01 |
 | ~~Q-047-01~~ | 047 – Person Smart Album | High | `AlbumPhotosController` + `GetAlbumPhotosRequest` + `AlbumHeadController` have hardcoded `TagAlbum` branches — PersonAlbum falls through to wrong code path or throws | Resolved (A – add PersonAlbum branches) | 2026-06-28 | 2026-06-28 |
 | ~~Q-047-02~~ | 047 – Person Smart Album | High | `Delete::do()` only checks `tag_albums` table for non-regular albums — PersonAlbums silently skipped then treated as regular Album (tree validation fails) | Resolved (A – add `deletePersonAlbums()`) | 2026-06-28 | 2026-06-28 |
 | ~~Q-047-03~~ | 047 – Person Smart Album | High | `EditableBaseAlbumResource` constructor and `fromModel()` accept `Album\|TagAlbum` only — PersonAlbum passed to it will cause a type error | Resolved (A – widen to `Album\|TagAlbum\|PersonAlbum`) | 2026-06-28 | 2026-06-28 |
@@ -56,6 +57,20 @@ Track unresolved high- and medium-impact questions here. Remove each row as soon
 | ~~Q-044-07~~ | 044 – Folder Drop | Low | `UploadPanel` internal drop zone bypasses `folderDrop.ts` | Resolved (A – out of scope, document boundary) | 2026-06-13 | 2026-06-13 |
 
 ## Question Details
+
+### ~~Q-048-01~~ · Direct user-level `AccessPermission` — override group grants, or merge with them? ✅ RESOLVED
+
+**Status:** Resolved — **Option A** (merge direct-user row + every matching group row via boolean OR)
+**Feature:** 048 – Fix Multi-Group Permissions
+**Priority:** High
+**Opened:** 2026-07-01
+**Resolved:** 2026-07-01
+
+**Resolution:** `current_user_permissions()` collects every `AccessPermission` row matching the current user — the direct `user_id` row (if any) plus every row whose `user_group_id` is one of the user's group ids — and returns a single synthetic, non-persisted `AccessPermission` whose 5 boolean grant flags are the logical OR across all collected rows. There is no precedence between a direct-user row and group rows; the most permissive applicable grant always wins, consistent with the existing public+current-user OR pattern in `AlbumPolicy` and the group-OR semantics already used in `canDeleteById`/`canEditById`.
+
+**Spec impact:** Captured in FR-048-01 and NFR-048-01 below.
+
+---
 
 ### ~~Q-047-01~~ · `AlbumPhotosController`, `GetAlbumPhotosRequest`, and `AlbumHeadController` don't handle PersonAlbum ✅ RESOLVED
 

--- a/docs/specs/4-architecture/roadmap.md
+++ b/docs/specs/4-architecture/roadmap.md
@@ -6,6 +6,7 @@ High-level planning document for Lychee features and architectural initiatives.
 
 | Feature ID | Name | Status | Priority | Assignee | Started | Updated | Progress |
 |------------|------|--------|----------|----------|---------|---------|----------|
+| 048 | Fix Multi-Group Permissions | Planning | P1 (bug fix) | LycheeOrg | 2026-07-01 | 2026-07-01 | Spec, plan, tasks drafted. 11 tasks across 7 increments. Fixes `BaseAlbumImpl::current_user_permissions()` using `Collection::first()` (order-dependent) instead of merging every matching `AccessPermission` row (direct-user + all groups) via boolean OR. Merged result returned as a new non-persistable DTO (`App\DTO\EffectiveAccessPermission`, `final readonly class`) instead of a synthetic `AccessPermission` model instance, so it cannot be mass-assigned/`save()`d by accident. Zero new DB queries (NFR-048-01). Q-048-01 resolved (Option A — merge everything, most-permissive-wins). ADR-0004 planned. |
 | 047 | Person Smart Album | Planning | P2 | LycheeOrg | 2026-06-28 | 2026-06-28 | Spec, plan, tasks drafted. 37 tasks across 14 increments. Mirrors TagAlbum pattern: PersonAlbum model, HasManyPhotosByPerson relation, AND/OR person matching, feature-gated by v8 + ai_vision_face_enabled. |
 
 ## Paused Features

--- a/docs/specs/6-decisions/ADR-0004-multi-group-permission-merge.md
+++ b/docs/specs/6-decisions/ADR-0004-multi-group-permission-merge.md
@@ -1,0 +1,65 @@
+# ADR-0004: Multi-Group Permission Merge Policy
+
+- **Status:** Accepted
+- **Date:** 2026-07-01
+- **Last updated:** 2026-07-01
+- **Related features/specs:** Feature 048 (docs/specs/4-architecture/features/048-fix-multi-group-permissions/spec.md)
+- **Related open questions:** Q-048-01 (resolved)
+
+## Context
+
+`BaseAlbumImpl::current_user_permissions()` resolves the effective `AccessPermission` for the current user on an album. Before this change, it used `Collection::first()` twice: once for a direct user-level row, and — only if that lookup failed — once for a matching user-group row. Because `first()` short-circuits on the first element satisfying the predicate, a user who belongs to **two or more groups** with different grants on the same album only ever received the grants of whichever group's row happened to sort first in the already-loaded `access_permissions` collection (effectively insertion/id order). Re-creating the same shares in a different order flipped which group's grants applied.
+
+This is a security-relevant authorization bug: a user could silently lose grants (e.g. Download) that an administrator intended them to have via a more permissive group, purely because of unrelated row ordering. It also crosses module boundaries — the resolution method lives in `app/Models`, but is consumed by the authorization layer (`app/Policies/AlbumPolicy.php`) and the gallery controller (`app/Http/Controllers/Gallery/PhotoController.php`) — so the merge policy needed to be decided once, centrally, rather than patched ad hoc at each call site.
+
+A related, narrower question (Q-048-01) was whether a **direct user-level** `AccessPermission` row should keep overriding group rows (the pre-existing `??` precedence), or be folded into the same union as the group rows once group-vs-group merging was fixed.
+
+## Decision
+
+We adopt a **most-permissive-wins, order-independent merge** across every `AccessPermission` row matching the current user — the direct `user_id` row (if any) plus every row whose `user_group_id` is one of the user's group ids. Each of the five boolean grant flags (`grants_full_photo_access`, `grants_download`, `grants_upload`, `grants_edit`, `grants_delete`) on the merged result is `true` if it is `true` on **any** matching row. There is no precedence between a direct-user row and a group row (Q-048-01, Option A) — the most permissive applicable grant always wins, regardless of row order or source.
+
+The merged result is represented by a new dedicated DTO, `App\DTO\EffectiveAccessPermission` (`final readonly class`, `app/DTO/EffectiveAccessPermission.php`), rather than a synthetic `App\Models\AccessPermission` Eloquent model instance. An `AccessPermission` model is inherently persistable (mass-assignable, `->save()`-able); a computed, request-scoped "effective grants for this user on this album" snapshot must never be written back to the database. Using a plain DTO makes "this can never hit the database" a type-level guarantee instead of a convention every future caller has to remember. `current_user_permissions()`'s return type changes from a nullable `AccessPermission` to a nullable `EffectiveAccessPermission` across `BaseAlbumImpl`, the `BaseAlbum` extension trait, and the `@property` docblocks on `Album`, `TagAlbum`, `PersonAlbum`.
+
+The merge is performed entirely **in memory**, with zero additional database queries: `access_permissions` is already eager-loaded per-album via `BaseAlbumImpl::$with`, and `$user->user_groups` was already read by the pre-fix code. The two `->first(...)` calls are replaced by a single `->filter(...)` over the same already-loaded collection, followed by a `EffectiveAccessPermission::merge($matching)` call when the filtered collection is non-empty.
+
+## Consequences
+
+### Positive
+- Eliminates the entire bug class (order-dependent effective permissions), not just the specific group-vs-group scenario reported — the same fix also makes direct-user-vs-group merging order-independent.
+- Zero new database queries: the fix is strictly a query-count-neutral change (verified by an explicit query-count-guard test).
+- `EffectiveAccessPermission` cannot be mass-assigned, `save()`d, or otherwise persisted — a future accidental write is now a compile-time/type error rather than a silent runtime bug.
+- Consistent with the "most permissive wins" pattern already used elsewhere in this codebase: `AlbumPolicy` already ORs `current_user_permissions()?->grants_*` with `public_permissions()?->grants_*`; `canDeleteById`/`canEditById` already OR across every matching group row directly in SQL via `orWhereIn(user_group_id, ...)`. This decision makes the in-memory merge match the SQL-level merge that already existed for a subset of cases.
+
+### Negative
+- Widens the diff beyond the single buggy method: the return-type change propagates to the `BaseAlbum` trait and three model docblocks (`Album`, `TagAlbum`, `PersonAlbum`), even though no consumer's logic changes (PHPStan confirms no consumer reads an `AccessPermission`-only member).
+- An admin who wanted to use a direct-user row to deliberately *restrict* a specific user below their group's grants would find that restriction silently ignored. No existing UI/flow supports this today, so this is a theoretical trade-off, not an observed regression.
+
+## Alternatives Considered
+
+### Merge algorithm
+- **Option B (Q-048-01): direct-user row keeps override precedence; only group rows merge among themselves.** Smaller behavioural change (only fixes the reported group-vs-group scenario), but keeps an inconsistent, order-sensitive special case at the user-vs-group boundary, and a low-privilege direct-user row could still silently suppress a high-privilege group row — arguably the same class of surprise as the original bug, just one level up the precedence chain. Rejected in favor of Option A (uniform merge, no precedence) for consistency with the rest of the codebase.
+
+### Representation of the merged result
+- **Synthetic `App\Models\AccessPermission` instance** (`new AccessPermission([...])`, mirroring the existing `AccessPermission::ofPublic()`/`ofPublicHidden()` static-factory pattern). Simpler — no new class, no return-type propagation. Rejected because an `AccessPermission` model is structurally persistable; a computed capability snapshot that happens to share the same class as a real, savable database row is a latent risk (accidental `->save()` or mass-assignment on the synthetic instance would silently attempt to write a bogus row). A plain DTO removes this risk entirely.
+- **DB-level aggregate merge** (e.g. a `MAX()`/boolean-OR SQL query per grant flag). Would also fix the bug, but adds a new query per `current_user_permissions()` call, directly violating the explicit "least heavy on database queries" requirement that drove this fix, given `access_permissions` and `user_groups` are already loaded in memory.
+
+## Security / Privacy Impact
+
+- This is a security-relevant authorization fix: before this change, a user could receive **fewer** grants than an administrator intended (a share downgrade caused by unrelated row ordering), which is a fail-safe direction (under-granting), but still incorrect and reported by the affected operator as a Download button silently missing.
+- The fix does not widen access beyond what the sum of a user's direct share and group memberships was always intended to grant — it only ensures that sum is computed correctly and deterministically. No new grant flag or capability is introduced.
+- `EffectiveAccessPermission` carries no secrets (only 5 booleans) and exposes no `password`/`is_link_required` fields — those remain exclusively on `public_permissions()`, which is unaffected by this change.
+
+## Operational Impact
+
+- No migration, no schema change, no new configuration. This is a pure application-layer fix.
+- No new monitoring/alerting requirements. The change is covered by unit tests (`EffectiveAccessPermission::merge()`, `BaseAlbumImpl::current_user_permissions()`) and a feature-level regression test (`MultiGroupPermissionMergeTest`) that reproduces the exact bug report end-to-end, plus a query-count-guard test that fails if a future change reintroduces an extra query.
+- No performance impact: query count is unchanged (verified); the in-memory merge operates over a small, bounded collection (the July 2026 `deduplicate_and_constrain_access_permissions` migration guarantees at most one row per `(album, user)` pair and per `(album, group)` pair, so the merge combines at most 1 direct-user row + N group rows, where N is the number of groups the user belongs to).
+
+## Links
+
+- Related spec sections: [docs/specs/4-architecture/features/048-fix-multi-group-permissions/spec.md](../4-architecture/features/048-fix-multi-group-permissions/spec.md) (FR-048-01, FR-048-02, FR-048-04, NFR-048-01, NFR-048-02, NFR-048-03)
+- Related open question (resolved): Q-048-01 in [docs/specs/4-architecture/open-questions.md](../4-architecture/open-questions.md)
+- Implementation: [app/DTO/EffectiveAccessPermission.php](../../../app/DTO/EffectiveAccessPermission.php), [app/Models/BaseAlbumImpl.php](../../../app/Models/BaseAlbumImpl.php)
+- Precedent for the "most permissive wins" pattern: [app/Policies/AlbumPolicy.php](../../../app/Policies/AlbumPolicy.php) (public+current OR pattern; `canDeleteById`/`canEditById` group-OR-in-SQL)
+- Regression tests: [tests/Unit/DTO/EffectiveAccessPermissionTest.php](../../../tests/Unit/DTO/EffectiveAccessPermissionTest.php), [tests/Unit/Models/BaseAlbumImplCurrentUserPermissionsTest.php](../../../tests/Unit/Models/BaseAlbumImplCurrentUserPermissionsTest.php), [tests/Feature_v2/Album/MultiGroupPermissionMergeTest.php](../../../tests/Feature_v2/Album/MultiGroupPermissionMergeTest.php)
+- Related prior work: `database/migrations/2026_07_01_120000_deduplicate_and_constrain_access_permissions.php` (merged in `adc58943`, "Fix propagation error"), which guarantees at most one `AccessPermission` row per `(base_album_id, user_id)` pair and per `(base_album_id, user_group_id)` pair.

--- a/docs/specs/_current-session.md
+++ b/docs/specs/_current-session.md
@@ -1,40 +1,42 @@
 # Current Session
 
-_Last updated: 2026-06-12_
+_Last updated: 2026-07-01_
 
 ## Active Features
 
-None currently in progress for Part A of Feature 042.
+Feature 048 – Fix Multi-Group Permissions: spec, plan, and tasks drafted (Draft status). Not yet implemented.
 
 ## Session Summary
 
-### Feature 042 Part A – Webshop Order Item Display — Complete
+### Feature 048 – Fix Multi-Group Permissions — Spec/Plan/Tasks Drafted
 
-**Status:** All I1–I6 tasks complete. PHPStan 0 errors. php-cs-fixer clean. npm format/check/lint clean. 4 backend tests passing.
+**Bug report:** A user who belongs to two groups on the same album (e.g. "All" = View only, "Support_VIP" = View+Access+Download) only received the grants of whichever group's `AccessPermission` row was created first. Reordering the shares flipped the outcome.
 
-**What was built:**
+**Root cause:** `BaseAlbumImpl::current_user_permissions()` (`app/Models/BaseAlbumImpl.php:261-271`) uses `Collection::first()` to pick a single matching `AccessPermission` row instead of merging every matching row.
 
-- **`OrderItemResource`** (`app/Http/Resources/Shop/OrderItemResource.php`): added `album_title: ?string` and `thumb_url: ?string` constructor params; `fromModel()` populates from `$item->album?->title` and `$item->photo?->size_variants->getSizeVariant(SizeVariantType::THUMB)?->url`.
-- **`OrderResource::fromModel()`** (`app/Http/Resources/Shop/OrderResource.php`): unconditionally eager-loads `items.album` and `items.photo.size_variants` (filtered to SMALL, SMALL2X, THUMB, THUMB2X, PLACEHOLDER types). The existing `items.size_variant` load for CLOSED orders is retained.
-- **Backend tests** (`tests/Webshop/OrderManagement/OrderItemDisplayTest.php`): 4 tests covering the happy path, absent album, absent photo, and missing THUMB variant.
-- **i18n** (`lang/php_en.json` + 22 other lang files): added `webshop.orderDownload.unknownAlbum` key ("Unknown album").
-- **TypeScript types** (`resources/js/lychee.d.ts`): added `album_title: string | null` and `thumb_url: string | null` to `OrderItemResource`.
-- **`OrderDownload.vue`** (`resources/js/views/webshop/OrderDownload.vue`): added `<img>` (with `loading="lazy"`) or `<i class="pi pi-image">` placeholder before the title block; added album title line below the photo title `RouterLink`.
+**Resolution direction (Q-048-01, resolved — Option A):** Collect every matching row (direct-user row + every row for a group the user belongs to) and OR each of the 5 boolean grant flags. No precedence between direct-user and group rows — most permissive always wins, matching the existing pattern already used elsewhere (`AlbumPolicy` ORs `current_user_permissions()` with `public_permissions()`; `canDeleteById`/`canEditById` already OR across groups in SQL).
 
-**Key implementation note:** `PhotoFactory::without_size_variants()` mutates factory state before the closure is bound; the closure captures the pre-clone `$this` so the flag has no effect. Worked around in the test by deleting the THUMB `SizeVariant` row directly after photo creation.
+**Follow-up design decision (user-requested):** instead of returning a synthetic `App\Models\AccessPermission` Eloquent instance (which is inherently persistable — mass-assignable, `save()`-able), the merged result is a new `App\DTO\EffectiveAccessPermission` (`final readonly class`, plain DTO, matches the existing `CheckoutDTO`/`PixelSizeAssignment` style). This makes "cannot be persisted by accident" a type-level guarantee (NFR-048-03). `current_user_permissions()`'s return type changes accordingly across `BaseAlbumImpl`, the `BaseAlbum` trait, and `@property` docblocks on `Album`/`TagAlbum`/`PersonAlbum` (FR-048-04).
+
+**Key constraint:** Zero new DB queries (NFR-048-01) — `access_permissions` is already eager-loaded via `BaseAlbumImpl::$with`, and `$user->user_groups` is already read by the current (buggy) code, so the fix is a pure in-memory `Collection` merge.
+
+**Not yet done:** Implementation (I1–I7 in plan.md / T-048-01–11 in tasks.md), ADR-0004, quality gates.
+
+### Feature 042 Part A – Webshop Order Item Display — Complete (prior session)
+All I1–I6 tasks complete. See roadmap.md for details; superseded as the session focus by Feature 048.
 
 ## Next Steps
-
-1. Implement Part B of Feature 042 (I7–I10): admin maintenance photo title links (`PhotoTitleLink.vue`, `DuplicateLine.vue`, `Moderation.vue`). Tasks T-042-16 to T-042-20 in [tasks.md](4-architecture/features/042-webshop-order-item-display/tasks.md).
-2. After Part B completes, move Feature 042 to "Completed" in roadmap with final completion date.
+1. Start Feature 048 implementation at T-048-01 (repo-wide caller sweep) then T-048-02/03 (unit tests reproducing the bug) — see [tasks.md](4-architecture/features/048-fix-multi-group-permissions/tasks.md).
+2. Work through T-048-04…11 (DTO implementation, wiring, feature regression test, query-count guard, regression pass, ADR-0004, roadmap/session sync, quality gates).
+3. Feature 047 (Person Smart Album) remains drafted but not implemented — no active work this session.
+4. Feature 042 Part B (I7–I10, admin maintenance photo title links) remains outstanding from the prior session — see [tasks.md](4-architecture/features/042-webshop-order-item-display/tasks.md) T-042-16 to T-042-20.
 
 ## Open Questions
-
-None.
+None blocking. Q-048-01 resolved 2026-07-01.
 
 ## Key Artefacts
-
-- Spec: [042-webshop-order-item-display/spec.md](4-architecture/features/042-webshop-order-item-display/spec.md)
-- Plan: [042-webshop-order-item-display/plan.md](4-architecture/features/042-webshop-order-item-display/plan.md)
-- Tasks: [042-webshop-order-item-display/tasks.md](4-architecture/features/042-webshop-order-item-display/tasks.md)
+- Spec: [048-fix-multi-group-permissions/spec.md](4-architecture/features/048-fix-multi-group-permissions/spec.md)
+- Plan: [048-fix-multi-group-permissions/plan.md](4-architecture/features/048-fix-multi-group-permissions/plan.md)
+- Tasks: [048-fix-multi-group-permissions/tasks.md](4-architecture/features/048-fix-multi-group-permissions/tasks.md)
+- Open questions: [open-questions.md](4-architecture/open-questions.md) (Q-048-01, resolved)
 - Roadmap: [roadmap.md](4-architecture/roadmap.md)

--- a/tests/Feature_v2/Album/MultiGroupPermissionMergeTest.php
+++ b/tests/Feature_v2/Album/MultiGroupPermissionMergeTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Feature_v2\Album;
+
+use App\Models\AccessPermission;
+use Illuminate\Support\Facades\DB;
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+
+/**
+ * Regression test for the bug report: a user who belongs to two groups
+ * sharing the same album (e.g. "All" = View only, "Support_VIP" = View,
+ * Access, Download) only received the grants of whichever group's
+ * AccessPermission row was created first, instead of the union of both.
+ *
+ * See Feature 048 (docs/specs/4-architecture/features/048-fix-multi-group-permissions).
+ */
+class MultiGroupPermissionMergeTest extends BaseApiWithDataTest
+{
+	public function testUserInTwoGroupsReceivesUnionOfGrantsLowGroupFirst(): void
+	{
+		$this->userWithGroup1->user_groups()->attach($this->group2);
+
+		// "All" - View only, created first.
+		AccessPermission::factory()
+			->for_user_group($this->group1)
+			->for_album($this->album3)
+			->visible()
+			->create();
+
+		// "Support_VIP" - View, Access, Download, created second.
+		AccessPermission::factory()
+			->for_user_group($this->group2)
+			->for_album($this->album3)
+			->visible()
+			->grants_download()
+			->grants_full_photo()
+			->create();
+
+		$response = $this->actingAs($this->userWithGroup1)->getJsonWithData('Album::head', ['album_id' => $this->album3->id]);
+		$this->assertOk($response);
+		$response->assertJsonPath('resource.rights.can_download', true);
+	}
+
+	public function testUserInTwoGroupsReceivesUnionOfGrantsHighGroupFirst(): void
+	{
+		$this->userWithGroup1->user_groups()->attach($this->group2);
+
+		// "Support_VIP" - View, Access, Download, created first this time.
+		AccessPermission::factory()
+			->for_user_group($this->group2)
+			->for_album($this->album3)
+			->visible()
+			->grants_download()
+			->grants_full_photo()
+			->create();
+
+		// "All" - View only, created second.
+		AccessPermission::factory()
+			->for_user_group($this->group1)
+			->for_album($this->album3)
+			->visible()
+			->create();
+
+		$response = $this->actingAs($this->userWithGroup1)->getJsonWithData('Album::head', ['album_id' => $this->album3->id]);
+		$this->assertOk($response);
+		$response->assertJsonPath('resource.rights.can_download', true);
+	}
+
+	/**
+	 * NFR-048-01: merging a second matching group's AccessPermission row must
+	 * not add any SQL query — access_permissions and user_groups are already
+	 * eager-loaded/read by the pre-fix code, so the merge is purely in-memory.
+	 *
+	 * A warm-up call primes process-lifetime caches (e.g. ConfigManager, which
+	 * only issues its "configs" table queries once per test method regardless
+	 * of scenario) so the two measured calls below are compared on equal
+	 * footing instead of the first call absorbing one-time warm-up queries.
+	 */
+	public function testQueryCountUnaffectedByNumberOfMatchingGroups(): void
+	{
+		AccessPermission::factory()
+			->for_user_group($this->group1)
+			->for_album($this->album3)
+			->visible()
+			->grants_download()
+			->create();
+
+		$this->assertOk($this->actingAs($this->userWithGroup1)->getJsonWithData('Album::head', ['album_id' => $this->album3->id]));
+
+		// Baseline: the user matches a single group's AccessPermission row.
+		DB::enableQueryLog();
+		$baseline_response = $this->actingAs($this->userWithGroup1)->getJsonWithData('Album::head', ['album_id' => $this->album3->id]);
+		$this->assertOk($baseline_response);
+		$baseline_count = count(DB::getQueryLog());
+		DB::flushQueryLog();
+		DB::disableQueryLog();
+
+		// Add a second group + matching row for the SAME user on the SAME album.
+		$this->userWithGroup1->user_groups()->attach($this->group2);
+		AccessPermission::factory()
+			->for_user_group($this->group2)
+			->for_album($this->album3)
+			->visible()
+			->create();
+
+		DB::enableQueryLog();
+		$multi_group_response = $this->actingAs($this->userWithGroup1)->getJsonWithData('Album::head', ['album_id' => $this->album3->id]);
+		$this->assertOk($multi_group_response);
+		$multi_group_count = count(DB::getQueryLog());
+		DB::flushQueryLog();
+		DB::disableQueryLog();
+
+		self::assertSame(
+			$baseline_count,
+			$multi_group_count,
+			'Adding a second matching group permission must not add any SQL query (NFR-048-01).'
+		);
+	}
+}

--- a/tests/Unit/DTO/EffectiveAccessPermissionTest.php
+++ b/tests/Unit/DTO/EffectiveAccessPermissionTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace Tests\Unit\DTO;
+
+use App\DTO\EffectiveAccessPermission;
+use App\Models\AccessPermission;
+use Illuminate\Support\Collection;
+use Tests\AbstractTestCase;
+
+/**
+ * Unit tests for EffectiveAccessPermission::merge().
+ *
+ * Regression coverage for the bug where a user belonging to multiple groups
+ * only received the grants of whichever group's AccessPermission row was
+ * created first, instead of the union of every applicable grant.
+ */
+class EffectiveAccessPermissionTest extends AbstractTestCase
+{
+	public function testMergeOfEmptyCollectionYieldsNoGrants(): void
+	{
+		$merged = EffectiveAccessPermission::merge(new Collection());
+
+		self::assertFalse($merged->grants_full_photo_access);
+		self::assertFalse($merged->grants_download);
+		self::assertFalse($merged->grants_upload);
+		self::assertFalse($merged->grants_edit);
+		self::assertFalse($merged->grants_delete);
+	}
+
+	/**
+	 * S-048-01: low-grant group row created before a high-grant group row —
+	 * the merged result must expose the union of both.
+	 */
+	public function testMergeUnionsLowThenHighGrantRows(): void
+	{
+		$low = new AccessPermission([
+			'grants_full_photo_access' => false,
+			'grants_download' => false,
+			'grants_upload' => false,
+			'grants_edit' => false,
+			'grants_delete' => false,
+		]);
+		$high = new AccessPermission([
+			'grants_full_photo_access' => true,
+			'grants_download' => true,
+			'grants_upload' => false,
+			'grants_edit' => false,
+			'grants_delete' => false,
+		]);
+
+		$merged = EffectiveAccessPermission::merge(new Collection([$low, $high]));
+
+		self::assertTrue($merged->grants_full_photo_access);
+		self::assertTrue($merged->grants_download);
+		self::assertFalse($merged->grants_upload);
+		self::assertFalse($merged->grants_edit);
+		self::assertFalse($merged->grants_delete);
+	}
+
+	/**
+	 * S-048-02: identical rows in reversed order must yield the identical
+	 * merged result (order-independence).
+	 */
+	public function testMergeIsOrderIndependent(): void
+	{
+		$low = new AccessPermission([
+			'grants_full_photo_access' => false,
+			'grants_download' => false,
+			'grants_upload' => false,
+			'grants_edit' => false,
+			'grants_delete' => false,
+		]);
+		$high = new AccessPermission([
+			'grants_full_photo_access' => true,
+			'grants_download' => true,
+			'grants_upload' => false,
+			'grants_edit' => false,
+			'grants_delete' => false,
+		]);
+
+		$mergedLowFirst = EffectiveAccessPermission::merge(new Collection([$low, $high]));
+		$mergedHighFirst = EffectiveAccessPermission::merge(new Collection([$high, $low]));
+
+		self::assertEquals($mergedLowFirst, $mergedHighFirst);
+		self::assertTrue($mergedHighFirst->grants_download);
+	}
+
+	/**
+	 * S-048-03 (Q-048-01, Option A): a direct-user row and a group row are
+	 * merged with no precedence — most permissive always wins.
+	 */
+	public function testMergeUnionsDirectUserRowWithGroupRow(): void
+	{
+		$directUser = new AccessPermission([
+			'user_id' => 1,
+			'grants_download' => false,
+			'grants_upload' => false,
+			'grants_edit' => false,
+			'grants_delete' => false,
+			'grants_full_photo_access' => false,
+		]);
+		$group = new AccessPermission([
+			'user_group_id' => 42,
+			'grants_download' => true,
+			'grants_upload' => true,
+			'grants_edit' => false,
+			'grants_delete' => false,
+			'grants_full_photo_access' => false,
+		]);
+
+		$merged = EffectiveAccessPermission::merge(new Collection([$directUser, $group]));
+
+		self::assertTrue($merged->grants_download);
+		self::assertTrue($merged->grants_upload);
+		self::assertFalse($merged->grants_edit);
+		self::assertFalse($merged->grants_delete);
+	}
+
+	public function testMergeOfSingleRowReflectsItsOwnGrants(): void
+	{
+		$permission = new AccessPermission([
+			'grants_full_photo_access' => true,
+			'grants_download' => false,
+			'grants_upload' => true,
+			'grants_edit' => false,
+			'grants_delete' => true,
+		]);
+
+		$merged = EffectiveAccessPermission::merge(new Collection([$permission]));
+
+		self::assertTrue($merged->grants_full_photo_access);
+		self::assertFalse($merged->grants_download);
+		self::assertTrue($merged->grants_upload);
+		self::assertFalse($merged->grants_edit);
+		self::assertTrue($merged->grants_delete);
+	}
+}

--- a/tests/Unit/Models/BaseAlbumImplCurrentUserPermissionsTest.php
+++ b/tests/Unit/Models/BaseAlbumImplCurrentUserPermissionsTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Unit\Models;
+
+use App\Constants\AccessPermissionConstants as APC;
+use App\DTO\EffectiveAccessPermission;
+use App\Models\AccessPermission;
+use App\Models\BaseAlbumImpl;
+use App\Models\User;
+use App\Models\UserGroup;
+use Illuminate\Support\Collection;
+use Tests\AbstractTestCase;
+
+/**
+ * Unit tests for BaseAlbumImpl::current_user_permissions() filter/delegate/
+ * null-short-circuit logic, using in-memory relations (no DB access).
+ */
+class BaseAlbumImplCurrentUserPermissionsTest extends AbstractTestCase
+{
+	private function makeUser(int $id, array $group_ids = []): User
+	{
+		$user = new User();
+		$user->id = $id;
+		$user->setRelation('user_groups', new Collection(array_map(
+			function (int $group_id): UserGroup {
+				$group = new UserGroup();
+				$group->id = $group_id;
+
+				return $group;
+			},
+			$group_ids
+		)));
+
+		return $user;
+	}
+
+	private function makeAlbum(Collection $access_permissions): BaseAlbumImpl
+	{
+		$album = new BaseAlbumImpl();
+		$album->setRelation(APC::ACCESS_PERMISSIONS, $access_permissions);
+
+		return $album;
+	}
+
+	public function testGuestReturnsNullWithoutEvaluatingAnyRow(): void
+	{
+		$album = $this->makeAlbum(new Collection([
+			new AccessPermission(['user_id' => 1, 'grants_download' => true]),
+		]));
+
+		self::assertNull($album->current_user_permissions());
+	}
+
+	public function testNoMatchingRowReturnsNull(): void
+	{
+		$user = $this->makeUser(1, [10]);
+		$album = $this->makeAlbum(new Collection([
+			new AccessPermission(['user_id' => 2, 'grants_download' => true]),
+			new AccessPermission(['user_group_id' => 20, 'grants_download' => true]),
+		]));
+
+		$this->actingAs($user);
+
+		self::assertNull($album->current_user_permissions());
+	}
+
+	public function testDirectShareOnlyIsReturnedUnaffected(): void
+	{
+		$user = $this->makeUser(1, []);
+		$album = $this->makeAlbum(new Collection([
+			new AccessPermission([
+				'user_id' => 1,
+				'grants_download' => true,
+				'grants_upload' => false,
+				'grants_edit' => false,
+				'grants_delete' => false,
+				'grants_full_photo_access' => false,
+			]),
+		]));
+
+		$this->actingAs($user);
+
+		$merged = $album->current_user_permissions();
+		self::assertInstanceOf(EffectiveAccessPermission::class, $merged);
+		self::assertTrue($merged->grants_download);
+		self::assertFalse($merged->grants_upload);
+	}
+
+	public function testSingleGroupOnlyIsReturnedUnaffected(): void
+	{
+		$user = $this->makeUser(1, [10]);
+		$album = $this->makeAlbum(new Collection([
+			new AccessPermission([
+				'user_group_id' => 10,
+				'grants_download' => true,
+				'grants_upload' => true,
+				'grants_edit' => false,
+				'grants_delete' => false,
+				'grants_full_photo_access' => false,
+			]),
+		]));
+
+		$this->actingAs($user);
+
+		$merged = $album->current_user_permissions();
+		self::assertInstanceOf(EffectiveAccessPermission::class, $merged);
+		self::assertTrue($merged->grants_download);
+		self::assertTrue($merged->grants_upload);
+	}
+
+	/**
+	 * Reproduces the reported bug: a user in two groups ("All" = View only,
+	 * "Support_VIP" = View+Access+Download) must receive the union of both,
+	 * regardless of row order.
+	 */
+	public function testUserInMultipleGroupsReceivesUnionOfGrants(): void
+	{
+		$user = $this->makeUser(1, [10, 20]);
+		$album = $this->makeAlbum(new Collection([
+			new AccessPermission([
+				'user_group_id' => 10, // "All" - View only
+				'grants_download' => false,
+				'grants_upload' => false,
+				'grants_edit' => false,
+				'grants_delete' => false,
+				'grants_full_photo_access' => false,
+			]),
+			new AccessPermission([
+				'user_group_id' => 20, // "Support_VIP" - View, Access, Download
+				'grants_download' => true,
+				'grants_upload' => false,
+				'grants_edit' => false,
+				'grants_delete' => false,
+				'grants_full_photo_access' => true,
+			]),
+		]));
+
+		$this->actingAs($user);
+
+		$merged = $album->current_user_permissions();
+		self::assertInstanceOf(EffectiveAccessPermission::class, $merged);
+		self::assertTrue($merged->grants_download);
+		self::assertTrue($merged->grants_full_photo_access);
+	}
+
+	public function testUserInMultipleGroupsUnaffectedByRowOrder(): void
+	{
+		$user = $this->makeUser(1, [10, 20]);
+		$album = $this->makeAlbum(new Collection([
+			new AccessPermission([
+				'user_group_id' => 20, // "Support_VIP" created first this time
+				'grants_download' => true,
+				'grants_upload' => false,
+				'grants_edit' => false,
+				'grants_delete' => false,
+				'grants_full_photo_access' => true,
+			]),
+			new AccessPermission([
+				'user_group_id' => 10, // "All"
+				'grants_download' => false,
+				'grants_upload' => false,
+				'grants_edit' => false,
+				'grants_delete' => false,
+				'grants_full_photo_access' => false,
+			]),
+		]));
+
+		$this->actingAs($user);
+
+		$merged = $album->current_user_permissions();
+		self::assertInstanceOf(EffectiveAccessPermission::class, $merged);
+		self::assertTrue($merged->grants_download);
+		self::assertTrue($merged->grants_full_photo_access);
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed album access permissions for users in multiple groups so effective grants are combined as a true union (download/upload/edit/delete/full photo access), independent of how group permissions are created.
  * Kept guest and “no matching permissions” behavior unchanged.
* **Performance**
  * Preserved performance by ensuring the effective-permission calculation does not add extra database queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->