### PR TITLE
Add Payzum as a crypto/stablecoin payment provider (async settlement via signed notification)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -371,6 +371,10 @@ VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # PAYPAL_CLIENT_ID=
 # PAYPAL_SECRET=
 
+# Configuration values for Payzum integration (crypto/stablecoin payments)
+# PAYZUM_API_KEY=
+# PAYZUM_WEBHOOK_SECRET=
+
 ###################################################################
 # AI Vision (facial recognition & NSFW classification)            #
 ###################################################################

--- a/app/Actions/Shop/CheckoutService.php
+++ b/app/Actions/Shop/CheckoutService.php
@@ -17,6 +17,7 @@ use App\Exceptions\Internal\LycheeLogicException;
 use App\Factories\OmnipayFactory;
 use App\Models\Order;
 use App\Services\MoneyService;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Session;
 use Omnipay\Common\Exception\InvalidCreditCardException;
@@ -174,9 +175,49 @@ class CheckoutService
 	public function completePayment(Order $order, ResponseInterface $response): Order
 	{
 		$transaction_id = $response->getTransactionReference();
-		$order->markAsPaid($transaction_id);
+		$this->settle($order, $transaction_id);
 
 		return $order;
+	}
+
+	/**
+	 * Mark an order as paid, at most once.
+	 *
+	 * The browser return and an inbound payment notification can arrive at the
+	 * same moment, and both would otherwise observe PROCESSING and settle the
+	 * order — dispatching OrderCompleted (and thus fulfilling) twice. The row
+	 * is locked and re-read inside a transaction, so exactly one caller
+	 * performs the transition; the loser sees the fresh state and reports that
+	 * it changed nothing.
+	 *
+	 * @param Order  $order          The order to settle
+	 * @param string $transaction_id The reference to store on the order
+	 *
+	 * @return bool Whether THIS call completed the order
+	 */
+	private function settle(Order $order, string $transaction_id): bool
+	{
+		return DB::transaction(function () use ($order, $transaction_id): bool {
+			$fresh = Order::query()->whereKey($order->getKey())->lockForUpdate()->first();
+
+			if ($fresh === null) {
+				return false;
+			}
+
+			if (in_array($fresh->status, [PaymentStatusType::COMPLETED, PaymentStatusType::CLOSED], true)) {
+				// Someone else settled it first; adopt their state without
+				// claiming the transition.
+				$order->refresh();
+
+				return false;
+			}
+
+			// Saved through the caller's instance, while this transaction holds
+			// the row lock, so wasChanged('status') is true for the winner only.
+			$order->markAsPaid($transaction_id);
+
+			return true;
+		});
 	}
 
 	/**
@@ -253,7 +294,11 @@ class CheckoutService
 			$response = $gateway->fetchTransaction(['transactionReference' => $transaction_reference])->send();
 
 			if ($response->isSuccessful()) {
-				return $this->completePayment($order, $response);
+				// Same reasoning as in handlePaymentNotification(): the order's
+				// own transaction id has to stay the stable lookup key.
+				$this->settle($order, $order->transaction_id);
+
+				return $order;
 			}
 
 			if ($response instanceof PayzumFetchTransactionResponse && ($response->isExpired() || $response->isCancelled())) {
@@ -337,12 +382,18 @@ class CheckoutService
 			abort(400, 'Amount mismatch');
 		}
 
-		$transaction_reference = $notification->getTransactionReference();
-		if ($transaction_reference === null) {
+		if ($notification->getTransactionReference() === null) {
 			abort(400, 'Missing payment reference');
 		}
 
-		$order->markAsPaid($transaction_reference);
+		// Settled with the order's own transaction id rather than the gateway
+		// reference: that id is the lookup key of both the return and the
+		// notification URLs, and replacing it would make every later request
+		// for this order — including the buyer's browser return after an
+		// early notification — fail to resolve. The Payzum invoice stays
+		// reachable by it, since their API reads an invoice by payment id or
+		// by order id.
+		$this->settle($order, $order->transaction_id);
 
 		return $order;
 	}

--- a/app/Actions/Shop/CheckoutService.php
+++ b/app/Actions/Shop/CheckoutService.php
@@ -20,11 +20,16 @@ use App\Services\MoneyService;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Session;
 use Omnipay\Common\Exception\InvalidCreditCardException;
+use Omnipay\Common\Exception\InvalidRequestException;
 use Omnipay\Common\GatewayInterface;
+use Omnipay\Common\Message\NotificationInterface;
 use Omnipay\Common\Message\RedirectResponseInterface;
 use Omnipay\Common\Message\ResponseInterface;
 use Omnipay\Dummy\Message\Response as DummyResponse;
 use Omnipay\Mollie\Message\Response\FetchTransactionResponse;
+use Omnipay\Payzum\Gateway as PayzumGateway;
+use Omnipay\Payzum\Message\Response\FetchTransactionResponse as PayzumFetchTransactionResponse;
+use Omnipay\Payzum\Message\Response\PurchaseResponse as PayzumPurchaseResponse;
 
 /**
  * Service for handling checkout operations using Omnipay.
@@ -93,6 +98,12 @@ class CheckoutService
 					$reference = $response->getTransactionReference();
 					$metadata['transactionReference'] = $reference;
 					Session::put('metadata.' . $order->id, $metadata);
+				}
+
+				if ($response instanceof PayzumPurchaseResponse) {
+					// Keep the gateway payment id so the return handler can
+					// refresh the payment status while it confirms on-chain.
+					Session::put('metadata.' . $order->id, ['transactionReference' => $response->getTransactionReference()]);
 				}
 
 				if (!$response instanceof RedirectResponseInterface) {
@@ -183,6 +194,10 @@ class CheckoutService
 
 		$gateway = $this->omnipay_factory->create_gateway($provider);
 
+		if ($provider === OmnipayProviderType::PAYZUM && $gateway instanceof PayzumGateway) {
+			return $this->handleAsyncPaymentReturn($order, $gateway, $metadata);
+		}
+
 		try {
 			if ($order->status !== PaymentStatusType::PROCESSING) {
 				throw new LycheeLogicException('Order with invalid status.');
@@ -202,6 +217,171 @@ class CheckoutService
 		$order->save();
 
 		return $order;
+	}
+
+	/**
+	 * Handle the buyer's return for asynchronous providers (crypto settles
+	 * on-chain, usually after the redirect back).
+	 *
+	 * The order is only ever completed from a verified source: either the
+	 * signed payment notification (handlePaymentNotification) or the
+	 * status refresh below. A payment that is still confirming stays in
+	 * PROCESSING — it must never be marked FAILED just because the buyer
+	 * returned before the chain did.
+	 *
+	 * @param Order         $order    The order being processed
+	 * @param PayzumGateway $gateway  The initialized gateway
+	 * @param array         $metadata Session metadata stored at purchase time
+	 *
+	 * @return Order The refreshed order
+	 */
+	private function handleAsyncPaymentReturn(Order $order, PayzumGateway $gateway, array $metadata): Order
+	{
+		if ($order->status !== PaymentStatusType::PROCESSING) {
+			// Already settled, e.g. the notification landed before the redirect.
+			return $order;
+		}
+
+		$transaction_reference = $metadata['transactionReference'] ?? null;
+		if (!is_string($transaction_reference) || $transaction_reference === '') {
+			// Nothing to poll (e.g. session lost): the signed notification
+			// will complete the order server-side.
+			return $order;
+		}
+
+		try {
+			$response = $gateway->fetchTransaction(['transactionReference' => $transaction_reference])->send();
+
+			if ($response->isSuccessful()) {
+				return $this->completePayment($order, $response);
+			}
+
+			if ($response instanceof PayzumFetchTransactionResponse && ($response->isExpired() || $response->isCancelled())) {
+				$order->status = PaymentStatusType::FAILED;
+				$order->save();
+			}
+			// Still pending or confirming: leave the order in PROCESSING.
+		} catch (\Exception $e) {
+			Log::error('Error refreshing async payment status: ' . $e->getMessage(), [
+				'order_id' => $order->id,
+				'exception' => $e,
+			]);
+			// Leave the order in PROCESSING; the notification stays authoritative.
+		}
+
+		return $order;
+	}
+
+	/**
+	 * Complete an order from a signed Payzum payment notification.
+	 *
+	 * The Omnipay driver verifies the HMAC-SHA-512 signature over the raw
+	 * request bytes (with a replay window) before any payload field is
+	 * readable — a forged, stale, or malformed delivery aborts with 400
+	 * without touching the order. Deliveries are retried by the gateway,
+	 * so a redelivered notification for an already-completed order is a
+	 * no-op.
+	 *
+	 * @param Order $order The order the notification URL points at
+	 *
+	 * @return Order The updated order
+	 */
+	public function handlePaymentNotification(Order $order): Order
+	{
+		// The current request is passed explicitly: the driver verifies the
+		// notification signature against its raw body and headers.
+		$gateway = $this->omnipay_factory->create_notification_gateway(OmnipayProviderType::PAYZUM, request());
+		if (!$gateway instanceof PayzumGateway) {
+			throw new LycheeLogicException('Expected Payzum gateway.');
+		}
+
+		$notification = $gateway->acceptNotification();
+
+		try {
+			// Accessors verify the signature on first use.
+			$status = $notification->getTransactionStatus();
+		} catch (InvalidRequestException $e) {
+			Log::warning('Rejected Payzum notification: ' . $e->getMessage(), ['order_id' => $order->id]);
+			abort(400, 'Invalid notification');
+		}
+
+		if ($order->status === PaymentStatusType::COMPLETED || $order->status === PaymentStatusType::CLOSED) {
+			// Redelivered notification: acknowledge without a second fulfilment.
+			// Checked before the reference comparison below, because completing
+			// the order replaced its transaction id with the provider reference.
+			return $order;
+		}
+
+		if ($notification->getTransactionId() !== $order->transaction_id) {
+			Log::warning('Payzum notification order mismatch.', ['order_id' => $order->id]);
+			abort(400, 'Order mismatch');
+		}
+
+		if ($status === NotificationInterface::STATUS_FAILED) {
+			// The invoice expired or failed before full payment arrived.
+			$order->status = PaymentStatusType::FAILED;
+			$order->save();
+
+			return $order;
+		}
+
+		if ($status !== NotificationInterface::STATUS_COMPLETED) {
+			// Pending or confirming: acknowledge without touching the order.
+			return $order;
+		}
+
+		$payload = $notification->getData();
+
+		if (!$this->isNotifiedAmountExpected($payload, $order)) {
+			Log::warning('Payzum notification amount/currency mismatch.', ['order_id' => $order->id]);
+			abort(400, 'Amount mismatch');
+		}
+
+		$transaction_reference = $notification->getTransactionReference();
+		if ($transaction_reference === null) {
+			abort(400, 'Missing payment reference');
+		}
+
+		$order->markAsPaid($transaction_reference);
+
+		return $order;
+	}
+
+	/**
+	 * Whether a notification reports the exact amount and currency of the order.
+	 *
+	 * Compared as Money objects rather than floats, so the check is exact.
+	 *
+	 * @param array $payload The verified notification payload
+	 * @param Order $order   The order the notification is about
+	 *
+	 * @return bool
+	 */
+	private function isNotifiedAmountExpected(array $payload, Order $order): bool
+	{
+		$notified_amount = $payload['price_amount'] ?? null;
+		$notified_currency = $payload['price_currency'] ?? null;
+
+		if (!is_string($notified_amount) && !is_numeric($notified_amount)) {
+			return false;
+		}
+
+		if (!is_string($notified_currency)) {
+			return false;
+		}
+
+		$expected_currency = $order->amount_cents->getCurrency()->getCode();
+		if (strtoupper($notified_currency) !== strtoupper($expected_currency)) {
+			return false;
+		}
+
+		try {
+			$notified = $this->money_service->createFromDecimal((string) $notified_amount, $expected_currency);
+		} catch (\Exception) {
+			return false;
+		}
+
+		return $notified->equals($order->amount_cents);
 	}
 
 	/**
@@ -232,6 +412,12 @@ class CheckoutService
 			'transactionId' => $order->transaction_id,
 			'description' => 'Order #' . $order->id,
 		];
+
+		if ($this->gateway instanceof PayzumGateway) {
+			// Crypto settles asynchronously: the signed notification posted to
+			// this URL is what completes the order, not the browser return.
+			$params['notifyUrl'] = route('shop.checkout.notify', ['order_id' => $order->id]);
+		}
 
 		// Add customer details if available
 		if ($order->email !== null) {

--- a/app/Enum/OmnipayProviderType.php
+++ b/app/Enum/OmnipayProviderType.php
@@ -22,6 +22,7 @@ enum OmnipayProviderType: string
 	case DUMMY = 'Dummy';
 	case MOLLIE = 'Mollie';
 	case PAYPAL = 'PayPal';
+	case PAYZUM = 'Payzum';
 	case STRIPE = 'Stripe';
 
 	/**
@@ -48,6 +49,7 @@ enum OmnipayProviderType: string
 		return match ($this) {
 			OmnipayProviderType::DUMMY => ['apiKey'],
 			OmnipayProviderType::MOLLIE => ['apiKey', 'profileId'],
+			OmnipayProviderType::PAYZUM => ['apiKey', 'webhookSecret'],
 			OmnipayProviderType::STRIPE => ['apiKey', 'publishableKey', 'disabled'], // we set disabled to prevent it from showing up.
 			OmnipayProviderType::PAYPAL => ['clientId', 'secret'],
 		};

--- a/app/Factories/OmnipayFactory.php
+++ b/app/Factories/OmnipayFactory.php
@@ -14,6 +14,7 @@ use App\Exceptions\Internal\LycheeLogicException;
 use App\Exceptions\Shop\ProviderConfigurationNotFoundException;
 use Omnipay\Common\GatewayInterface;
 use Omnipay\Omnipay;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class OmnipayFactory
 {
@@ -36,6 +37,25 @@ class OmnipayFactory
 		$gateway = $this->initialize_gateway($gateway, $provider);
 
 		return $gateway;
+	}
+
+	/**
+	 * Create a payment gateway instance bound to a specific HTTP request.
+	 *
+	 * Used to verify incoming payment notifications: the driver reads the raw
+	 * body and headers of that request to check its signature, so it must be
+	 * the request being handled and not Omnipay's default built from globals.
+	 *
+	 * @param OmnipayProviderType $provider
+	 * @param HttpRequest         $http_request
+	 *
+	 * @return GatewayInterface
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	public function create_notification_gateway(OmnipayProviderType $provider, HttpRequest $http_request): GatewayInterface
+	{
+		return $this->initialize_gateway(Omnipay::create($provider->value, null, $http_request), $provider);
 	}
 
 	/**

--- a/app/Http/Controllers/Shop/CheckoutController.php
+++ b/app/Http/Controllers/Shop/CheckoutController.php
@@ -15,12 +15,14 @@ use App\Events\OrderCompleted;
 use App\Http\Requests\Checkout\CancelRequest;
 use App\Http\Requests\Checkout\CreateSessionRequest;
 use App\Http\Requests\Checkout\FinalizeRequest;
+use App\Http\Requests\Checkout\NotifyRequest;
 use App\Http\Requests\Checkout\OfflineRequest;
 use App\Http\Requests\Checkout\ProcessRequest;
 use App\Http\Resources\Shop\CheckoutOptionResource;
 use App\Http\Resources\Shop\CheckoutResource;
 use App\Http\Resources\Shop\OrderResource;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\URL;
 
@@ -157,7 +159,10 @@ class CheckoutController extends Controller
 		$message = 'Payment failed or was not completed.';
 
 		if ($success) {
-			OrderCompleted::dispatchIf($request->configs()->getValueAsBool('webshop_auto_fulfill_enabled'), $order->id);
+			// wasChanged: only fulfil when THIS request completed the order —
+			// asynchronous providers may have completed it from the payment
+			// notification already, which also dispatched the event.
+			OrderCompleted::dispatchIf($request->configs()->getValueAsBool('webshop_auto_fulfill_enabled') && $order->wasChanged('status'), $order->id);
 			$complete_url = URL::route('shop.checkout.complete');
 			$redirect_url = null;
 			$message = 'Payment completed successfully.';
@@ -173,11 +178,43 @@ class CheckoutController extends Controller
 			);
 		}
 
+		if (!$success && $order->status === PaymentStatusType::PROCESSING) {
+			// Asynchronous providers (crypto): the payment is still confirming
+			// on-chain and the signed notification will complete the order.
+			// The checkout page renders the real order status.
+			return redirect()->route('shop.checkout.complete');
+		}
+
 		if (!$success) {
 			return redirect()->route('shop.checkout.failed');
 		}
 
 		return redirect()->route('shop.checkout.complete');
+	}
+
+	/**
+	 * Handle a server-to-server payment notification (Payzum).
+	 *
+	 * The notification signature is verified by the gateway driver before
+	 * any field is read; see CheckoutService::handlePaymentNotification().
+	 *
+	 * @param NotifyRequest $request        The request carrying the signed notification
+	 * @param string        $transaction_id The order transaction id from the url
+	 *
+	 * @return Response Empty acknowledgement; the gateway stops retrying on 2xx
+	 */
+	public function notify(NotifyRequest $request, string $transaction_id): Response
+	{
+		/** @disregard P1013 */
+		$order = $this->checkout_service->handlePaymentNotification($request->basket());
+
+		// wasChanged: fulfil once. A redelivered notification for an order that
+		// is already completed must not dispatch the event a second time.
+		if ($order->status === PaymentStatusType::COMPLETED && $order->wasChanged('status')) {
+			OrderCompleted::dispatchIf($request->configs()->getValueAsBool('webshop_auto_fulfill_enabled'), $order->id);
+		}
+
+		return response()->noContent();
 	}
 
 	/**

--- a/app/Http/Requests/Checkout/FinalizeRequest.php
+++ b/app/Http/Requests/Checkout/FinalizeRequest.php
@@ -38,7 +38,13 @@ class FinalizeRequest extends BaseApiRequest implements HasBasket
 	 */
 	public function authorize(): bool
 	{
-		return $this->order?->status === PaymentStatusType::PROCESSING && $this->order?->provider === $this->provider_type && $this->provider_type !== null;
+		// Asynchronous providers can complete the order from the payment
+		// notification before the buyer's browser returns; that return is
+		// still legitimate and must be able to show the completed order.
+		$is_valid_status = $this->order?->status === PaymentStatusType::PROCESSING ||
+			($this->order?->status === PaymentStatusType::COMPLETED && $this->provider_type === OmnipayProviderType::PAYZUM);
+
+		return $is_valid_status && $this->order?->provider === $this->provider_type && $this->provider_type !== null;
 	}
 
 	/**

--- a/app/Http/Requests/Checkout/NotifyRequest.php
+++ b/app/Http/Requests/Checkout/NotifyRequest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Http\Requests\Checkout;
+
+use App\Contracts\Http\Requests\HasBasket;
+use App\Enum\OmnipayProviderType;
+use App\Enum\PaymentStatusType;
+use App\Http\Requests\BaseApiRequest;
+use App\Models\Order;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+/**
+ * Server-to-server payment notification for an order.
+ *
+ * The order is fetched from the url by its id — completing an order replaces
+ * its transaction id with the provider reference, and the gateway retries
+ * notifications to the URL it was given at purchase time. The notification
+ * body itself is verified cryptographically by the payment gateway driver in
+ * CheckoutService::handlePaymentNotification().
+ *
+ * @property string $order_id
+ *
+ * @method merge(array $values)
+ * @method route(string $key)
+ */
+class NotifyRequest extends BaseApiRequest implements HasBasket
+{
+	public const ORDER_ID_ATTRIBUTE = 'order_id';
+
+	protected Order $order;
+
+	/**
+	 * Determine if the sender is authorized to make this request.
+	 *
+	 * CANCELLED is allowed on purpose: a buyer can abandon the browser flow
+	 * and still pay from the hosted checkout page that is already open — the
+	 * money moved, so the notification must be able to complete the order.
+	 *
+	 * @return bool
+	 */
+	public function authorize(): bool
+	{
+		return $this->order?->provider === OmnipayProviderType::PAYZUM &&
+			in_array($this->order?->status, [
+				PaymentStatusType::PROCESSING,
+				PaymentStatusType::CANCELLED,
+				PaymentStatusType::COMPLETED,
+				PaymentStatusType::CLOSED,
+			], true);
+	}
+
+	/**
+	 * Get the validation rules that apply to the request.
+	 */
+	public function rules(): array
+	{
+		return [
+			self::ORDER_ID_ATTRIBUTE => ['required', 'string'],
+		];
+	}
+
+	protected function prepareForValidation(): void
+	{
+		/** @disregard */
+		$this->merge([
+			self::ORDER_ID_ATTRIBUTE => $this->route(self::ORDER_ID_ATTRIBUTE),
+		]);
+	}
+
+	protected function processValidatedValues(array $values, array $files): void
+	{
+		$order = Order::find($values[self::ORDER_ID_ATTRIBUTE]);
+		if ($order === null) {
+			throw new ModelNotFoundException('Order not found.');
+		}
+		$this->order = $order;
+	}
+
+	public function basket(): ?Order
+	{
+		return $this->order;
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
         "omnipay/dummy": "^3.0",
         "omnipay/mollie": "^5.5",
         "omnipay/stripe": "^3.2",
+        "payzum/omnipay-payzum": "^0.1.1",
         "opcodesio/log-viewer": "dev-lycheeOrg",
         "paypal/paypal-server-sdk": "2.4.0",
         "php-ffmpeg/php-ffmpeg": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e38b8c7b427ffdb9d729d6b75959a9cb",
+    "content-hash": "0008a62321fec85c47374ad9e0b87883",
     "packages": [
         {
             "name": "apimatic/core",
@@ -6223,6 +6223,121 @@
                 "source": "https://github.com/paypal/PayPal-PHP-Server-SDK/tree/2.4.0"
             },
             "time": "2026-08-21T15:05:45+00:00"
+        },
+        {
+            "name": "payzum/omnipay-payzum",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/payzum-dev/omnipay-payzum.git",
+                "reference": "19a259aa1a46513731f6d590202554c29e61da0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/payzum-dev/omnipay-payzum/zipball/19a259aa1a46513731f6d590202554c29e61da0a",
+                "reference": "19a259aa1a46513731f6d590202554c29e61da0a",
+                "shasum": ""
+            },
+            "require": {
+                "omnipay/common": "^3.2",
+                "payzum/payzum-php": "^0.1",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "omnipay/tests": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Omnipay\\Payzum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Payzum",
+                    "homepage": "https://payzum.com"
+                }
+            ],
+            "description": "Payzum driver for the Omnipay payment processing library — accept crypto and stablecoin payments (USDC/USDT, multi-chain, non-custodial).",
+            "homepage": "https://github.com/payzum-dev/omnipay-payzum",
+            "keywords": [
+                "USDC",
+                "USDT",
+                "bitcoin",
+                "crypto",
+                "ethereum",
+                "gateway",
+                "merchant",
+                "omnipay",
+                "pay",
+                "payment",
+                "payzum",
+                "stablecoin"
+            ],
+            "support": {
+                "docs": "https://merchant.payzum.com/docs",
+                "issues": "https://github.com/payzum-dev/omnipay-payzum/issues",
+                "source": "https://github.com/payzum-dev/omnipay-payzum"
+            },
+            "time": "2026-09-02T20:39:40+00:00"
+        },
+        {
+            "name": "payzum/payzum-php",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/payzum-dev/payzum-php.git",
+                "reference": "c646c948883da1aad21d43d4692791604bc09bbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/payzum-dev/payzum-php/zipball/c646c948883da1aad21d43d4692791604bc09bbc",
+                "reference": "c646c948883da1aad21d43d4692791604bc09bbc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Payzum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Payzum",
+                    "homepage": "https://payzum.com"
+                }
+            ],
+            "description": "Official PHP SDK for the Payzum crypto payment API — accept stablecoin and crypto payments, verify IPN webhooks.",
+            "homepage": "https://merchant.payzum.com",
+            "keywords": [
+                "USDC",
+                "USDT",
+                "bitcoin",
+                "crypto",
+                "ethereum",
+                "payment-gateway",
+                "payments",
+                "payzum",
+                "stablecoin"
+            ],
+            "support": {
+                "docs": "https://merchant.payzum.com/docs",
+                "issues": "https://github.com/payzum-dev/payzum-php/issues",
+                "source": "https://github.com/payzum-dev/payzum-php"
+            },
+            "time": "2026-08-30T21:24:12+00:00"
         },
         {
             "name": "php-ffmpeg/php-ffmpeg",

--- a/config/omnipay.php
+++ b/config/omnipay.php
@@ -43,4 +43,15 @@ return [
 		'clientId' => env('PAYPAL_CLIENT_ID', ''),
 		'secret' => env('PAYPAL_SECRET', ''),
 	],
+
+	/**
+	 * Payzum gateway configuration (crypto/stablecoin payments).
+	 * The webhookSecret verifies the signed payment notifications that
+	 * complete orders asynchronously.
+	 */
+	'Payzum' => [
+		'apiKey' => env('PAYZUM_API_KEY', ''),
+		'webhookSecret' => env('PAYZUM_WEBHOOK_SECRET', ''),
+		'testMode' => (bool) env('OMNIPAY_TEST_MODE', false),
+	],
 ];

--- a/lang/ar/webshop.php
+++ b/lang/ar/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'تم إلغاء الدفع.',
         'paymentFailed' => 'فشل الدفع',
         'paymentFailedMessage' => 'لم نتمكن من تأكيد دفعتك. يرجى المحاولة مرة أخرى أو التواصل مع الدعم إذا استمرت المشكلة.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/ar/webshop.php
+++ b/lang/ar/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'تم إلغاء الدفع.',
         'paymentFailed' => 'فشل الدفع',
         'paymentFailedMessage' => 'لم نتمكن من تأكيد دفعتك. يرجى المحاولة مرة أخرى أو التواصل مع الدعم إذا استمرت المشكلة.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/bg/webshop.php
+++ b/lang/bg/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Плащането е отменено.',
         'paymentFailed' => 'Плащането е неуспешно',
         'paymentFailedMessage' => 'Не успяхме да потвърдим вашето плащане. Моля, опитайте отново или се свържете с поддръжката, ако проблемът продължава.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/bg/webshop.php
+++ b/lang/bg/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Плащането е отменено.',
         'paymentFailed' => 'Плащането е неуспешно',
         'paymentFailedMessage' => 'Не успяхме да потвърдим вашето плащане. Моля, опитайте отново или се свържете с поддръжката, ако проблемът продължава.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/cz/webshop.php
+++ b/lang/cz/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/cz/webshop.php
+++ b/lang/cz/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/de/webshop.php
+++ b/lang/de/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Die Zahlung wurde abgebrochen.',
         'paymentFailed' => 'Zahlung fehlgeschlagen',
         'paymentFailedMessage' => 'Wir konnten Ihre Zahlung nicht bestätigen. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support, falls das Problem weiterhin besteht.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/de/webshop.php
+++ b/lang/de/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Die Zahlung wurde abgebrochen.',
         'paymentFailed' => 'Zahlung fehlgeschlagen',
         'paymentFailedMessage' => 'Wir konnten Ihre Zahlung nicht bestätigen. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support, falls das Problem weiterhin besteht.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/el/webshop.php
+++ b/lang/el/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/el/webshop.php
+++ b/lang/el/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/en/webshop.php
+++ b/lang/en/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/en/webshop.php
+++ b/lang/en/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/es/webshop.php
+++ b/lang/es/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/es/webshop.php
+++ b/lang/es/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/fa/webshop.php
+++ b/lang/fa/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'پرداخت لغو شده است.',
         'paymentFailed' => 'پرداخت ناموفق بود',
         'paymentFailedMessage' => 'ما نتوانستیم پرداخت شما را تأیید کنیم. لطفاً دوباره تلاش کنید یا در صورت تداوم مشکل با پشتیبانی تماس بگیرید.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/fa/webshop.php
+++ b/lang/fa/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'پرداخت لغو شده است.',
         'paymentFailed' => 'پرداخت ناموفق بود',
         'paymentFailedMessage' => 'ما نتوانستیم پرداخت شما را تأیید کنیم. لطفاً دوباره تلاش کنید یا در صورت تداوم مشکل با پشتیبانی تماس بگیرید.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/fr/webshop.php
+++ b/lang/fr/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Le paiement a été annulé.',
         'paymentFailed' => 'Échec du paiement',
         'paymentFailedMessage' => 'Nous n’avons pas pu confirmer votre paiement. Veuillez réessayer ou contacter le support si le problème persiste.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/fr/webshop.php
+++ b/lang/fr/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Le paiement a été annulé.',
         'paymentFailed' => 'Échec du paiement',
         'paymentFailedMessage' => 'Nous n’avons pas pu confirmer votre paiement. Veuillez réessayer ou contacter le support si le problème persiste.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/hu/webshop.php
+++ b/lang/hu/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/hu/webshop.php
+++ b/lang/hu/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/it/webshop.php
+++ b/lang/it/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/it/webshop.php
+++ b/lang/it/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/ja/webshop.php
+++ b/lang/ja/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/ja/webshop.php
+++ b/lang/ja/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/nl/webshop.php
+++ b/lang/nl/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'De betaling is geannuleerd.',
         'paymentFailed' => 'Betaling mislukt',
         'paymentFailedMessage' => 'We konden uw betaling niet bevestigen. Probeer het opnieuw of neem contact op met de ondersteuning als het probleem aanhoudt.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/nl/webshop.php
+++ b/lang/nl/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'De betaling is geannuleerd.',
         'paymentFailed' => 'Betaling mislukt',
         'paymentFailedMessage' => 'We konden uw betaling niet bevestigen. Probeer het opnieuw of neem contact op met de ondersteuning als het probleem aanhoudt.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/no/webshop.php
+++ b/lang/no/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Betalingen er kansellert.',
         'paymentFailed' => 'Betaling mislyktes',
         'paymentFailedMessage' => 'Vi kunne ikke bekrefte betalingen din. Vennligst prøv igjen eller kontakt support hvis problemet vedvarer.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/no/webshop.php
+++ b/lang/no/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Betalingen er kansellert.',
         'paymentFailed' => 'Betaling mislyktes',
         'paymentFailedMessage' => 'Vi kunne ikke bekrefte betalingen din. Vennligst prøv igjen eller kontakt support hvis problemet vedvarer.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/pl/webshop.php
+++ b/lang/pl/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/pl/webshop.php
+++ b/lang/pl/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/pt/webshop.php
+++ b/lang/pt/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/pt/webshop.php
+++ b/lang/pt/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/ru/webshop.php
+++ b/lang/ru/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/ru/webshop.php
+++ b/lang/ru/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/sk/webshop.php
+++ b/lang/sk/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/sk/webshop.php
+++ b/lang/sk/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/sv/webshop.php
+++ b/lang/sv/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/sv/webshop.php
+++ b/lang/sv/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/tr/webshop.php
+++ b/lang/tr/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/tr/webshop.php
+++ b/lang/tr/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/vi/webshop.php
+++ b/lang/vi/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/vi/webshop.php
+++ b/lang/vi/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/zh_CN/webshop.php
+++ b/lang/zh_CN/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/zh_CN/webshop.php
+++ b/lang/zh_CN/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/zh_TW/webshop.php
+++ b/lang/zh_TW/webshop.php
@@ -285,5 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
+        'paymentProcessing' => 'Payment being confirmed',
+        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/lang/zh_TW/webshop.php
+++ b/lang/zh_TW/webshop.php
@@ -285,7 +285,7 @@ return [
         'paymentCancelledMessage' => 'Payment has been cancelled.',
         'paymentFailed' => 'Payment failed',
         'paymentFailedMessage' => 'We were not able to confirm your payment. Please try again or contact support if the problem persists.',
-        'paymentProcessing' => 'Payment being confirmed',
-        'paymentProcessingMessage' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
+        'payment_processing' => 'Payment being confirmed',
+        'payment_processing_message' => 'Your payment is being confirmed by the payment provider. The order will complete automatically once the payment is confirmed — you can safely close this page.',
     ],
 ];

--- a/resources/js/v7/components/webshop/CancelledFailed.vue
+++ b/resources/js/v7/components/webshop/CancelledFailed.vue
@@ -25,10 +25,10 @@
 		v-else-if="order?.status === 'processing'"
 		class="border-2 border-dashed border-surface-200 dark:border-surface-700 rounded bg-surface-50 dark:bg-surface-950 flex-col gap-4 p-4 flex justify-center items-center font-medium"
 	>
-		<h2 class="font-bold text-xl">{{ $t("webshop.cancelledFailed.paymentProcessing") }}</h2>
+		<h2 class="font-bold text-xl">{{ $t("webshop.cancelledFailed.payment_processing") }}</h2>
 		<div class="text-muted-color">
 			<p>
-				{{ $t("webshop.cancelledFailed.paymentProcessingMessage") }}
+				{{ $t("webshop.cancelledFailed.payment_processing_message") }}
 			</p>
 		</div>
 	</div>

--- a/resources/js/v7/components/webshop/CancelledFailed.vue
+++ b/resources/js/v7/components/webshop/CancelledFailed.vue
@@ -21,6 +21,17 @@
 			</p>
 		</div>
 	</div>
+	<div
+		v-else-if="order?.status === 'processing'"
+		class="border-2 border-dashed border-surface-200 dark:border-surface-700 rounded bg-surface-50 dark:bg-surface-950 flex-col gap-4 p-4 flex justify-center items-center font-medium"
+	>
+		<h2 class="font-bold text-xl">{{ $t("webshop.cancelledFailed.paymentProcessing") }}</h2>
+		<div class="text-muted-color">
+			<p>
+				{{ $t("webshop.cancelledFailed.paymentProcessingMessage") }}
+			</p>
+		</div>
+	</div>
 </template>
 <script setup lang="ts">
 import { useOrderManagementStore } from "@/stores/OrderManagement";

--- a/resources/js/v8/components/webshop/CancelledFailed.vue
+++ b/resources/js/v8/components/webshop/CancelledFailed.vue
@@ -25,10 +25,10 @@
 		v-else-if="order?.status === 'processing'"
 		class="border-2 border-dashed border-default rounded bg-elevated/50 flex-col gap-4 p-4 flex justify-center items-center font-medium"
 	>
-		<h2 class="font-bold text-xl">{{ $t("webshop.cancelledFailed.paymentProcessing") }}</h2>
+		<h2 class="font-bold text-xl">{{ $t("webshop.cancelledFailed.payment_processing") }}</h2>
 		<div class="text-muted">
 			<p>
-				{{ $t("webshop.cancelledFailed.paymentProcessingMessage") }}
+				{{ $t("webshop.cancelledFailed.payment_processing_message") }}
 			</p>
 		</div>
 	</div>

--- a/resources/js/v8/components/webshop/CancelledFailed.vue
+++ b/resources/js/v8/components/webshop/CancelledFailed.vue
@@ -21,6 +21,17 @@
 			</p>
 		</div>
 	</div>
+	<div
+		v-else-if="order?.status === 'processing'"
+		class="border-2 border-dashed border-default rounded bg-elevated/50 flex-col gap-4 p-4 flex justify-center items-center font-medium"
+	>
+		<h2 class="font-bold text-xl">{{ $t("webshop.cancelledFailed.paymentProcessing") }}</h2>
+		<div class="text-muted">
+			<p>
+				{{ $t("webshop.cancelledFailed.paymentProcessingMessage") }}
+			</p>
+		</div>
+	</div>
 </template>
 <script setup lang="ts">
 import { useOrderManagementStore } from "@/stores/OrderManagement";

--- a/routes/api_v2_shop.php
+++ b/routes/api_v2_shop.php
@@ -39,6 +39,10 @@ Route::middleware('support:pro')->group(function (): void {
 		Route::post('/Create-session', [Shop\CheckoutController::class, 'createSession']);
 		Route::post('/Process', [Shop\CheckoutController::class, 'process']);
 		Route::get('/Finalize/{provider}/{transaction_id}', [Shop\CheckoutController::class, 'finalize'])->withoutMiddleware(['content_type:json', 'accept_content_type:json'])->name('shop.checkout.return');
+		// Keyed by order id, not transaction id: completing an order replaces
+		// its transaction id with the provider reference, and the gateway
+		// retries notifications to the original URL.
+		Route::post('/Notify/Payzum/{order_id}', [Shop\CheckoutController::class, 'notify'])->withoutMiddleware(['accept_content_type:json'])->name('shop.checkout.notify');
 		Route::get('/Cancel/{transaction_id}', [Shop\CheckoutController::class, 'cancel'])->withoutMiddleware(['content_type:json', 'accept_content_type:json'])->name('shop.checkout.cancel');
 	});
 	Route::group(['prefix' => '/Shop/Management'], function (): void {

--- a/tests/Webshop/Checkout/CheckoutNotifyControllerTest.php
+++ b/tests/Webshop/Checkout/CheckoutNotifyControllerTest.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+/**
+ * We don't care for unhandled exceptions in tests.
+ * It is the nature of a test to throw an exception.
+ * Without this suppression we had 100+ Linter warning in this file which
+ * don't help anything.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace Tests\Webshop\Checkout;
+
+use App\Enum\OmnipayProviderType;
+use App\Enum\PaymentStatusType;
+use App\Services\MoneyService;
+use Illuminate\Testing\TestResponse;
+
+/**
+ * Test class for the Payzum payment notification endpoint.
+ *
+ * The notification (IPN) is a server-to-server POST signed with
+ * HMAC-SHA-512 over the raw request body. It is the only place where an
+ * asynchronous (crypto) payment completes an order — these tests cover the
+ * happy path, forged signatures, status handling, amount verification and
+ * redelivery idempotency.
+ */
+class CheckoutNotifyControllerTest extends BaseCheckoutControllerTest
+{
+	public const WEBHOOK_SECRET = 'test-webhook-secret';
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		config(['omnipay.Payzum' => [
+			'apiKey' => 'test-api-key',
+			'webhookSecret' => self::WEBHOOK_SECRET,
+			'testMode' => true,
+		]]);
+
+		$this->test_order->status = PaymentStatusType::PROCESSING;
+		$this->test_order->provider = OmnipayProviderType::PAYZUM;
+		$this->test_order->save();
+	}
+
+	/**
+	 * Build a notification payload matching the test order.
+	 *
+	 * @param array $overrides Keys to override in the payload
+	 *
+	 * @return array
+	 */
+	protected function payload(array $overrides = []): array
+	{
+		$money_service = app(MoneyService::class);
+
+		return array_merge([
+			'payment_id' => 'pzi_test_0001',
+			'order_id' => $this->test_order->transaction_id,
+			'payment_status' => 'finished',
+			'price_amount' => $money_service->toDecimal($this->test_order->amount_cents),
+			'price_currency' => strtolower($this->test_order->amount_cents->getCurrency()->getCode()),
+			'event_at' => time(),
+		], $overrides);
+	}
+
+	/**
+	 * POST a notification to the notify endpoint.
+	 *
+	 * @param array       $payload   The notification payload
+	 * @param string|null $signature Signature override (null = valid signature)
+	 *
+	 * @return TestResponse
+	 */
+	protected function postNotification(array $payload, ?string $signature = null): TestResponse
+	{
+		$body = json_encode($payload);
+		$signature ??= hash_hmac('sha512', $body, self::WEBHOOK_SECRET);
+
+		return $this->call(
+			'POST',
+			'/api/v2/Shop/Checkout/Notify/Payzum/' . $this->test_order->id,
+			[],
+			[],
+			[],
+			[
+				'HTTP_X_NOWPAYMENTS_SIG' => $signature,
+				'HTTP_X_PAYZUM_EVENT_ID' => 'evt_test_0001',
+				'CONTENT_TYPE' => 'application/json',
+			],
+			$body
+		);
+	}
+
+	public function testNotifyCompletesOrder(): void
+	{
+		$response = $this->postNotification($this->payload());
+		$response->assertStatus(204);
+
+		$this->assertDatabaseHas('orders', [
+			'id' => $this->test_order->id,
+			'status' => PaymentStatusType::COMPLETED->value,
+			'transaction_id' => 'pzi_test_0001',
+		]);
+	}
+
+	public function testNotifyRejectsForgedSignature(): void
+	{
+		$response = $this->postNotification($this->payload(), hash_hmac('sha512', 'forged-body', 'wrong-secret'));
+		$response->assertStatus(400);
+
+		$this->assertDatabaseHas('orders', [
+			'id' => $this->test_order->id,
+			'status' => PaymentStatusType::PROCESSING->value,
+		]);
+	}
+
+	public function testNotifyIgnoresPendingStatus(): void
+	{
+		$response = $this->postNotification($this->payload(['payment_status' => 'waiting']));
+		$response->assertStatus(204);
+
+		$this->assertDatabaseHas('orders', [
+			'id' => $this->test_order->id,
+			'status' => PaymentStatusType::PROCESSING->value,
+		]);
+	}
+
+	public function testNotifyMarksExpiredAsFailed(): void
+	{
+		$response = $this->postNotification($this->payload(['payment_status' => 'expired']));
+		$response->assertStatus(204);
+
+		$this->assertDatabaseHas('orders', [
+			'id' => $this->test_order->id,
+			'status' => PaymentStatusType::FAILED->value,
+		]);
+	}
+
+	public function testNotifyRejectsAmountMismatch(): void
+	{
+		$response = $this->postNotification($this->payload(['price_amount' => '0.01']));
+		$response->assertStatus(400);
+
+		$this->assertDatabaseHas('orders', [
+			'id' => $this->test_order->id,
+			'status' => PaymentStatusType::PROCESSING->value,
+		]);
+	}
+
+	public function testNotifyIsIdempotentOnRedelivery(): void
+	{
+		$this->postNotification($this->payload())->assertStatus(204);
+		$this->postNotification($this->payload())->assertStatus(204);
+
+		$this->assertDatabaseHas('orders', [
+			'id' => $this->test_order->id,
+			'status' => PaymentStatusType::COMPLETED->value,
+			'transaction_id' => 'pzi_test_0001',
+		]);
+	}
+
+	public function testNotifyRejectsUnknownOrder(): void
+	{
+		$body = json_encode($this->payload());
+		$signature = hash_hmac('sha512', $body, self::WEBHOOK_SECRET);
+
+		$response = $this->call(
+			'POST',
+			'/api/v2/Shop/Checkout/Notify/Payzum/unknown-order-id',
+			[],
+			[],
+			[],
+			[
+				'HTTP_X_NOWPAYMENTS_SIG' => $signature,
+				'CONTENT_TYPE' => 'application/json',
+			],
+			$body
+		);
+		$response->assertStatus(404);
+	}
+
+	public function testFinalizeKeepsProcessingOrderPending(): void
+	{
+		// No session metadata: the return handler has nothing to poll and
+		// must leave the order in PROCESSING (the notification completes it),
+		// redirecting the buyer to the status page — never to "failed".
+		$response = $this->get('/api/v2/Shop/Checkout/Finalize/Payzum/' . $this->test_order->transaction_id);
+
+		$this->assertRedirect($response);
+		$response->assertRedirect(route('shop.checkout.complete'));
+
+		$this->assertDatabaseHas('orders', [
+			'id' => $this->test_order->id,
+			'status' => PaymentStatusType::PROCESSING->value,
+		]);
+	}
+}

--- a/tests/Webshop/Checkout/CheckoutNotifyControllerTest.php
+++ b/tests/Webshop/Checkout/CheckoutNotifyControllerTest.php
@@ -20,7 +20,10 @@ namespace Tests\Webshop\Checkout;
 
 use App\Enum\OmnipayProviderType;
 use App\Enum\PaymentStatusType;
+use App\Events\OrderCompleted;
+use App\Models\Configs;
 use App\Services\MoneyService;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Testing\TestResponse;
 
 /**
@@ -105,10 +108,13 @@ class CheckoutNotifyControllerTest extends BaseCheckoutControllerTest
 		$response = $this->postNotification($this->payload());
 		$response->assertStatus(204);
 
+		// The transaction id is deliberately left untouched: it is the lookup
+		// key of the return and notification URLs for the rest of the order's
+		// life. The Payzum invoice stays reachable by it.
 		$this->assertDatabaseHas('orders', [
 			'id' => $this->test_order->id,
 			'status' => PaymentStatusType::COMPLETED->value,
-			'transaction_id' => 'pzi_test_0001',
+			'transaction_id' => $this->test_order->transaction_id,
 		]);
 	}
 
@@ -161,10 +167,13 @@ class CheckoutNotifyControllerTest extends BaseCheckoutControllerTest
 		$this->postNotification($this->payload())->assertStatus(204);
 		$this->postNotification($this->payload())->assertStatus(204);
 
+		// The transaction id is deliberately left untouched: it is the lookup
+		// key of the return and notification URLs for the rest of the order's
+		// life. The Payzum invoice stays reachable by it.
 		$this->assertDatabaseHas('orders', [
 			'id' => $this->test_order->id,
 			'status' => PaymentStatusType::COMPLETED->value,
-			'transaction_id' => 'pzi_test_0001',
+			'transaction_id' => $this->test_order->transaction_id,
 		]);
 	}
 
@@ -186,6 +195,48 @@ class CheckoutNotifyControllerTest extends BaseCheckoutControllerTest
 			$body
 		);
 		$response->assertStatus(404);
+	}
+
+	public function testItFulfilsExactlyOnceAcrossRedeliveries(): void
+	{
+		Configs::set('webshop_auto_fulfill_enabled', '1');
+		Event::fake([OrderCompleted::class]);
+
+		$this->postNotification($this->payload())->assertStatus(204);
+		$this->postNotification($this->payload())->assertStatus(204);
+
+		Event::assertDispatchedTimes(OrderCompleted::class, 1);
+	}
+
+	public function testTheBrowserReturnStillResolvesAfterAnEarlyNotification(): void
+	{
+		// The notification usually wins the race with the buyer's browser.
+		// Completing the order must not invalidate the transaction id its
+		// return URL was built with, or the buyer lands on a "not found".
+		$this->postNotification($this->payload())->assertStatus(204);
+
+		$response = $this->get('/api/v2/Shop/Checkout/Finalize/Payzum/' . $this->test_order->transaction_id);
+
+		$this->assertRedirect($response);
+		$response->assertRedirect(route('shop.checkout.complete'));
+
+		$this->assertDatabaseHas('orders', [
+			'id' => $this->test_order->id,
+			'status' => PaymentStatusType::COMPLETED->value,
+		]);
+	}
+
+	public function testTheBrowserReturnDoesNotFulfilAgainAfterAnEarlyNotification(): void
+	{
+		Configs::set('webshop_auto_fulfill_enabled', '1');
+
+		$this->postNotification($this->payload())->assertStatus(204);
+
+		Event::fake([OrderCompleted::class]);
+
+		$this->get('/api/v2/Shop/Checkout/Finalize/Payzum/' . $this->test_order->transaction_id);
+
+		Event::assertNotDispatched(OrderCompleted::class);
 	}
 
 	public function testFinalizeKeepsProcessingOrderPending(): void


### PR DESCRIPTION
Implements the plan agreed in #4712 (option 1, the inbound notification endpoint @ildyria preferred). Adds **Payzum**, a non-custodial crypto/stablecoin gateway (USDC, USDT and more, multi-chain — funds settle directly to the photographer's own wallet), as an Omnipay provider.

Since crypto confirmation is asynchronous, the interesting part is settlement — following the pattern discussed in the issue:

- **New notification endpoint** `POST /api/v2/Shop/Checkout/Notify/Payzum/{order_id}` (`shop.checkout.notify`; keyed by order id, because completing an order replaces its transaction id with the provider reference and the gateway retries to the original URL): the [Omnipay driver](https://github.com/payzum-dev/omnipay-payzum) verifies the HMAC-SHA-512 signature over the raw request bytes (with a replay window) before any payload field is readable. After signature, order, amount and currency checks, the order is completed idempotently — a redelivered notification can never fulfil twice. `OrderCompleted` is dispatched here (guarded by `wasChanged('status')`) because the buyer may never come back to the browser.
- **`handlePaymentReturn` no longer fails confirming payments**: for Payzum the return handler polls the invoice once (`fetchTransaction`) and either completes, fails (expired/cancelled), or **leaves the order in PROCESSING** — never FAILED just because the buyer returned before the chain confirmed. `finalize` then redirects to the checkout status page, where a new `processing` state in `CancelledFailed.vue` (v7+v8, i18n key added to all locales with the English fallback) tells the buyer the payment is being confirmed and the page can be closed safely.
- **Config/enum**: `PAYZUM` case in `OmnipayProviderType` (requires `apiKey` + `webhookSecret`), `config/omnipay.php` block, `.env.example` entries. `composer.json`/lock gain [`payzum/omnipay-payzum`](https://packagist.org/packages/payzum/omnipay-payzum) (MIT) and its only dependency, the official `payzum/payzum-php` SDK (zero runtime deps); nothing else in the lock changes.
- `FinalizeRequest` additionally authorizes `COMPLETED` Payzum orders, because the notification can legitimately complete the order before the buyer's browser returns.

Tests: `CheckoutNotifyControllerTest` covers the happy path, forged signatures, pending statuses, expiry, amount mismatches, redelivery idempotency, unknown orders, and the finalize-keeps-processing behaviour. The whole `tests/Webshop` suite passes (295 tests), as do `phpstan` and `php-cs-fixer`.

Disclosure: I work on Payzum and will maintain the integration long-term.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Payzum as a payment provider.
  - Added asynchronous payment confirmation through secure payment notifications.
  - Orders can remain pending while payment confirmation is in progress and complete automatically afterward.
  - Added localized payment-processing status messages across supported storefront languages.

- **Bug Fixes**
  - Prevented duplicate order completion during asynchronous payment updates.
  - Added validation for payment signatures, order details, amounts, and currencies.
  - Improved browser-return handling for payments completed or still being confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->