### PR TITLE
Improve feedback on mail notification command

### DIFF
--- a/app/Console/Commands/PhotosAddedNotification.php
+++ b/app/Console/Commands/PhotosAddedNotification.php
@@ -83,7 +83,7 @@ class PhotosAddedNotification extends Command
 
 					// Mail clients do not like relative paths.
 					// if url does not start with 'http', it is not absolute...
-					if (!Str::startsWith('http', $thumb_url)) {
+					if (!Str::startsWith($thumb_url, 'http')) {
 						$thumb_url = URL::asset($thumb_url);
 					}
 

--- a/app/Console/Commands/PhotosAddedNotification.php
+++ b/app/Console/Commands/PhotosAddedNotification.php
@@ -15,6 +15,7 @@ use App\Models\Photo;
 use App\Models\User;
 use App\Repositories\ConfigManager;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
@@ -47,9 +48,25 @@ class PhotosAddedNotification extends Command
 	public function handle(): int
 	{
 		if (!$this->config_manager->getValueAsBool('new_photos_notification')) {
-			return 0;
+			$this->warn('Skipped: the "new_photos_notification" setting is disabled. Enable it in the admin settings to send email notifications.');
+
+			return Command::SUCCESS;
 		}
+
 		$users = User::query()->whereNotNull('email')->get();
+
+		if ($users->isEmpty()) {
+			$this->warn('No users with an email address were found. Nothing to do.');
+
+			return Command::SUCCESS;
+		}
+
+		$this->info('Checking pending photo notifications for ' . $users->count() . ' user(s) with an email address...');
+
+		$emails_sent = 0;
+		$emails_failed = 0;
+		$photos_notified = 0;
+		$users_skipped = 0;
 
 		/** @var User $user */
 		foreach ($users as $user) {
@@ -93,12 +110,40 @@ class PhotosAddedNotification extends Command
 				}
 			}
 
-			if (count($photos) > 0) {
+			if (count($photos) === 0) {
+				$users_skipped++;
+				$this->line("  - {$user->email}: no pending notifications.", null, 'v');
+				continue;
+			}
+
+			$photo_count = collect($photos)->sum(fn (array $album) => count($album['photos']));
+
+			try {
 				Mail::to($user->email)->send(new PhotosAdded($photos));
 				$user->notifications()->delete();
+
+				$emails_sent++;
+				$photos_notified += $photo_count;
+				$this->line("  - {$user->email}: sent notification for {$photo_count} photo(s).", null, 'v');
+			} catch (\Throwable $e) {
+				$emails_failed++;
+				$this->error("  - {$user->email}: failed to send notification ({$e->getMessage()}).");
+				Log::error('Failed to send photo-added notification to ' . $user->email . ': ' . $e->getMessage());
 			}
 		}
 
-		return 0;
+		if ($emails_sent === 0 && $emails_failed === 0) {
+			$this->info("No pending photo notifications found for any of the {$users->count()} user(s).");
+		} else {
+			$this->info("Sent {$emails_sent} notification email(s) covering {$photos_notified} photo(s). {$users_skipped} user(s) had nothing pending.");
+		}
+
+		if ($emails_failed > 0) {
+			$this->error("{$emails_failed} notification email(s) failed to send. Check the mail configuration and storage/logs for details.");
+
+			return Command::FAILURE;
+		}
+
+		return Command::SUCCESS;
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Added clearer feedback when photo notifications are sent, skipped, or fail.
  - Notification runs now report delivery results for each recipient and summarize processed photos.
  - Runs complete successfully when notifications are disabled or no eligible recipients are available.
  - Failed email deliveries are logged, and the notification process reports a failure when any message cannot be sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->