### PR TITLE
Fix Sqlite bug on virtual columns

### DIFF
--- a/database/migrations/2026_07_01_120000_deduplicate_and_constrain_access_permissions.php
+++ b/database/migrations/2026_07_01_120000_deduplicate_and_constrain_access_permissions.php
@@ -66,8 +66,16 @@ return new class() extends Migration {
 			// NULL clause on generated columns entirely (even in CREATE TABLE),
 			// so Laravel must omit it here. COALESCE already guarantees the
 			// stored value is never actually NULL.
-			$table->unsignedInteger(self::USER_ID_UNIQUE_KEY)->storedAs('COALESCE(' . self::USER_ID . ', 0)');
-			$table->unsignedInteger(self::USER_GROUP_ID_UNIQUE_KEY)->storedAs('COALESCE(' . self::USER_GROUP_ID . ', 0)');
+			// SQLite's ALTER TABLE ADD COLUMN refuses STORED generated columns
+			// outright (only VIRTUAL is allowed there); VIRTUAL is fine since
+			// these columns only exist to be indexed below, not read directly.
+			if (DB::getDriverName() === 'sqlite') {
+				$table->unsignedInteger(self::USER_ID_UNIQUE_KEY)->virtualAs('COALESCE(' . self::USER_ID . ', 0)');
+				$table->unsignedInteger(self::USER_GROUP_ID_UNIQUE_KEY)->virtualAs('COALESCE(' . self::USER_GROUP_ID . ', 0)');
+			} else {
+				$table->unsignedInteger(self::USER_ID_UNIQUE_KEY)->storedAs('COALESCE(' . self::USER_ID . ', 0)');
+				$table->unsignedInteger(self::USER_GROUP_ID_UNIQUE_KEY)->storedAs('COALESCE(' . self::USER_GROUP_ID . ', 0)');
+			}
 		});
 
 		Schema::table(self::TABLE_NAME, function (Blueprint $table) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database compatibility by ensuring access permission deduplication works correctly with SQLite and other supported database engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->