### PR TITLE
Avoid alert() in titles

### DIFF
--- a/resources/js/v7/components/drawers/LiveMetrics.vue
+++ b/resources/js/v7/components/drawers/LiveMetrics.vue
@@ -152,7 +152,11 @@ function titlize(title: string) {
     title = tmp.textContent || tmp.innerText || '';
 	// Truncate the title if it's too long
 	const t = title.length > 20 ? title.substring(0, 20) + "..." : title;
-	return `<span class="font-bold text-primary-emphasis">${t}</span>`;
+
+	const span = document.createElement('span');
+	span.className = 'font-bold text-primary-emphasis';
+	span.textContent = t;
+	return span.outerHTML;
 }
 
 function prettifyData() {

--- a/resources/js/v7/components/drawers/LiveMetrics.vue
+++ b/resources/js/v7/components/drawers/LiveMetrics.vue
@@ -147,14 +147,14 @@ function printPlural(data: LiveMetrics) {
 
 function titlize(title: string) {
 	// Strip HTML tags from the title to prevent XSS attacks and ensure proper display
-	const tmp = document.createElement('div');
-    tmp.innerHTML = title;
-    title = tmp.textContent || tmp.innerText || '';
+	const tmp = document.createElement("div");
+	tmp.innerHTML = title;
+	title = tmp.textContent || tmp.innerText || "";
 	// Truncate the title if it's too long
 	const t = title.length > 20 ? title.substring(0, 20) + "..." : title;
 
-	const span = document.createElement('span');
-	span.className = 'font-bold text-primary-emphasis';
+	const span = document.createElement("span");
+	span.className = "font-bold text-primary-emphasis";
 	span.textContent = t;
 	return span.outerHTML;
 }

--- a/resources/js/v7/components/drawers/LiveMetrics.vue
+++ b/resources/js/v7/components/drawers/LiveMetrics.vue
@@ -146,6 +146,11 @@ function printPlural(data: LiveMetrics) {
 }
 
 function titlize(title: string) {
+	// Strip HTML tags from the title to prevent XSS attacks and ensure proper display
+	const tmp = document.createElement('div');
+    tmp.innerHTML = title;
+    title = tmp.textContent || tmp.innerText || '';
+	// Truncate the title if it's too long
 	const t = title.length > 20 ? title.substring(0, 20) + "..." : title;
 	return `<span class="font-bold text-primary-emphasis">${t}</span>`;
 }

--- a/resources/js/v8/components/drawers/LiveMetrics.vue
+++ b/resources/js/v8/components/drawers/LiveMetrics.vue
@@ -156,7 +156,11 @@ function titlize(title: string) {
     title = tmp.textContent || tmp.innerText || '';
 	// Truncate the title if it's too long
 	const t = title.length > 20 ? title.substring(0, 20) + "..." : title;
-	return `<span class="font-bold text-primary">${t}</span>`;
+
+	const span = document.createElement('span');
+	span.className = 'font-bold text-primary';
+	span.textContent = t;
+	return span.outerHTML;
 }
 
 function prettifyData() {

--- a/resources/js/v8/components/drawers/LiveMetrics.vue
+++ b/resources/js/v8/components/drawers/LiveMetrics.vue
@@ -151,14 +151,14 @@ function printPlural(data: LiveMetrics) {
 
 function titlize(title: string) {
 	// Strip HTML tags from the title to prevent XSS attacks and ensure proper display
-	const tmp = document.createElement('div');
-    tmp.innerHTML = title;
-    title = tmp.textContent || tmp.innerText || '';
+	const tmp = document.createElement("div");
+	tmp.innerHTML = title;
+	title = tmp.textContent || tmp.innerText || "";
 	// Truncate the title if it's too long
 	const t = title.length > 20 ? title.substring(0, 20) + "..." : title;
 
-	const span = document.createElement('span');
-	span.className = 'font-bold text-primary';
+	const span = document.createElement("span");
+	span.className = "font-bold text-primary";
 	span.textContent = t;
 	return span.outerHTML;
 }

--- a/resources/js/v8/components/drawers/LiveMetrics.vue
+++ b/resources/js/v8/components/drawers/LiveMetrics.vue
@@ -150,6 +150,11 @@ function printPlural(data: LiveMetrics) {
 }
 
 function titlize(title: string) {
+	// Strip HTML tags from the title to prevent XSS attacks and ensure proper display
+	const tmp = document.createElement('div');
+    tmp.innerHTML = title;
+    title = tmp.textContent || tmp.innerText || '';
+	// Truncate the title if it's too long
 	const t = title.length > 20 ? title.substring(0, 20) + "..." : title;
 	return `<span class="font-bold text-primary">${t}</span>`;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live metric titles by decoding text and removing HTML markup before display.
  * Ensured truncated metric titles render as clean, readable text.
  * Prevented title content from being interpreted as HTML when displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->