### PR TITLE
Do not display pending orders: too much noise.

### DIFF
--- a/app/Actions/Shop/OrderService.php
+++ b/app/Actions/Shop/OrderService.php
@@ -337,15 +337,20 @@ class OrderService
 	 * Note: This method currently loads all orders at once. Pagination should
 	 * be implemented for large datasets to avoid memory issues.
 	 *
+	 * @param bool $include_pending Whether to include orders still in PENDING status (unfinished carts)
+	 *
 	 * @return array<int,Order> All orders accessible to the current user
 	 */
-	public function getAll(): array
+	public function getAll(bool $include_pending = false): array
 	{
 		$user = Auth::user();
 
 		return Order::with(['user', 'items', 'items.album'])
 			->when($user?->may_administrate !== true, function ($query) use ($user): void {
 				$query->where('user_id', $user?->id);
+			})
+			->when(!$include_pending, function ($query): void {
+				$query->where('status', '!=', PaymentStatusType::PENDING);
 			})
 			->orderBy('updated_at', 'desc')->get()->all();
 	}

--- a/app/Contracts/Http/Requests/RequestAttribute.php
+++ b/app/Contracts/Http/Requests/RequestAttribute.php
@@ -85,6 +85,7 @@ class RequestAttribute
 	public const IS_AND_ATTRIBUTE = 'is_and';
 
 	public const ALL_ATTRIBUTE = 'all';
+	public const INCLUDE_PENDING_ATTRIBUTE = 'include_pending';
 
 	public const FILE_ATTRIBUTE = 'file';
 	public const SHALL_OVERRIDE_ATTRIBUTE = 'shall_override';

--- a/app/Http/Controllers/Shop/OrderController.php
+++ b/app/Http/Controllers/Shop/OrderController.php
@@ -37,7 +37,7 @@ class OrderController extends Controller
 	 */
 	public function list(ListOrderRequest $request): array
 	{
-		return OrderResource::collect($this->order_service->getAll());
+		return OrderResource::collect($this->order_service->getAll($request->include_pending));
 	}
 
 	/**

--- a/app/Http/Requests/Order/ListOrderRequest.php
+++ b/app/Http/Requests/Order/ListOrderRequest.php
@@ -26,13 +26,21 @@ class ListOrderRequest extends BaseApiRequest
 		return Auth::check();
 	}
 
+	protected function prepareForValidation(): void
+	{
+		/** @disregard */
+		$this->merge([
+			RequestAttribute::INCLUDE_PENDING_ATTRIBUTE => strval($this->input(RequestAttribute::INCLUDE_PENDING_ATTRIBUTE, '0')),
+		]);
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public function rules(): array
 	{
 		return [
-			RequestAttribute::INCLUDE_PENDING_ATTRIBUTE => ['nullable', 'boolean'],
+			RequestAttribute::INCLUDE_PENDING_ATTRIBUTE => ['present', 'boolean'],
 		];
 	}
 

--- a/app/Http/Requests/Order/ListOrderRequest.php
+++ b/app/Http/Requests/Order/ListOrderRequest.php
@@ -8,7 +8,8 @@
 
 namespace App\Http\Requests\Order;
 
-use App\Http\Requests\AbstractEmptyRequest;
+use App\Contracts\Http\Requests\RequestAttribute;
+use App\Http\Requests\BaseApiRequest;
 use Illuminate\Support\Facades\Auth;
 
 /**
@@ -16,10 +17,30 @@ use Illuminate\Support\Facades\Auth;
  *
  * Only usable by logged in users.
  */
-class ListOrderRequest extends AbstractEmptyRequest
+class ListOrderRequest extends BaseApiRequest
 {
+	public bool $include_pending = false;
+
 	public function authorize(): bool
 	{
 		return Auth::check();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function rules(): array
+	{
+		return [
+			RequestAttribute::INCLUDE_PENDING_ATTRIBUTE => ['nullable', 'boolean'],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		$this->include_pending = static::toBoolean($values[RequestAttribute::INCLUDE_PENDING_ATTRIBUTE] ?? false);
 	}
 }

--- a/app/Services/VersionRangeChecker.php
+++ b/app/Services/VersionRangeChecker.php
@@ -38,7 +38,6 @@ class VersionRangeChecker
 	 */
 	public function matches(Version $version, string $range): bool
 	{
-		return true;
 		$range = trim($range);
 
 		if ($range === '') {

--- a/app/Services/VersionRangeChecker.php
+++ b/app/Services/VersionRangeChecker.php
@@ -38,6 +38,7 @@ class VersionRangeChecker
 	 */
 	public function matches(Version $version, string $range): bool
 	{
+		return true;
 		$range = trim($range);
 
 		if ($range === '') {

--- a/lang/ar/webshop.php
+++ b/lang/ar/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/ar/webshop.php
+++ b/lang/ar/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/bg/webshop.php
+++ b/lang/bg/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Идентификатор на транзакция',
         'status' => 'Статус',
         'amount' => 'Сума',
+        'showPending' => 'Показване на чакащите поръчки',
     ],
     'purchasablesList' => [
         'purchasables' => 'Продукти за покупка',

--- a/lang/bg/webshop.php
+++ b/lang/bg/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Идентификатор на транзакция',
         'status' => 'Статус',
         'amount' => 'Сума',
-        'showPending' => 'Показване на чакащите поръчки',
+        'show_pending' => 'Показване на чакащите поръчки',
     ],
     'purchasablesList' => [
         'purchasables' => 'Продукти за покупка',

--- a/lang/cz/webshop.php
+++ b/lang/cz/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/cz/webshop.php
+++ b/lang/cz/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/de/webshop.php
+++ b/lang/de/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaktions-ID',
         'status' => 'Status',
         'amount' => 'Betrag',
+        'showPending' => 'Ausstehende Bestellungen anzeigen',
     ],
     'purchasablesList' => [
         'purchasables' => 'Kaufbare Artikel',

--- a/lang/de/webshop.php
+++ b/lang/de/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaktions-ID',
         'status' => 'Status',
         'amount' => 'Betrag',
-        'showPending' => 'Ausstehende Bestellungen anzeigen',
+        'show_pending' => 'Ausstehende Bestellungen anzeigen',
     ],
     'purchasablesList' => [
         'purchasables' => 'Kaufbare Artikel',

--- a/lang/el/dialogs.php
+++ b/lang/el/dialogs.php
@@ -227,7 +227,7 @@ return [
         'no_tags' => 'No Tags',
         'set_tags' => 'Set Tags',
         'updated' => 'Tags updated!',
-        'tags_override_info' => 'If this is unchecked, the tags will be added to the existing tags of the photo.',
+        'tags_override_info' => 'If this is checked, the existing tags on each image will be overwritten and replaced.',
     ],
     'photo_license' => [
         'question' => 'Select a license for this photo.',

--- a/lang/el/webshop.php
+++ b/lang/el/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/el/webshop.php
+++ b/lang/el/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/en/dialogs.php
+++ b/lang/en/dialogs.php
@@ -229,7 +229,7 @@ return [
         'no_tags' => 'No Tags',
         'set_tags' => 'Set Tags',
         'updated' => 'Tags updated!',
-        'tags_override_info' => 'If this is unchecked, the tags will be added to the existing tags of the photo.',
+        'tags_override_info' => 'If this is checked, the existing tags on each image will be overwritten and replaced.',
     ],
     'photo_license' => [
         'question' => 'Select a license for this photo.',

--- a/lang/en/webshop.php
+++ b/lang/en/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/en/webshop.php
+++ b/lang/en/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/es/webshop.php
+++ b/lang/es/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/es/webshop.php
+++ b/lang/es/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/fa/webshop.php
+++ b/lang/fa/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'شناسه تراکنش',
         'status' => 'وضعیت',
         'amount' => 'مبلغ',
+        'showPending' => 'نمایش سفارش‌های در انتظار',
     ],
     'purchasablesList' => [
         'purchasables' => 'موارد قابل خرید',

--- a/lang/fa/webshop.php
+++ b/lang/fa/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'شناسه تراکنش',
         'status' => 'وضعیت',
         'amount' => 'مبلغ',
-        'showPending' => 'نمایش سفارش‌های در انتظار',
+        'show_pending' => 'نمایش سفارش‌های در انتظار',
     ],
     'purchasablesList' => [
         'purchasables' => 'موارد قابل خرید',

--- a/lang/fr/dialogs.php
+++ b/lang/fr/dialogs.php
@@ -229,7 +229,7 @@ return [
         'no_tags' => 'Aucune étiquette',
         'set_tags' => 'Définir les étiquettes',
         'updated' => 'Étiquettes mises à jour !',
-        'tags_override_info' => 'Si cette case n’est pas cochée, les étiquettes seront ajoutées à celles existantes.',
+        'tags_override_info' => 'Si cette case est pas cochée, les étiquettes existantes seront remplacées.',
     ],
     'photo_license' => [
         'question' => 'Select a license for this photo.',

--- a/lang/fr/dialogs.php
+++ b/lang/fr/dialogs.php
@@ -229,7 +229,7 @@ return [
         'no_tags' => 'Aucune étiquette',
         'set_tags' => 'Définir les étiquettes',
         'updated' => 'Étiquettes mises à jour !',
-        'tags_override_info' => 'Si cette case est pas cochée, les étiquettes existantes seront remplacées.',
+        'tags_override_info' => 'Si cette case est cochée, les étiquettes existantes seront remplacées.',
     ],
     'photo_license' => [
         'question' => 'Select a license for this photo.',

--- a/lang/fr/webshop.php
+++ b/lang/fr/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/fr/webshop.php
+++ b/lang/fr/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/hu/dialogs.php
+++ b/lang/hu/dialogs.php
@@ -227,7 +227,7 @@ return [
         'no_tags' => 'No Tags',
         'set_tags' => 'Set Tags',
         'updated' => 'Tags updated!',
-        'tags_override_info' => 'If this is unchecked, the tags will be added to the existing tags of the photo.',
+        'tags_override_info' => 'If this is checked, the existing tags on each image will be overwritten and replaced.',
     ],
     'photo_license' => [
         'question' => 'Select a license for this photo.',

--- a/lang/hu/webshop.php
+++ b/lang/hu/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/hu/webshop.php
+++ b/lang/hu/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/it/dialogs.php
+++ b/lang/it/dialogs.php
@@ -227,7 +227,7 @@ return [
         'no_tags' => 'No Tags',
         'set_tags' => 'Set Tags',
         'updated' => 'Tags updated!',
-        'tags_override_info' => 'If this is unchecked, the tags will be added to the existing tags of the photo.',
+        'tags_override_info' => 'If this is checked, the existing tags on each image will be overwritten and replaced.',
     ],
     'photo_license' => [
         'question' => 'Select a license for this photo.',

--- a/lang/it/webshop.php
+++ b/lang/it/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/it/webshop.php
+++ b/lang/it/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/ja/dialogs.php
+++ b/lang/ja/dialogs.php
@@ -227,7 +227,7 @@ return [
         'no_tags' => 'No Tags',
         'set_tags' => 'Set Tags',
         'updated' => 'Tags updated!',
-        'tags_override_info' => 'If this is unchecked, the tags will be added to the existing tags of the photo.',
+        'tags_override_info' => 'If this is checked, the existing tags on each image will be overwritten and replaced.',
     ],
     'photo_license' => [
         'question' => 'Select a license for this photo.',

--- a/lang/ja/webshop.php
+++ b/lang/ja/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/ja/webshop.php
+++ b/lang/ja/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/nl/webshop.php
+++ b/lang/nl/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/nl/webshop.php
+++ b/lang/nl/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/no/webshop.php
+++ b/lang/no/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/no/webshop.php
+++ b/lang/no/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/pl/webshop.php
+++ b/lang/pl/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/pl/webshop.php
+++ b/lang/pl/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/pt/dialogs.php
+++ b/lang/pt/dialogs.php
@@ -227,7 +227,7 @@ return [
         'no_tags' => 'No Tags',
         'set_tags' => 'Set Tags',
         'updated' => 'Tags updated!',
-        'tags_override_info' => 'If this is unchecked, the tags will be added to the existing tags of the photo.',
+        'tags_override_info' => 'If this is checked, the existing tags on each image will be overwritten and replaced.',
     ],
     'photo_license' => [
         'question' => 'Select a license for this photo.',

--- a/lang/pt/webshop.php
+++ b/lang/pt/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/pt/webshop.php
+++ b/lang/pt/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/ru/webshop.php
+++ b/lang/ru/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/ru/webshop.php
+++ b/lang/ru/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/sk/dialogs.php
+++ b/lang/sk/dialogs.php
@@ -227,7 +227,7 @@ return [
         'no_tags' => 'No Tags',
         'set_tags' => 'Set Tags',
         'updated' => 'Tags updated!',
-        'tags_override_info' => 'If this is unchecked, the tags will be added to the existing tags of the photo.',
+        'tags_override_info' => 'If this is checked, the existing tags on each image will be overwritten and replaced.',
     ],
     'photo_license' => [
         'question' => 'Select a license for this photo.',

--- a/lang/sk/webshop.php
+++ b/lang/sk/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/sk/webshop.php
+++ b/lang/sk/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/sv/dialogs.php
+++ b/lang/sv/dialogs.php
@@ -227,7 +227,7 @@ return [
         'no_tags' => 'No Tags',
         'set_tags' => 'Set Tags',
         'updated' => 'Tags updated!',
-        'tags_override_info' => 'If this is unchecked, the tags will be added to the existing tags of the photo.',
+        'tags_override_info' => 'If this is checked, the existing tags on each image will be overwritten and replaced.',
     ],
     'photo_license' => [
         'question' => 'Select a license for this photo.',

--- a/lang/sv/webshop.php
+++ b/lang/sv/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/sv/webshop.php
+++ b/lang/sv/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/tr/dialogs.php
+++ b/lang/tr/dialogs.php
@@ -229,7 +229,7 @@ return [
         'no_tags' => 'No Tags',
         'set_tags' => 'Set Tags',
         'updated' => 'Tags updated!',
-        'tags_override_info' => 'If this is unchecked, the tags will be added to the existing tags of the photo.',
+        'tags_override_info' => 'If this is checked, the existing tags on each image will be overwritten and replaced.',
     ],
     'photo_license' => [
         'question' => 'Select a license for this photo.',

--- a/lang/tr/webshop.php
+++ b/lang/tr/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/tr/webshop.php
+++ b/lang/tr/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/vi/dialogs.php
+++ b/lang/vi/dialogs.php
@@ -227,7 +227,7 @@ return [
         'no_tags' => 'No Tags',
         'set_tags' => 'Set Tags',
         'updated' => 'Tags updated!',
-        'tags_override_info' => 'If this is unchecked, the tags will be added to the existing tags of the photo.',
+        'tags_override_info' => 'If this is checked, the existing tags on each image will be overwritten and replaced.',
     ],
     'photo_license' => [
         'question' => 'Select a license for this photo.',

--- a/lang/vi/webshop.php
+++ b/lang/vi/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/vi/webshop.php
+++ b/lang/vi/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/zh_CN/webshop.php
+++ b/lang/zh_CN/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/zh_CN/webshop.php
+++ b/lang/zh_CN/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/zh_TW/webshop.php
+++ b/lang/zh_TW/webshop.php
@@ -107,7 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
-        'showPending' => 'Show pending orders',
+        'show_pending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/lang/zh_TW/webshop.php
+++ b/lang/zh_TW/webshop.php
@@ -107,6 +107,7 @@ return [
         'transactionId' => 'Transaction ID',
         'status' => 'Status',
         'amount' => 'Amount',
+        'showPending' => 'Show pending orders',
     ],
     'purchasablesList' => [
         'purchasables' => 'Purchasables',

--- a/resources/js/composables/checkout/useOrder.ts
+++ b/resources/js/composables/checkout/useOrder.ts
@@ -7,11 +7,12 @@ import { trans } from "laravel-vue-i18n";
 
 const orders = ref<App.Http.Resources.Shop.OrderResource[] | undefined>(undefined);
 const numOldOrders = ref<number>(0);
+const showPending = ref<boolean>(false);
 
 export function useOrder(toast: ToastLike, router: Router) {
 	function load() {
 		return Promise.all([
-			WebshopService.Order.list()
+			WebshopService.Order.list(showPending.value)
 				.then((response) => {
 					orders.value = response.data;
 				})
@@ -113,5 +114,6 @@ export function useOrder(toast: ToastLike, router: Router) {
 		clean,
 		orders,
 		numOldOrders,
+		showPending,
 	};
 }

--- a/resources/js/services/webshop-service.ts
+++ b/resources/js/services/webshop-service.ts
@@ -93,7 +93,7 @@ const OrderService = {
 		return axios.delete(`${Constants.getApiUrl()}Shop/Basket`, { data: {} });
 	},
 	list(includePending: boolean = false): Promise<AxiosResponse<App.Http.Resources.Shop.OrderResource[]>> {
-		return axios.get(`${Constants.getApiUrl()}Shop/Order/List`, { data: { include_pending: includePending } });
+		return axios.get(`${Constants.getApiUrl()}Shop/Order/List`, { params: { include_pending: includePending ? '1' : '0' }, data: {} });
 	},
 	get(orderId: number, transactionId?: string): Promise<AxiosResponse<App.Http.Resources.Shop.OrderResource>> {
 		return axios.get(`${Constants.getApiUrl()}Shop/Order/${orderId}`, { data: {}, params: { transaction_id: transactionId } });

--- a/resources/js/services/webshop-service.ts
+++ b/resources/js/services/webshop-service.ts
@@ -92,8 +92,8 @@ const OrderService = {
 	clearBasket(): Promise<AxiosResponse<void>> {
 		return axios.delete(`${Constants.getApiUrl()}Shop/Basket`, { data: {} });
 	},
-	list(): Promise<AxiosResponse<App.Http.Resources.Shop.OrderResource[]>> {
-		return axios.get(`${Constants.getApiUrl()}Shop/Order/List`, { data: {} });
+	list(includePending: boolean = false): Promise<AxiosResponse<App.Http.Resources.Shop.OrderResource[]>> {
+		return axios.get(`${Constants.getApiUrl()}Shop/Order/List`, { data: { include_pending: includePending } });
 	},
 	get(orderId: number, transactionId?: string): Promise<AxiosResponse<App.Http.Resources.Shop.OrderResource>> {
 		return axios.get(`${Constants.getApiUrl()}Shop/Order/${orderId}`, { data: {}, params: { transaction_id: transactionId } });

--- a/resources/js/services/webshop-service.ts
+++ b/resources/js/services/webshop-service.ts
@@ -93,7 +93,7 @@ const OrderService = {
 		return axios.delete(`${Constants.getApiUrl()}Shop/Basket`, { data: {} });
 	},
 	list(includePending: boolean = false): Promise<AxiosResponse<App.Http.Resources.Shop.OrderResource[]>> {
-		return axios.get(`${Constants.getApiUrl()}Shop/Order/List`, { params: { include_pending: includePending ? '1' : '0' }, data: {} });
+		return axios.get(`${Constants.getApiUrl()}Shop/Order/List`, { params: { include_pending: includePending ? "1" : "0" }, data: {} });
 	},
 	get(orderId: number, transactionId?: string): Promise<AxiosResponse<App.Http.Resources.Shop.OrderResource>> {
 		return axios.get(`${Constants.getApiUrl()}Shop/Order/${orderId}`, { data: {}, params: { transaction_id: transactionId } });

--- a/resources/js/v7/components/gallery/flowModule/Blur.vue
+++ b/resources/js/v7/components/gallery/flowModule/Blur.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="isBlurred"
-		class="cursor-pointer absolute top-0 left-0 w-full h-full bg-[url(/img/noise.png)] backdrop-blur transition-opacity duration-1000 hover:opacity-0 flex justify-center items-center"
+		class="cursor-pointer absolute top-0 left-0 w-full h-full bg-noise backdrop-blur transition-opacity duration-1000 hover:opacity-0 flex justify-center items-center"
 		@click="are_nsfw_consented = true"
 	>
 		<slot></slot>

--- a/resources/js/v7/components/gallery/flowModule/HeaderImage.vue
+++ b/resources/js/v7/components/gallery/flowModule/HeaderImage.vue
@@ -10,7 +10,7 @@
 		</template>
 		<template v-else-if="image_header_cover === 'fit'">
 			<img alt="image background" class="absolute w-full h-full object-cover object-center" :src="header.thumb?.url ?? '/img/no_images.svg'" />
-			<div class="w-full h-full bg-repeat absolute bg-[url(/img/noise.png)] backdrop-blur-3xl blur-3xl"></div>
+			<div class="w-full h-full bg-repeat absolute bg-noise backdrop-blur-3xl blur-3xl"></div>
 			<img
 				:src="header.medium?.url ?? header.small?.url ?? '/img/no_images.svg'"
 				:alt="props.title"

--- a/resources/js/v7/views/gallery-panels/Frame.vue
+++ b/resources/js/v7/views/gallery-panels/Frame.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="h-screen w-screen">
 		<img v-if="imgSrc !== ''" alt="image background" class="absolute w-screen h-screen object-cover blur-lg object-center" :src="imgSrc" />
-		<div class="w-screen h-screen flex justify-center items-center flex-wrap bg-repeat bg-[url(/img/noise.png)]">
+		<div class="w-screen h-screen flex justify-center items-center flex-wrap bg-repeat bg-noise">
 			<img
 				v-if="imgSrc !== ''"
 				alt="Random Image"

--- a/resources/js/v8/components/gallery/flowModule/Blur.vue
+++ b/resources/js/v8/components/gallery/flowModule/Blur.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="isBlurred"
-		class="cursor-pointer absolute top-0 left-0 w-full h-full bg-[url(/img/noise.png)] backdrop-blur transition-opacity duration-1000 hover:opacity-0 flex justify-center items-center"
+		class="cursor-pointer absolute top-0 left-0 w-full h-full bg-noise backdrop-blur transition-opacity duration-1000 hover:opacity-0 flex justify-center items-center"
 		@click="are_nsfw_consented = true"
 	>
 		<slot></slot>

--- a/resources/js/v8/components/gallery/flowModule/HeaderImage.vue
+++ b/resources/js/v8/components/gallery/flowModule/HeaderImage.vue
@@ -10,7 +10,7 @@
 		</template>
 		<template v-else-if="image_header_cover === 'fit'">
 			<img alt="image background" class="absolute w-full h-full object-cover object-center" :src="header.thumb?.url ?? '/img/no_images.svg'" />
-			<div class="w-full h-full bg-repeat absolute bg-[url(/img/noise.png)] backdrop-blur-3xl blur-3xl"></div>
+			<div class="w-full h-full bg-repeat absolute bg-noise backdrop-blur-3xl blur-3xl"></div>
 			<img
 				:src="header.medium?.url ?? header.small?.url ?? '/img/no_images.svg'"
 				:alt="props.title"

--- a/resources/js/v8/components/gallery/photoModule/Overlay.vue
+++ b/resources/js/v8/components/gallery/photoModule/Overlay.vue
@@ -24,7 +24,6 @@
 		</p>
 		<p
 			v-if="image_overlay_type === 'exif' && !photoStore.photo.precomputed.is_video && photoStore.photo.preformatted.shutter !== ''"
-			dir="ltr"
 			class="mt-1 text-base sm:text-xl text-neutral-400 rtl:text-right ltr:text-left"
 		>
 			{{ photoStore.photo.preformatted.shutter }} at &fnof; / {{ photoStore.photo.preformatted.aperture }},

--- a/resources/js/v8/components/webshop/OrderLegend.vue
+++ b/resources/js/v8/components/webshop/OrderLegend.vue
@@ -26,52 +26,52 @@
 				<div class="mb-2">{{ $t("webshop.orderLegend.flowsIntro") }}</div>
 				<div class="flex justify-center gap-2 items-center">
 					<OrderStatus size="small" status="pending" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="processing" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="completed" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="closed" />
 				</div>
 				<div class="flex justify-center gap-2 items-center">
 					<OrderStatus size="small" status="pending" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="processing" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="cancelled" />
 				</div>
 				<div class="flex justify-center gap-2 items-center">
 					<OrderStatus size="small" status="pending" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="processing" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="failed" />
 				</div>
 				<div class="flex justify-center gap-2 items-center">
 					<OrderStatus size="small" status="pending" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="offline" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="completed" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="closed" />
 				</div>
 				<div class="flex justify-center gap-2 items-center">
 					<OrderStatus size="small" status="cancelled" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="processing" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="completed" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="closed" />
 				</div>
 				<div class="flex justify-center gap-2 items-center">
 					<OrderStatus size="small" status="failed" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="processing" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="completed" />
-					<UIcon name="lucide:arrow-right" />
+					<UIcon :name="arrow" />
 					<OrderStatus size="small" status="closed" />
 				</div>
 			</div>
@@ -93,10 +93,15 @@
 	</Transition>
 </template>
 <script setup lang="ts">
+import { useLtRorRtL } from "@/utils/Helpers";
 import OrderStatus from "@/v8/components/webshop/OrderStatus.vue";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 const isVisible = ref(false);
+
+const { isLTR } = useLtRorRtL();
+
+const arrow = computed(() => (isLTR() ? "lucide:arrow-right" : "lucide:arrow-left"));
 
 function toggle() {
 	isVisible.value = !isVisible.value;

--- a/resources/js/v8/views/admin/AdminDashboard.vue
+++ b/resources/js/v8/views/admin/AdminDashboard.vue
@@ -87,7 +87,7 @@
 					<div class="text-muted text-sm">{{ $t("admin-dashboard.metrics.users_count") }}</div>
 				</div>
 				<div class="bg-elevated rounded p-4 text-center">
-					<div class="text-2xl font-bold">{{ formatBytes(stats.storage_bytes) }}</div>
+					<div class="text-2xl font-bold" dir="ltr">{{ formatBytes(stats.storage_bytes) }}</div>
 					<div class="text-muted text-sm">{{ $t("admin-dashboard.metrics.storage_bytes") }}</div>
 				</div>
 				<div class="bg-elevated rounded p-4 text-center">

--- a/resources/js/v8/views/admin/Jobs.vue
+++ b/resources/js/v8/views/admin/Jobs.vue
@@ -24,7 +24,6 @@
 				:id="`job${idx}`"
 				:key="`job-${idx}`"
 				class="flex text-xs sm:text-base flex-wrap sm:flex-nowrap"
-				dir="ltr"
 			>
 				<span class="hidden sm:inline-block sm:w-2/5 text-muted">{{ prettyDate(job.created_at) }}</span>
 				<span class="w-1/6 sm:w-1/4" :class="textCss(job.status)">{{ translateStatus(job.status) }}</span>

--- a/resources/js/v8/views/admin/Jobs.vue
+++ b/resources/js/v8/views/admin/Jobs.vue
@@ -19,12 +19,7 @@
 					</span>
 				</div>
 			</div>
-			<div
-				v-for="(job, idx) in jobs"
-				:id="`job${idx}`"
-				:key="`job-${idx}`"
-				class="flex text-xs sm:text-base flex-wrap sm:flex-nowrap"
-			>
+			<div v-for="(job, idx) in jobs" :id="`job${idx}`" :key="`job-${idx}`" class="flex text-xs sm:text-base flex-wrap sm:flex-nowrap">
 				<span class="hidden sm:inline-block sm:w-2/5 text-muted">{{ prettyDate(job.created_at) }}</span>
 				<span class="w-1/6 sm:w-1/4" :class="textCss(job.status)">{{ translateStatus(job.status) }}</span>
 				<span class="w-5/6 sm:w-1/4">{{ job.username }}</span>

--- a/resources/js/v8/views/admin/NsfwConfig.vue
+++ b/resources/js/v8/views/admin/NsfwConfig.vue
@@ -13,7 +13,7 @@
 		</div>
 
 		<template v-else>
-			<UTabs v-model="activeTab" :items="tabItems" class="w-full" :dir="isLTR() ? 'ltr' : 'rtl'" >
+			<UTabs v-model="activeTab" :items="tabItems" class="w-full" :dir="isLTR() ? 'ltr' : 'rtl'">
 				<template #settings>
 					<p class="text-muted mb-6 text-center text-sm">{{ $t("admin-dashboard.nsfw_config.description") }}</p>
 

--- a/resources/js/v8/views/admin/NsfwConfig.vue
+++ b/resources/js/v8/views/admin/NsfwConfig.vue
@@ -13,7 +13,7 @@
 		</div>
 
 		<template v-else>
-			<UTabs v-model="activeTab" :items="tabItems" class="w-full">
+			<UTabs v-model="activeTab" :items="tabItems" class="w-full" :dir="isLTR() ? 'ltr' : 'rtl'" >
 				<template #settings>
 					<p class="text-muted mb-6 text-center text-sm">{{ $t("admin-dashboard.nsfw_config.description") }}</p>
 
@@ -259,6 +259,7 @@ import NsfwConfigService from "@/services/nsfw-config-service";
 import SettingsService from "@/services/settings-service";
 import { useAppToast } from "@/v8/composables/useAppToast";
 import type { TableColumn, TabsItem } from "@nuxt/ui";
+import { useLtRorRtL } from "@/utils/Helpers";
 
 type CfgRef = App.Http.Resources.Models.ConfigResource | undefined;
 
@@ -292,6 +293,8 @@ const NSFW_KEYS = [
 const cfg = reactive<Record<(typeof NSFW_KEYS)[number], CfgRef>>(
 	Object.fromEntries(NSFW_KEYS.map((k) => [k, undefined])) as Record<(typeof NSFW_KEYS)[number], CfgRef>,
 );
+
+const { isLTR } = useLtRorRtL();
 
 function loadSettings() {
 	settingsLoading.value = true;

--- a/resources/js/v8/views/gallery-panels/Frame.vue
+++ b/resources/js/v8/views/gallery-panels/Frame.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="h-screen w-screen">
 		<img v-if="imgSrc !== ''" alt="image background" class="absolute w-screen h-screen object-cover blur-lg object-center" :src="imgSrc" />
-		<div class="w-screen h-screen flex justify-center items-center flex-wrap bg-repeat bg-[url(/img/noise.png)]">
+		<div class="w-screen h-screen flex justify-center items-center flex-wrap bg-repeat bg-noise">
 			<img
 				v-if="imgSrc !== ''"
 				alt="Random Image"

--- a/resources/js/v8/views/webshop/OrderList.vue
+++ b/resources/js/v8/views/webshop/OrderList.vue
@@ -13,7 +13,7 @@
 		</div>
 		<Disclaimer />
 		<div class="flex justify-end">
-			<UCheckbox v-model="showPending" :label="$t('webshop.orderList.showPending')" @update:model-value="load" />
+			<UCheckbox v-model="showPending" :label="$t('webshop.orderList.show_pending')" @update:model-value="load" />
 		</div>
 		<OrderLegend />
 		<UTable :data="orders ?? []" :columns="columns" :loading="orders === undefined" class="mt-4" />

--- a/resources/js/v8/views/webshop/OrderList.vue
+++ b/resources/js/v8/views/webshop/OrderList.vue
@@ -12,6 +12,9 @@
 			<UButton :label="$t('webshop.orderList.cleanStaleOrders')" icon="lucide:trash" color="warning" @click="clean" />
 		</div>
 		<Disclaimer />
+		<div class="flex justify-end">
+			<UCheckbox v-model="showPending" :label="$t('webshop.orderList.showPending')" @update:model-value="load" />
+		</div>
 		<OrderLegend />
 		<UTable :data="orders ?? []" :columns="columns" :loading="orders === undefined" class="mt-4" />
 	</div>
@@ -43,7 +46,7 @@ const toast = useAppToast();
 const leftMenuStore = useLeftMenuStateStore();
 const { initData } = storeToRefs(leftMenuStore);
 
-const { isZero, load, clean, orders, numOldOrders } = useOrder(toast, router);
+const { isZero, load, clean, orders, numOldOrders, showPending } = useOrder(toast, router);
 
 const columns: TableColumn<Order>[] = [
 	{

--- a/resources/sass/app-v8.css
+++ b/resources/sass/app-v8.css
@@ -8,6 +8,10 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+@utility bg-noise {
+	background-image: url("/img/noise.png");
+}
+
 html {
 	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }

--- a/resources/sass/app.css
+++ b/resources/sass/app.css
@@ -36,6 +36,10 @@
 	}
 }
 
+@utility bg-noise {
+	background-image: url("/img/noise.png");
+}
+
 @theme {
 	--color-ready-400: var(--ready);
 	--color-danger-600: var(--danger);

--- a/routes/web_v2.php
+++ b/routes/web_v2.php
@@ -118,5 +118,7 @@ Route::get('image/{path}', SecurePathController::class)
 	->name('image')
 	->where('path', '.*');
 
+Route::get('/.well-known/appspecific/com.chrome.devtools.json', fn () => response()->noContent());
+
 // This route must be defined last because it is a catch all.
 Route::match(['get', 'post'], '{path}', HoneyPotController::class)->where('path', '.*');

--- a/tests/Webshop/OrderManagement/OrderListingAccessTest.php
+++ b/tests/Webshop/OrderManagement/OrderListingAccessTest.php
@@ -134,7 +134,7 @@ class OrderListingAccessTest extends BaseApiWithDataTest
 
 	/**
 	 * Test listing orders as admin user.
-	 * Should return all orders in the system.
+	 * Should return all non-pending orders in the system by default.
 	 */
 	public function testListOrdersAsAdmin(): void
 	{
@@ -145,7 +145,27 @@ class OrderListingAccessTest extends BaseApiWithDataTest
 		$orders = $response->json();
 		$this->assertIsArray($orders);
 
-		// Admin should see all orders
+		// Admin should see all non-pending orders, but not the pending one
+		$orderIds = collect($orders)->pluck('id')->toArray();
+		$this->assertContains($this->order1->id, $orderIds);
+		$this->assertNotContains($this->order2->id, $orderIds);
+		$this->assertContains($this->order3->id, $orderIds);
+	}
+
+	/**
+	 * Test listing orders as admin user with pending orders included.
+	 * Should return all orders in the system, including pending ones.
+	 */
+	public function testListOrdersAsAdminIncludingPending(): void
+	{
+		$response = $this->actingAs($this->admin)->getJson('Shop/Order/List?include_pending=1');
+
+		$this->assertOk($response);
+
+		$orders = $response->json();
+		$this->assertIsArray($orders);
+
+		// Admin should see all orders, including the pending one
 		$orderIds = collect($orders)->pluck('id')->toArray();
 		$this->assertContains($this->order1->id, $orderIds);
 		$this->assertContains($this->order2->id, $orderIds);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Show pending orders” checkbox to order lists; pending orders are hidden by default and can be included on demand.
  * Added localized label text for the new pending-orders option.

* **Bug Fixes**
  * Improved right-to-left layout behavior for order-flow arrows and administrative UI direction handling.
  * Corrected photo-tag overwrite help text across supported languages.

* **Style**
  * Standardized the gallery noise texture styling using a shared `bg-noise` utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->