### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ volumes:
 
 - **Pre-built releases:** Download from [GitHub Releases](https://github.com/LycheeOrg/Lychee/releases)
 - **From source:** Requires PHP 8.4+, Composer, and npm
+- **Managed hosting:** [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/lychee)
 
 For detailed installation, configuration, and update instructions, see our **[Documentation](https://lycheeorg.dev/docs/)**.
 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Lychee to our marketplace, so this PR adds a small "Deploy with Zenith" link under the Installation section's Other Installation Methods list (links to https://zenith.hosting/host/lychee).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

---

Docs-only change (one line added to README). Targets master per the PR template. No new features, so tests and build steps are N/A. No LLM was used for the copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new managed hosting option to the installation methods section, with a badge linking to the deployment guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->