### PR TITLE
Add middleware and caching for docs API.

### DIFF
--- a/app/Http/Middleware/RestrictApiDocsAccess.php
+++ b/app/Http/Middleware/RestrictApiDocsAccess.php
@@ -9,6 +9,8 @@
 namespace App\Http\Middleware;
 
 use App\Assets\Features;
+use Dedoc\Scramble\Generator;
+use Dedoc\Scramble\Scramble;
 use Illuminate\Http\Request;
 
 /**
@@ -31,6 +33,33 @@ class RestrictApiDocsAccess
 			abort(404);
 		}
 
+		$this->ensureDocumentationIsCached();
+
 		return $next($request);
+	}
+
+	/**
+	 * Warm the OpenAPI document cache on demand if it is not already cached.
+	 */
+	private function ensureDocumentationIsCached(): void
+	{
+		$store = config('scramble.cache.store');
+		$keyBase = config('scramble.cache.key');
+
+		if ($store === null || $keyBase === null) {
+			return;
+		}
+
+		$cache = cache()->store($store);
+		$key = $keyBase . ':' . Scramble::DEFAULT_API;
+
+		if ($cache->has($key)) {
+			return;
+		}
+
+		$config = Scramble::getGeneratorConfig(Scramble::DEFAULT_API);
+		$generator = app(Generator::class);
+
+		$cache->forever($key, $generator($config));
 	}
 }

--- a/app/Http/Middleware/RestrictApiDocsAccess.php
+++ b/app/Http/Middleware/RestrictApiDocsAccess.php
@@ -44,14 +44,14 @@ class RestrictApiDocsAccess
 	private function ensureDocumentationIsCached(): void
 	{
 		$store = config('scramble.cache.store');
-		$keyBase = config('scramble.cache.key');
+		$key_base = config('scramble.cache.key');
 
-		if ($store === null || $keyBase === null) {
+		if ($store === null || $key_base === null) {
 			return;
 		}
 
 		$cache = cache()->store($store);
-		$key = $keyBase . ':' . Scramble::DEFAULT_API;
+		$key = $key_base . ':' . Scramble::DEFAULT_API;
 
 		if ($cache->has($key)) {
 			return;

--- a/app/Http/Middleware/RestrictApiDocsAccess.php
+++ b/app/Http/Middleware/RestrictApiDocsAccess.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Http\Middleware;
+
+use App\Assets\Features;
+use Illuminate\Http\Request;
+
+/**
+ * Class RestrictApiDocsAccess.
+ *
+ * White label installs must not expose the existence of the API docs,
+ * so the route is hidden entirely (404) instead of merely unauthorized.
+ */
+class RestrictApiDocsAccess
+{
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @param Request  $request the incoming request to serve
+	 * @param \Closure $next    the next operation to be applied to the request
+	 */
+	public function handle(Request $request, \Closure $next): mixed
+	{
+		if (Features::active('white_label_enabled')) {
+			abort(404);
+		}
+
+		return $next($request);
+	}
+}

--- a/config/scramble.php
+++ b/config/scramble.php
@@ -93,7 +93,6 @@ return [
 
 	'middleware' => [
 		'web',
-		'throttle:1,1',
 		\App\Http\Middleware\RestrictApiDocsAccess::class,
 	],
 

--- a/config/scramble.php
+++ b/config/scramble.php
@@ -82,7 +82,7 @@ return [
 
 	'middleware' => [
 		'web',
-		// RestrictedDocsAccess::class,
+		\App\Http\Middleware\RestrictApiDocsAccess::class,
 	],
 
 	'extensions' => [

--- a/config/scramble.php
+++ b/config/scramble.php
@@ -20,6 +20,17 @@ return [
 	 */
 	'export_path' => 'api.json',
 
+	/*
+	 * Cache configuration for the generated OpenAPI document.
+	 *
+	 * Use `php artisan scramble:cache` to warm the cache and
+	 * `php artisan scramble:clear` to invalidate it.
+	 */
+	'cache' => [
+		'key' => 'scramble.openapi',
+		'store' => config('cache.default'),
+	],
+
 	'info' => [
 		/*
 		 * API version.
@@ -82,6 +93,7 @@ return [
 
 	'middleware' => [
 		'web',
+		'throttle:1,1',
 		\App\Http\Middleware\RestrictApiDocsAccess::class,
 	],
 

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -83,6 +83,8 @@ web)
   run_as_www php artisan route:cache
   run_as_www php artisan view:clear
   run_as_www php artisan view:cache
+  run_as_www php artisan scramble:clear
+  run_as_www php artisan scramble:cache
 
   echo "✅ Application ready!"
 

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -83,8 +83,6 @@ web)
   run_as_www php artisan route:cache
   run_as_www php artisan view:clear
   run_as_www php artisan view:cache
-  run_as_www php artisan scramble:clear
-  run_as_www php artisan scramble:cache
 
   echo "✅ Application ready!"
 

--- a/resources/js/v7/views/admin/AdminDashboard.vue
+++ b/resources/js/v7/views/admin/AdminDashboard.vue
@@ -145,7 +145,7 @@
 
 		<div class="flex items-center justify-center gap-6 mt-6 text-sm">
 			<a
-				v-if="initData?.settings.can_edit"
+				v-if="initData?.settings.can_edit && !lycheeStore.is_white_label_enabled"
 				:href="`${Constants.BASE_URL}/docs/api`"
 				target="_blank"
 				rel="noopener noreferrer"

--- a/resources/js/v8/views/admin/AdminDashboard.vue
+++ b/resources/js/v8/views/admin/AdminDashboard.vue
@@ -145,7 +145,7 @@
 
 		<div class="flex items-center justify-center gap-6 mt-6 text-sm">
 			<a
-				v-if="initData?.settings.can_edit"
+				v-if="initData?.settings.can_edit && !lycheeStore.is_white_label_enabled"
 				:href="`${Constants.BASE_URL}/docs/api`"
 				target="_blank"
 				rel="noopener noreferrer"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API documentation is now blocked in white-label installations.
  * OpenAPI documentation caching is configured to improve performance.
* **Bug Fixes**
  * Admin dashboard “API” link is shown only when the user can edit and white-label mode is not enabled.
* **Chores**
  * OpenAPI documentation cache is automatically warmed/cleared during application startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->