### PR TITLE
feat/album-name-and-breadcrumb

### DIFF
--- a/lang/ar/gallery.php
+++ b/lang/ar/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'لا يوجد شيء هنا',
         'upload' => 'رفع الصور',
         'edit_title' => 'إعدادات الألبوم',
+        'edit_title_with_name' => 'إعدادات الألبوم: :title',
         'tabs' => [
             'about' => 'حول الألبوم',
             'visibility' => 'الظهور',

--- a/lang/bg/gallery.php
+++ b/lang/bg/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Няма какво да се покаже',
         'upload' => 'Качване на снимки',
         'edit_title' => 'Настройки на албума',
+        'edit_title_with_name' => 'Настройки на албума: :title',
         'tabs' => [
             'about' => 'За албума',
             'visibility' => 'Видимост',

--- a/lang/cz/gallery.php
+++ b/lang/cz/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Zde není nic k vidění',
         'upload' => 'Nahrát fotografie',
         'edit_title' => 'Nastavení alba',
+        'edit_title_with_name' => 'Nastavení alba: :title',
         'tabs' => [
             'about' => 'O albu',
             'visibility' => 'Viditelnost',

--- a/lang/de/gallery.php
+++ b/lang/de/gallery.php
@@ -154,6 +154,7 @@ return [
         'no_results' => 'Hier gibt es nichts zu sehen',
         'upload' => 'Fotos hochladen',
         'edit_title' => 'Albumeinstellungen',
+        'edit_title_with_name' => 'Albumeinstellungen: :title',
         'tabs' => [
             'about' => 'Über das Album',
             'visibility' => 'Sichtbarkeit',

--- a/lang/el/gallery.php
+++ b/lang/el/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'edit_title' => 'Album Settings',
+        'edit_title_with_name' => 'Album Settings: :title',
         'tabs' => [
             'about' => 'About Album',
             'visibility' => 'Visibility',

--- a/lang/en/gallery.php
+++ b/lang/en/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'edit_title' => 'Album Settings',
+        'edit_title_with_name' => 'Album Settings: :title',
         'tabs' => [
             'about' => 'About Album',
             'visibility' => 'Visibility',

--- a/lang/es/gallery.php
+++ b/lang/es/gallery.php
@@ -154,6 +154,7 @@ return [
         'no_results' => 'No hay nada que ver aquí',
         'upload' => 'Subir fotos',
         'edit_title' => 'Ajustes del álbum',
+        'edit_title_with_name' => 'Ajustes del álbum: :title',
         'tabs' => [
             'about' => 'Acerca del álbum',
             'visibility' => 'Visibilidad',

--- a/lang/fa/gallery.php
+++ b/lang/fa/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'اینجا چیزی برای نمایش نیست',
         'upload' => 'بارگذاری عکس‌ها',
         'edit_title' => 'تنظیمات آلبوم',
+        'edit_title_with_name' => 'تنظیمات آلبوم: :title',
         'tabs' => [
             'about' => 'درباره آلبوم',
             'visibility' => 'نمایانی',

--- a/lang/fr/gallery.php
+++ b/lang/fr/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Rien à voir ici',
         'upload' => 'Téléverser des photos',
         'edit_title' => 'Paramètres de l’album',
+        'edit_title_with_name' => 'Paramètres de l’album : :title',
         'tabs' => [
             'about' => 'À propos de l’album',
             'visibility' => 'Visibilité',

--- a/lang/hu/gallery.php
+++ b/lang/hu/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'edit_title' => 'Album Settings',
+        'edit_title_with_name' => 'Album Settings: :title',
         'tabs' => [
             'about' => 'About Album',
             'visibility' => 'Visibility',

--- a/lang/it/gallery.php
+++ b/lang/it/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'edit_title' => 'Album Settings',
+        'edit_title_with_name' => 'Album Settings: :title',
         'tabs' => [
             'about' => 'About Album',
             'visibility' => 'Visibilità',

--- a/lang/ja/gallery.php
+++ b/lang/ja/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'edit_title' => 'アルバム設定',
+        'edit_title_with_name' => 'アルバム設定：:title',
         'tabs' => [
             'about' => 'About Album',
             'visibility' => 'Visibility',

--- a/lang/nl/gallery.php
+++ b/lang/nl/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Niets te zien hier',
         'upload' => 'Foto’s uploaden',
         'edit_title' => 'Albuminstellingen',
+        'edit_title_with_name' => 'Albuminstellingen: :title',
         'tabs' => [
             'about' => 'Over Album',
             'visibility' => 'Zichtbaarheid',

--- a/lang/no/gallery.php
+++ b/lang/no/gallery.php
@@ -154,6 +154,7 @@ return [
         'no_results' => 'Ingenting å se her',
         'upload' => 'Last opp bilder',
         'edit_title' => 'Albuminnstillinger',
+        'edit_title_with_name' => 'Albuminnstillinger: :title',
         'tabs' => [
             'about' => 'Om Album',
             'visibility' => 'Synlighet',

--- a/lang/pl/gallery.php
+++ b/lang/pl/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Nie ma tu nic do oglądania',
         'upload' => 'Przesyłanie zdjęć',
         'edit_title' => 'Ustawienia albumu',
+        'edit_title_with_name' => 'Ustawienia albumu: :title',
         'tabs' => [
             'about' => 'Informacje o albumie',
             'visibility' => 'Widoczność',

--- a/lang/pt/gallery.php
+++ b/lang/pt/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'edit_title' => 'Album Settings',
+        'edit_title_with_name' => 'Album Settings: :title',
         'tabs' => [
             'about' => 'About Album',
             'visibility' => 'Visibility',

--- a/lang/ru/gallery.php
+++ b/lang/ru/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Здесь ничего нет',
         'upload' => 'Загрузить фотографии',
         'edit_title' => 'Настройки альбома',
+        'edit_title_with_name' => 'Настройки альбома: :title',
         'tabs' => [
             'about' => 'О альбоме',
             'visibility' => 'Видимость',

--- a/lang/sk/gallery.php
+++ b/lang/sk/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'edit_title' => 'Album Settings',
+        'edit_title_with_name' => 'Album Settings: :title',
         'tabs' => [
             'about' => 'About Album',
             'visibility' => 'Visibility',

--- a/lang/sv/gallery.php
+++ b/lang/sv/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'edit_title' => 'Album Settings',
+        'edit_title_with_name' => 'Album Settings: :title',
         'tabs' => [
             'about' => 'About Album',
             'visibility' => 'Visibility',

--- a/lang/tr/gallery.php
+++ b/lang/tr/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'edit_title' => 'Albüm Ayarları',
+        'edit_title_with_name' => 'Albüm Ayarları: :title',
         'tabs' => [
             'about' => 'About Album',
             'visibility' => 'Visibility',

--- a/lang/vi/gallery.php
+++ b/lang/vi/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'edit_title' => 'Album Settings',
+        'edit_title_with_name' => 'Album Settings: :title',
         'tabs' => [
             'about' => 'About Album',
             'visibility' => 'Visibility',

--- a/lang/zh_CN/gallery.php
+++ b/lang/zh_CN/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => '这里什么都没有',
         'upload' => '上传照片',
         'edit_title' => '相册设置',
+        'edit_title_with_name' => '相册设置：:title',
         'tabs' => [
             'about' => '关于相册',
             'visibility' => '可见性',

--- a/lang/zh_TW/gallery.php
+++ b/lang/zh_TW/gallery.php
@@ -155,6 +155,7 @@ return [
         'no_results' => 'Nothing to see here',
         'upload' => 'Upload photos',
         'edit_title' => 'Album Settings',
+        'edit_title_with_name' => 'Album Settings: :title',
         'tabs' => [
             'about' => 'About Album',
             'visibility' => '可見性',

--- a/resources/js/v8/components/drawers/AlbumEdit.vue
+++ b/resources/js/v8/components/drawers/AlbumEdit.vue
@@ -1,5 +1,5 @@
 <template>
-	<UModal v-model:open="is_album_edit_open" fullscreen :title="$t('gallery.album.edit_title')" :close="{ icon: 'lucide:x' }">
+	<UModal v-model:open="is_album_edit_open" fullscreen :title="modalTitle" :close="{ icon: 'lucide:x' }">
 		<template #body>
 			<div class="w-full max-w-6xl mx-auto">
 				<!-- Mobile fallback: the aside (where this same toggle lives on desktop) is hidden below `lg`. -->
@@ -105,6 +105,13 @@ const { is_album_edit_open } = storeToRefs(togglableStore);
 const { expert_album_settings } = storeToRefs(useLycheeStateStore());
 
 const is_expert_mode = ref(expert_album_settings.value);
+
+// Show which album is being edited: "Album Settings : My Album" (falls back to the plain
+// section title while the album is still loading).
+const modalTitle = computed(() => {
+	const albumTitle = albumStore.album?.title;
+	return albumTitle ? `${trans("gallery.album.edit_title")} : ${albumTitle}` : trans("gallery.album.edit_title");
+});
 
 const numUsers = ref(0);
 

--- a/resources/js/v8/components/drawers/AlbumEdit.vue
+++ b/resources/js/v8/components/drawers/AlbumEdit.vue
@@ -106,11 +106,12 @@ const { expert_album_settings } = storeToRefs(useLycheeStateStore());
 
 const is_expert_mode = ref(expert_album_settings.value);
 
-// Show which album is being edited: "Album Settings : My Album" (falls back to the plain
-// section title while the album is still loading).
+// Show which album is being edited: "Album Settings: My Album". Separator and word order live in
+// the translation string so locales can differ; falls back to the plain section title while the
+// album is still loading.
 const modalTitle = computed(() => {
 	const albumTitle = albumStore.album?.title;
-	return albumTitle ? `${trans("gallery.album.edit_title")} : ${albumTitle}` : trans("gallery.album.edit_title");
+	return albumTitle ? trans("gallery.album.edit_title_with_name", { title: albumTitle }) : trans("gallery.album.edit_title");
 });
 
 const numUsers = ref(0);

--- a/resources/js/v8/components/headers/LycheeBreadcrumb.vue
+++ b/resources/js/v8/components/headers/LycheeBreadcrumb.vue
@@ -15,7 +15,15 @@
 		<!-- Leftmost item of the trail (the row is reversed). A plain "up one level" arrow is
 		     redundant here since every ancestor above is already a link, so this anchors the trail
 		     at the gallery root instead. -->
-		<UButton as="router-link" :to="{ name: 'gallery' }" icon="lucide:home" color="neutral" variant="ghost" :class="isLTR() ? 'mr-2' : 'ml-2'" />
+		<UButton
+			as="router-link"
+			:to="{ name: 'gallery' }"
+			icon="lucide:home"
+			:aria-label="$t('left-menu.back_to_gallery')"
+			color="neutral"
+			variant="ghost"
+			:class="isLTR() ? 'mr-2' : 'ml-2'"
+		/>
 	</nav>
 	<div class="flex sm:hidden">
 		<GoBack @go-back="emits('goBack')" />

--- a/resources/js/v8/components/headers/LycheeBreadcrumb.vue
+++ b/resources/js/v8/components/headers/LycheeBreadcrumb.vue
@@ -12,7 +12,10 @@
 			</RouterLink>
 			<span v-else class="text-base truncate max-w-32 text-muted">{{ item.title }}</span>
 		</template>
-		<GoBack @go-back="emits('goBack')" />
+		<!-- Leftmost item of the trail (the row is reversed). A plain "up one level" arrow is
+		     redundant here since every ancestor above is already a link, so this anchors the trail
+		     at the gallery root instead. -->
+		<UButton as="router-link" :to="{ name: 'gallery' }" icon="lucide:home" color="neutral" variant="ghost" :class="isLTR() ? 'mr-2' : 'ml-2'" />
 	</nav>
 	<div class="flex sm:hidden">
 		<GoBack @go-back="emits('goBack')" />

--- a/resources/js/v8/menus/LeftMenu.vue
+++ b/resources/js/v8/menus/LeftMenu.vue
@@ -7,8 +7,11 @@
 					{{ $t("left-menu.login") }}
 				</RouterLink>
 			</div>
-			<div v-else-if="!isGallery">
-				<RouterLink :to="{ name: 'gallery' }" class="text-lg font-bold text-muted hover:text-primary">
+			<div v-else>
+				<!-- Shown on every route, gallery included. The route watcher below cannot close the
+				     menu when the link points at the page we are already on - `fullPath` never
+				     changes - so close it here explicitly. -->
+				<RouterLink :to="{ name: 'gallery' }" class="text-lg font-bold text-muted hover:text-primary" @click="left_menu_open = false">
 					{{ $t("left-menu.back_to_gallery") }}
 				</RouterLink>
 			</div>
@@ -168,10 +171,6 @@ function logout() {
 		window.location.href = Constants.BASE_URL + "/home";
 	});
 }
-
-const isGallery = computed(() => {
-	return route.name === "gallery";
-});
 
 onMounted(() => {
 	Promise.allSettled([lycheeStore.load(), userStore.load(), load()]);


### PR DESCRIPTION
- add album name in Album settings, even thought the title shows the album name
- replace `<`breadcrumb icon with a :home: icon with a link to /gallery
- always add a `Back to gallery` link when the left menu is opened


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Album editing now displays the album’s name in the modal title when available.
  * Desktop breadcrumbs now include a home button linking to the gallery, while mobile navigation retains the back control.
  * The gallery header is consistently available across authenticated pages.
  * Navigating to the gallery from the left menu now automatically closes the navigation panel.

* **Localization**
  * Added album settings title translations across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->