### PR TITLE
Fix wrong frame detection

### DIFF
--- a/app/Actions/Photo/Pipes/Standalone/FetchSourceImage.php
+++ b/app/Actions/Photo/Pipes/Standalone/FetchSourceImage.php
@@ -22,7 +22,7 @@ class FetchSourceImage implements StandalonePipe
 			if ($state->photo->isVideo()) {
 				$video_handler = new VideoHandler();
 				$video_handler->load($state->source_file);
-				$position = is_numeric($state->photo->aperture) ? floatval($state->photo->aperture) / 2 : 0.0;
+				$position = VideoHandler::resolveThumbnailFramePosition($state->photo->duration);
 				$state->source_image = $video_handler->extractFrame($position);
 			} else {
 				// Load source image if it is a supported photo format

--- a/app/Enum/VideoThumbnailFrameMode.php
+++ b/app/Enum/VideoThumbnailFrameMode.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Enum;
+
+/**
+ * Which frame of a video is used to generate its thumbnail.
+ */
+enum VideoThumbnailFrameMode: string
+{
+	case FIRST = 'first';
+	case MIDDLE = 'middle';
+	case CUSTOM = 'custom';
+}

--- a/app/Image/Handlers/VideoHandler.php
+++ b/app/Image/Handlers/VideoHandler.php
@@ -9,6 +9,7 @@
 namespace App\Image\Handlers;
 
 use App\Contracts\Image\ImageHandlerInterface;
+use App\Enum\VideoThumbnailFrameMode;
 use App\Exceptions\ConfigurationException;
 use App\Exceptions\ExternalComponentMissingException;
 use App\Exceptions\ImageProcessingException;
@@ -65,6 +66,26 @@ class VideoHandler
 		} catch (InvalidArgumentException $e) {
 			throw new MediaFileOperationException('FFmpeg could not open media file', $e);
 		}
+	}
+
+	/**
+	 * Determines the position (in seconds) of the frame that should be
+	 * extracted for a video thumbnail, based on the
+	 * `video_thumbnail_frame_mode` / `video_thumbnail_frame_seconds`
+	 * configuration.
+	 *
+	 * @param string|null $duration the video duration in seconds, as stored on {@link \App\Models\Photo::$duration}
+	 */
+	public static function resolveThumbnailFramePosition(?string $duration): float
+	{
+		$config_manager = resolve(ConfigManager::class);
+		$mode = $config_manager->getValueAsEnum('video_thumbnail_frame_mode', VideoThumbnailFrameMode::class) ?? VideoThumbnailFrameMode::MIDDLE;
+
+		return match ($mode) {
+			VideoThumbnailFrameMode::FIRST => 0.0,
+			VideoThumbnailFrameMode::CUSTOM => floatval($config_manager->getValueAsInt('video_thumbnail_frame_seconds')),
+			VideoThumbnailFrameMode::MIDDLE => is_numeric($duration) ? floatval($duration) / 2 : 0.0,
+		};
 	}
 
 	/**

--- a/app/Image/SizeVariantDefaultFactory.php
+++ b/app/Image/SizeVariantDefaultFactory.php
@@ -97,7 +97,7 @@ class SizeVariantDefaultFactory implements SizeVariantFactory
 
 			$video_handler = new VideoHandler();
 			$video_handler->load($source_file);
-			$position = is_numeric($this->photo->aperture) ? floatval($this->photo->aperture) / 2 : 0.0;
+			$position = VideoHandler::resolveThumbnailFramePosition($this->photo->duration);
 			$this->reference_image = $video_handler->extractFrame($position);
 
 			// Clean up

--- a/database/migrations/2026_08_16_000005_add_video_thumbnail_frame_config.php
+++ b/database/migrations/2026_08_16_000005_add_video_thumbnail_frame_config.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+use App\Models\Extensions\BaseConfigMigration;
+
+return new class() extends BaseConfigMigration {
+	public const PROCESSING = 'Image Processing';
+	public const FRAME_MODE = 'first|middle|custom';
+	public const FRAME_SECONDS_RANGE = 'int:0:3600';
+
+	public function getConfigs(): array
+	{
+		return [
+			[
+				'key' => 'video_thumbnail_frame_mode',
+				'value' => 'middle',
+				'cat' => self::PROCESSING,
+				'type_range' => self::FRAME_MODE,
+				'description' => 'Frame to use for the video thumbnail',
+				'details' => 'First: always the very first frame (0s), which can be black on some videos. Middle: the frame halfway through the video, falling back to 0s if the duration is unknown. Custom: the fixed number of seconds set below.',
+				'is_secret' => false,
+				'is_expert' => true,
+				'level' => 0,
+				'order' => 93,
+			],
+			[
+				'key' => 'video_thumbnail_frame_seconds',
+				'value' => '1',
+				'cat' => self::PROCESSING,
+				'type_range' => self::FRAME_SECONDS_RANGE,
+				'description' => 'Timing frame (in seconds) used for video thumbnails',
+				'details' => 'Only used when "Frame to use for the video thumbnail" is set to custom.',
+				'is_secret' => false,
+				'is_expert' => true,
+				'level' => 0,
+				'order' => 94,
+			],
+		];
+	}
+};

--- a/tests/Unit/Image/Handlers/VideoHandlerUnitTest.php
+++ b/tests/Unit/Image/Handlers/VideoHandlerUnitTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Unit\Image\Handlers;
+
+use App\Image\Handlers\VideoHandler;
+use App\Models\Configs;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\AbstractTestCase;
+
+class VideoHandlerUnitTest extends AbstractTestCase
+{
+	use DatabaseTransactions;
+
+	public function testMiddleModeUsesHalfOfDuration(): void
+	{
+		Configs::set('video_thumbnail_frame_mode', 'middle');
+
+		self::assertEquals(5.0, VideoHandler::resolveThumbnailFramePosition('10'));
+		self::assertEquals(2.5, VideoHandler::resolveThumbnailFramePosition('5.0'));
+	}
+
+	public function testMiddleModeFallsBackToZeroWithoutDuration(): void
+	{
+		Configs::set('video_thumbnail_frame_mode', 'middle');
+
+		self::assertEquals(0.0, VideoHandler::resolveThumbnailFramePosition(null));
+		self::assertEquals(0.0, VideoHandler::resolveThumbnailFramePosition('not-a-number'));
+	}
+
+	public function testFirstModeAlwaysReturnsZero(): void
+	{
+		Configs::set('video_thumbnail_frame_mode', 'first');
+
+		self::assertEquals(0.0, VideoHandler::resolveThumbnailFramePosition('10'));
+		self::assertEquals(0.0, VideoHandler::resolveThumbnailFramePosition(null));
+	}
+
+	public function testCustomModeUsesConfiguredSeconds(): void
+	{
+		Configs::set('video_thumbnail_frame_mode', 'custom');
+		Configs::set('video_thumbnail_frame_seconds', 7);
+
+		self::assertEquals(7.0, VideoHandler::resolveThumbnailFramePosition('100'));
+		self::assertEquals(7.0, VideoHandler::resolveThumbnailFramePosition(null));
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable video thumbnail frame selection: first frame, middle frame, or a custom timestamp.
  * Added support for custom timestamps from 0 to 3600 seconds.

* **Bug Fixes**
  * Improved thumbnail extraction by selecting frames based on video duration, with safe fallback behavior when duration data is unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->