### PR TITLE
Avoid email oracle on registration

### DIFF
--- a/app/Actions/User/Create.php
+++ b/app/Actions/User/Create.php
@@ -41,6 +41,9 @@ class Create
 		if (User::query()->where('username', '=', $username)->count() !== 0) {
 			throw new ConflictingPropertyException('Username already exists');
 		}
+		if ($email !== null && User::query()->where('email', '=', $email)->count() !== 0) {
+			throw new ConflictingPropertyException('email already exists');
+		}
 		if ($quota_kb === 0) {
 			$default_bytes = $this->config_manager->getValueAsByteSize('default_user_quota');
 			$quota_kb = $default_bytes === 0 ? null : max(1, intdiv($default_bytes, 1024));

--- a/app/Http/Requests/Profile/RegistrationRequest.php
+++ b/app/Http/Requests/Profile/RegistrationRequest.php
@@ -47,7 +47,7 @@ class RegistrationRequest extends BaseApiRequest implements HasUsername, HasPass
 	{
 		return [
 			RequestAttribute::USERNAME_ATTRIBUTE => ['required', new UsernameRule()],
-			RequestAttribute::EMAIL_ATTRIBUTE => ['required', 'string', 'email', 'max:255', 'unique:users'],
+			RequestAttribute::EMAIL_ATTRIBUTE => ['required', 'string', 'email', 'max:255'],
 			RequestAttribute::PASSWORD_ATTRIBUTE => ['required', 'confirmed', new PasswordRule(true)],
 		];
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented registration with an email address already associated with an existing account.
  - Added a clear “email already exists” conflict message when duplicate emails are detected.
  - Preserved registration support for accounts without an email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->