### PR TITLE
RSS Feed includes one <item> per photo

### DIFF
--- a/app/Actions/RSS/Generate.php
+++ b/app/Actions/RSS/Generate.php
@@ -22,14 +22,16 @@ use Carbon\Exceptions\InvalidFormatException;
 use Carbon\Exceptions\UnitException;
 use GrahamCampbell\Markdown\Facades\Markdown;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use function Safe\parse_url;
 use Spatie\Feed\FeedItem;
 
 /**
- * @template T of object{id:string,title:string,description:?string,type:string,created_at:string,updated_at:string,album_id:string,album_title:string,short_path:string,filesize:int,storage_disk:string,size_variant_type:string,username:string}
+ * @template T of object{id:string,title:string,description:?string,type:string,created_at:string,updated_at:string,short_path:string,filesize:int,storage_disk:string,size_variant_type:string,username:string}
  */
 class Generate
 {
@@ -43,17 +45,25 @@ class Generate
 	}
 
 	/**
-	 * @param T $data
+	 * @param T        $data       the row supplying the item's photo/user fields
+	 * @param string   $album_id   the album whose view of the photo the item links to
+	 * @param string[] $categories album titles to list on the item as `<category>`
 	 *
 	 * @return FeedItem
 	 *
 	 * @throws BindingResolutionException
 	 */
-	private function toFeedItem(object $data): FeedItem
+	private function toFeedItem(object $data, string $album_id, array $categories): FeedItem
 	{
-		$page_link = route('gallery', ['albumId' => $data->album_id, 'photoId' => $data->id]);
+		$page_link = route('gallery', ['albumId' => $album_id, 'photoId' => $data->id]);
+		// A tag: URI (RFC 4151) is an opaque, album-independent identity for the
+		// photo. Unlike $page_link (which points at the newest album and moves if
+		// that album changes), it depends only on the host and the photo's
+		// immutable id/created_at, so a photo keeps the same <guid> for life.
+		$host = parse_url((string) config('app.url'), PHP_URL_HOST) ?? 'lychee';
+		$guid = sprintf('tag:%s,%s:photo/%s', $host, Carbon::parse($data->created_at)->format('Y-m-d'), $data->id);
 		$feed_item = [
-			'id' => $page_link,
+			'id' => $guid,
 			'title' => $data->title,
 			'summary' => Markdown::convert($data->description ?? '')->getContent(),
 			'updated' => $this->asDateTime($data->updated_at),
@@ -64,7 +74,7 @@ class Generate
 			'authorName' => ($data->display_name !== null && $data->display_name !== '')
 				? $data->display_name
 				: $data->username,
-			'category' => [$data->album_title],
+			'category' => $categories,
 		];
 
 		return FeedItem::create($feed_item);
@@ -97,11 +107,17 @@ class Generate
 				origin: null,
 				include_nsfw: !$this->config_manager->getValueAsBool('hide_nsfw_in_rss')
 			)
-			->joinSub(DB::table(PA::PHOTO_ALBUM), 'outer_' . PA::PHOTO_ALBUM, 'photos.id', '=', 'outer_' . PA::PHOTO_ID)
-			->join('base_albums', 'base_albums.id', '=', 'outer_' . PA::ALBUM_ID)
 			->join('size_variants', 'size_variants.photo_id', '=', 'photos.id')
 			->join('users', 'users.id', '=', 'photos.owner_id')
 			->where('size_variants.type', '=', SizeVariantType::ORIGINAL->value)
+			// Require at least one album (needed for the item's link) without
+			// re-introducing the per-album fan-out a join would add. The
+			// base_albums join mirrors the categories query below, so every
+			// selected photo is guaranteed a row there.
+			->whereExists(fn (BaseBuilder $q) => $q
+				->from(PA::PHOTO_ALBUM)
+				->join('base_albums', 'base_albums.id', '=', PA::ALBUM_ID)
+				->whereColumn(PA::PHOTO_ID, 'photos.id'))
 			->select([
 				'photos.id',
 				'photos.title',
@@ -109,8 +125,6 @@ class Generate
 				'photos.type',
 				'photos.created_at',
 				'photos.updated_at',
-				'outer_' . PA::ALBUM_ID,
-				'base_albums.title as album_title',
 				'size_variants.short_path',
 				'size_variants.filesize',
 				'size_variants.storage_disk',
@@ -118,6 +132,9 @@ class Generate
 				'users.display_name',
 			]
 			)
+			// distinct() collapses the photo_album fan-out that
+			// applySearchabilityFilter's internal left-join introduces, so each
+			// photo yields a single row (and the LIMIT counts photos).
 			->distinct()
 			->where('photos.created_at', '>=', $now_minus)
 			->limit($rss_max)
@@ -125,6 +142,39 @@ class Generate
 			->toBase() // We use toBase() to avoid the use of the Eloquent casts etc.
 			->get();
 
-		return $photos->map(fn (object $p) => $this->toFeedItem($p));
+		// All album memberships of the selected photos, newest-first so first()
+		// is the album each item links to: the most recently created album that
+		// holds the photo (album_id breaks created_at ties for a stable choice).
+		$albums_by_photo = DB::table(PA::PHOTO_ALBUM)
+			->join('base_albums', 'base_albums.id', '=', PA::ALBUM_ID)
+			->whereIn(PA::PHOTO_ID, $photos->pluck('id')->all())
+			->orderBy('base_albums.created_at', 'desc')
+			->orderBy(PA::ALBUM_ID)
+			->get([
+				PA::PHOTO_ID . ' as photo_id',
+				PA::ALBUM_ID . ' as album_id',
+				'base_albums.title as album_title',
+			])
+			->groupBy('photo_id');
+
+		return $photos
+			->map(function (object $photo) use ($albums_by_photo): ?FeedItem {
+				/** @var Collection<int,object{album_id:string,album_title:string}>|null $albums */
+				$albums = $albums_by_photo->get($photo->id);
+				// The two queries are not a single snapshot: a concurrent request
+				// can detach the photo from its last album between them, leaving
+				// no album to link to. Drop the photo rather than fatal on null.
+				if ($albums === null) {
+					return null;
+				}
+
+				return $this->toFeedItem(
+					$photo,
+					$albums->first()->album_id,
+					$albums->pluck('album_title')->all(),
+				);
+			})
+			->filter()
+			->values();
 	}
 }

--- a/app/Actions/RSS/Generate.php
+++ b/app/Actions/RSS/Generate.php
@@ -15,6 +15,7 @@ use App\Exceptions\Internal\FrameworkException;
 use App\Models\Extensions\UTCBasedTimes;
 use App\Models\Photo;
 use App\Policies\AlbumPolicy;
+use App\Policies\AlbumQueryPolicy;
 use App\Policies\PhotoQueryPolicy;
 use App\Repositories\ConfigManager;
 use App\Services\UrlGenerator;
@@ -39,6 +40,7 @@ class Generate
 
 	public function __construct(
 		protected PhotoQueryPolicy $photo_query_policy,
+		protected AlbumQueryPolicy $album_query_policy,
 		protected readonly ConfigManager $config_manager,
 		protected readonly UrlGenerator $url_generator,
 	) {
@@ -145,9 +147,41 @@ class Generate
 		// All album memberships of the selected photos, newest-first so first()
 		// is the album each item links to: the most recently created album that
 		// holds the photo (album_id breaks created_at ties for a stable choice).
-		$albums_by_photo = DB::table(PA::PHOTO_ALBUM)
+		//
+		// The same accessibility/NSFW constraints the photo query applies must
+		// also be applied here: a photo can be shared into a locked or sensitive
+		// album, and that album must not surface as the item's link or as a
+		// <category> to a viewer who cannot reach it.
+		$albums_query = DB::table(PA::PHOTO_ALBUM)
 			->join('base_albums', 'base_albums.id', '=', PA::ALBUM_ID)
-			->whereIn(PA::PHOTO_ID, $photos->pluck('id')->all())
+			->whereIn(PA::PHOTO_ID, $photos->pluck('id')->all());
+
+		// Accessibility: keep only albums the current user (or a guest, when
+		// $user is null) may access, honouring password locks. Admins may reach
+		// every album, so — like the album policies themselves — they skip this.
+		if ($user?->may_administrate !== true) {
+			$this->album_query_policy->joinSubComputedAccessPermissions(
+				query: $albums_query,
+				second: PA::ALBUM_ID,
+				type: 'left',
+				user: $user,
+			);
+			$albums_query->where(fn (BaseBuilder $q) => $this->album_query_policy
+				->appendAccessibilityConditions($q, $user, $unlocked_album_ids));
+		}
+
+		// NSFW: when the feed is configured to hide sensitive content, drop
+		// albums that are marked sensitive or sit under a sensitive ancestor.
+		// This mirrors the include_nsfw filter applied to the photo query above
+		// (which is applied to admins too), so it is applied unconditionally.
+		if ($this->config_manager->getValueAsBool('hide_nsfw_in_rss')) {
+			$albums_query
+				->join('albums', 'albums.id', '=', PA::ALBUM_ID)
+				->whereNotExists(fn (BaseBuilder $q) => $this->album_query_policy
+					->appendRecursiveSensitiveAlbumsCondition($q, null, null));
+		}
+
+		$albums_by_photo = $albums_query
 			->orderBy('base_albums.created_at', 'desc')
 			->orderBy(PA::ALBUM_ID)
 			->get([
@@ -167,6 +201,12 @@ class Generate
 				if ($albums === null) {
 					return null;
 				}
+
+				// The computed-access-permissions join can return an album more
+				// than once (e.g. shared to several of the user's groups), so
+				// collapse to one row per album before listing categories. first()
+				// still yields the newest album for the link (order is preserved).
+				$albums = $albums->unique('album_id');
 
 				return $this->toFeedItem(
 					$photo,

--- a/resources/views/vendor/feed/rss.blade.php
+++ b/resources/views/vendor/feed/rss.blade.php
@@ -23,7 +23,7 @@
                 <link>{{ url($item->link) }}</link>
                 <description><![CDATA[@if($item->__isset('enclosure'))<img src="{{ url($item->enclosure) }}" /><br/><br/>@endif{!! $item->summary !!}]]></description>
                 <author><![CDATA[{{ $item->authorName }}@if(!empty($item->authorEmail)) <{{ $item->authorEmail }}>@endif]]></author>
-                <guid>{{ url($item->id) }}</guid>
+                <guid isPermaLink="false">{{ $item->id }}</guid>
                 <pubDate>{{ $item->timestamp() }}</pubDate>
                 @foreach($item->category as $category)
                     <category>{{ $category }}</category>

--- a/tests/Feature_v2/RssTest.php
+++ b/tests/Feature_v2/RssTest.php
@@ -18,10 +18,12 @@
 
 namespace Tests\Feature_v2;
 
+use App\Models\Album;
 use App\Models\Configs;
 use App\Models\Photo;
 use App\Repositories\ConfigManager;
 use Exception;
+use Illuminate\Support\Facades\DB;
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 
 class RssTest extends BaseApiWithDataTest
@@ -148,6 +150,105 @@ class RssTest extends BaseApiWithDataTest
 			$this->assertTrue(false, 'Exception occurred: ' . $e->getMessage());
 		} finally {
 			Configs::set('rss_enable', $init_config_value);
+		}
+	}
+
+	/**
+	 * A photo shared into an album the viewer cannot access must not leak that
+	 * album: neither as the item's `<link>` nor as a `<category>`. The album's
+	 * owner, however, must still see it.
+	 */
+	public function testRSSInaccessibleAlbumIsNotExposed(): void
+	{
+		$config_manager = resolve(ConfigManager::class);
+		$init_config_value = $config_manager->getValue('rss_enable');
+
+		try {
+			Configs::set('rss_enable', '1');
+
+			// album4 is public (a guest may reach it); the private album is only
+			// owned by userMayUpload1 and has no public permission. It is created
+			// last, so it is the newest album — pre-fix it would have been chosen
+			// as the item's link.
+			$public_album = $this->album4;
+			$private_album = Album::factory()->as_root()->owned_by($this->userMayUpload1)->create();
+
+			$photo = Photo::factory()->owned_by($this->userMayUpload1)->in($public_album)->create();
+			$photo->albums()->attach($private_album->id);
+
+			$public_link = '<link>' . route('gallery', ['albumId' => $public_album->id, 'photoId' => $photo->id]) . '</link>';
+			$private_link = '<link>' . route('gallery', ['albumId' => $private_album->id, 'photoId' => $photo->id]) . '</link>';
+			$public_category = '<category>' . e($public_album->title) . '</category>';
+			$private_category = '<category>' . e($private_album->title) . '</category>';
+
+			// A guest reaches the photo only via the public album; the private
+			// album must be completely absent.
+			$guest_content = $this->get('/feed')->getContent();
+			self::assertIsString($guest_content);
+			$this->assertSame(1, substr_count($guest_content, $public_link), 'guest item links to the public album');
+			$this->assertSame(0, substr_count($guest_content, $private_link), 'guest item must not link to the inaccessible album');
+			$this->assertStringContainsString($public_category, $guest_content, 'public album is a category for the guest');
+			$this->assertStringNotContainsString($private_category, $guest_content, 'inaccessible album must not be a category for the guest');
+
+			// The owner of the private album sees both albums as categories.
+			$owner_content = $this->actingAs($this->userMayUpload1)->get('/feed')->getContent();
+			self::assertIsString($owner_content);
+			$this->assertStringContainsString($public_category, $owner_content, 'owner still sees the public album');
+			$this->assertStringContainsString($private_category, $owner_content, 'owner sees their own private album');
+		} catch (\Exception $e) {
+			$this->assertTrue(false, 'Exception occurred: ' . $e->getMessage());
+		} finally {
+			Configs::set('rss_enable', $init_config_value);
+		}
+	}
+
+	/**
+	 * A photo shared into a sensitive (NSFW) album must not expose that album as
+	 * a `<link>` or `<category>` when `hide_nsfw_in_rss` is enabled, while a
+	 * non-sensitive album it also belongs to still surfaces. Disabling the
+	 * setting exposes the sensitive album again.
+	 */
+	public function testRSSNsfwAlbumHiddenWhenConfigured(): void
+	{
+		$config_manager = resolve(ConfigManager::class);
+		$init_rss = $config_manager->getValue('rss_enable');
+		$init_nsfw = $config_manager->getValue('hide_nsfw_in_rss');
+
+		try {
+			Configs::set('rss_enable', '1');
+
+			// A normal album keeps the photo visible in the feed; the sensitive
+			// album is the one whose exposure we are testing.
+			$normal_album = Album::factory()->as_root()->owned_by($this->admin)->create();
+			$nsfw_album = Album::factory()->as_root()->owned_by($this->admin)->create();
+			DB::table('base_albums')->where('id', $nsfw_album->id)->update(['is_nsfw' => true]);
+
+			$photo = Photo::factory()->owned_by($this->admin)->in($normal_album)->create();
+			$photo->albums()->attach($nsfw_album->id);
+
+			$normal_category = '<category>' . e($normal_album->title) . '</category>';
+			$nsfw_category = '<category>' . e($nsfw_album->title) . '</category>';
+			$nsfw_link = '<link>' . route('gallery', ['albumId' => $nsfw_album->id, 'photoId' => $photo->id]) . '</link>';
+
+			// With hiding enabled (the safe default), the sensitive album is gone
+			// but the photo is still present via the normal album.
+			Configs::set('hide_nsfw_in_rss', '1');
+			$hidden_content = $this->actingAs($this->admin)->get('/feed')->getContent();
+			self::assertIsString($hidden_content);
+			$this->assertStringContainsString($normal_category, $hidden_content, 'non-sensitive album is a category');
+			$this->assertStringNotContainsString($nsfw_category, $hidden_content, 'sensitive album must not be a category');
+			$this->assertSame(0, substr_count($hidden_content, $nsfw_link), 'item must not link to the sensitive album');
+
+			// With hiding disabled, the sensitive album is exposed again.
+			Configs::set('hide_nsfw_in_rss', '0');
+			$shown_content = $this->actingAs($this->admin)->get('/feed')->getContent();
+			self::assertIsString($shown_content);
+			$this->assertStringContainsString($nsfw_category, $shown_content, 'sensitive album is a category when hiding is disabled');
+		} catch (\Exception $e) {
+			$this->assertTrue(false, 'Exception occurred: ' . $e->getMessage());
+		} finally {
+			Configs::set('rss_enable', $init_rss);
+			Configs::set('hide_nsfw_in_rss', $init_nsfw);
 		}
 	}
 

--- a/tests/Feature_v2/RssTest.php
+++ b/tests/Feature_v2/RssTest.php
@@ -70,9 +70,11 @@ class RssTest extends BaseApiWithDataTest
 
 	/**
 	 * A single photo (one row in `photos`) that belongs to two albums (two rows
-	 * in `photo_album`) must appear exactly once per album in the RSS feed.
+	 * in `photo_album`) must appear exactly once in the RSS feed: as a single
+	 * item that links to the newest of its albums (by `created_at`) and lists
+	 * every one of its albums as a `<category>`.
 	 */
-	public function testRSSPhotoInMultipleAlbumsIsNotDuplicated(): void
+	public function testRSSPhotoInMultipleAlbumsAppearsOnceWithAllCategories(): void
 	{
 		$config_manager = resolve(ConfigManager::class);
 		$init_config_value = $config_manager->getValue('rss_enable');
@@ -87,22 +89,80 @@ class RssTest extends BaseApiWithDataTest
 				->create();
 			$photo->albums()->attach($this->album2->id);
 
+			// The item links to whichever album is newest by created_at; compute
+			// it here so the test is robust to the fixtures' creation order.
+			$newest = $this->album1->created_at >= $this->album2->created_at ? $this->album1 : $this->album2;
+			$older = $newest->id === $this->album1->id ? $this->album2 : $this->album1;
+
 			$response = $this->actingAs($this->admin)->get('/feed');
 			$this->assertOk($response);
 			$content = $response->getContent();
 
-			// `<guid>` is rendered exactly once per feed item, so it is a reliable
-			// per-item marker (the page link itself also appears in `<link>`).
-			$guid_album1 = '<guid>' . route('gallery', ['albumId' => $this->album1->id, 'photoId' => $photo->id]) . '</guid>';
-			$guid_album2 = '<guid>' . route('gallery', ['albumId' => $this->album2->id, 'photoId' => $photo->id]) . '</guid>';
+			// The `<link>` carries the album the item points at (the `<guid>` is
+			// now a photo-scoped identifier), so it marks both the single item
+			// and which album that item links to.
+			$link_newest = '<link>' . route('gallery', ['albumId' => $newest->id, 'photoId' => $photo->id]) . '</link>';
+			$link_older = '<link>' . route('gallery', ['albumId' => $older->id, 'photoId' => $photo->id]) . '</link>';
 
-			// The photo is in two albums, so it must appear exactly once per album.
-			$this->assertSame(1, substr_count($content, $guid_album1), 'photo should appear once for album1');
-			$this->assertSame(1, substr_count($content, $guid_album2), 'photo should appear once for album2');
+			// Exactly one item, linking to the newest album only.
+			$this->assertSame(1, substr_count($content, $link_newest), 'photo should appear once, linked to the newest album');
+			$this->assertSame(0, substr_count($content, $link_older), 'photo must not produce a second item for the older album');
+
+			// Both albums appear as categories on that one item (Blade escapes the text).
+			$this->assertStringContainsString('<category>' . e($this->album1->title) . '</category>', $content, 'album1 should be a category');
+			$this->assertStringContainsString('<category>' . e($this->album2->title) . '</category>', $content, 'album2 should be a category');
 		} catch (\Exception $e) {
 			$this->assertTrue(false, 'Exception occurred: ' . $e->getMessage());
 		} finally {
 			Configs::set('rss_enable', $init_config_value);
 		}
+	}
+
+	/**
+	 * A photo's `<guid>` identifies the photo itself, so it must stay constant
+	 * even as the photo's album membership (and therefore its `<link>`) changes.
+	 */
+	public function testRSSPhotoGuidIsStableAcrossAlbumMembership(): void
+	{
+		$config_manager = resolve(ConfigManager::class);
+		$init_config_value = $config_manager->getValue('rss_enable');
+
+		try {
+			Configs::set('rss_enable', '1');
+
+			$photo = Photo::factory()->owned_by($this->admin)->in($this->album1)->create();
+
+			// GUID while the photo is in a single album. It identifies the photo,
+			// not the album, so it must not embed the album id.
+			$guid = $this->fetchPhotoGuid($photo->id);
+			$this->assertStringNotContainsString($this->album1->id, $guid, 'GUID must not embed the album id');
+
+			// Adding a second album must not change it.
+			$photo->albums()->attach($this->album2->id);
+			$this->assertSame($guid, $this->fetchPhotoGuid($photo->id), 'GUID must be stable when an album is added');
+
+			// Nor must moving the photo to a different album entirely.
+			$photo->albums()->detach($this->album1->id);
+			$this->assertSame($guid, $this->fetchPhotoGuid($photo->id), 'GUID must be stable when album membership changes');
+		} catch (\Exception $e) {
+			$this->assertTrue(false, 'Exception occurred: ' . $e->getMessage());
+		} finally {
+			Configs::set('rss_enable', $init_config_value);
+		}
+	}
+
+	/**
+	 * Fetches the RSS feed as admin and returns the `<guid>` text of the single
+	 * feed item belonging to the given photo.
+	 */
+	private function fetchPhotoGuid(string $photo_id): string
+	{
+		$content = $this->actingAs($this->admin)->get('/feed')->getContent();
+		self::assertIsString($content);
+
+		$count = preg_match_all('#<guid[^>]*>([^<]*' . preg_quote($photo_id, '#') . '[^<]*)</guid>#', $content, $matches);
+		self::assertSame(1, $count, 'feed should contain exactly one guid for the photo');
+
+		return $matches[1][0];
 	}
 }


### PR DESCRIPTION
Prior to this PR, the RSS feed included one item for every album each photo belonged to -- that is, if a photo belonged to 3 albums, it appeared 3 times in the RSS feed.

This change causes each photo to appear exactly once in the RSS feed, with multiple `<category>` tags if the photo belongs in multiple albums.

Care is taken to avoid pitfalls:
- The feed includes up to `$rss_max` photos (not `(photo, album)` pairs).
- We include _all_ albums a photo belongs to in the feed, as categories.
- The link for each photo is generated deterministically, by linking to the photo in the newest album (by created_at) it belongs to.
- The GUID for each RSS <item> is a deterministically-generated `tag:` URI, ensuring no GUID churn as photos' album memberships change.
- The `applySearchabilityFilter` logic/arguments are unchanged in this PR; visibility/NSFW filtering is unchanged.
- The only test that changes is the test for multi-album behavior added in https://github.com/LycheeOrg/Lychee/pull/4499 ; other tests covering RSS remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RSS feeds now show each photo only once when it belongs to multiple albums.
  * RSS item GUIDs are stable and remain photo-scoped even as album memberships change.
  * Feed links consistently point to the newest relevant album while still listing all associated album names as categories.
* **Refactor**
  * Streamlined RSS item generation to improve identifier reliability and album/category selection.
* **Tests**
  * Updated RSS tests to assert single-item behavior, correct category listing, and GUID stability across membership changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->