### PR TITLE
Please do not report fopen DNS rebinding issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,3 +27,11 @@ please note that **it is intentionally public and does not require authenticatio
 The responses from this endpoint do not contain any sensitive information or secrets and have been anonymized.
 
 Its main goal is to allow users to easily diagnose issues with their Lychee installation even if they can't log in.
+
+## About `fopen` and DNS Rebinding
+
+We do **not** accept vulnerability reports related to DNS rebinding attacks on `fopen` when `USE_FOPEN_FOR_URL_IMPORTS` is enabled.
+
+We know that this setting switches URL-based imports from `curl` to PHP's native `fopen`. Unlike `curl`, `fopen` performs its own DNS resolution with no built-in mechanism to detect or prevent DNS rebinding — there is no supported way to mitigate this at the application level while still using `fopen`.
+
+Deliberately enabling `USE_FOPEN_FOR_URL_IMPORTS` and then expecting the system to be immune to DNS rebinding is not a valid threat model. **Putting the system into a known-vulnerable configuration and then reporting the resulting exposure is not considered a security vulnerability in Lychee.**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the security policy with guidance on DNS-rebinding reports involving `fopen`.
  * Clarified the security implications of enabling URL imports through `fopen` and how they differ from `curl`.
  * Specified that exposure resulting from intentionally enabling this option is not considered a security vulnerability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->