### PR TITLE
Fixes per_page

### DIFF
--- a/app/Http/Controllers/Admin/BulkAlbumController.php
+++ b/app/Http/Controllers/Admin/BulkAlbumController.php
@@ -46,7 +46,7 @@ class BulkAlbumController extends Controller
 	public function index(IndexBulkAlbumRequest $request): PaginatedBulkAlbumResource
 	{
 		$search = $request->validated('search');
-		$per_page = (int) $request->validated('per_page', 50);
+		$per_page = (int) $request->validated('per_page', 100);
 		$page = (int) $request->validated('page', 1);
 
 		$query = Album::query()->without(

--- a/app/Http/Controllers/Admin/ModerationController.php
+++ b/app/Http/Controllers/Admin/ModerationController.php
@@ -44,7 +44,7 @@ class ModerationController extends Controller
 	 */
 	public function list(ListModerationRequest $request): PaginatedModerationResource
 	{
-		$per_page = min((int) $request->query('per_page', 30), 100);
+		$per_page = min((int) $request->query('per_page', 100), 100);
 
 		/** @var \Illuminate\Pagination\LengthAwarePaginator<Photo> $paginated */
 		$paginated = Photo::where('is_validated', false)

--- a/app/Http/Controllers/Admin/ModerationController.php
+++ b/app/Http/Controllers/Admin/ModerationController.php
@@ -44,13 +44,11 @@ class ModerationController extends Controller
 	 */
 	public function list(ListModerationRequest $request): PaginatedModerationResource
 	{
-		$per_page = min((int) $request->query('per_page', 100), 100);
-
 		/** @var \Illuminate\Pagination\LengthAwarePaginator<Photo> $paginated */
 		$paginated = Photo::where('is_validated', false)
 			->with(['owner', 'albums', 'size_variants'])
 			->orderBy('created_at', 'desc')
-			->paginate($per_page);
+			->paginate($request->per_page);
 
 		return new PaginatedModerationResource($paginated);
 	}

--- a/app/Http/Requests/Admin/BulkAlbumEdit/IndexBulkAlbumRequest.php
+++ b/app/Http/Requests/Admin/BulkAlbumEdit/IndexBulkAlbumRequest.php
@@ -32,7 +32,7 @@ class IndexBulkAlbumRequest extends BaseApiRequest
 		return [
 			'search' => ['sometimes', 'nullable', 'string', 'max:255'],
 			'page' => ['sometimes', 'integer', 'min:1'],
-			'per_page' => ['sometimes', 'integer', 'in:25,50,100'],
+			'per_page' => ['sometimes', 'integer', 'in:100,200,500'],
 		];
 	}
 

--- a/app/Http/Requests/Moderation/ListModerationRequest.php
+++ b/app/Http/Requests/Moderation/ListModerationRequest.php
@@ -8,7 +8,7 @@
 
 namespace App\Http\Requests\Moderation;
 
-use App\Http\Requests\AbstractEmptyRequest;
+use App\Http\Requests\BaseApiRequest;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 
@@ -17,13 +17,34 @@ use Illuminate\Support\Facades\Auth;
  *
  * Only administrators may access the moderation queue.
  */
-class ListModerationRequest extends AbstractEmptyRequest
+class ListModerationRequest extends BaseApiRequest
 {
+	/** @var int<1, 100> */
+	public int $per_page = 100;
+
 	public function authorize(): bool
 	{
 		/** @var User|null */
 		$user = Auth::user();
 
 		return $user?->may_administrate === true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function rules(): array
+	{
+		return [
+			'per_page' => ['nullable', 'integer', 'min:1', 'max:500'],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		$this->per_page = (int) ($values['per_page'] ?? 100);
 	}
 }

--- a/resources/js/v8/components/headers/AlbumsHeader.vue
+++ b/resources/js/v8/components/headers/AlbumsHeader.vue
@@ -273,7 +273,7 @@ const menu = computed(() =>
 			to: { name: "basket" },
 			type: "link",
 			icon: "lucide:shopping-cart",
-			severity: orderManagementStore.order?.status === "processing" ? "danger" : "secondary",
+			severity: orderManagementStore.order?.status === "processing" ? "danger" : "neutral",
 			if: orderManagementStore.hasItems,
 			key: "basket",
 		},

--- a/tests/Feature_v2/BulkAlbumEdit/IndexTest.php
+++ b/tests/Feature_v2/BulkAlbumEdit/IndexTest.php
@@ -171,7 +171,7 @@ class IndexTest extends BaseApiWithDataTest
 
 	public function testPaginationMetaIsPresent(): void
 	{
-		$response = $this->actingAs($this->admin)->getJsonWithData('BulkAlbumEdit', ['per_page' => 25, 'page' => 1]);
+		$response = $this->actingAs($this->admin)->getJsonWithData('BulkAlbumEdit', ['per_page' => 100, 'page' => 1]);
 		$this->assertOk($response);
 
 		$data = $response->json();

--- a/tests/Feature_v2/BulkAlbumEdit/IndexTest.php
+++ b/tests/Feature_v2/BulkAlbumEdit/IndexTest.php
@@ -177,7 +177,7 @@ class IndexTest extends BaseApiWithDataTest
 		$data = $response->json();
 		$this->assertSame(1, $data['current_page']);
 		$this->assertGreaterThanOrEqual(1, $data['last_page']);
-		$this->assertSame(25, $data['per_page']);
+		$this->assertSame(100, $data['per_page']);
 		$this->assertIsInt($data['total']);
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Album management now displays up to 100 albums per page by default.
  * Moderation photo listings now display 100 items per page by default, with configurable pagination up to 500 items.
  * Bulk album pagination options are now 100, 200, or 500 items per page.

* **Style**
  * The basket menu clearly indicates processing orders with a danger state and uses a neutral state otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->