### PR TITLE
(fix): do not display the warning-misconfiguration.blade.php 

### DIFF
--- a/resources/views/components/warning-misconfiguration.blade.php
+++ b/resources/views/components/warning-misconfiguration.blade.php
@@ -1,4 +1,21 @@
-<div class="hidden" style="font-size: 24px; height: 100vh;" dir="ltr">
+<style>
+	#lychee_misconfiguration_warning {
+		visibility: hidden;
+		position: fixed;
+		inset: 0;
+		overflow: auto;
+		background: #fff;
+		color: #000;
+		z-index: 2147483647;
+		animation: lychee_misconfiguration_reveal 1ms linear 3s forwards;
+	}
+	@keyframes lychee_misconfiguration_reveal {
+		to {
+			visibility: visible;
+		}
+	}
+</style>
+<div id="lychee_misconfiguration_warning" class="hidden" style="font-size: 24px; height: 100vh;" dir="ltr">
 @if(Features::active('white_label_enabled'))
 	<h1>If you can read me, it means that you misconfigured your-application.</h1>
 	<p style="font-size: 20px;">Please check that:


### PR DESCRIPTION
(fix): do not display the warning-misconfiguration.blade.php misconfiguration message if not legit. Hide the message and then show it if required.

Change default behaviour: hide the block and show it if `build/assets/app-v8-<hash>.css` is not properly loaded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full-screen warning overlay for configuration issues.
  * The warning appears automatically after a brief delay and remains prominently visible above other content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->