### PR TITLE
Trivy ignore CVE-2026-84445

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -27,3 +27,4 @@ CVE-2026-56854
 # There is no fix yet compiled in a new Frankenphp docker image.
 # It would be nice if Douglas was a bit more reactive on those.
 CVE-2026-84304
+CVE-2026-84445


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability scanning exclusions to ignore `CVE-2026-84445`.
  * Retained the existing exclusion for `CVE-2026-84304`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->