### PR TITLE
Add missing check on face displays

### DIFF
--- a/app/Http/Controllers/AiVision/FaceClusterController.php
+++ b/app/Http/Controllers/AiVision/FaceClusterController.php
@@ -18,18 +18,50 @@ use App\Http\Resources\Collections\PaginatedClustersResource;
 use App\Http\Resources\Collections\PaginatedFaceResource;
 use App\Http\Resources\Models\ClusterPreviewResource;
 use App\Models\Face;
+use App\Models\Photo;
+use App\Policies\AlbumPolicy;
+use App\Policies\PhotoQueryPolicy;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
 
 class FaceClusterController extends Controller
 {
 	private const PER_PAGE = 20;
 	private const SAMPLE_SIZE = 5;
 
+	public function __construct(protected PhotoQueryPolicy $photo_query_policy)
+	{
+	}
+
+	/**
+	 * Restricts a face query to faces of photos which are accessible to the current user.
+	 *
+	 * @template TModel of Face
+	 *
+	 * @param Builder<TModel> $query
+	 *
+	 * @return Builder<TModel>
+	 */
+	private function applyAccessibilityFilter(Builder $query): Builder
+	{
+		$user = Auth::user();
+		$unlocked_album_ids = AlbumPolicy::getUnlockedAlbumIDs();
+
+		$accessible_photo_ids = $this->photo_query_policy->applySearchabilityFilter(
+			query: Photo::query()->select('photos.id'),
+			user: $user,
+			unlocked_album_ids: $unlocked_album_ids,
+		);
+
+		return $query->whereIn('photo_id', $accessible_photo_ids);
+	}
+
 	public function index(ClusterIndexRequest $request): PaginatedClustersResource
 	{
 		$page = (int) $request->query('page', '1');
-		$totals = Face::query()
+		$totals = $this->applyAccessibilityFilter(Face::query())
 			->whereNotNull('cluster_label')
 			->where('cluster_label', '>', -1)
 			->whereNull('person_id')
@@ -43,7 +75,7 @@ class FaceClusterController extends Controller
 
 		// Prefetch sample faces for all clusters in the paginated set to avoid N+1
 		$cluster_labels = $paginated->pluck('cluster_label')->all();
-		$samples_by_cluster = Face::query()
+		$samples_by_cluster = $this->applyAccessibilityFilter(Face::query())
 			->whereIn('cluster_label', $cluster_labels)
 			->whereNull('person_id')
 			->notDismissed()
@@ -73,7 +105,7 @@ class FaceClusterController extends Controller
 	public function assign(ClusterAssignRequest $request, int $label, PersonFactory $person_factory): array
 	{
 		$person = $person_factory->findOrCreate($request->person_id, $request->new_person_name);
-		$count = Face::where('cluster_label', '=', $label)
+		$count = $this->applyAccessibilityFilter(Face::where('cluster_label', '=', $label))
 			->whereNull('person_id')
 			->notDismissed()
 			->update(['person_id' => $person->id]);
@@ -88,7 +120,7 @@ class FaceClusterController extends Controller
 
 	public function dismiss(ClusterDismissRequest $request, int $label): array
 	{
-		$count = Face::where('cluster_label', '=', $label)
+		$count = $this->applyAccessibilityFilter(Face::where('cluster_label', '=', $label))
 			->whereNull('person_id')
 			->notDismissed()
 			->update(['is_dismissed' => true]);
@@ -106,7 +138,7 @@ class FaceClusterController extends Controller
 	 */
 	public function uncluster(UnclusterFacesRequest $request, int $label): array
 	{
-		$count = Face::whereIn('id', $request->face_ids)
+		$count = $this->applyAccessibilityFilter(Face::whereIn('id', $request->face_ids))
 			->where('cluster_label', '=', $label)
 			->whereNull('person_id')
 			->notDismissed()
@@ -122,7 +154,8 @@ class FaceClusterController extends Controller
 	 */
 	public function faces(ClusterFacesRequest $request, int $label): PaginatedFaceResource
 	{
-		$exists = Face::where('cluster_label', '=', $label)
+		$exists = $this->applyAccessibilityFilter(Face::query())
+			->where('cluster_label', '=', $label)
 			->whereNull('person_id')
 			->notDismissed()
 			->exists();
@@ -131,7 +164,7 @@ class FaceClusterController extends Controller
 			abort(404, 'Cluster not found or has no qualifying faces.');
 		}
 
-		$paginated = Face::query()
+		$paginated = $this->applyAccessibilityFilter(Face::query())
 			->where('cluster_label', '=', $label)
 			->whereNull('person_id')
 			->notDismissed()

--- a/tests/AssistedVision/Face/FaceClusterFacesTest.php
+++ b/tests/AssistedVision/Face/FaceClusterFacesTest.php
@@ -87,6 +87,21 @@ class FaceClusterFacesTest extends BaseApiWithDataTest
 		$this->assertUnauthorized($response);
 	}
 
+	/**
+	 * A user who has access to the batch-face-ops feature (public mode) must not be able
+	 * to list faces of a cluster that only contains faces from photos in albums they
+	 * cannot access. See CVE-2026-61838 for the analogous issue on /Zip.
+	 */
+	public function testGetFacesForClusterInAccessibleAlbumReturns404ForOtherUser(): void
+	{
+		// photo1 lives in album1, which is private and owned by userMayUpload1.
+		Face::factory()->for_photo($this->photo1)->with_cluster(50)->count(3)->create();
+
+		// userNoUpload owns unrelated album3 and has not been granted access to album1.
+		$response = $this->actingAs($this->userNoUpload)->getJson('FaceDetection/clusters/50/faces');
+		$this->assertNotFound($response);
+	}
+
 	public function testGetFacesPaginated(): void
 	{
 		Face::factory()->for_photo($this->photo1)->with_cluster(40)->count(5)->create();

--- a/tests/AssistedVision/Face/FaceClusterPasswordProtectedAlbumTest.php
+++ b/tests/AssistedVision/Face/FaceClusterPasswordProtectedAlbumTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+/**
+ * Regression test: the face-cluster endpoints (GET /FaceDetection/clusters and
+ * GET /FaceDetection/clusters/{label}/faces) must not disclose face-crop
+ * preview URLs or photo_id references for photos inside a password-protected
+ * album that the requesting user has never unlocked.
+ *
+ * This is the same asymmetric-access bug class as CVE-2026-61838, which hit
+ * /Zip: one code path enforces the album password while a sibling path
+ * doesn't. `5dcb0bf1` ("Add missing check on face displays") added the
+ * accessibility filter these endpoints rely on, but the only regression
+ * tests it shipped with (FaceClusterFacesTest, FaceClusterReviewTest) cover a
+ * plain *private* album, not a *password-protected* one. This file closes
+ * that gap.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\AssistedVision\Face;
+
+use App\Models\Configs;
+use App\Models\Face;
+use App\Policies\AlbumPolicy;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Tests\Feature_v2\Base\BaseApiWithDataTest;
+
+class FaceClusterPasswordProtectedAlbumTest extends BaseApiWithDataTest
+{
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		Configs::set('ai_vision_enabled', '1');
+		Configs::set('ai_vision_face_enabled', '1');
+		Configs::set('ai_vision_face_permission_mode', 'public');
+		Configs::set('ai_vision_face_person_is_searchable_default', '1');
+	}
+
+	public function tearDown(): void
+	{
+		DB::table('face_suggestions')->delete();
+		DB::table('faces')->delete();
+		DB::table('persons')->delete();
+		parent::tearDown();
+	}
+
+	/**
+	 * Turns album4 (public, visible, owned by userLocked; photo4 lives inside
+	 * it) into a password-protected album, mirroring
+	 * PasswordDownloadBypassTest::makePublicPasswordDownloadableAlbum().
+	 */
+	private function protectAlbum4WithPassword(): void
+	{
+		$this->perm4->is_link_required = false;
+		$this->perm4->user_id = null;
+		$this->perm4->user_group_id = null;
+		$this->perm4->password = Hash::make('the-secret');
+		$this->perm4->save();
+		$this->album4->refresh();
+	}
+
+	// ── LEAK: cluster listing (preview crop URLs) ─────────────────
+
+	public function testListClustersExcludesFacesFromPasswordProtectedAlbum(): void
+	{
+		$this->protectAlbum4WithPassword();
+		Face::factory()->for_photo($this->photo4)->with_cluster(200)->count(3)->create();
+
+		// Attacker: a logged-in, unrelated user (userNoUpload owns unrelated
+		// album3) who has never supplied the password / unlocked album4.
+		$response = $this->actingAs($this->userNoUpload)->getJson('FaceDetection/clusters');
+		$this->assertOk($response);
+
+		$cluster_labels = collect($response->json('data'))->pluck('cluster_label')->all();
+		self::assertNotContains(200, $cluster_labels,
+			'LEAK: face-cluster preview crops from a password-protected album were returned to a user who never unlocked it.');
+	}
+
+	public function testListClustersExcludesFacesFromPasswordProtectedAlbumInPrivateMode(): void
+	{
+		Configs::set('ai_vision_face_permission_mode', 'private');
+		$this->protectAlbum4WithPassword();
+		Face::factory()->for_photo($this->photo4)->with_cluster(201)->count(3)->create();
+
+		$response = $this->actingAs($this->userNoUpload)->getJson('FaceDetection/clusters');
+		$this->assertOk($response);
+
+		$cluster_labels = collect($response->json('data'))->pluck('cluster_label')->all();
+		self::assertNotContains(201, $cluster_labels,
+			'LEAK: face-cluster preview crops from a password-protected album were returned in PRIVATE face mode to a user who never unlocked it.');
+	}
+
+	// ── LEAK: cluster faces (photo_id disclosure) ─────────────────
+
+	public function testGetFacesReturns404ForPasswordProtectedAlbum(): void
+	{
+		$this->protectAlbum4WithPassword();
+		Face::factory()->for_photo($this->photo4)->with_cluster(210)->count(3)->create();
+
+		$response = $this->actingAs($this->userNoUpload)->getJson('FaceDetection/clusters/210/faces');
+		$this->assertNotFound($response);
+	}
+
+	// ── SANITY: filter is unlock-aware, not a blanket block ────────
+
+	/**
+	 * Proves the two tests above are meaningful: the same cluster becomes
+	 * visible once the attacker's session actually unlocks album4, so the
+	 * prior 404/exclusion is specifically due to the missing password, not
+	 * some unrelated blanket restriction.
+	 */
+	public function testUnlockingAlbumRestoresVisibilityOfItsFaceCluster(): void
+	{
+		$this->protectAlbum4WithPassword();
+		Face::factory()->for_photo($this->photo4)->with_cluster(220)->count(3)->create();
+
+		$locked = $this->actingAs($this->userNoUpload)->getJson('FaceDetection/clusters');
+		$this->assertOk($locked);
+		self::assertNotContains(220, collect($locked->json('data'))->pluck('cluster_label')->all());
+
+		// Simulate the user having supplied the correct password.
+		session()->push(AlbumPolicy::UNLOCKED_ALBUMS_SESSION_KEY, $this->album4->id);
+
+		$unlocked = $this->actingAs($this->userNoUpload)->getJson('FaceDetection/clusters');
+		$this->assertOk($unlocked);
+		self::assertContains(220, collect($unlocked->json('data'))->pluck('cluster_label')->all());
+	}
+
+	// ── CONTROL: browsing and /Zip correctly require the password ─
+
+	/**
+	 * Control confirming the leak surface is specific to the face-cluster
+	 * path: ordinary album browsing and archive download both correctly deny
+	 * the attacker (post-CVE-2026-61838).
+	 */
+	public function testControlAlbumBrowsingAndZipDenyAccessToPasswordProtectedAlbum(): void
+	{
+		$this->protectAlbum4WithPassword();
+
+		$head = $this->actingAs($this->userNoUpload)->getJsonWithData('Album::head', ['album_id' => $this->album4->id]);
+		self::assertContains($head->getStatusCode(), [401, 403], 'Expected album browsing to be blocked by the password, got ' . $head->getStatusCode());
+
+		$photos = $this->actingAs($this->userNoUpload)->getJsonWithData('Album::photos', ['album_id' => $this->album4->id]);
+		self::assertContains($photos->getStatusCode(), [401, 403], 'Expected photo listing to be blocked by the password, got ' . $photos->getStatusCode());
+
+		$zip = $this->actingAs($this->userNoUpload)->getWithParameters('/api/v2/Zip', ['album_ids' => $this->album4->id], ['Accept' => '*/*']);
+		if ($zip->baseResponse instanceof StreamedResponse) {
+			$zip->streamedContent();
+		}
+		self::assertContains($zip->getStatusCode(), [401, 403], 'Expected /Zip to be blocked by the password, got ' . $zip->getStatusCode());
+	}
+}

--- a/tests/AssistedVision/Face/FaceClusterReviewTest.php
+++ b/tests/AssistedVision/Face/FaceClusterReviewTest.php
@@ -97,6 +97,24 @@ class FaceClusterReviewTest extends BaseApiWithDataTest
 		$this->assertForbidden($response);
 	}
 
+	/**
+	 * A user who has access to the batch-face-ops feature (public mode) must not see
+	 * face clusters belonging to photos in albums they cannot access (e.g. private
+	 * albums owned by someone else). See CVE-2026-61838 for the analogous issue on /Zip.
+	 */
+	public function testListClustersExcludesFacesFromInaccessibleAlbum(): void
+	{
+		// photo1 lives in album1, which is private and owned by userMayUpload1.
+		Face::factory()->for_photo($this->photo1)->with_cluster(100)->count(3)->create();
+
+		// userNoUpload owns unrelated album3 and has not been granted access to album1.
+		$response = $this->actingAs($this->userNoUpload)->getJson('FaceDetection/clusters');
+		$this->assertOk($response);
+
+		$cluster_labels = collect($response->json('data'))->pluck('cluster_label')->all();
+		self::assertNotContains(100, $cluster_labels);
+	}
+
 	public function testAssignClusterPrivacyPreservingNonAdminForbidden(): void
 	{
 		Configs::set('ai_vision_face_permission_mode', 'privacy-preserving');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Face clusters now respect album access permissions across listing, face retrieval, and cluster actions.
  - Faces from inaccessible or locked albums are excluded from results.
  - Access is restored after unlocking a protected album.
  - Unauthorized cluster requests now return a not-found response.

- **Tests**
  - Added coverage for private, inaccessible, and password-protected album scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->