### PR TITLE
Close menu once a left-menu item is clicked

### DIFF
--- a/resources/js/v7/menus/LeftMenu.vue
+++ b/resources/js/v7/menus/LeftMenu.vue
@@ -170,6 +170,15 @@ onMounted(() => {
 	Promise.allSettled([lycheeStore.load(), userStore.load(), load()]);
 });
 
+// Fold the menu as soon as one of its entries navigates somewhere,
+// otherwise the drawer stays open on top of the freshly loaded page.
+watch(
+	() => route.fullPath,
+	() => {
+		left_menu_open.value = false;
+	},
+);
+
 watch(
 	() => user.value,
 	(newValue, oldValue) => {

--- a/resources/js/v8/menus/LeftMenu.vue
+++ b/resources/js/v8/menus/LeftMenu.vue
@@ -177,6 +177,15 @@ onMounted(() => {
 	Promise.allSettled([lycheeStore.load(), userStore.load(), load()]);
 });
 
+// Fold the menu as soon as one of its entries navigates somewhere,
+// otherwise the slideover stays open on top of the freshly loaded page.
+watch(
+	() => route.fullPath,
+	() => {
+		left_menu_open.value = false;
+	},
+);
+
 watch(
 	() => user.value,
 	(newValue, oldValue) => {


### PR DESCRIPTION
Close the left menu once an item has been clicked, for instance Admin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The left navigation menu now closes automatically after navigating to a different page.
  * Improved menu behavior across both supported interface versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->