### PR TITLE
Throttle WebAuthn option endpoint

### DIFF
--- a/app/Http/Controllers/WebAuthn/WebAuthnLoginController.php
+++ b/app/Http/Controllers/WebAuthn/WebAuthnLoginController.php
@@ -45,45 +45,7 @@ class WebAuthnLoginController extends Controller
 		$user_id = $fields['user_id'] ?? null;
 		$authenticatable = $user_id ?? ($username !== null ? ['username' => $username] : null);
 
-		// If the user does not exist, we generate a fake response to prevent user enumeration.
-		// If there was no username and no user_id, this means that we are dealing quite likely with
-		// a Yubikey 5.
-		//
-		// Yubikey 4 requires the use of username or passwords.
-		if (
-			($username !== null || $user_id !== null) &&
-			!User::where('id', $user_id)->orWhere('username', $username)->exists()
-		) {
-			return $this->generateFakeResponse();
-		}
-
 		return $request->toVerify($authenticatable);
-	}
-
-	/**
-	 * We mask real responses with fake ones to prevent user enumeration.
-	 */
-	private function generateFakeResponse(): Responsable
-	{
-		return new class() implements Responsable {
-			public function toResponse($request): \Symfony\Component\HttpFoundation\Response
-			{
-				$count = random_int(1, 3);
-				$credentials = [];
-				for ($i = 0; $i < $count; $i++) {
-					$credentials[] = [
-						'id' => strtr(base64_encode(random_bytes(96)), '+/', '-_'),
-						'type' => 'public-key',
-					];
-				}
-
-				return response()->json([
-					'timeout' => 60000,
-					'allowCredentials' => $credentials,
-					'challenge' => strtr(base64_encode(random_bytes(18)), '+/', '-_'),
-				]);
-			}
-		};
 	}
 
 	/**

--- a/app/Http/Controllers/WebAuthn/WebAuthnLoginController.php
+++ b/app/Http/Controllers/WebAuthn/WebAuthnLoginController.php
@@ -42,9 +42,47 @@ class WebAuthnLoginController extends Controller
 		]);
 
 		$username = $fields['username'] ?? null;
-		$authenticatable = $fields['user_id'] ?? ($username !== null ? ['username' => $username] : null);
+		$user_id = $fields['user_id'] ?? null;
+		$authenticatable = $user_id ?? ($username !== null ? ['username' => $username] : null);
+
+		// If the user does not exist, we generate a fake response to prevent user enumeration.
+		// If there was no username and no user_id, this means that we are dealing quite likely with
+		// a Yubikey 5.
+		//
+		// Yubikey 4 requires the use of username or passwords.
+		if (
+			($username !== null || $user_id !== null)
+			&& !User::where('id', $user_id)->orWhere('username', $username)->exists()
+		) {
+			return $this->generateFakeResponse();
+		}
 
 		return $request->toVerify($authenticatable);
+	}
+
+	/**
+	 * We mask real responses with fake ones to prevent user enumeration.
+	 */
+	private function generateFakeResponse(): Responsable
+	{
+		return new class implements Responsable {
+			function toResponse($request): \Symfony\Component\HttpFoundation\Response {
+				$count = random_int(1, 3);
+				$credentials = [];
+				for ($i = 0; $i < $count; $i++) {
+					$credentials[] = [
+						"id" => strtr(base64_encode(random_bytes(96)), '+/', '-_'),
+						"type" => "public-key",
+					];
+				}
+
+				return response()->json([
+					"timeout" => 60000,
+					"allowCredentials" => $credentials,
+					"challenge" => strtr(base64_encode(random_bytes(18)), '+/', '-_'),
+				]);
+			}
+		};
 	}
 
 	/**

--- a/app/Http/Controllers/WebAuthn/WebAuthnLoginController.php
+++ b/app/Http/Controllers/WebAuthn/WebAuthnLoginController.php
@@ -51,8 +51,8 @@ class WebAuthnLoginController extends Controller
 		//
 		// Yubikey 4 requires the use of username or passwords.
 		if (
-			($username !== null || $user_id !== null)
-			&& !User::where('id', $user_id)->orWhere('username', $username)->exists()
+			($username !== null || $user_id !== null) &&
+			!User::where('id', $user_id)->orWhere('username', $username)->exists()
 		) {
 			return $this->generateFakeResponse();
 		}
@@ -65,21 +65,22 @@ class WebAuthnLoginController extends Controller
 	 */
 	private function generateFakeResponse(): Responsable
 	{
-		return new class implements Responsable {
-			function toResponse($request): \Symfony\Component\HttpFoundation\Response {
+		return new class() implements Responsable {
+			public function toResponse($request): \Symfony\Component\HttpFoundation\Response
+			{
 				$count = random_int(1, 3);
 				$credentials = [];
 				for ($i = 0; $i < $count; $i++) {
 					$credentials[] = [
-						"id" => strtr(base64_encode(random_bytes(96)), '+/', '-_'),
-						"type" => "public-key",
+						'id' => strtr(base64_encode(random_bytes(96)), '+/', '-_'),
+						'type' => 'public-key',
 					];
 				}
 
 				return response()->json([
-					"timeout" => 60000,
-					"allowCredentials" => $credentials,
-					"challenge" => strtr(base64_encode(random_bytes(18)), '+/', '-_'),
+					'timeout' => 60000,
+					'allowCredentials' => $credentials,
+					'challenge' => strtr(base64_encode(random_bytes(18)), '+/', '-_'),
 				]);
 			}
 		};

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -241,7 +241,7 @@ Route::delete('/WebAuthn', [WebAuthn\WebAuthnManageController::class, 'delete'])
 
 // Special Webauthn operations
 Route::post('/WebAuthn::register/options', [WebAuthn\WebAuthnRegisterController::class, 'options'])
-	->name('webauthn.register.options');
+	->name('webauthn.register.options')->middleware(['throttle:10,1']); // Limit to 10 requests per minute per IP to prevent abuse
 Route::post('/WebAuthn::register', [WebAuthn\WebAuthnRegisterController::class, 'register'])
 	->name('webauthn.register');
 Route::post('/WebAuthn::login/options', [WebAuthn\WebAuthnLoginController::class, 'options'])

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -241,7 +241,7 @@ Route::delete('/WebAuthn', [WebAuthn\WebAuthnManageController::class, 'delete'])
 
 // Special Webauthn operations
 Route::post('/WebAuthn::register/options', [WebAuthn\WebAuthnRegisterController::class, 'options'])
-	->name('webauthn.register.options')->middleware(['throttle:10,1']); // Limit to 10 requests per minute per IP to prevent abuse
+	->name('webauthn.register.options')->middleware(['throttle:10,1,login']); // Limit to 10 requests per minute per IP to prevent abuse
 Route::post('/WebAuthn::register', [WebAuthn\WebAuthnRegisterController::class, 'register'])
 	->name('webauthn.register');
 Route::post('/WebAuthn::login/options', [WebAuthn\WebAuthnLoginController::class, 'options'])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * WebAuthn login requests for unknown users now return indistinguishable responses, helping prevent account enumeration.
  * WebAuthn registration-option requests continue to be limited to 10 requests per minute per IP address, using the standard login throttling configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->