### PR TITLE
Trivy ignore CVE-2026-56854

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -19,3 +19,7 @@ CVE-2026-76905
 
 # kin-openapi has uncontrolled resource consumption in openapi3filter deepObject query parameter decoding
 CVE-2026-77354
+
+# Authentication bypass on the ssh part of the golang.org/x/crypto package, which is used by the golang.org/x/crypto/ssh
+# This is not impactful on Lychee as it is not used in frankenphp
+CVE-2026-56854


### PR DESCRIPTION
This has no impact on Lychee: Frankenphp is used as a webserver, we do not use the ssh component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to ignore a non-impactful vulnerability in an unused dependency component.
  * Added context documenting why the vulnerability does not affect the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->