### PR TITLE
Update README.md - Fix URL for upgrade process from v6 > v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For even more advanced features, consider the Supporter Edition (SE). The SE ver
 
 ## ⚠️ Upgrade Notice to Version 7.0
 
-**Version 7.0 introduces significant changes on the docker image.** Please refer to our [Upgrade Guide](https://lycheeorg.dev/docs/upgrade.html#upgrading-lychee-docker-installations-from-v6-to-v7) for detailed instructions on how to upgrade from previous versions.
+**Version 7.0 introduces significant changes on the docker image.** Please refer to our [Upgrade Guide](https://lycheeorg.dev/docs/administration/upgrade/) for detailed instructions on how to upgrade from previous versions.
 
 ## Support the Team
 


### PR DESCRIPTION
Fix URL in README.md for upgrade process from v6 > v7

The old link gives a 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Version 7.0 upgrade notice to link to the current upgrade guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->