### PR TITLE
Avoid large malicious uploads and wasting CPU cycles

### DIFF
--- a/app/Image/Handlers/ImagickHandler.php
+++ b/app/Image/Handlers/ImagickHandler.php
@@ -23,6 +23,7 @@ use App\Repositories\ConfigManager;
 use App\Services\Image\FileExtensionService;
 use Imagick;
 use function Safe\fclose;
+use function Safe\filesize;
 use function Safe\fopen;
 use function Safe\fread;
 use function Safe\preg_match;
@@ -44,6 +45,19 @@ class ImagickHandler extends BaseImageHandler
 	 * Rejecting such files up front avoids that wasted cost.
 	 */
 	private const MAX_PDF_MEDIABOX_POINTS = 32000;
+
+	/**
+	 * Maximum plausible `/MediaBox` area (width x height, in sq. points) per byte of PDF file size.
+	 *
+	 * A hand-crafted, near-empty PDF can declare a huge page while weighing only a few
+	 * hundred bytes (e.g. 383 bytes for a 32000x32000pt page, a ratio of ~2,700,000
+	 * sq. pt/byte). Real single-page PDFs, even lean vector-only ones, sit in the tens
+	 * to low hundreds of sq. pt/byte (e.g. ~24 for a 20 KB Letter page, ~40 for a 200 KB
+	 * A0 poster). This threshold sits ~1,000x above that realistic range and ~50x below
+	 * the crafted PoC, so it catches implausibly large/empty pages even when their
+	 * dimensions individually stay under {@see MAX_PDF_MEDIABOX_POINTS}.
+	 */
+	private const MAX_MEDIABOX_AREA_PER_BYTE = 50_000;
 
 	/** Number of leading bytes scanned for a `/MediaBox` entry; ample for the first page object of any real-world PDF. */
 	private const MEDIABOX_SCAN_LIMIT = 1_048_576;
@@ -181,6 +195,13 @@ class ImagickHandler extends BaseImageHandler
 
 		if ($width > self::MAX_PDF_MEDIABOX_POINTS || $height > self::MAX_PDF_MEDIABOX_POINTS) {
 			throw new MediaFileUnsupportedException(\sprintf('PDF page size (%dx%d pt) exceeds the maximum supported dimension of %d pt', $width, $height, self::MAX_PDF_MEDIABOX_POINTS));
+		}
+
+		$filesize = filesize($pdf_path);
+		$area_per_byte = ($width * $height) / $filesize;
+
+		if ($area_per_byte > self::MAX_MEDIABOX_AREA_PER_BYTE) {
+			throw new MediaFileUnsupportedException(\sprintf('PDF page size (%dx%d pt) is implausibly large for a %d byte file', $width, $height, $filesize));
 		}
 	}
 

--- a/app/Image/Handlers/ImagickHandler.php
+++ b/app/Image/Handlers/ImagickHandler.php
@@ -14,6 +14,7 @@ use App\Contracts\Image\StreamStats;
 use App\DTO\ImageDimension;
 use App\Exceptions\ImageProcessingException;
 use App\Exceptions\MediaFileOperationException;
+use App\Exceptions\MediaFileUnsupportedException;
 use App\Facades\Helpers;
 use App\Image\Files\FlysystemFile;
 use App\Image\Files\InMemoryBuffer;
@@ -23,6 +24,8 @@ use App\Services\Image\FileExtensionService;
 use Imagick;
 use function Safe\fclose;
 use function Safe\fopen;
+use function Safe\fread;
+use function Safe\preg_match;
 use function Safe\rename;
 use function Safe\stream_copy_to_stream;
 use function Safe\tempnam;
@@ -30,6 +33,21 @@ use function Safe\unlink;
 
 class ImagickHandler extends BaseImageHandler
 {
+	/**
+	 * Maximum accepted `/MediaBox` width or height, in PDF points (1/72 inch).
+	 *
+	 * Mirrors the `width`/`height` resource limits already configured in
+	 * ImageMagick's `policy.xml` (32,000 pixels). PDFs are rendered at the
+	 * default 72 DPI, so a MediaBox beyond this threshold is guaranteed to be
+	 * rejected by that policy anyway - but only after Ghostscript has already
+	 * spent tens of seconds to minutes of CPU time attempting to rasterize it.
+	 * Rejecting such files up front avoids that wasted cost.
+	 */
+	private const MAX_PDF_MEDIABOX_POINTS = 32000;
+
+	/** Number of leading bytes scanned for a `/MediaBox` entry; ample for the first page object of any real-world PDF. */
+	private const MEDIABOX_SCAN_LIMIT = 1_048_576;
+
 	/** @var \Imagick|null the internal Imagick image */
 	private ?\Imagick $im_image = null;
 
@@ -118,6 +136,8 @@ class ImagickHandler extends BaseImageHandler
 				}
 			}
 
+			$this->assertPdfPageSizeIsSafe($pdf_path);
+
 			// The [0] suffix tells Imagick to read only the first page of the PDF,
 			// avoiding the overhead of rendering all pages just to generate a thumbnail.
 			$this->im_image->readImage($pdf_path . '[0]');
@@ -125,6 +145,42 @@ class ImagickHandler extends BaseImageHandler
 			if ($tmp_path !== null && is_file($tmp_path)) {
 				unlink($tmp_path);
 			}
+		}
+	}
+
+	/**
+	 * Rejects PDFs whose first page declares a `/MediaBox` larger than we're willing
+	 * to rasterize.
+	 *
+	 * A crafted PDF can declare an enormous page size while remaining tiny on disk
+	 * (a few hundred bytes). Ghostscript will still attempt to rasterize such a page
+	 * at full resolution before Imagick's own pixel-cache policy has a chance to
+	 * reject the result, burning CPU for tens of seconds to minutes per request for
+	 * no usable output. This check is a cheap, best-effort guard performed before
+	 * handing the file to Ghostscript; it does not replace the resource policy
+	 * itself, and legitimate PDFs without a plainly readable `/MediaBox` are passed
+	 * through unchanged.
+	 *
+	 * @throws MediaFileUnsupportedException
+	 */
+	private function assertPdfPageSizeIsSafe(string $pdf_path): void
+	{
+		$handle = fopen($pdf_path, 'rb');
+		try {
+			$head = fread($handle, self::MEDIABOX_SCAN_LIMIT);
+		} finally {
+			fclose($handle);
+		}
+
+		if (preg_match('/\/MediaBox\s*\[\s*(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)/', $head, $matches) !== 1) {
+			return;
+		}
+
+		$width = abs((float) $matches[3] - (float) $matches[1]);
+		$height = abs((float) $matches[4] - (float) $matches[2]);
+
+		if ($width > self::MAX_PDF_MEDIABOX_POINTS || $height > self::MAX_PDF_MEDIABOX_POINTS) {
+			throw new MediaFileUnsupportedException(\sprintf('PDF page size (%dx%d pt) exceeds the maximum supported dimension of %d pt', $width, $height, self::MAX_PDF_MEDIABOX_POINTS));
 		}
 	}
 

--- a/tests/Constants/TestConstants.php
+++ b/tests/Constants/TestConstants.php
@@ -47,6 +47,7 @@ class TestConstants
 	public const SAMPLE_FILE_ORIENTATION_VFLIP = 'tests/Samples/orientation-vflip.jpg';
 	public const SAMPLE_FILE_PDF = 'tests/Samples/pdf.pdf';
 	public const SAMPLE_FILE_PDF_OVERSIZED_MEDIABOX = 'tests/Samples/pdf_oversized_mediabox.pdf';
+	public const SAMPLE_FILE_PDF_DISPROPORTIONATE_MEDIABOX = 'tests/Samples/pdf_disproportionate_mediabox.pdf';
 	public const SAMPLE_FILE_PNG = 'tests/Samples/png.png';
 	public const SAMPLE_FILE_SUNSET_IMAGE = 'tests/Samples/fin de journée.jpg';
 	public const SAMPLE_FILE_TIFF = 'tests/Samples/tiff.tif';
@@ -76,6 +77,7 @@ class TestConstants
 		self::SAMPLE_FILE_ORIENTATION_VFLIP => self::MIME_TYPE_IMG_JPEG,
 		self::SAMPLE_FILE_PDF => self::MIME_TYPE_APP_PDF,
 		self::SAMPLE_FILE_PDF_OVERSIZED_MEDIABOX => self::MIME_TYPE_APP_PDF,
+		self::SAMPLE_FILE_PDF_DISPROPORTIONATE_MEDIABOX => self::MIME_TYPE_APP_PDF,
 		self::SAMPLE_FILE_PNG => self::MIME_TYPE_IMG_PNG,
 		self::SAMPLE_FILE_SUNSET_IMAGE => self::MIME_TYPE_IMG_JPEG,
 		self::SAMPLE_FILE_TIFF => self::MIME_TYPE_IMG_TIFF,

--- a/tests/Constants/TestConstants.php
+++ b/tests/Constants/TestConstants.php
@@ -46,6 +46,7 @@ class TestConstants
 	public const SAMPLE_FILE_ORIENTATION_HFLIP = 'tests/Samples/orientation-hflip.jpg';
 	public const SAMPLE_FILE_ORIENTATION_VFLIP = 'tests/Samples/orientation-vflip.jpg';
 	public const SAMPLE_FILE_PDF = 'tests/Samples/pdf.pdf';
+	public const SAMPLE_FILE_PDF_OVERSIZED_MEDIABOX = 'tests/Samples/pdf_oversized_mediabox.pdf';
 	public const SAMPLE_FILE_PNG = 'tests/Samples/png.png';
 	public const SAMPLE_FILE_SUNSET_IMAGE = 'tests/Samples/fin de journée.jpg';
 	public const SAMPLE_FILE_TIFF = 'tests/Samples/tiff.tif';
@@ -74,6 +75,7 @@ class TestConstants
 		self::SAMPLE_FILE_ORIENTATION_HFLIP => self::MIME_TYPE_IMG_JPEG,
 		self::SAMPLE_FILE_ORIENTATION_VFLIP => self::MIME_TYPE_IMG_JPEG,
 		self::SAMPLE_FILE_PDF => self::MIME_TYPE_APP_PDF,
+		self::SAMPLE_FILE_PDF_OVERSIZED_MEDIABOX => self::MIME_TYPE_APP_PDF,
 		self::SAMPLE_FILE_PNG => self::MIME_TYPE_IMG_PNG,
 		self::SAMPLE_FILE_SUNSET_IMAGE => self::MIME_TYPE_IMG_JPEG,
 		self::SAMPLE_FILE_TIFF => self::MIME_TYPE_IMG_TIFF,

--- a/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerImagickTest.php
+++ b/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerImagickTest.php
@@ -92,7 +92,36 @@ class PhotosAddHandlerImagickTest extends BaseImageHandler
 		$photo = $response->json('photos.0');
 
 		self::assertEquals(TestConstants::MIME_TYPE_APP_PDF, $photo['type']);
-		self::assertEquals(null, $photo['size_variants']['thumb']);
+		self::assertNull( $photo['size_variants']['thumb']);
+		self::assertNotEmpty(file_get_contents(storage_path('logs/daily-' . date('Y-m-d') . '.log')));
+		self::assertLessThan(10, $elapsed);
+	}
+
+	/**
+	 * Tests that a PDF whose `/MediaBox` is implausibly large relative to its
+	 * file size is rejected, even though its dimensions individually stay
+	 * under the absolute cap tested by {@see testOversizedPdfMediaBoxIsRejected}.
+	 *
+	 * A ~350-byte file declaring a 20000x20000pt page has no plausible
+	 * legitimate content behind it (a real single-page PDF, even a lean
+	 * vector-only one, sits in the tens to low hundreds of sq. pt per byte;
+	 * this file is at roughly 1,000,000 sq. pt/byte) and would still burn
+	 * substantial CPU to rasterize despite passing the per-dimension check.
+	 *
+	 * @return void
+	 */
+	public function testDisproportionateMediaBoxIsRejected(): void
+	{
+		file_put_contents(storage_path('logs/daily-' . date('Y-m-d') . '.log'), '');
+
+		$started_at = microtime(true);
+		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_PDF_DISPROPORTIONATE_MEDIABOX);
+		$elapsed = microtime(true) - $started_at;
+
+		$photo = $response->json('photos.0');
+
+		self::assertEquals(TestConstants::MIME_TYPE_APP_PDF, $photo['type']);
+		self::assertNull( $photo['size_variants']['thumb']);
 		self::assertNotEmpty(file_get_contents(storage_path('logs/daily-' . date('Y-m-d') . '.log')));
 		self::assertLessThan(10, $elapsed);
 	}

--- a/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerImagickTest.php
+++ b/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerImagickTest.php
@@ -18,6 +18,9 @@
 
 namespace Tests\ImageProcessing\Image\Handlers;
 
+use function Safe\date;
+use function Safe\file_get_contents;
+use function Safe\file_put_contents;
 use Tests\Constants\TestConstants;
 use Tests\Traits\InteractsWithRaw;
 use Tests\Traits\RequiresImageHandler;
@@ -58,6 +61,40 @@ class PhotosAddHandlerImagickTest extends BaseImageHandler
 		self::assertNotNull($photo['size_variants']['thumb']);
 		self::assertEquals(200, $photo['size_variants']['thumb']['width']);
 		self::assertEquals(200, $photo['size_variants']['thumb']['height']);
+	}
+
+	/**
+	 * Tests that a PDF declaring an oversized `/MediaBox` on its first page
+	 * is rejected before ever being handed to Ghostscript.
+	 *
+	 * A crafted PDF can declare an enormous page size while remaining tiny on
+	 * disk. Without an upfront check, Ghostscript would spend a large amount
+	 * of CPU time attempting to rasterize such a page before ultimately
+	 * failing to produce any output.
+	 *
+	 * As with other thumbnail-generation failures (e.g. a broken Google
+	 * Motion Photo, see {@see testBrokenGoogleMotionPhotoUpload}), the import
+	 * follows a best-effort approach: the upload still succeeds and the
+	 * original file is kept, but no size variants are generated and the
+	 * error is logged. What matters here is that this happens near-instantly
+	 * rather than after minutes of wasted CPU time.
+	 *
+	 * @return void
+	 */
+	public function testOversizedPdfMediaBoxIsRejected(): void
+	{
+		file_put_contents(storage_path('logs/daily-' . date('Y-m-d') . '.log'), '');
+
+		$started_at = microtime(true);
+		$response = $this->uploadImage(TestConstants::SAMPLE_FILE_PDF_OVERSIZED_MEDIABOX);
+		$elapsed = microtime(true) - $started_at;
+
+		$photo = $response->json('photos.0');
+
+		self::assertEquals(TestConstants::MIME_TYPE_APP_PDF, $photo['type']);
+		self::assertEquals(null, $photo['size_variants']['thumb']);
+		self::assertNotEmpty(file_get_contents(storage_path('logs/daily-' . date('Y-m-d') . '.log')));
+		self::assertLessThan(10, $elapsed);
 	}
 
 	/**

--- a/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerImagickTest.php
+++ b/tests/ImageProcessing/Image/Handlers/PhotosAddHandlerImagickTest.php
@@ -92,7 +92,7 @@ class PhotosAddHandlerImagickTest extends BaseImageHandler
 		$photo = $response->json('photos.0');
 
 		self::assertEquals(TestConstants::MIME_TYPE_APP_PDF, $photo['type']);
-		self::assertNull( $photo['size_variants']['thumb']);
+		self::assertNull($photo['size_variants']['thumb']);
 		self::assertNotEmpty(file_get_contents(storage_path('logs/daily-' . date('Y-m-d') . '.log')));
 		self::assertLessThan(10, $elapsed);
 	}
@@ -121,7 +121,7 @@ class PhotosAddHandlerImagickTest extends BaseImageHandler
 		$photo = $response->json('photos.0');
 
 		self::assertEquals(TestConstants::MIME_TYPE_APP_PDF, $photo['type']);
-		self::assertNull( $photo['size_variants']['thumb']);
+		self::assertNull($photo['size_variants']['thumb']);
 		self::assertNotEmpty(file_get_contents(storage_path('logs/daily-' . date('Y-m-d') . '.log')));
 		self::assertLessThan(10, $elapsed);
 	}

--- a/tests/Samples/pdf_disproportionate_mediabox.pdf
+++ b/tests/Samples/pdf_disproportionate_mediabox.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 20000 20000] /Resources << >> >>
+endobj
+xref
+0 4
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+200
+%%EOF

--- a/tests/Samples/pdf_oversized_mediabox.pdf
+++ b/tests/Samples/pdf_oversized_mediabox.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 40000 40000] /Resources << >> >>
+endobj
+xref
+0 4
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+200
+%%EOF


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added a safety preflight for PDFs with unusual `/MediaBox` values before rendering, preventing risky or resource-intensive page processing.
  - For problematic PDFs, the original PDF upload is preserved while thumbnail generation is skipped.
  - Improved handling and logging for rejected/unsupported PDF page dimensions.

- **Tests**
  - Added new end-to-end tests for oversized and disproportionate `/MediaBox` PDFs, verifying no thumbnail is created, log output is written, and processing completes in under 10 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->