### PR TITLE
Fix LinuxServer.io base path (though, they should fix their env)

### DIFF
--- a/app/Actions/Diagnostics/Pipes/Infos/DockerVersionInfo.php
+++ b/app/Actions/Diagnostics/Pipes/Infos/DockerVersionInfo.php
@@ -61,7 +61,7 @@ class DockerVersionInfo implements DiagnosticStringPipe
 	 *
 	 * @return bool
 	 */
-	private function isLinuxServer(): bool
+	public function isLinuxServer(): bool
 	{
 		return is_file('/build_version');
 	}
@@ -71,7 +71,7 @@ class DockerVersionInfo implements DiagnosticStringPipe
 	 *
 	 * @return bool
 	 */
-	private function isLycheeOrg(): bool
+	public function isLycheeOrg(): bool
 	{
 		return is_file(base_path('/docker_target'));
 	}
@@ -81,7 +81,7 @@ class DockerVersionInfo implements DiagnosticStringPipe
 	 *
 	 * @return bool
 	 */
-	private function isLycheeFrankenPHP(): bool
+	public function isLycheeFrankenPHP(): bool
 	{
 		return is_file(base_path('/frankenphp_target'));
 	}

--- a/app/Http/Controllers/SecurePathController.php
+++ b/app/Http/Controllers/SecurePathController.php
@@ -34,9 +34,8 @@ use function Safe\realpath;
 class SecurePathController extends Controller
 {
 	public function __construct(
-		protected DockerVersionInfo $docker_version_info
-	)
-	{
+		protected DockerVersionInfo $docker_version_info,
+	) {
 	}
 
 	public function __invoke(SecurePathRequest $request, ?string $path)

--- a/app/Http/Controllers/SecurePathController.php
+++ b/app/Http/Controllers/SecurePathController.php
@@ -8,6 +8,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\Diagnostics\Pipes\Infos\DockerVersionInfo;
 use App\Enum\StorageDiskType;
 use App\Exceptions\SecurePaths\InvalidPayloadException;
 use App\Exceptions\SecurePaths\InvalidSignatureException;
@@ -32,6 +33,12 @@ use function Safe\realpath;
  */
 class SecurePathController extends Controller
 {
+	public function __construct(
+		protected DockerVersionInfo $docker_version_info
+	)
+	{
+	}
+
 	public function __invoke(SecurePathRequest $request, ?string $path)
 	{
 		$url_generator = new UrlGenerator($request->configs());
@@ -67,6 +74,12 @@ class SecurePathController extends Controller
 		}
 
 		$valid_path_start = Storage::disk(StorageDiskType::LOCAL->value)->path('');
+
+		// If we are on LinuxServer.io docker image they moved the photo folder to /pictures.
+		if ($this->docker_version_info->isDocker() && $this->docker_version_info->isLinuxServer()) {
+			$valid_path_start = '/pictures/';
+		}
+
 		if (!str_starts_with($file, $valid_path_start)) {
 			Log::error('Invalid path for secure path request.', [
 				'path' => $file,

--- a/tests/Unit/Http/Controllers/SecurePathControllerTest.php
+++ b/tests/Unit/Http/Controllers/SecurePathControllerTest.php
@@ -18,6 +18,7 @@
 
 namespace Tests\Unit\Http\Controllers;
 
+use App\Actions\Diagnostics\Pipes\Infos\DockerVersionInfo;
 use App\Enum\StorageDiskType;
 use App\Exceptions\SecurePaths\InvalidPayloadException;
 use App\Exceptions\SecurePaths\PathTraversalException;
@@ -51,7 +52,7 @@ class SecurePathControllerTest extends AbstractTestCase
 	public function setUp(): void
 	{
 		parent::setUp();
-		$this->controller = new SecurePathController();
+		$this->controller = new SecurePathController(new DockerVersionInfo());
 	}
 
 	/**


### PR DESCRIPTION
See here: https://github.com/linuxserver/docker-lychee/blob/master/root/etc/s6-overlay/s6-rc.d/init-lychee-config/run#L19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure file path validation for LinuxServer.io Docker deployments.
  * Preserved existing secure storage path handling for other installation types.
* **Improvements**
  * Enhanced environment detection for more reliable handling of Docker-based installations.
  * Maintained existing detection behavior and user-facing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->