### PR TITLE
Support 2 lines titles on thumbs with disabled second line

### DIFF
--- a/resources/js/components/gallery/albumModule/thumbs/AlbumThumbOverlay.vue
+++ b/resources/js/components/gallery/albumModule/thumbs/AlbumThumbOverlay.vue
@@ -8,7 +8,9 @@
 	>
 		<h1
 			:class="{
-				'w-full pt-3 pb-1 text-sm text-surface-0 font-bold text-ellipsis whitespace-nowrap overflow-x-hidden': true,
+				'w-full pt-3 pb-1 text-sm text-surface-0 font-bold text-ellipsis overflow-x-hidden': true,
+				'whitespace-nowrap': album_subtitle_type !== 'disabled',
+				'line-clamp-2': album_subtitle_type === 'disabled',
 				'pr-1 pl-2 sm:pl-3 md:pl-4': isLTR(),
 				'pl-1 pr-2 sm:pr-3 md:pr-4': !isLTR(),
 			}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved album title display so longer titles now wrap to two lines when subtitles are disabled, instead of always being cut off.
  * Preserved the existing single-line title behavior when subtitles are enabled, keeping the gallery layout consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->