### PR TITLE
Fix caching issue on tree global update

### DIFF
--- a/app/Http/Controllers/Admin/Maintenance/FullTree.php
+++ b/app/Http/Controllers/Admin/Maintenance/FullTree.php
@@ -15,6 +15,7 @@ use App\Http\Requests\Maintenance\MaintenanceRequest;
 use App\Http\Resources\Diagnostics\AlbumTree;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -36,6 +37,7 @@ class FullTree extends Controller
 			batch()->update($album_instance, $request->albums(), $key_name);
 		});
 
+		Cache::forget('tree_state');
 		AlbumRouteCacheUpdated::dispatch();
 	}
 


### PR DESCRIPTION
@gitsult4n as per your review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refreshed album tree state after album updates, ensuring users see the latest changes immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->