### PR TITLE
Fix inheritance issue on album creation

### DIFF
--- a/app/Constants/AccessPermissionConstants.php
+++ b/app/Constants/AccessPermissionConstants.php
@@ -27,4 +27,10 @@ class AccessPermissionConstants
 	public const GRANTS_EDIT = 'grants_edit';
 	public const GRANTS_DELETE = 'grants_delete';
 	public const PASSWORD = 'password';
+
+	// Generated columns (see database/migrations/2026_07_01_120000_deduplicate_and_constrain_access_permissions.php).
+	// MySQL rejects explicit inserts into STORED generated columns, so these
+	// must never be copied via Model::replicate().
+	public const USER_ID_UNIQUE_KEY = 'user_id_unique_key';
+	public const USER_GROUP_ID_UNIQUE_KEY = 'user_group_id_unique_key';
 }

--- a/app/Models/AccessPermission.php
+++ b/app/Models/AccessPermission.php
@@ -141,7 +141,12 @@ class AccessPermission extends Model
 	 */
 	public static function ofAccessPermission(AccessPermission $access_permission): self
 	{
-		return $access_permission->replicate([APC::PASSWORD, APC::BASE_ALBUM_ID]);
+		return $access_permission->replicate([
+			APC::PASSWORD,
+			APC::BASE_ALBUM_ID,
+			APC::USER_ID_UNIQUE_KEY,
+			APC::USER_GROUP_ID_UNIQUE_KEY,
+		]);
 	}
 
 	/**

--- a/resources/js/v8/components/settings/ConfirmSave.vue
+++ b/resources/js/v8/components/settings/ConfirmSave.vue
@@ -59,8 +59,12 @@
 			></div>
 		</div>
 	</div>
-	<div v-else class="sticky z-30 w-full top-0 flex bg-white dark:bg-neutral-800 h-auto lg:h-11">
-		<UAlert color="warning" class="w-full ltr:rounded-r-none rtl:rounded-l-none" :description="$t('settings.all.change_detected')" />
+	<div v-else class="sticky z-50 w-full top-0 flex bg-white dark:bg-neutral-800 h-auto lg:h-12">
+		<UAlert
+			color="warning"
+			class="w-full ltr:rounded-r-none rtl:rounded-l-none font-bold border-none"
+			:description="$t('settings.all.change_detected')"
+		/>
 		<UButton class="bg-error-800 text-white font-bold px-8 hover:bg-error-700 rtl:rounded-r-none ltr:rounded-l-none" @click="emits('save')">{{
 			$t("settings.all.save")
 		}}</UButton>

--- a/resources/js/v8/views/admin/Settings.vue
+++ b/resources/js/v8/views/admin/Settings.vue
@@ -17,7 +17,7 @@
 				@ready="isReady = true"
 			/>
 			<template v-if="isReady && configs !== undefined">
-				<div v-if="tab !== 'all'" class="flex gap-4 flex-wrap lg:flex-nowrap">
+				<div v-if="tab !== 'all'" class="flex gap-4 flex-wrap lg:flex-nowrap mt-2">
 					<div class="w-full lg:w-3xs shrink-0">
 						<nav class="border-0 lg:sticky top-11 mt-2 flex flex-col">
 							<a

--- a/tests/Feature_v2/Album/AlbumCreateTest.php
+++ b/tests/Feature_v2/Album/AlbumCreateTest.php
@@ -18,6 +18,9 @@
 
 namespace Tests\Feature_v2\Album;
 
+use App\Constants\AccessPermissionConstants as APC;
+use App\Models\AccessPermission;
+use App\Models\Configs;
 use App\Models\Statistics;
 use Tests\Feature_v2\Base\BaseApiWithDataTest;
 
@@ -69,5 +72,45 @@ class AlbumCreateTest extends BaseApiWithDataTest
 		$this->assertOk($response);
 		$response->assertSee($new_album_id);
 		$this->assertEquals(1, Statistics::where('album_id', $new_album_id)->count());
+	}
+
+	/**
+	 * album1 has both a user-based permission (perm1, for userMayUpload2) and a
+	 * user-group-based permission (perm11, for group1). When default_album_protection
+	 * is set to "inherit", creating a sub-album must copy both permissions onto the
+	 * new album via AccessPermission::ofAccessPermission()/replicate().
+	 *
+	 * Regression test: replicate() used to also copy the `user_id_unique_key` /
+	 * `user_group_id_unique_key` generated columns, which the DB rejects on
+	 * insert, making this scenario throw instead of creating the sub-album.
+	 */
+	public function testCreateAlbumInheritsPermissionsFromParent(): void
+	{
+		Configs::set('default_album_protection', 'inherit');
+
+		$response = $this->actingAs($this->userMayUpload1)->postJson('Album', [
+			'parent_id' => $this->album1->id,
+			'title' => 'test',
+		]);
+		$this->assertOk($response);
+		$new_album_id = $response->getOriginalContent();
+
+		$copied_permissions = AccessPermission::where(APC::BASE_ALBUM_ID, '=', $new_album_id)->get();
+
+		$user_permission = $copied_permissions->firstWhere(APC::USER_ID, $this->userMayUpload2->id);
+		self::assertNotNull($user_permission);
+		self::assertTrue($user_permission->grants_edit);
+		self::assertTrue($user_permission->grants_delete);
+		self::assertTrue($user_permission->grants_upload);
+		self::assertTrue($user_permission->grants_download);
+		self::assertTrue($user_permission->grants_full_photo_access);
+
+		$group_permission = $copied_permissions->firstWhere(APC::USER_GROUP_ID, $this->group1->id);
+		self::assertNotNull($group_permission);
+		self::assertTrue($group_permission->grants_edit);
+		self::assertTrue($group_permission->grants_delete);
+		self::assertTrue($group_permission->grants_upload);
+		self::assertTrue($group_permission->grants_download);
+		self::assertTrue($group_permission->grants_full_photo_access);
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inherited album permissions so user and user-group access settings are copied correctly when creating sub-albums.
  * Prevented database errors during permission duplication.

* **Style**
  * Improved the visibility, spacing, and emphasis of the settings change notification banner.
  * Adjusted spacing in the administration settings layout.

* **Tests**
  * Added coverage validating permission inheritance for newly created sub-albums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->