### PR TITLE
Prevent editing pictures if they are not validated yet

### DIFF
--- a/app/Policies/PhotoPolicy.php
+++ b/app/Policies/PhotoPolicy.php
@@ -115,6 +115,9 @@ class PhotoPolicy extends BasePolicy
 	 */
 	public function canEdit(User $user, Photo $photo)
 	{
+		if ($photo->is_validated !== true) {
+			return false;
+		}
 		if ($this->isOwner($user, $photo)) {
 			return true;
 		}
@@ -141,6 +144,7 @@ class PhotoPolicy extends BasePolicy
 			$user->may_upload &&
 			Photo::query()
 			->whereIn('id', $photo_ids)
+			->where('is_validated', true)
 			->where('owner_id', $user->id)
 			->count() === count($photo_ids)
 		) {

--- a/app/Policies/PhotoPolicy.php
+++ b/app/Policies/PhotoPolicy.php
@@ -140,11 +140,20 @@ class PhotoPolicy extends BasePolicy
 		// Make IDs unique as otherwise count will fail.
 		$photo_ids = array_unique($photo_ids);
 
+		// If there are any photos which are not validated at this point, we fail.
+		if (
+			Photo::query()
+			->whereIn('id', $photo_ids)
+			->where('is_validated', false)
+			->count() > 0
+		) {
+			return false;
+		}
+
 		if (
 			$user->may_upload &&
 			Photo::query()
 			->whereIn('id', $photo_ids)
-			->where('is_validated', true)
 			->where('owner_id', $user->id)
 			->count() === count($photo_ids)
 		) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Editing is now blocked for photo sets containing any unvalidated photos.
  - Bulk photo editing consistently enforces photo validation before applying ownership or album-based permissions.
  - This prevents edits from proceeding when even one photo in the set has not been validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->