### PR TITLE
Show inline error for wrong album password instead of opening login

### DIFF
--- a/lang/ar/dialogs.php
+++ b/lang/ar/dialogs.php
@@ -226,6 +226,7 @@ return [
         'password_required' => 'هذا الألبوم محمي بكلمة مرور. أدخل كلمة المرور أدناه لعرض صور هذا الألبوم:',
         'password' => 'كلمة المرور',
         'unlock' => 'فتح',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'أدخل العلامات لهذه الصورة.',

--- a/lang/bg/dialogs.php
+++ b/lang/bg/dialogs.php
@@ -225,6 +225,7 @@ return [
         'password_required' => 'Този албум е защитен с парола. Въведете паролата по-долу, за да видите снимките:',
         'password' => 'Парола',
         'unlock' => 'Отключи',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Въведете тагове за тази снимка.',

--- a/lang/cz/dialogs.php
+++ b/lang/cz/dialogs.php
@@ -225,6 +225,7 @@ return [
         'password_required' => 'Toto album je chráněné heslem. Xsdejte heslo, pokud si chcete album prohlédnout:',
         'password' => 'Heslo',
         'unlock' => 'Odemknout',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Zadejte Štítky k této fotografii.',

--- a/lang/de/dialogs.php
+++ b/lang/de/dialogs.php
@@ -225,6 +225,7 @@ return [
         'password_required' => 'Dieses Album ist durch ein Passwort geschützt. Passwort unten eingeben, um die Fotos dieses Albums zu sehen:',
         'password' => 'Passwort',
         'unlock' => 'freischalten',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Tags für dieses Foto eingeben.',

--- a/lang/el/dialogs.php
+++ b/lang/el/dialogs.php
@@ -224,6 +224,7 @@ return [
         'password_required' => 'This album is protected by a password. Enter the password below to view the photos of this album:',
         'password' => 'Password',
         'unlock' => 'Unlock',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Enter your tags for this photo.',

--- a/lang/en/dialogs.php
+++ b/lang/en/dialogs.php
@@ -226,6 +226,7 @@ return [
         'password_required' => 'This album is protected by a password. Enter the password below to view the photos of this album:',
         'password' => 'Password',
         'unlock' => 'Unlock',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Enter your tags for this photo.',

--- a/lang/es/dialogs.php
+++ b/lang/es/dialogs.php
@@ -225,6 +225,7 @@ return [
         'password_required' => 'Este álbum está protegido con contraseña. Introdúzcala a continuación para ver las fotos de este álbum:',
         'password' => 'Contraseña',
         'unlock' => 'Descubrir',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Introduzca sus etiquetas para esta foto.',

--- a/lang/fa/dialogs.php
+++ b/lang/fa/dialogs.php
@@ -225,6 +225,7 @@ return [
         'password_required' => 'این آلبوم با یک رمز محافظت شده است. برای مشاهده عکس‌های این آلبوم، رمز را در زیر وارد کنید:',
         'password' => 'رمز',
         'unlock' => 'باز کردن قفل',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'برچسب‌های خود را برای این عکس وارد کنید.',

--- a/lang/fr/dialogs.php
+++ b/lang/fr/dialogs.php
@@ -226,6 +226,7 @@ return [
         'password_required' => 'Cet album est protégé par un mot de passe. Entrez-le ci-dessous pour voir les photos :',
         'password' => 'Mot de passe',
         'unlock' => 'Déverrouiller',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Entrez les étiquettes pour cette photo.',

--- a/lang/hu/dialogs.php
+++ b/lang/hu/dialogs.php
@@ -224,6 +224,7 @@ return [
         'password_required' => 'This album is protected by a password. Enter the password below to view the photos of this album:',
         'password' => 'Password',
         'unlock' => 'Unlock',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Enter your tags for this photo.',

--- a/lang/it/dialogs.php
+++ b/lang/it/dialogs.php
@@ -224,6 +224,7 @@ return [
         'password_required' => 'This album is protected by a password. Enter the password below to view the photos of this album:',
         'password' => 'Password',
         'unlock' => 'Unlock',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Enter your tags for this photo.',

--- a/lang/ja/dialogs.php
+++ b/lang/ja/dialogs.php
@@ -224,6 +224,7 @@ return [
         'password_required' => 'This album is protected by a password. Enter the password below to view the photos of this album:',
         'password' => 'Password',
         'unlock' => 'Unlock',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Enter your tags for this photo.',

--- a/lang/nl/dialogs.php
+++ b/lang/nl/dialogs.php
@@ -225,6 +225,7 @@ return [
         'password_required' => 'Dit album is beschermd met een wachtwoord. Voer het wachtwoord hieronder in om de foto’s van dit album te bekijken:',
         'password' => 'Wachtwoord',
         'unlock' => 'Ontgrendelen',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Voer uw tags voor deze foto in.',

--- a/lang/no/dialogs.php
+++ b/lang/no/dialogs.php
@@ -225,6 +225,7 @@ return [
         'password_required' => 'Dette albumet er passordbeskyttet. Skriv inn passordet nedenfor for å se bildene i dette albumet:',
         'password' => 'Passord',
         'unlock' => 'Låse opp',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Skriv inn taggene dine for dette bildet.',

--- a/lang/pl/dialogs.php
+++ b/lang/pl/dialogs.php
@@ -225,6 +225,7 @@ return [
         'password_required' => 'Ten album jest chroniony hasłem. Wprowadź hasło poniżej, aby wyświetlić zdjęcia z tego albumu:',
         'password' => 'Hasło',
         'unlock' => 'Odblokowanie',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Wprowadź tagi dla tego zdjęcia.',

--- a/lang/pt/dialogs.php
+++ b/lang/pt/dialogs.php
@@ -224,6 +224,7 @@ return [
         'password_required' => 'This album is protected by a password. Enter the password below to view the photos of this album:',
         'password' => 'Password',
         'unlock' => 'Unlock',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Enter your tags for this photo.',

--- a/lang/ru/dialogs.php
+++ b/lang/ru/dialogs.php
@@ -225,6 +225,7 @@ return [
         'password_required' => 'Этот альбом защищен паролем. Введите пароль ниже для просмотра фотографий в этом альбоме:',
         'password' => 'Пароль',
         'unlock' => 'Разблокировать',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Введите теги для этой фотографии.',

--- a/lang/sk/dialogs.php
+++ b/lang/sk/dialogs.php
@@ -224,6 +224,7 @@ return [
         'password_required' => 'This album is protected by a password. Enter the password below to view the photos of this album:',
         'password' => 'Password',
         'unlock' => 'Unlock',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Enter your tags for this photo.',

--- a/lang/sv/dialogs.php
+++ b/lang/sv/dialogs.php
@@ -224,6 +224,7 @@ return [
         'password_required' => 'This album is protected by a password. Enter the password below to view the photos of this album:',
         'password' => 'Password',
         'unlock' => 'Unlock',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Enter your tags for this photo.',

--- a/lang/tr/dialogs.php
+++ b/lang/tr/dialogs.php
@@ -226,6 +226,7 @@ return [
         'password_required' => 'This album is protected by a password. Enter the password below to view the photos of this album:',
         'password' => 'Password',
         'unlock' => 'Unlock',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Enter your tags for this photo.',

--- a/lang/vi/dialogs.php
+++ b/lang/vi/dialogs.php
@@ -224,6 +224,7 @@ return [
         'password_required' => 'This album is protected by a password. Enter the password below to view the photos of this album:',
         'password' => 'Password',
         'unlock' => 'Unlock',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => 'Enter your tags for this photo.',

--- a/lang/zh_CN/dialogs.php
+++ b/lang/zh_CN/dialogs.php
@@ -225,6 +225,7 @@ return [
         'password_required' => '此相册受密码保护。请在下方输入密码以查看相册中的照片：',
         'password' => '密码',
         'unlock' => '解锁',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => '为此照片输入标签。',

--- a/lang/zh_TW/dialogs.php
+++ b/lang/zh_TW/dialogs.php
@@ -225,6 +225,7 @@ return [
         'password_required' => '此相簿被密碼保護。請在下方輸入密碼來瀏覽此相簿中的相片：',
         'password' => '密碼',
         'unlock' => '解鎖',
+        'invalid_password' => 'Incorrect password for this album. Please try again.',
     ],
     'photo_tags' => [
         'question' => '輸入此相片的標籤。',

--- a/resources/js/v7/components/forms/album/Unlock.vue
+++ b/resources/js/v7/components/forms/album/Unlock.vue
@@ -8,6 +8,7 @@
 						<InputPassword id="albumPassword" v-model="password" @keydown.enter="unlock" />
 						<label for="albumPassword">{{ $t("dialogs.unlock.password") }}</label>
 					</FloatLabel>
+					<Message v-if="invalidPassword" severity="error">{{ $t("dialogs.unlock.invalid_password") }}</Message>
 				</div>
 				<div class="flex items-center mt-9">
 					<Button severity="secondary" class="w-full font-bold border-none rounded-bl-xl" @click="hide">
@@ -31,7 +32,8 @@ import AlbumService from "@/services/album-service";
 import Button from "primevue/button";
 import Dialog from "primevue/dialog";
 import FloatLabel from "primevue/floatlabel";
-import { computed, ref } from "vue";
+import Message from "primevue/message";
+import { computed, ref, watch } from "vue";
 import InputPassword from "@/v7/components/forms/basic/InputPassword.vue";
 import { useAlbumStore } from "@/stores/AlbumState";
 
@@ -48,6 +50,11 @@ const albumId = computed(() => albumStore.albumId);
 
 const password = ref<string | undefined>(undefined);
 const deactivate = computed(() => password.value !== undefined && password.value.length > 0);
+const invalidPassword = ref(false);
+
+watch(password, () => {
+	invalidPassword.value = false;
+});
 
 function unlock() {
 	if (albumId.value === undefined || password.value === undefined) {
@@ -58,9 +65,15 @@ function unlock() {
 		.then((_response) => {
 			AlbumService.clearAlbums();
 			AlbumService.clearCache(albumId.value);
+			invalidPassword.value = false;
 			emits("reload");
 		})
-		.catch((_error) => {
+		.catch((error) => {
+			if (error.response && error.response.status === 403) {
+				invalidPassword.value = true;
+				return;
+			}
+
 			visible.value = false;
 			emits("fail");
 		});

--- a/resources/js/v8/components/forms/album/Unlock.vue
+++ b/resources/js/v8/components/forms/album/Unlock.vue
@@ -4,6 +4,7 @@
 			<p class="mb-5">{{ $t("dialogs.unlock.password_required") }}</p>
 			<UFormField :label="$t('dialogs.unlock.password')">
 				<InputPassword id="albumPassword" v-model="password" @keydown.enter="unlock" />
+				<UAlert v-if="invalidPassword" color="error" variant="soft" class="mt-2" :description="$t('dialogs.unlock.invalid_password')" />
 			</UFormField>
 		</template>
 		<template #footer>
@@ -20,7 +21,7 @@
 </template>
 <script setup lang="ts">
 import AlbumService from "@/services/album-service";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import InputPassword from "@/v8/components/forms/basic/InputPassword.vue";
 import { useAlbumStore } from "@/stores/AlbumState";
 import { useAlbumListStore } from "@/stores/AlbumListState";
@@ -39,6 +40,11 @@ const albumId = computed(() => albumStore.albumId);
 
 const password = ref<string | undefined>(undefined);
 const deactivate = computed(() => password.value !== undefined && password.value.length > 0);
+const invalidPassword = ref(false);
+
+watch(password, () => {
+	invalidPassword.value = false;
+});
 
 function unlock() {
 	if (albumId.value === undefined || password.value === undefined) {
@@ -50,9 +56,15 @@ function unlock() {
 			AlbumService.clearAlbums();
 			AlbumService.clearCache(albumId.value);
 			albumListStore.invalidate();
+			invalidPassword.value = false;
 			emits("reload");
 		})
-		.catch((_error) => {
+		.catch((error) => {
+			if (error.response && error.response.status === 403) {
+				invalidPassword.value = true;
+				return;
+			}
+
 			visible.value = false;
 			emits("fail");
 		});


### PR DESCRIPTION
## Summary
When an album is password-protected and the wrong password is entered, the unlock dialog currently closes and the site-wide login form opens instead, with no indication the password itself was wrong.

This makes the unlock dialog stay open and show an inline error on a 403 response, so the user can just retry the password. Other failure types keep the existing fallback behavior. Applied to both the v7 and v8 Unlock dialogs, following the same pattern already used in LoginForm.vue.

## Test plan
- [x] `npm run format` — no changes
- [x] `npm run check` (vue-tsc) — passes
- [x] `npm run build` — succeeds
- [x] Manually verified against a running v7.7.5 instance: entering a wrong album password now shows the inline error and keeps the dialog open; correct password still unlocks normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Incorrect passwords entered when unlocking a protected album now display a clear inline error message.
  * The unlock dialog remains open so the password can be corrected and resubmitted.
  * The error clears automatically when the password is edited.
  * Other unlock failures continue to follow the existing error-handling behavior.

* **Localization**
  * Added incorrect-password messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->