### PR TITLE
Fix photos appearing multiple times per-album in RSS feed

### DIFF
--- a/app/Actions/RSS/Generate.php
+++ b/app/Actions/RSS/Generate.php
@@ -107,6 +107,7 @@ class Generate
 				'photos.title',
 				'photos.description',
 				'photos.type',
+				'photos.created_at',
 				'photos.updated_at',
 				'outer_' . PA::ALBUM_ID,
 				'base_albums.title as album_title',
@@ -117,6 +118,7 @@ class Generate
 				'users.display_name',
 			]
 			)
+			->distinct()
 			->where('photos.created_at', '>=', $now_minus)
 			->limit($rss_max)
 			->orderBy('photos.created_at', 'desc')

--- a/tests/Feature_v2/RssTest.php
+++ b/tests/Feature_v2/RssTest.php
@@ -19,6 +19,7 @@
 namespace Tests\Feature_v2;
 
 use App\Models\Configs;
+use App\Models\Photo;
 use App\Repositories\ConfigManager;
 use Exception;
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
@@ -61,6 +62,44 @@ class RssTest extends BaseApiWithDataTest
 			$this->assertOk($response);
 		} catch (\Exception $e) {
 			// handle exception
+			$this->assertTrue(false, 'Exception occurred: ' . $e->getMessage());
+		} finally {
+			Configs::set('rss_enable', $init_config_value);
+		}
+	}
+
+	/**
+	 * A single photo (one row in `photos`) that belongs to two albums (two rows
+	 * in `photo_album`) must appear exactly once per album in the RSS feed.
+	 */
+	public function testRSSPhotoInMultipleAlbumsIsNotDuplicated(): void
+	{
+		$config_manager = resolve(ConfigManager::class);
+		$init_config_value = $config_manager->getValue('rss_enable');
+
+		try {
+			Configs::set('rss_enable', '1');
+
+			// One photo, two album memberships.
+			$photo = Photo::factory()
+				->owned_by($this->admin)
+				->in($this->album1)
+				->create();
+			$photo->albums()->attach($this->album2->id);
+
+			$response = $this->actingAs($this->admin)->get('/feed');
+			$this->assertOk($response);
+			$content = $response->getContent();
+
+			// `<guid>` is rendered exactly once per feed item, so it is a reliable
+			// per-item marker (the page link itself also appears in `<link>`).
+			$guid_album1 = '<guid>' . route('gallery', ['albumId' => $this->album1->id, 'photoId' => $photo->id]) . '</guid>';
+			$guid_album2 = '<guid>' . route('gallery', ['albumId' => $this->album2->id, 'photoId' => $photo->id]) . '</guid>';
+
+			// The photo is in two albums, so it must appear exactly once per album.
+			$this->assertSame(1, substr_count($content, $guid_album1), 'photo should appear once for album1');
+			$this->assertSame(1, substr_count($content, $guid_album2), 'photo should appear once for album2');
+		} catch (\Exception $e) {
 			$this->assertTrue(false, 'Exception occurred: ' . $e->getMessage());
 		} finally {
 			Configs::set('rss_enable', $init_config_value);


### PR DESCRIPTION
Before this change, a photo belonging to N albums appeared N^2 times in the RSS feed.

With this change, a photo belonging to N albums shows up N times in the RSS feed, once per album.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RSS feed output so items that appear in multiple albums are no longer duplicated.
  * Feed entries now generate more consistently when a photo is shared across several galleries.
* **Tests**
  * Added coverage for RSS feeds to confirm a photo linked to multiple albums appears only once per gallery link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->