### PR TITLE
Add Struct As Array to smart albums.

### DIFF
--- a/app/Actions/Photo/StructOfArrays/QueryPhotoBuckets.php
+++ b/app/Actions/Photo/StructOfArrays/QueryPhotoBuckets.php
@@ -95,6 +95,18 @@ class QueryPhotoBuckets
 	 * (bounded by this album's own photo count, exactly the scale the
 	 * un-grouped `Album` case already visits for {@see QueryPhotoRatios}).
 	 *
+	 * Grouped by run-length counting over the already-ordered rows, never
+	 * by keying a PHP array on the `bucket_id` string itself: PHP silently
+	 * casts a canonical-integer-looking string key (e.g. `"2026"`, a
+	 * YEAR-granularity date bucket, or `"1"`/`"0"` for `IS_HIGHLIGHTED`) to
+	 * an actual `int` array key, which would corrupt the `string[]`
+	 * `bucket_ids` contract on the way out to JSON. This is safe because
+	 * rows sharing the same live-computed bucket are always contiguous in
+	 * this SQL-ordered result - `bucket_id` is a deterministic,
+	 * order-preserving function of the exact column being sorted on for
+	 * every supported sort column (date truncation, rounding, or a direct
+	 * column value).
+	 *
 	 * @return array{0:string[],1:int[]}
 	 */
 	private function queryLiveBuckets(AbstractAlbum $album, ?User $user, ColumnSortingType $column, OrderSortingType $order): array
@@ -106,21 +118,34 @@ class QueryPhotoBuckets
 
 		$granularity = $this->bucket_computer->resolveGranularity($this->resolvePhotoTimeline($album));
 
-		$counts_by_bucket = [];
+		$bucket_ids = [];
+		$counts = [];
+		$unknown_count = null;
 		foreach ($rows as $row) {
-			$bucket_id = $this->liveBucketId($column, $granularity, $row) ?? 'unknown';
-			$counts_by_bucket[$bucket_id] = ($counts_by_bucket[$bucket_id] ?? 0) + 1;
+			$bucket_id = $this->liveBucketId($column, $granularity, $row);
+			if ($bucket_id === null) {
+				// Accumulated separately and always appended last (below),
+				// regardless of $order - "unknown" rows need not even be
+				// contiguous with each other in the sorted result.
+				$unknown_count = ($unknown_count ?? 0) + 1;
+				continue;
+			}
+
+			$last_index = count($bucket_ids) - 1;
+			if ($last_index >= 0 && $bucket_ids[$last_index] === $bucket_id) {
+				$counts[$last_index]++;
+			} else {
+				$bucket_ids[] = $bucket_id;
+				$counts[] = 1;
+			}
 		}
 
-		// NULL ("unknown") always sorts last, regardless of $order - move it
-		// to the end regardless of when it was first encountered above.
-		if (array_key_exists('unknown', $counts_by_bucket)) {
-			$unknown_count = $counts_by_bucket['unknown'];
-			unset($counts_by_bucket['unknown']);
-			$counts_by_bucket['unknown'] = $unknown_count;
+		if ($unknown_count !== null) {
+			$bucket_ids[] = 'unknown';
+			$counts[] = $unknown_count;
 		}
 
-		return [array_keys($counts_by_bucket), array_values($counts_by_bucket)];
+		return [$bucket_ids, $counts];
 	}
 
 	/**

--- a/app/Actions/Photo/StructOfArrays/QueryPhotoBuckets.php
+++ b/app/Actions/Photo/StructOfArrays/QueryPhotoBuckets.php
@@ -8,15 +8,14 @@
 
 namespace App\Actions\Photo\StructOfArrays;
 
-use App\Constants\PhotoAlbum as PA;
+use App\Contracts\Models\AbstractAlbum;
 use App\Enum\ColumnSortingType;
 use App\Enum\OrderSortingType;
 use App\Enum\TimelinePhotoGranularity;
 use App\Enum\TitleBucketMode;
 use App\Http\Resources\V3\PhotoBucketResource;
 use App\Models\Album;
-use App\Models\Extensions\FiltersUploadValidation;
-use App\Models\Photo;
+use App\Models\Extensions\SortingDecorator;
 use App\Models\User;
 use App\Services\PhotoBucketComputer;
 use function Safe\mktime;
@@ -28,16 +27,21 @@ use function Safe\mktime;
  */
 class QueryPhotoBuckets
 {
-	use FiltersUploadValidation;
+	use ResolvesPhotoSource;
+
+	private const LIVE_BUCKET_COLUMNS = [
+		'photos.title', 'photos.title_base', 'photos.created_at', 'photos.taken_at',
+		'photos.is_highlighted', 'photos.type', 'photos.rating_avg',
+	];
 
 	public function __construct(
 		private readonly PhotoBucketComputer $bucket_computer,
 	) {
 	}
 
-	public function do(Album $album, ?User $user): PhotoBucketResource
+	public function do(AbstractAlbum $album, ?User $user): PhotoBucketResource
 	{
-		$sorting = $album->getEffectivePhotoSorting();
+		$sorting = $this->resolveEffectiveSorting($album);
 
 		// OWNER_ID is excluded from photo bucketing entirely, per explicit
 		// user direction - short-circuit without ever running a GROUP BY.
@@ -45,17 +49,24 @@ class QueryPhotoBuckets
 			return new PhotoBucketResource(bucket_ids: [], counts: [], labels: [], bucketable: false);
 		}
 
-		$query = Photo::query()
-			->join(PA::PHOTO_ALBUM, PA::PHOTO_ID, '=', 'photos.id')
-			->where(PA::ALBUM_ID, '=', $album->id);
-
-		// Non-admins must not see unvalidated photos uploaded by other
-		// users - including in bucket counts.
-		if ($user?->may_administrate !== true) {
-			$this->applyUploadValidationFilter($query, $user?->id);
+		if ($album instanceof Album) {
+			[$bucket_ids, $counts] = $this->queryStoredBuckets($album, $user, $sorting->order);
+		} else {
+			[$bucket_ids, $counts] = $this->queryLiveBuckets($album, $user, $sorting->column, $sorting->order);
 		}
 
-		$direction = $sorting->order === OrderSortingType::DESC ? 'desc' : 'asc';
+		$labels = $this->computeLabels($bucket_ids, $sorting->column, $this->resolvePhotoTimeline($album));
+
+		return new PhotoBucketResource(bucket_ids: $bucket_ids, counts: $counts, labels: $labels, bucketable: true);
+	}
+
+	/**
+	 * @return array{0:string[],1:int[]}
+	 */
+	private function queryStoredBuckets(Album $album, ?User $user, OrderSortingType $order): array
+	{
+		$query = $this->resolvePhotoQuery($album, $user);
+		$direction = $order === OrderSortingType::DESC ? 'desc' : 'asc';
 
 		$rows = $query
 			->select(['photo_album.bucket_id'])
@@ -74,9 +85,42 @@ class QueryPhotoBuckets
 			$counts[] = (int) $row->bucket_count;
 		}
 
-		$labels = $this->computeLabels($bucket_ids, $sorting->column, $album->photo_timeline);
+		return [$bucket_ids, $counts];
+	}
 
-		return new PhotoBucketResource(bucket_ids: $bucket_ids, counts: $counts, labels: $labels, bucketable: true);
+	/**
+	 * `TagAlbum`/`PersonAlbum`/`BaseSmartAlbum` have no stored `bucket_id`
+	 * to `GROUP BY` (see {@see ResolvesPhotoSource}) - every candidate row's
+	 * bucket is computed live instead, then grouped in PHP after the query
+	 * (bounded by this album's own photo count, exactly the scale the
+	 * un-grouped `Album` case already visits for {@see QueryPhotoRatios}).
+	 *
+	 * @return array{0:string[],1:int[]}
+	 */
+	private function queryLiveBuckets(AbstractAlbum $album, ?User $user, ColumnSortingType $column, OrderSortingType $order): array
+	{
+		$query = $this->resolvePhotoQuery($album, $user);
+		(new SortingDecorator($query))->orderPhotosBy($column, $order)->applyOrdering();
+
+		$rows = $query->select(self::LIVE_BUCKET_COLUMNS)->toBase()->get();
+
+		$granularity = $this->bucket_computer->resolveGranularity($this->resolvePhotoTimeline($album));
+
+		$counts_by_bucket = [];
+		foreach ($rows as $row) {
+			$bucket_id = $this->liveBucketId($column, $granularity, $row) ?? 'unknown';
+			$counts_by_bucket[$bucket_id] = ($counts_by_bucket[$bucket_id] ?? 0) + 1;
+		}
+
+		// NULL ("unknown") always sorts last, regardless of $order - move it
+		// to the end regardless of when it was first encountered above.
+		if (array_key_exists('unknown', $counts_by_bucket)) {
+			$unknown_count = $counts_by_bucket['unknown'];
+			unset($counts_by_bucket['unknown']);
+			$counts_by_bucket['unknown'] = $unknown_count;
+		}
+
+		return [array_keys($counts_by_bucket), array_values($counts_by_bucket)];
 	}
 
 	/**

--- a/app/Actions/Photo/StructOfArrays/QueryPhotoDetails.php
+++ b/app/Actions/Photo/StructOfArrays/QueryPhotoDetails.php
@@ -8,18 +8,18 @@
 
 namespace App\Actions\Photo\StructOfArrays;
 
-use App\Constants\PhotoAlbum as PA;
+use App\Contracts\Models\AbstractAlbum;
 use App\Enum\MetricsAccess;
 use App\Http\Resources\Models\ColourPaletteResource;
 use App\Http\Resources\Models\PhotoStatisticsResource;
 use App\Http\Resources\Models\SizeVariantsResouce;
 use App\Http\Resources\V3\PhotoDetailResource;
 use App\Models\Album;
-use App\Models\Extensions\FiltersUploadValidation;
 use App\Models\Photo;
 use App\Models\User;
 use App\Policies\PhotoPolicy;
 use App\Repositories\ConfigManager;
+use App\Services\PhotoBucketComputer;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Gate;
 use Spatie\LaravelData\Optional;
@@ -42,36 +42,36 @@ use Spatie\LaravelData\Optional;
  */
 class QueryPhotoDetails
 {
-	use FiltersUploadValidation;
+	use ResolvesPhotoSource;
 
 	public function __construct(
 		private readonly ConfigManager $config_manager,
+		private readonly PhotoBucketComputer $bucket_computer,
 	) {
 	}
 
 	/**
 	 * @param string[]|null $photo_ids
 	 */
-	public function do(Album $album, ?User $user, ?string $bucket_id, ?array $photo_ids): PhotoDetailResource
+	public function do(AbstractAlbum $album, ?User $user, ?string $bucket_id, ?array $photo_ids): PhotoDetailResource
 	{
-		$query = Photo::query()
-			->join(PA::PHOTO_ALBUM, PA::PHOTO_ID, '=', 'photos.id')
-			->where(PA::ALBUM_ID, '=', $album->id)
-			->select('photos.*');
-
-		// Non-admins must not see unvalidated photos uploaded by other
-		// users.
-		if ($user?->may_administrate !== true) {
-			$this->applyUploadValidationFilter($query, $user?->id);
-		}
+		$query = $this->resolvePhotoQuery($album, $user)->select('photos.*');
 
 		if ($bucket_id !== null) {
-			// The literal "unknown" sentinel maps to a NULL bucket_id -
-			// uncapped, resolves every matching row.
-			if ($bucket_id === 'unknown') {
-				$query->whereNull('photo_album.bucket_id');
+			if ($album instanceof Album) {
+				// The literal "unknown" sentinel maps to a NULL bucket_id -
+				// uncapped, resolves every matching row.
+				if ($bucket_id === 'unknown') {
+					$query->whereNull('photo_album.bucket_id');
+				} else {
+					$query->where('photo_album.bucket_id', '=', $bucket_id);
+				}
 			} else {
-				$query->where('photo_album.bucket_id', '=', $bucket_id);
+				// TagAlbum/PersonAlbum/BaseSmartAlbum have no stored
+				// `bucket_id` to filter by in SQL - resolve the matching ids
+				// live first (mirrors QueryPhotoBuckets/QueryPhotoRatios),
+				// then curate the main query down to exactly those rows.
+				$query->whereIn('photos.id', $this->resolveLiveBucketPhotoIds($album, $user, $bucket_id));
 			}
 		} else {
 			// Ids not actually in this album or not visible to the caller
@@ -83,6 +83,37 @@ class QueryPhotoDetails
 		$photos = $query->with(['size_variants', 'palette', 'statistics', 'tags', 'albums'])->get();
 
 		return $this->buildResource($photos, $user);
+	}
+
+	/**
+	 * Lean pass over this album's candidate photos to resolve exactly which
+	 * ids live-compute to `$bucket_id` (or to `NULL`/"unknown" if
+	 * `$bucket_id === 'unknown'`) - see {@see ResolvesPhotoSource} for why a
+	 * non-`Album` source has no stored `bucket_id` column to filter by
+	 * directly in SQL.
+	 *
+	 * @return string[]
+	 */
+	private function resolveLiveBucketPhotoIds(AbstractAlbum $album, ?User $user, string $bucket_id): array
+	{
+		$sorting = $this->resolveEffectiveSorting($album);
+		$granularity = $this->bucket_computer->resolveGranularity($this->resolvePhotoTimeline($album));
+
+		$query = $this->resolvePhotoQuery($album, $user);
+		$rows = $query->select([
+			'photos.id', 'photos.title', 'photos.title_base', 'photos.created_at', 'photos.taken_at',
+			'photos.is_highlighted', 'photos.type', 'photos.rating_avg',
+		])->toBase()->get();
+
+		$matching_ids = [];
+		foreach ($rows as $row) {
+			$row_bucket_id = $this->liveBucketId($sorting->column, $granularity, $row) ?? 'unknown';
+			if ($row_bucket_id === $bucket_id) {
+				$matching_ids[] = $row->id;
+			}
+		}
+
+		return $matching_ids;
 	}
 
 	/**

--- a/app/Actions/Photo/StructOfArrays/QueryPhotoRatios.php
+++ b/app/Actions/Photo/StructOfArrays/QueryPhotoRatios.php
@@ -9,7 +9,8 @@
 namespace App\Actions\Photo\StructOfArrays;
 
 use App\Assets\DbBool;
-use App\Constants\PhotoAlbum as PA;
+use App\Contracts\Models\AbstractAlbum;
+use App\DTO\PhotoSortingCriterion;
 use App\Eloquent\FixedQueryBuilder;
 use App\Enum\OrderSortingType;
 use App\Enum\PhotoThumbInfoType;
@@ -17,12 +18,12 @@ use App\Enum\SizeVariantType;
 use App\Enum\VisibilityType;
 use App\Http\Resources\V3\PhotoRatioResource;
 use App\Models\Album;
-use App\Models\Extensions\FiltersUploadValidation;
 use App\Models\Extensions\SortingDecorator;
 use App\Models\Photo;
 use App\Models\User;
 use App\Repositories\ConfigManager;
 use App\Services\Image\FileExtensionService;
+use App\Services\PhotoBucketComputer;
 use GrahamCampbell\Markdown\Facades\Markdown;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Facades\DB;
@@ -37,17 +38,19 @@ use Spatie\LaravelData\Optional;
  */
 class QueryPhotoRatios
 {
-	use FiltersUploadValidation;
+	use ResolvesPhotoSource;
 
 	public function __construct(
 		private readonly ConfigManager $config_manager,
 		private readonly FileExtensionService $file_extension_service,
+		private readonly PhotoBucketComputer $bucket_computer,
 	) {
 	}
 
-	public function do(Album $album, ?User $user): PhotoRatioResource
+	public function do(AbstractAlbum $album, ?User $user): PhotoRatioResource
 	{
-		$sorting = $album->getEffectivePhotoSorting();
+		$sorting = $this->resolveEffectiveSorting($album);
+		$is_regular_album = $album instanceof Album;
 
 		$rating_enabled = $this->config_manager->getValueAsBool('rating_enabled');
 		// PhotoPolicy::canReadRatings() ignores its own $photo argument
@@ -61,23 +64,14 @@ class QueryPhotoRatios
 		$tags_on = $overlay !== VisibilityType::NEVER && $thumb_info_mode === PhotoThumbInfoType::TITLE && $this->config_manager->getValueAsBool('photo_thumb_tags_enabled');
 		$blank_titles = $this->config_manager->getValueAsBool('file_name_hidden') && $user === null;
 
-		$query = Photo::query()
-			->join(PA::PHOTO_ALBUM, PA::PHOTO_ID, '=', 'photos.id')
-			->where(PA::ALBUM_ID, '=', $album->id);
-
-		// Non-admins must not see unvalidated photos uploaded by other
-		// users.
-		if ($user?->may_administrate !== true) {
-			$this->applyUploadValidationFilter($query, $user?->id);
-		}
-
+		$query = $this->resolvePhotoQuery($album, $user);
 		$this->joinRatioSizeVariants($query);
 
 		$select = [
 			'photos.id',
 			'photos.title',
+			'photos.title_base',
 			'photos.type',
-			'photo_album.bucket_id',
 			'photos.owner_id',
 			'photos.is_highlighted',
 			'photos.is_validated',
@@ -85,17 +79,25 @@ class QueryPhotoRatios
 			'photos.created_at',
 			'photos.taken_at_orig_tz',
 			'photos.live_photo_short_path',
+			// Always selected, independent of $can_read_ratings: a
+			// non-`Album` source needs the raw value for live bucket
+			// computation (RATING_AVG may be the effective sort column) even
+			// when the viewer isn't permitted to see ratings - the output
+			// array below still only ever gets populated when
+			// $can_read_ratings is true, so nothing extra reaches the
+			// response.
+			'photos.rating_avg',
 		];
+		if ($is_regular_album) {
+			$select[] = 'photo_album.bucket_id';
+		}
 		$selects_raw = ['COALESCE(sv_original.ratio, sv_medium.ratio, sv_small.ratio, 1) as ratio'];
 
-		if ($can_read_ratings) {
-			$select[] = 'photos.rating_avg';
-			if ($user !== null) {
-				$query->leftJoin('photo_ratings as pr', function (JoinClause $join) use ($user): void {
-					$join->on('pr.photo_id', '=', 'photos.id')->where('pr.user_id', '=', $user->id);
-				});
-				$select[] = 'pr.rating as rating_user';
-			}
+		if ($can_read_ratings && $user !== null) {
+			$query->leftJoin('photo_ratings as pr', function (JoinClause $join) use ($user): void {
+				$join->on('pr.photo_id', '=', 'photos.id')->where('pr.user_id', '=', $user->id);
+			});
+			$select[] = 'pr.rating as rating_user';
 		}
 
 		if ($thumb_infos_on) {
@@ -107,19 +109,24 @@ class QueryPhotoRatios
 			$select[] = 'tag_agg.tag_names';
 		}
 
-		$direction = $sorting->order === OrderSortingType::DESC ? 'desc' : 'asc';
-		// Order by bucket_id first (mirrors QueryPhotoBuckets exactly,
-		// "unknown" always last) so grouping this endpoint's rows by
-		// bucket_id reproduces the buckets endpoint's own {bucket_ids,counts}
-		// byte-for-byte, then the album's effective photo sort criterion as
-		// intra-bucket tie-break.
-		$query->orderByRaw('(photo_album.bucket_id IS NULL) ASC')
-			->orderBy('photo_album.bucket_id', $direction);
+		if ($is_regular_album) {
+			$direction = $sorting->order === OrderSortingType::DESC ? 'desc' : 'asc';
+			// Order by bucket_id first (mirrors QueryPhotoBuckets exactly,
+			// "unknown" always last) so grouping this endpoint's rows by
+			// bucket_id reproduces the buckets endpoint's own {bucket_ids,counts}
+			// byte-for-byte, then the album's effective photo sort criterion as
+			// intra-bucket tie-break.
+			$query->orderByRaw('(photo_album.bucket_id IS NULL) ASC')
+				->orderBy('photo_album.bucket_id', $direction);
+		}
+		// For a non-`Album` source there is no stored `bucket_id` to
+		// pre-sort by - `buildResource()` computes it live per row below
+		// instead, off the same effective-sort-ordered rows.
 		(new SortingDecorator($query))->orderPhotosBy($sorting->column, $sorting->order)->applyOrdering();
 
 		$rows = $query->select($select)->selectRaw(implode(', ', $selects_raw))->toBase()->get();
 
-		return $this->buildResource($rows, $can_read_ratings, $user !== null, $thumb_infos_on, $tags_on, $blank_titles);
+		return $this->buildResource($rows, $can_read_ratings, $user !== null, $thumb_infos_on, $tags_on, $blank_titles, $is_regular_album, $sorting, $album);
 	}
 
 	/**
@@ -178,7 +185,18 @@ class QueryPhotoRatios
 		bool $thumb_infos_on,
 		bool $tags_on,
 		bool $blank_titles,
+		bool $is_regular_album,
+		PhotoSortingCriterion $sorting,
+		AbstractAlbum $album,
 	): PhotoRatioResource {
+		// Only used for a non-`Album` source (see below) - there is no
+		// stored `bucket_id` to read off the row in that case, so it is
+		// computed live per row instead, mirroring
+		// `QueryPhotoBuckets::queryLiveBuckets()` exactly so both tiers
+		// agree on the same bucket for the same photo. Harmless to resolve
+		// unconditionally - cheap, and simply unused for a regular `Album`.
+		$granularity = $this->bucket_computer->resolveGranularity($this->resolvePhotoTimeline($album));
+
 		$ids = [];
 		$titles = [];
 		$types = [];
@@ -206,7 +224,9 @@ class QueryPhotoRatios
 			$ids[] = $row->id;
 			$titles[] = $blank_titles ? '' : $row->title;
 			$types[] = $type;
-			$bucket_ids[] = $row->bucket_id ?? 'unknown';
+			$bucket_ids[] = $is_regular_album
+				? ($row->bucket_id ?? 'unknown')
+				: ($this->liveBucketId($sorting->column, $granularity, $row) ?? 'unknown');
 			$ratios[] = (float) $row->ratio;
 			$owner_ids[] = (int) $row->owner_id;
 			$is_highlighteds[] = DbBool::parse($row->is_highlighted);

--- a/app/Actions/Photo/StructOfArrays/ResolvesPhotoSource.php
+++ b/app/Actions/Photo/StructOfArrays/ResolvesPhotoSource.php
@@ -57,11 +57,20 @@ trait ResolvesPhotoSource
 				->join(PA::PHOTO_ALBUM, PA::PHOTO_ID, '=', 'photos.id')
 				->where(PA::ALBUM_ID, '=', $album->id);
 		} elseif ($album instanceof BaseSmartAlbum) {
-			// Already a `FixedQueryBuilder<Photo>` at runtime (built off
-			// `Photo::query()`) - only typed as the looser `Builder` by
-			// `BaseSmartAlbum::photos()`'s own signature.
-			/** @var FixedQueryBuilder<Photo> $query */
-			$query = $album->photos();
+			// `BaseSmartAlbum::photos()` applies its visibility filter
+			// directly on a query that already carries an un-scoped
+			// `leftJoin(photo_album, ...)` (no album_id restriction -
+			// BaseSmartAlbum.php's own `photos()`) - a photo belonging to N
+			// regular albums therefore fans out to N rows there. This is
+			// exactly the duplication `HasManyPhotosByTag::addEagerConstraints()`'s
+			// own doc comment describes and deliberately avoids, via a
+			// `whereIn` id-subquery instead of joining directly on the
+			// outer/returned query - mirrored here for the same reason: the
+			// query this method returns must carry exactly one row per
+			// `photos.id`, regardless of how many regular albums a photo
+			// belongs to.
+			$matching_ids = $album->photos()->select('photos.id');
+			$query = Photo::query()->whereIn('photos.id', $matching_ids);
 		} else {
 			// TagAlbum | PersonAlbum - `photos()` returns a `Relation`
 			// (`HasManyPhotosByTag`/`HasManyPhotosByPerson`); `getQuery()`

--- a/app/Actions/Photo/StructOfArrays/ResolvesPhotoSource.php
+++ b/app/Actions/Photo/StructOfArrays/ResolvesPhotoSource.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2017-2018 Tobias Reich
+ * Copyright (c) 2018-2026 LycheeOrg.
+ */
+
+namespace App\Actions\Photo\StructOfArrays;
+
+use App\Assets\DbBool;
+use App\Constants\PhotoAlbum as PA;
+use App\Contracts\Models\AbstractAlbum;
+use App\DTO\PhotoSortingCriterion;
+use App\Eloquent\FixedQueryBuilder;
+use App\Enum\ColumnSortingType;
+use App\Enum\TimelinePhotoGranularity;
+use App\Enum\TitleBucketMode;
+use App\Exceptions\Internal\LycheeLogicException;
+use App\Models\Album;
+use App\Models\Extensions\BaseAlbum;
+use App\Models\Extensions\FiltersUploadValidation;
+use App\Models\Photo;
+use App\Models\User;
+use App\SmartAlbums\BaseSmartAlbum;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Safe\Exceptions\PcreException;
+use function Safe\preg_match;
+
+/**
+ * Resolves the base photo query for any {@see AbstractAlbum} implementation
+ * — a regular {@see Album}, a {@see \App\Models\TagAlbum}, a
+ * {@see \App\Models\PersonAlbum}, or a {@see BaseSmartAlbum} — shared by
+ * {@see QueryPhotoBuckets}, {@see QueryPhotoRatios} and
+ * {@see QueryPhotoDetails}.
+ *
+ * Only a regular `Album` has a `photo_album` pivot row per photo (and
+ * therefore a stored `bucket_id`). The other three types have no such row —
+ * `TagAlbum`/`PersonAlbum` membership resolves via `photos_tags`/face
+ * matching, and `BaseSmartAlbum`'s own `leftJoin` to `photo_album` is
+ * unscoped access-control plumbing, not a per-photo bucket source — so they
+ * are resolved through their own existing `photos()` accessor instead,
+ * which already applies membership/visibility filtering, and their
+ * `bucket_id` must be computed live instead (see {@see self::liveBucketId()}).
+ */
+trait ResolvesPhotoSource
+{
+	use FiltersUploadValidation;
+
+	/**
+	 * @return FixedQueryBuilder<Photo>
+	 */
+	private function resolvePhotoQuery(AbstractAlbum $album, ?User $user): FixedQueryBuilder
+	{
+		if ($album instanceof Album) {
+			$query = Photo::query()
+				->join(PA::PHOTO_ALBUM, PA::PHOTO_ID, '=', 'photos.id')
+				->where(PA::ALBUM_ID, '=', $album->id);
+		} elseif ($album instanceof BaseSmartAlbum) {
+			// Already a `FixedQueryBuilder<Photo>` at runtime (built off
+			// `Photo::query()`) - only typed as the looser `Builder` by
+			// `BaseSmartAlbum::photos()`'s own signature.
+			/** @var FixedQueryBuilder<Photo> $query */
+			$query = $album->photos();
+		} else {
+			// TagAlbum | PersonAlbum - `photos()` returns a `Relation`
+			// (`HasManyPhotosByTag`/`HasManyPhotosByPerson`); `getQuery()`
+			// unwraps it to the underlying `FixedQueryBuilder<Photo>`
+			// (mirrors `BaseHasManyPhotos::getRelationQuery()`, which is
+			// `protected` and therefore not reachable from here directly).
+			/** @var Relation<Photo,BaseAlbum,mixed> $relation */
+			$relation = $album->photos();
+			/** @var FixedQueryBuilder<Photo> $query */
+			$query = $relation->getQuery();
+		}
+
+		if ($user?->may_administrate !== true) {
+			$this->applyUploadValidationFilter($query, $user?->id);
+		}
+
+		return $query;
+	}
+
+	/**
+	 * `getEffectivePhotoSorting()` is only defined on `Album`/`TagAlbum`/
+	 * `PersonAlbum` (via `App\Models\Extensions\BaseAlbum`) - a
+	 * `BaseSmartAlbum` has no per-album override and always resolves to the
+	 * instance-wide default instead, mirroring `BaseSmartAlbum`'s own
+	 * internal use of {@see PhotoSortingCriterion::createDefault()}.
+	 */
+	private function resolveEffectiveSorting(AbstractAlbum $album): PhotoSortingCriterion
+	{
+		if ($album instanceof BaseAlbum) {
+			return $album->getEffectivePhotoSorting();
+		}
+
+		return PhotoSortingCriterion::createDefault();
+	}
+
+	/**
+	 * `photo_timeline` (the per-album granularity override) only exists on
+	 * `Album`/`TagAlbum`/`PersonAlbum` - a `BaseSmartAlbum` has no such
+	 * property, so `null` (-> the instance-wide default, resolved by
+	 * {@see \App\Services\PhotoBucketComputer::resolveGranularity()}) is
+	 * always used for it.
+	 */
+	private function resolvePhotoTimeline(AbstractAlbum $album): ?TimelinePhotoGranularity
+	{
+		return $album instanceof BaseAlbum ? $album->photo_timeline : null;
+	}
+
+	/**
+	 * Computes one row's live `bucket_id`, given the raw scalar columns
+	 * selected via {@see self::resolvePhotoQuery()} (`title`, `title_base`,
+	 * `created_at`, `taken_at`, `is_highlighted`, `type`, `rating_avg`),
+	 * mirroring {@see \App\Services\PhotoBucketComputer::compute()}'s write-path logic
+	 * exactly - but deliberately reimplemented Carbon-free (raw string
+	 * truncation instead of `Carbon::parse()` per row), the same "no Carbon
+	 * in this request-path tier" discipline {@see QueryPhotoBuckets::formatBucketLabel()}
+	 * already documents and follows, here applied to a call that runs once
+	 * per candidate photo rather than once per distinct bucket.
+	 */
+	private function liveBucketId(ColumnSortingType $column, TimelinePhotoGranularity $granularity, \stdClass $row): ?string
+	{
+		if ($column === ColumnSortingType::OWNER_ID) {
+			return null;
+		}
+
+		if ($column === ColumnSortingType::TITLE) {
+			return $this->liveTitleBucket($granularity, $row->title ?? '', $row->title_base ?? '');
+		}
+
+		if ($column === ColumnSortingType::IS_HIGHLIGHTED) {
+			return DbBool::parse($row->is_highlighted) ? '1' : '0';
+		}
+
+		if ($column === ColumnSortingType::TYPE) {
+			return $row->type ?? '';
+		}
+
+		if ($column === ColumnSortingType::RATING_AVG) {
+			return $row->rating_avg === null ? null : (string) round((float) $row->rating_avg);
+		}
+
+		$raw_date = match ($column) {
+			ColumnSortingType::CREATED_AT => $row->created_at,
+			ColumnSortingType::TAKEN_AT => $row->taken_at,
+			default => null,
+		};
+
+		return $raw_date === null ? null : $this->truncateRawDate((string) $raw_date, $granularity);
+	}
+
+	/**
+	 * Bucket computation for a `TITLE`-sorted, non-`Album` source, mirroring
+	 * {@see \App\Services\PhotoBucketComputer::computeTitleBucket()} - the date-prefix
+	 * branch reimplements {@see \App\Http\Resources\Models\Utils\TimelineData::parseDateFromTitle()}'s
+	 * own regex directly rather than calling it, purely to avoid the
+	 * `Carbon` instance that helper constructs and immediately discards
+	 * (only `$year`/`$month`/`$day` are ever used here).
+	 */
+	private function liveTitleBucket(TimelinePhotoGranularity $granularity, string $title, string $title_base): ?string
+	{
+		$mode = request()->configs()->getValueAsEnum('photo_title_bucket_mode', TitleBucketMode::class) ?? TitleBucketMode::DATE_PREFIX;
+
+		if ($mode === TitleBucketMode::ALPHABETICAL) {
+			$length = max(1, request()->configs()->getValueAsInt('photo_title_bucket_prefix_length'));
+
+			return mb_substr($title_base, 0, $length);
+		}
+
+		try {
+			if (preg_match('/^(\d{4})(?:-(\d{2}))?(?:-(\d{2}))?/', trim($title), $matches) !== 1) {
+				return null;
+			}
+			// @codeCoverageIgnoreStart
+		} catch (PcreException) {
+			// Mirrors TimelineData::parseDateFromTitle()'s own "fail
+			// silently" handling of this same pattern.
+			return null;
+		}
+		// @codeCoverageIgnoreEnd
+
+		$year = $matches[1];
+		$month = $matches[2] ?? '01';
+		$day = $matches[3] ?? '01';
+
+		return match ($granularity) {
+			TimelinePhotoGranularity::YEAR => $year,
+			TimelinePhotoGranularity::MONTH => $year . '-' . $month,
+			TimelinePhotoGranularity::DAY, TimelinePhotoGranularity::HOUR => $year . '-' . $month . '-' . $day,
+			// @codeCoverageIgnoreStart
+			TimelinePhotoGranularity::DEFAULT, TimelinePhotoGranularity::DISABLED => throw new LycheeLogicException('DEFAULT/DISABLED is not a valid resolved granularity for photos'),
+			// @codeCoverageIgnoreEnd
+		};
+	}
+
+	/**
+	 * Truncates a raw, un-cast `photos.created_at`/`photos.taken_at`
+	 * datetime string (`"Y-m-d H:i:s[.u]"`, the exact form every supported
+	 * DB driver's PDO layer returns for a `toBase()` row) at `$granularity`,
+	 * matching {@see \App\Services\PhotoBucketComputer::truncateDate()}'s output format
+	 * byte-for-byte - via plain substring slicing, deliberately never a
+	 * `Carbon`/`DateTime` object.
+	 */
+	private function truncateRawDate(string $raw_date, TimelinePhotoGranularity $granularity): string
+	{
+		return match ($granularity) {
+			TimelinePhotoGranularity::YEAR => substr($raw_date, 0, 4),
+			TimelinePhotoGranularity::MONTH => substr($raw_date, 0, 7),
+			TimelinePhotoGranularity::DAY => substr($raw_date, 0, 10),
+			TimelinePhotoGranularity::HOUR => substr($raw_date, 0, 10) . '-' . substr($raw_date, 11, 2),
+			// @codeCoverageIgnoreStart
+			TimelinePhotoGranularity::DEFAULT, TimelinePhotoGranularity::DISABLED => throw new LycheeLogicException('DEFAULT/DISABLED is not a valid resolved granularity for photos'),
+			// @codeCoverageIgnoreEnd
+		};
+	}
+}

--- a/app/Enum/SizeVariantType.php
+++ b/app/Enum/SizeVariantType.php
@@ -64,4 +64,24 @@ enum SizeVariantType: int
 			self::ORIGINAL => __('gallery.original'),
 		};
 	}
+
+	/**
+	 * The next-smaller thumbnail-class type to try when this one is
+	 * unavailable (no DB row at all, or its file is missing on disk) — the
+	 * single source of truth for the Feature 056 asset endpoint's fallback
+	 * chain, shared by {@see \App\Http\Requests\Photo\GetPhotoAssetRequest}
+	 * (no DB row for the originally requested type) and
+	 * {@see \App\Http\Controllers\Gallery\PhotoAssetController} (DB row
+	 * exists but the file itself is missing). `null` means there is nothing
+	 * smaller left to try.
+	 */
+	public function fallbackType(): ?self
+	{
+		return match ($this) {
+			self::SMALL2X => self::SMALL,
+			self::SMALL => self::THUMB,
+			self::THUMB2X => self::THUMB,
+			default => null,
+		};
+	}
 }

--- a/app/Events/PhotoTagsChanged.php
+++ b/app/Events/PhotoTagsChanged.php
@@ -20,8 +20,13 @@ class PhotoTagsChanged
 	 * Create a new event instance.
 	 *
 	 * @param array<int,string> $photo_ids batched so listeners can resolve affected albums once per call instead of once per photo
+	 * @param array<int,int>    $tag_ids   the union of old and new tag IDs affected by the change (both sides of an
+	 *                                     attach/detach), so listeners which cache by tag ID (e.g. the TagAlbum
+	 *                                     photo-listing cache) can evict precisely. Deriving this from current
+	 *                                     `photos_tags` state after the fact would miss a tag that was just removed
+	 *                                     — mirrors {@see PhotoPersonsChanged::$person_ids} exactly.
 	 */
-	public function __construct(public array $photo_ids)
+	public function __construct(public array $photo_ids, public array $tag_ids)
 	{
 	}
 }

--- a/app/Http/Controllers/Gallery/AlbumListing/PhotoChildrenController.php
+++ b/app/Http/Controllers/Gallery/AlbumListing/PhotoChildrenController.php
@@ -48,7 +48,7 @@ class PhotoChildrenController extends Controller
 		/** @var User|null $user */
 		$user = Auth::user();
 
-		$key = $this->cache_key_provider->photoBucketsKey($album->id, $user?->id);
+		$key = $this->cache_key_provider->photoBucketsKey($album->get_id(), $user?->id);
 		$enabled = $request->configs()->getValueAsBool('managed_cache_albums_enabled');
 		$ttl = $request->configs()->getValueAsInt('managed_cache_ttl');
 
@@ -56,7 +56,7 @@ class PhotoChildrenController extends Controller
 			$enabled,
 			$key,
 			[
-				$this->cache_key_provider->photoListingTag($album->id),
+				$this->cache_key_provider->photoListingTag($album->get_id()),
 				$this->cache_key_provider->userTag($user?->id),
 			],
 			fn (): PhotoBucketResource => $this->query_photo_buckets->do($album, $user),
@@ -72,7 +72,7 @@ class PhotoChildrenController extends Controller
 		/** @var User|null $user */
 		$user = Auth::user();
 
-		$key = $this->cache_key_provider->photoRatiosKey($album->id, $user?->id);
+		$key = $this->cache_key_provider->photoRatiosKey($album->get_id(), $user?->id);
 		$enabled = $request->configs()->getValueAsBool('managed_cache_albums_enabled');
 		$ttl = $request->configs()->getValueAsInt('managed_cache_ttl');
 
@@ -80,7 +80,7 @@ class PhotoChildrenController extends Controller
 			$enabled,
 			$key,
 			[
-				$this->cache_key_provider->photoListingTag($album->id),
+				$this->cache_key_provider->photoListingTag($album->get_id()),
 				$this->cache_key_provider->userTag($user?->id),
 			],
 			fn (): PhotoRatioResource => $this->query_photo_ratios->do($album, $user),
@@ -97,7 +97,7 @@ class PhotoChildrenController extends Controller
 		$user = Auth::user();
 
 		$scope_digest = $this->cache_key_provider->photoDetailsScopeDigest($request->bucketId(), $request->photoIds());
-		$key = $this->cache_key_provider->photoDetailsKey($album->id, $scope_digest, $user?->id);
+		$key = $this->cache_key_provider->photoDetailsKey($album->get_id(), $scope_digest, $user?->id);
 		$enabled = $request->configs()->getValueAsBool('managed_cache_albums_enabled');
 		$ttl = $request->configs()->getValueAsInt('managed_cache_ttl');
 
@@ -105,7 +105,7 @@ class PhotoChildrenController extends Controller
 			$enabled,
 			$key,
 			[
-				$this->cache_key_provider->photoListingTag($album->id),
+				$this->cache_key_provider->photoListingTag($album->get_id()),
 				$this->cache_key_provider->userTag($user?->id),
 			],
 			fn (): PhotoDetailResource => $this->query_photo_details->do($album, $user, $request->bucketId(), $request->photoIds()),

--- a/app/Http/Controllers/Gallery/PhotoAssetController.php
+++ b/app/Http/Controllers/Gallery/PhotoAssetController.php
@@ -49,12 +49,7 @@ class PhotoAssetController extends Controller
 	 */
 	private function fallback(string $photo_id, SizeVariantType $type, Watermarker $watermarker)
 	{
-		$fallback = match ($type) {
-			SizeVariantType::SMALL2X => SizeVariantType::SMALL,
-			SizeVariantType::SMALL => SizeVariantType::THUMB,
-			SizeVariantType::THUMB2X => SizeVariantType::THUMB,
-			default => null,
-		};
+		$fallback = $type->fallbackType();
 
 		if ($fallback === null) {
 			return response()->json(['error' => 'File not found'], 404);

--- a/app/Http/Controllers/Gallery/PhotoController.php
+++ b/app/Http/Controllers/Gallery/PhotoController.php
@@ -179,9 +179,10 @@ class PhotoController extends Controller
 		$photo->created_at = $request->uploadDate();
 
 		$existing_tags = Tag::from($request->tags());
+		$old_tag_ids = $photo->tags()->pluck('tags.id')->all();
 		$photo->tags()->sync($existing_tags->pluck('id'));
 		$photo->load('tags');
-		PhotoTagsChanged::dispatch([$photo->id]);
+		PhotoTagsChanged::dispatch([$photo->id], array_values(array_unique([...$old_tag_ids, ...$existing_tags->pluck('id')->all()])));
 		$photo->license = $request->license()->value;
 
 		// if the request takenAt is null, then we set the initial value back.
@@ -334,6 +335,12 @@ class PhotoController extends Controller
 		// Fetch existing tags
 		$existing_tags = Tag::from($tags);
 
+		// Captured before the mutation below - PhotoTagsChanged::$tag_ids
+		// must carry the union of old and new tag IDs (a tag removed by
+		// `shall_override` is otherwise unrecoverable once the delete below
+		// has run), mirroring PhotoPersonsChanged::$person_ids exactly.
+		$old_tag_ids = DB::table('photos_tags')->whereIn('photo_id', $photo_ids)->distinct()->pluck('tag_id')->all();
+
 		DB::transaction(function () use ($request, $existing_tags, $photo_ids): void {
 			if ($request->shall_override) {
 				// Delete existing associations for those photos ids if we override the tags
@@ -348,7 +355,7 @@ class PhotoController extends Controller
 			});
 			DB::commit();
 		});
-		PhotoTagsChanged::dispatch($photo_ids->all());
+		PhotoTagsChanged::dispatch($photo_ids->all(), array_values(array_unique([...$old_tag_ids, ...$existing_tags->pluck('id')->all()])));
 
 		if ($request->configs()->getValueAsBool('embed_metadata_in_files_enabled')) {
 			$photos->each(fn (Photo $photo) => EmbedMetadataJob::dispatch($photo));

--- a/app/Http/Requests/Photo/GetPhotoAssetRequest.php
+++ b/app/Http/Requests/Photo/GetPhotoAssetRequest.php
@@ -26,6 +26,7 @@ use App\Rules\AlbumIDRule;
 use App\Rules\RandomIDRule;
 use App\Services\TemporaryLinkSigner;
 use App\SmartAlbums\BaseSmartAlbum;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
@@ -258,14 +259,40 @@ class GetPhotoAssetRequest extends BaseApiRequest
 		$this->album = $this->album_factory->findAbstractAlbumOrFail($album_id, false);
 		$this->size_variant_type = SizeVariantAssetType::from($size_variant_token)->toSizeVariantType();
 
-		// SizeVariant must stay a real model: Watermarker::get_path() and the
-		// controller rely on its enum casts (type, storage_disk). We still
-		// limit the hydrated columns to only what those two call sites read.
-		$this->size_variant = SizeVariant::query()
-			->select(['id', 'photo_id', 'type', 'short_path', 'short_path_watermarked', 'storage_disk'])
-			->where('photo_id', '=', $this->photo_id)
-			->where('type', '=', $this->size_variant_type)
-			->firstOrFail();
+		// The requested type may simply never have been generated for this
+		// photo (e.g. a `small2x` variant when the source is too small to
+		// warrant a 2x thumbnail) - walk the same fallback chain
+		// PhotoAssetController::fallback() uses for a missing *file*
+		// (SizeVariantType::fallbackType()) so a missing DB *row* degrades
+		// the same way instead of 404ing outright. The controller then
+		// continues that exact chain from whichever type we resolve to here
+		// if that type's file also turns out to be missing on disk.
+		$type = $this->size_variant_type;
+		$size_variant = null;
+		while ($size_variant === null) {
+			// SizeVariant must stay a real model: Watermarker::get_path() and
+			// the controller rely on its enum casts (type, storage_disk). We
+			// still limit the hydrated columns to only what those two call
+			// sites read.
+			$size_variant = SizeVariant::query()
+				->select(['id', 'photo_id', 'type', 'short_path', 'short_path_watermarked', 'storage_disk'])
+				->where('photo_id', '=', $this->photo_id)
+				->where('type', '=', $type)
+				->first();
+
+			if ($size_variant !== null) {
+				break;
+			}
+
+			$next = $type->fallbackType();
+			if ($next === null) {
+				throw (new ModelNotFoundException())->setModel(SizeVariant::class);
+			}
+			$type = $next;
+		}
+
+		$this->size_variant_type = $type;
+		$this->size_variant = $size_variant;
 
 		$this->mac = $values[self::MAC_ATTRIBUTE] ?? null;
 	}

--- a/app/Http/Requests/Photo/GetPhotoBucketsRequest.php
+++ b/app/Http/Requests/Photo/GetPhotoBucketsRequest.php
@@ -8,12 +8,13 @@
 
 namespace App\Http\Requests\Photo;
 
+use App\Contracts\Http\Requests\HasAbstractAlbum;
 use App\Contracts\Http\Requests\RequestAttribute;
 use App\Contracts\Models\AbstractAlbum;
 use App\Http\Requests\BaseApiRequest;
-use App\Models\Album;
+use App\Http\Requests\Traits\HasAbstractAlbumTrait;
 use App\Policies\AlbumPolicy;
-use App\Rules\RandomIDRule;
+use App\Rules\AlbumIDRule;
 use Illuminate\Support\Facades\Gate;
 
 /**
@@ -21,19 +22,14 @@ use Illuminate\Support\Facades\Gate;
  * `album_id` is bound from the route segment via
  * {@see self::prepareForValidation()}, mirroring
  * {@see \App\Http\Requests\Album\GetAlbumBucketsRequest}'s pattern.
- * Resolves to a regular {@see Album} only — a `TagAlbum`/`PersonAlbum` id
- * or an unresolved id both yield a 404
- * ({@see \Illuminate\Database\Eloquent\ModelNotFoundException}), never the
- * broader `AlbumFactory::findAbstractAlbumOrFail()` resolution.
+ * Resolves via
+ * {@see \App\Factories\AlbumFactory::findAbstractAlbumOrFail()}, covering a
+ * regular {@see \App\Models\Album}, a {@see \App\Models\TagAlbum}, a
+ * {@see \App\Models\PersonAlbum}, or a {@see \App\SmartAlbums\BaseSmartAlbum}.
  */
-class GetPhotoBucketsRequest extends BaseApiRequest
+class GetPhotoBucketsRequest extends BaseApiRequest implements HasAbstractAlbum
 {
-	private Album $album;
-
-	public function album(): Album
-	{
-		return $this->album;
-	}
+	use HasAbstractAlbumTrait;
 
 	/**
 	 * {@inheritDoc}
@@ -50,7 +46,7 @@ class GetPhotoBucketsRequest extends BaseApiRequest
 	public function rules(): array
 	{
 		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new AlbumIDRule(false)],
 		];
 	}
 
@@ -72,6 +68,7 @@ class GetPhotoBucketsRequest extends BaseApiRequest
 	{
 		/** @var string $album_id */
 		$album_id = $values[RequestAttribute::ALBUM_ID_ATTRIBUTE];
-		$this->album = Album::query()->where('id', '=', $album_id)->firstOrFail();
+		// We do not need the relations. We try to be lean.
+		$this->album = $this->album_factory->findAbstractAlbumOrFail($album_id, false);
 	}
 }

--- a/app/Http/Requests/Photo/GetPhotoDetailsRequest.php
+++ b/app/Http/Requests/Photo/GetPhotoDetailsRequest.php
@@ -8,11 +8,13 @@
 
 namespace App\Http\Requests\Photo;
 
+use App\Contracts\Http\Requests\HasAbstractAlbum;
 use App\Contracts\Http\Requests\RequestAttribute;
 use App\Contracts\Models\AbstractAlbum;
 use App\Http\Requests\BaseApiRequest;
-use App\Models\Album;
+use App\Http\Requests\Traits\HasAbstractAlbumTrait;
 use App\Policies\AlbumPolicy;
+use App\Rules\AlbumIDRule;
 use App\Rules\RandomIDRule;
 use Illuminate\Support\Facades\Gate;
 
@@ -22,20 +24,18 @@ use Illuminate\Support\Facades\Gate;
  * returns everything it contains, no truncation, per explicit user
  * direction) / `photo_ids[]` (array, capped at 300 entries as input — 422
  * above). `album_id` resolution mirrors
- * {@see \App\Http\Requests\Photo\GetPhotoBucketsRequest} exactly (regular
- * `Album` only).
+ * {@see \App\Http\Requests\Photo\GetPhotoBucketsRequest} exactly — resolves
+ * via {@see \App\Factories\AlbumFactory::findAbstractAlbumOrFail()}, covering
+ * a regular {@see \App\Models\Album}, a {@see \App\Models\TagAlbum}, a
+ * {@see \App\Models\PersonAlbum}, or a {@see \App\SmartAlbums\BaseSmartAlbum}.
  */
-class GetPhotoDetailsRequest extends BaseApiRequest
+class GetPhotoDetailsRequest extends BaseApiRequest implements HasAbstractAlbum
 {
-	private Album $album;
+	use HasAbstractAlbumTrait;
+
 	private ?string $bucket_id = null;
 	/** @var string[]|null */
 	private ?array $photo_ids = null;
-
-	public function album(): Album
-	{
-		return $this->album;
-	}
 
 	public function bucketId(): ?string
 	{
@@ -65,7 +65,7 @@ class GetPhotoDetailsRequest extends BaseApiRequest
 	public function rules(): array
 	{
 		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new AlbumIDRule(false)],
 			RequestAttribute::BUCKET_ID_ATTRIBUTE => [
 				'required_without:' . RequestAttribute::PHOTO_IDS_ATTRIBUTE,
 				'prohibits:' . RequestAttribute::PHOTO_IDS_ATTRIBUTE,
@@ -99,7 +99,8 @@ class GetPhotoDetailsRequest extends BaseApiRequest
 	{
 		/** @var string $album_id */
 		$album_id = $values[RequestAttribute::ALBUM_ID_ATTRIBUTE];
-		$this->album = Album::query()->where('id', '=', $album_id)->firstOrFail();
+		// We do not need the relations. We try to be lean.
+		$this->album = $this->album_factory->findAbstractAlbumOrFail($album_id, false);
 
 		/** @var string|null $bucket_id */
 		$bucket_id = $values[RequestAttribute::BUCKET_ID_ATTRIBUTE] ?? null;

--- a/app/Http/Requests/Photo/GetPhotoRatiosRequest.php
+++ b/app/Http/Requests/Photo/GetPhotoRatiosRequest.php
@@ -8,28 +8,26 @@
 
 namespace App\Http\Requests\Photo;
 
+use App\Contracts\Http\Requests\HasAbstractAlbum;
 use App\Contracts\Http\Requests\RequestAttribute;
 use App\Contracts\Models\AbstractAlbum;
 use App\Http\Requests\BaseApiRequest;
-use App\Models\Album;
+use App\Http\Requests\Traits\HasAbstractAlbumTrait;
 use App\Policies\AlbumPolicy;
-use App\Rules\RandomIDRule;
+use App\Rules\AlbumIDRule;
 use Illuminate\Support\Facades\Gate;
 
 /**
  * Request for `GET /api/v3/Albums/{album_id}/Photos` — mirrors
- * {@see \App\Http\Requests\Photo\GetPhotoBucketsRequest} exactly (same
- * `album_id` route-segment resolution, same regular-`Album`-only
- * restriction).
+ * {@see \App\Http\Requests\Photo\GetPhotoBucketsRequest} exactly. `album_id`
+ * resolves via {@see \App\Factories\AlbumFactory::findAbstractAlbumOrFail()},
+ * covering a regular {@see \App\Models\Album}, a
+ * {@see \App\Models\TagAlbum}, a {@see \App\Models\PersonAlbum}, or a
+ * {@see \App\SmartAlbums\BaseSmartAlbum}.
  */
-class GetPhotoRatiosRequest extends BaseApiRequest
+class GetPhotoRatiosRequest extends BaseApiRequest implements HasAbstractAlbum
 {
-	private Album $album;
-
-	public function album(): Album
-	{
-		return $this->album;
-	}
+	use HasAbstractAlbumTrait;
 
 	/**
 	 * {@inheritDoc}
@@ -46,7 +44,7 @@ class GetPhotoRatiosRequest extends BaseApiRequest
 	public function rules(): array
 	{
 		return [
-			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new RandomIDRule(false)],
+			RequestAttribute::ALBUM_ID_ATTRIBUTE => ['required', new AlbumIDRule(false)],
 		];
 	}
 
@@ -68,6 +66,7 @@ class GetPhotoRatiosRequest extends BaseApiRequest
 	{
 		/** @var string $album_id */
 		$album_id = $values[RequestAttribute::ALBUM_ID_ATTRIBUTE];
-		$this->album = Album::query()->where('id', '=', $album_id)->firstOrFail();
+		// We do not need the relations. We try to be lean.
+		$this->album = $this->album_factory->findAbstractAlbumOrFail($album_id, false);
 	}
 }

--- a/app/Listeners/ManagedCachePhotoListingInvalidator.php
+++ b/app/Listeners/ManagedCachePhotoListingInvalidator.php
@@ -8,11 +8,17 @@
 
 namespace App\Listeners;
 
+use App\Constants\PersonAlbumPersons as PAP;
+use App\Enum\SmartAlbumType;
 use App\Events\AlbumPhotoSortingChanged;
 use App\Events\PhotoBucketsRecomputed;
 use App\Events\PhotoDeleted;
+use App\Events\PhotoHighlightToggled;
 use App\Events\PhotoMoved;
+use App\Events\PhotoPersonsChanged;
+use App\Events\PhotoRatingChanged;
 use App\Events\PhotoSaved;
+use App\Events\PhotoTagsChanged;
 use App\Services\Cache\CacheKeyProvider;
 use App\Services\Cache\ManagedCacheService;
 use Illuminate\Support\Facades\DB;
@@ -97,5 +103,86 @@ class ManagedCachePhotoListingInvalidator
 		}
 
 		$this->cache->forgetTags($this->cache_key_provider->photoListingTags($event->album_ids));
+	}
+
+	/**
+	 * A `TagAlbum`'s photo listing has no `photo_album` row to key off (see
+	 * {@see \App\Actions\Photo\StructOfArrays\ResolvesPhotoSource}) - every
+	 * `TagAlbum` whose tag set overlaps `$event->tag_ids` (the union of old
+	 * and new tags, see {@see PhotoTagsChanged}) must be evicted, since the
+	 * photo may have just entered or left its membership.
+	 */
+	public function handlePhotoTagsChanged(PhotoTagsChanged $event): void
+	{
+		if ($event->tag_ids === []) {
+			return;
+		}
+
+		$tag_album_ids = DB::table('tag_albums_tags')
+			->whereIn('tag_id', $event->tag_ids)
+			->distinct()
+			->pluck('album_id')
+			->all();
+
+		if ($tag_album_ids !== []) {
+			$this->cache->forgetTags($this->cache_key_provider->photoListingTags($tag_album_ids));
+		}
+	}
+
+	/**
+	 * Same reasoning as {@see self::handlePhotoTagsChanged()}, for
+	 * `PersonAlbum`. `$event->person_ids` is already the old/new union, so
+	 * no "removed person" gap here.
+	 */
+	public function handlePhotoPersonsChanged(PhotoPersonsChanged $event): void
+	{
+		if ($event->person_ids === []) {
+			return;
+		}
+
+		$person_album_ids = DB::table(PAP::PERSON_ALBUM_PERSONS)
+			->whereIn(PAP::PERSON_ID, $event->person_ids)
+			->distinct()
+			->pluck('album_id')
+			->all();
+
+		if ($person_album_ids !== []) {
+			$this->cache->forgetTags($this->cache_key_provider->photoListingTags($person_album_ids));
+		}
+	}
+
+	/**
+	 * Every built-in smart album whose condition reads `rating_avg` (see
+	 * `App\SmartAlbums\{OneStarAlbum,...,FiveStarsAlbum,UnratedAlbum,
+	 * BestPicturesAlbum,MyRatedPicturesAlbum,MyBestPicturesAlbum}`) must be
+	 * evicted unconditionally - {@see PhotoRatingChanged} carries neither
+	 * the old nor the new rating, and several of these conditions are
+	 * threshold/rank-based (`best_pictures`, `my_best_pictures`), so which
+	 * one(s) actually flipped can't be determined cheaply here. Mirrors
+	 * {@see \App\Listeners\RecomputeAlbumUserThumbsOnPhotoChange}'s own
+	 * unconditional smart-album refresh for the same reason.
+	 */
+	public function handlePhotoRatingChanged(PhotoRatingChanged $event): void
+	{
+		$this->cache->forgetTags($this->cache_key_provider->photoListingTags([
+			SmartAlbumType::ONE_STAR->value,
+			SmartAlbumType::TWO_STARS->value,
+			SmartAlbumType::THREE_STARS->value,
+			SmartAlbumType::FOUR_STARS->value,
+			SmartAlbumType::FIVE_STARS->value,
+			SmartAlbumType::UNRATED->value,
+			SmartAlbumType::BEST_PICTURES->value,
+			SmartAlbumType::MY_RATED_PICTURES->value,
+			SmartAlbumType::MY_BEST_PICTURES->value,
+		]));
+	}
+
+	/**
+	 * Only the `highlighted` smart album's condition reads `is_highlighted`
+	 * (`App\SmartAlbums\HighlightedAlbum`).
+	 */
+	public function handlePhotoHighlightToggled(PhotoHighlightToggled $event): void
+	{
+		$this->cache->forgetTag($this->cache_key_provider->photoListingTag(SmartAlbumType::HIGHLIGHTED->value));
 	}
 }

--- a/app/Listeners/ManagedCachePhotoListingInvalidator.php
+++ b/app/Listeners/ManagedCachePhotoListingInvalidator.php
@@ -110,7 +110,10 @@ class ManagedCachePhotoListingInvalidator
 	 * {@see \App\Actions\Photo\StructOfArrays\ResolvesPhotoSource}) - every
 	 * `TagAlbum` whose tag set overlaps `$event->tag_ids` (the union of old
 	 * and new tags, see {@see PhotoTagsChanged}) must be evicted, since the
-	 * photo may have just entered or left its membership.
+	 * photo may have just entered or left its membership. The `untagged`
+	 * smart album is evicted unconditionally too: a photo enters it when its
+	 * last tag is removed and leaves it when its first tag is added, and
+	 * `$event->tag_ids` alone can't tell which of those happened.
 	 */
 	public function handlePhotoTagsChanged(PhotoTagsChanged $event): void
 	{
@@ -127,6 +130,8 @@ class ManagedCachePhotoListingInvalidator
 		if ($tag_album_ids !== []) {
 			$this->cache->forgetTags($this->cache_key_provider->photoListingTags($tag_album_ids));
 		}
+
+		$this->cache->forgetTag($this->cache_key_provider->photoListingTag(SmartAlbumType::UNTAGGED->value));
 	}
 
 	/**

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -178,5 +178,9 @@ class EventServiceProvider extends ServiceProvider
 		Event::listen(PhotoDeleted::class, ManagedCachePhotoListingInvalidator::class . '@handlePhotoDeleted');
 		Event::listen(AlbumPhotoSortingChanged::class, ManagedCachePhotoListingInvalidator::class . '@handleAlbumPhotoSortingChanged');
 		Event::listen(PhotoBucketsRecomputed::class, ManagedCachePhotoListingInvalidator::class . '@handlePhotoBucketsRecomputed');
+		Event::listen(PhotoTagsChanged::class, ManagedCachePhotoListingInvalidator::class . '@handlePhotoTagsChanged');
+		Event::listen(PhotoPersonsChanged::class, ManagedCachePhotoListingInvalidator::class . '@handlePhotoPersonsChanged');
+		Event::listen(PhotoRatingChanged::class, ManagedCachePhotoListingInvalidator::class . '@handlePhotoRatingChanged');
+		Event::listen(PhotoHighlightToggled::class, ManagedCachePhotoListingInvalidator::class . '@handlePhotoHighlightToggled');
 	}
 }

--- a/resources/js/stores/AlbumState.ts
+++ b/resources/js/stores/AlbumState.ts
@@ -1044,16 +1044,20 @@ export const useAlbumStore = defineStore("album-store", {
 		 * (`loadPhotoDetails()`, gated at its call sites in `PhotoState.ts`
 		 * and the edit dialogs), and drag-select (`getPhotoBoxesV3()`)
 		 * instead of each independently re-deriving the same condition.
-		 * `true` only for a regular `Album` parent (NG5 — `TagAlbum`/
-		 * `PersonAlbum`/`BaseSmartAlbum` 404 on Feature 064's routes) with
-		 * no active tag/person filter (NG4 — neither is supported by any of
-		 * the three v3 tiers).
+		 * `true` for a regular `Album`, a `TagAlbum`, a `PersonAlbum`, or a
+		 * `BaseSmartAlbum` parent alike — the v3 photo-listing tier now
+		 * covers all four album types — with no active tag/person *filter*
+		 * (NG4 — filtering a regular album's photos by tag/person is a
+		 * separate, unrelated feature still served by v2 only).
 		 */
 		isPhotoSoaActive(state): boolean {
 			const lycheeStore = useLycheeStateStore();
 			return (
 				lycheeStore.is_struct_of_array_enabled &&
-				state.modelAlbum !== undefined &&
+				(state.modelAlbum !== undefined ||
+					state.tagAlbum !== undefined ||
+					state.personAlbum !== undefined ||
+					state.smartAlbum !== undefined) &&
 				state.active_tag_filter === null &&
 				state.active_person_filter === null
 			);

--- a/tests/Feature_v3/Photo/PhotoAssetV3Test.php
+++ b/tests/Feature_v3/Photo/PhotoAssetV3Test.php
@@ -593,6 +593,29 @@ class PhotoAssetV3Test extends BaseApiWithDataTest
 	}
 
 	/**
+	 * GetPhotoAssetRequest::processValidatedValues() case: the *originally
+	 * requested* type has no DB row at all (e.g. a photo too small to have
+	 * warranted a small2x variant at generation time) — unlike the other
+	 * fallback tests above, this never reaches PhotoAssetController::fallback()
+	 * with a resolved size_variant to begin with, so the chain-walk must
+	 * happen at request-validation time instead of 404ing outright.
+	 */
+	public function testMissingDbRowForOriginallyRequestedTypeFallsBackToNextSize(): void
+	{
+		$this->putBytes($this->smallVariantOf($this->photo1), 'small-bytes');
+		SizeVariant::query()
+			->where('photo_id', '=', $this->photo1->id)
+			->where('type', '=', SizeVariantType::SMALL2X)
+			->delete();
+		// small2x row is gone entirely; small has a row and a file.
+
+		$response = $this->actingAs($this->userMayUpload1)->getV3("Asset/{$this->album1->id}/{$this->photo1->id}/small2x");
+
+		$response->assertOk();
+		self::assertSame('small-bytes', $response->streamedContent());
+	}
+
+	/**
 	 * PhotoAssetController::fallback() exhausted-chain case: small2x, small
 	 * and thumb all have DB rows but none has a file on disk, and thumb has
 	 * no further fallback target → 404.
@@ -600,6 +623,24 @@ class PhotoAssetV3Test extends BaseApiWithDataTest
 	public function testFallbackChainExhaustedReturnsNotFound(): void
 	{
 		// Every relevant row exists (factory default) but no bytes are put for any of them.
+
+		$response = $this->actingAs($this->userMayUpload1)->getV3("Asset/{$this->album1->id}/{$this->photo1->id}/small2x");
+
+		$response->assertNotFound();
+	}
+
+	/**
+	 * GetPhotoAssetRequest's own chain-walk (see
+	 * testMissingDbRowForOriginallyRequestedTypeFallsBackToNextSize above)
+	 * must still 404 once it has walked every DB row all the way down to
+	 * nothing, exactly like the controller's own exhausted-chain case.
+	 */
+	public function testMissingDbRowsForEntireChainReturnsNotFound(): void
+	{
+		SizeVariant::query()
+			->where('photo_id', '=', $this->photo1->id)
+			->whereIn('type', [SizeVariantType::SMALL2X, SizeVariantType::SMALL, SizeVariantType::THUMB])
+			->delete();
 
 		$response = $this->actingAs($this->userMayUpload1)->getV3("Asset/{$this->album1->id}/{$this->photo1->id}/small2x");
 

--- a/tests/Feature_v3/Photo/PhotoBucketsV3Test.php
+++ b/tests/Feature_v3/Photo/PhotoBucketsV3Test.php
@@ -194,10 +194,33 @@ class PhotoBucketsV3Test extends BaseApiWithDataTest
 
 	// ── Access / resolution edge cases ────────────────────────────
 
-	public function testTagAlbumIdReturns404(): void
+	public function testTagAlbumIdSucceedsWithLiveComputedBuckets(): void
 	{
+		$this->setInstanceDefaults('created_at', 'year');
+		// tagAlbum1 matches photo1 (tagged `test`) only - photo1b (untagged,
+		// same album) and every other fixture photo must not appear.
 		$response = $this->actingAs($this->userMayUpload1)->getJsonV3("Albums/{$this->tagAlbum1->id}/Photos/buckets");
-		$this->assertNotFound($response);
+		$this->assertOk($response);
+		$response->assertJson([
+			'bucket_ids' => [$this->photo1->created_at->format('Y')],
+			'counts' => [1],
+			'bucketable' => true,
+		]);
+	}
+
+	public function testSmartAlbumIdSucceedsWithLiveComputedBuckets(): void
+	{
+		$this->setInstanceDefaults('created_at', 'year');
+		$this->photo1->is_highlighted = true;
+		$this->photo1->save();
+
+		$response = $this->actingAs($this->userMayUpload1)->getJsonV3('Albums/highlighted/Photos/buckets');
+		$this->assertOk($response);
+		$response->assertJson([
+			'bucket_ids' => [$this->photo1->created_at->format('Y')],
+			'counts' => [1],
+			'bucketable' => true,
+		]);
 	}
 
 	public function testUnknownAlbumIdReturns404(): void

--- a/tests/Feature_v3/Photo/PhotoBucketsV3Test.php
+++ b/tests/Feature_v3/Photo/PhotoBucketsV3Test.php
@@ -223,6 +223,29 @@ class PhotoBucketsV3Test extends BaseApiWithDataTest
 		]);
 	}
 
+	/**
+	 * `BaseSmartAlbum::photos()` left-joins `photo_album` without any
+	 * `album_id` restriction - a photo belonging to more than one regular
+	 * album must still be counted exactly once here, not once per
+	 * membership (see `ResolvesPhotoSource::resolvePhotoQuery()`'s
+	 * `whereIn` id-subquery fix for this exact fan-out).
+	 */
+	public function testSmartAlbumDeduplicatesPhotoBelongingToMultipleAlbums(): void
+	{
+		$this->setInstanceDefaults('created_at', 'year');
+		$this->photo1->is_highlighted = true;
+		$this->photo1->save();
+		// photo1 already belongs to album1 (base fixture) - attach it to a
+		// second, same-owner album too.
+		$this->photo1->albums()->attach($this->subAlbum1->id);
+
+		$response = $this->actingAs($this->userMayUpload1)->getJsonV3('Albums/highlighted/Photos/buckets');
+		$this->assertOk($response);
+		$json = $response->json();
+		$this->assertSame([$this->photo1->created_at->format('Y')], $json['bucket_ids']);
+		$this->assertSame([1], $json['counts']);
+	}
+
 	public function testUnknownAlbumIdReturns404(): void
 	{
 		$response = $this->actingAs($this->userMayUpload1)->getJsonV3('Albums/AAAAAAAAAAAAAAAAAAAAAAAA/Photos/buckets');

--- a/tests/Feature_v3/Photo/PhotoBucketsV3Test.php
+++ b/tests/Feature_v3/Photo/PhotoBucketsV3Test.php
@@ -24,7 +24,11 @@ use App\Enum\OrderSortingType;
 use App\Jobs\RecomputeAlbumPhotoBucketsJob;
 use App\Models\Album;
 use App\Models\Configs;
+use App\Models\Face;
+use App\Models\Person;
 use App\Models\Photo;
+use App\Models\Tag;
+use App\Models\TagAlbum;
 use App\Services\TitleSplitter;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -410,5 +414,124 @@ class PhotoBucketsV3Test extends BaseApiWithDataTest
 
 		$after = $this->actingAs($this->userMayUpload1)->getJsonV3("Albums/{$album->id}/Photos/buckets")->assertOk()->json('bucket_ids');
 		self::assertSame(['2023-01'], $after);
+	}
+
+	/**
+	 * A `TagAlbum`'s photo listing has no `photo_album` row to invalidate
+	 * against (see `ResolvesPhotoSource`) - a warm cache must still reflect
+	 * a photo gaining a matching tag, via `ManagedCachePhotoListingInvalidator::handlePhotoTagsChanged()`.
+	 */
+	public function testCacheInvalidatedOnPhotoTagsChanged(): void
+	{
+		config(['features.enable-caching' => true]);
+		Configs::set('managed_cache_enabled', '1');
+		Configs::set('managed_cache_albums_enabled', '1');
+
+		$tag = Tag::factory()->with_name('cache_regression_tag')->create();
+		$tag_album = TagAlbum::factory()->owned_by($this->userMayUpload1)->of_tags([$tag])->create();
+		$photo = Photo::factory()->owned_by($this->userMayUpload1)->create();
+
+		// Warm the cache while the photo does not yet carry the tag.
+		$before = $this->actingAs($this->userMayUpload1)->getJsonV3("Albums/{$tag_album->id}/Photos/buckets")->assertOk()->json('counts');
+		self::assertSame([], $before);
+
+		$this->actingAs($this->userMayUpload1)->patchJson('Photo::tags', [
+			'photo_ids' => [$photo->id],
+			'tags' => ['cache_regression_tag'],
+			'shall_override' => true,
+		])->assertNoContent();
+
+		$after = $this->actingAs($this->userMayUpload1)->getJsonV3("Albums/{$tag_album->id}/Photos/buckets")->assertOk()->json('counts');
+		self::assertSame([1], $after);
+	}
+
+	/**
+	 * Same as above, for `PersonAlbum` -
+	 * `ManagedCachePhotoListingInvalidator::handlePhotoPersonsChanged()`.
+	 */
+	public function testCacheInvalidatedOnPhotoPersonsChanged(): void
+	{
+		config(['features.enable-caching' => true]);
+		Configs::set('managed_cache_enabled', '1');
+		Configs::set('managed_cache_albums_enabled', '1');
+		Configs::set('ai_vision_enabled', '1');
+		Configs::set('ai_vision_face_enabled', '1');
+		Configs::set('ai_vision_face_permission_mode', 'private');
+
+		$person = Person::factory()->create(['name' => 'CacheRegressionPerson', 'is_searchable' => true]);
+		$create_response = $this->actingAs($this->userMayUpload1)->postJson('PersonAlbum', [
+			'title' => 'person_album_cache_regression',
+			'persons' => [$person->id],
+			'is_and' => false,
+		]);
+		$this->assertOk($create_response);
+		$person_album_id = $create_response->getOriginalContent();
+
+		$photo = Photo::factory()->owned_by($this->userMayUpload1)->create();
+		$face = Face::factory()->for_photo($photo)->create();
+
+		// Warm the cache while the face is not yet assigned to the person.
+		$before = $this->actingAs($this->userMayUpload1)->getJsonV3("Albums/{$person_album_id}/Photos/buckets")->assertOk()->json('counts');
+		self::assertSame([], $before);
+
+		$this->actingAs($this->userMayUpload1)->postJson("Face/{$face->id}/assign", [
+			'person_id' => $person->id,
+		])->assertCreated();
+
+		$after = $this->actingAs($this->userMayUpload1)->getJsonV3("Albums/{$person_album_id}/Photos/buckets")->assertOk()->json('counts');
+		self::assertSame([1], $after);
+	}
+
+	/**
+	 * A rating-dependent smart album (`five_stars`) - `PhotoRatingChanged`
+	 * carries no rating value, so
+	 * `ManagedCachePhotoListingInvalidator::handlePhotoRatingChanged()`
+	 * evicts every rating-dependent smart album unconditionally.
+	 */
+	public function testCacheInvalidatedOnPhotoRatingChanged(): void
+	{
+		config(['features.enable-caching' => true]);
+		Configs::set('managed_cache_enabled', '1');
+		Configs::set('managed_cache_albums_enabled', '1');
+		Configs::set('rating_enabled', '1');
+
+		$photo = Photo::factory()->owned_by($this->userMayUpload1)->create();
+
+		// Warm the cache while the photo is unrated.
+		$before = $this->actingAs($this->userMayUpload1)->getJsonV3('Albums/five_stars/Photos/buckets')->assertOk()->json('counts');
+		self::assertSame([], $before);
+
+		$this->actingAs($this->userMayUpload1)->postJson('Photo::setRating', [
+			'photo_id' => $photo->id,
+			'rating' => 5,
+		])->assertCreated();
+
+		$after = $this->actingAs($this->userMayUpload1)->getJsonV3('Albums/five_stars/Photos/buckets')->assertOk()->json('counts');
+		self::assertSame([1], $after);
+	}
+
+	/**
+	 * The `highlighted` smart album -
+	 * `ManagedCachePhotoListingInvalidator::handlePhotoHighlightToggled()`.
+	 */
+	public function testCacheInvalidatedOnPhotoHighlightToggled(): void
+	{
+		config(['features.enable-caching' => true]);
+		Configs::set('managed_cache_enabled', '1');
+		Configs::set('managed_cache_albums_enabled', '1');
+
+		$photo = Photo::factory()->owned_by($this->userMayUpload1)->create();
+
+		// Warm the cache while the photo is not yet highlighted.
+		$before = $this->actingAs($this->userMayUpload1)->getJsonV3('Albums/highlighted/Photos/buckets')->assertOk()->json('counts');
+		self::assertSame([], $before);
+
+		$this->actingAs($this->userMayUpload1)->postJson('Photo::highlight', [
+			'photo_ids' => [$photo->id],
+			'is_highlighted' => true,
+		])->assertNoContent();
+
+		$after = $this->actingAs($this->userMayUpload1)->getJsonV3('Albums/highlighted/Photos/buckets')->assertOk()->json('counts');
+		self::assertSame([1], $after);
 	}
 }

--- a/tests/Feature_v3/Photo/PhotoDetailsV3Test.php
+++ b/tests/Feature_v3/Photo/PhotoDetailsV3Test.php
@@ -223,10 +223,39 @@ class PhotoDetailsV3Test extends BaseApiWithDataTest
 
 	// ── Access / resolution edge cases ────────────────────────────
 
-	public function testTagAlbumIdReturns404(): void
+	public function testTagAlbumIdSucceeds(): void
 	{
-		$response = $this->actingAs($this->userMayUpload1)->getJsonV3("Albums/{$this->tagAlbum1->id}/Photos/details", ['bucket_id' => 'unknown']);
-		$this->assertNotFound($response);
+		// tagAlbum1 matches photo1 (tagged `test`) only.
+		$response = $this->actingAs($this->userMayUpload1)->getJsonV3("Albums/{$this->tagAlbum1->id}/Photos/details", ['photo_ids' => [$this->photo1->id]]);
+		$this->assertOk($response);
+		$response->assertJson(['ids' => [$this->photo1->id]]);
+	}
+
+	/**
+	 * `bucket_id` mode for a non-`Album` source has no stored `bucket_id`
+	 * column to filter by directly - it resolves matching ids through a
+	 * lean live-computation pass first ({@see \App\Actions\Photo\StructOfArrays\QueryPhotoDetails::resolveLiveBucketPhotoIds()}).
+	 * This exercises that path directly, distinct from `photo_ids` mode.
+	 */
+	public function testTagAlbumBucketIdModeSucceeds(): void
+	{
+		DB::table('configs')->where('key', '=', 'sorting_photos_col')->update(['value' => 'created_at']);
+		DB::table('configs')->where('key', '=', 'timeline_photos_granularity')->update(['value' => 'year']);
+		$bucket_id = $this->photo1->created_at->format('Y');
+
+		$response = $this->actingAs($this->userMayUpload1)->getJsonV3("Albums/{$this->tagAlbum1->id}/Photos/details", ['bucket_id' => $bucket_id]);
+		$this->assertOk($response);
+		$response->assertJson(['ids' => [$this->photo1->id]]);
+	}
+
+	public function testSmartAlbumIdSucceeds(): void
+	{
+		$this->photo1->is_highlighted = true;
+		$this->photo1->save();
+
+		$response = $this->actingAs($this->userMayUpload1)->getJsonV3('Albums/highlighted/Photos/details', ['photo_ids' => [$this->photo1->id]]);
+		$this->assertOk($response);
+		$response->assertJson(['ids' => [$this->photo1->id]]);
 	}
 
 	public function testNoAccessReturns403(): void

--- a/tests/Feature_v3/Photo/PhotoRatiosV3Test.php
+++ b/tests/Feature_v3/Photo/PhotoRatiosV3Test.php
@@ -20,6 +20,9 @@ namespace Tests\Feature_v3\Photo;
 
 use App\Enum\SizeVariantType;
 use App\Models\Album;
+use App\Models\Configs;
+use App\Models\Face;
+use App\Models\Person;
 use App\Models\Photo;
 use App\Models\SizeVariant;
 use App\Models\Tag;
@@ -273,10 +276,49 @@ class PhotoRatiosV3Test extends BaseApiWithDataTest
 
 	// ── Access / resolution edge cases ────────────────────────────
 
-	public function testTagAlbumIdReturns404(): void
+	public function testTagAlbumIdSucceedsWithLiveComputedBucketIds(): void
 	{
+		// tagAlbum1 matches photo1 (tagged `test`) only - photo1b (untagged,
+		// same album) and every other fixture photo must not appear.
 		$response = $this->actingAs($this->userMayUpload1)->getJsonV3("Albums/{$this->tagAlbum1->id}/Photos");
-		$this->assertNotFound($response);
+		$this->assertOk($response);
+		$json = $response->json();
+		$this->assertSame([$this->photo1->id], $json['ids']);
+		$this->assertNotSame('unknown', $json['bucket_ids'][0]);
+	}
+
+	public function testSmartAlbumIdSucceeds(): void
+	{
+		$this->photo1->is_highlighted = true;
+		$this->photo1->save();
+
+		$response = $this->actingAs($this->userMayUpload1)->getJsonV3('Albums/highlighted/Photos');
+		$this->assertOk($response);
+		$response->assertJson(['ids' => [$this->photo1->id]]);
+	}
+
+	public function testPersonAlbumIdSucceeds(): void
+	{
+		Configs::set('ai_vision_enabled', '1');
+		Configs::set('ai_vision_face_enabled', '1');
+		$person = Person::factory()->create(['name' => 'Alice', 'is_searchable' => true]);
+		Face::factory()->for_photo($this->photo1)->for_person($person)->create();
+
+		// PersonAlbum creation is a v2 (JSON) endpoint - reused here purely
+		// as fixture setup, mirroring Tests\AssistedVision\PersonAlbumTest;
+		// there is no PersonAlbum::factory() equivalent that also wires up
+		// matching Face rows.
+		$create_response = $this->actingAs($this->userMayUpload1)->postJson('PersonAlbum', [
+			'title' => 'person_album_v3_test',
+			'persons' => [$person->id],
+			'is_and' => false,
+		]);
+		$this->assertOk($create_response);
+		$person_album_id = $create_response->getOriginalContent();
+
+		$response = $this->actingAs($this->userMayUpload1)->getJsonV3("Albums/{$person_album_id}/Photos");
+		$this->assertOk($response);
+		$response->assertJson(['ids' => [$this->photo1->id]]);
 	}
 
 	public function testNoAccessReturns403(): void

--- a/tests/Feature_v3/Photo/PhotoRatiosV3Test.php
+++ b/tests/Feature_v3/Photo/PhotoRatiosV3Test.php
@@ -297,6 +297,27 @@ class PhotoRatiosV3Test extends BaseApiWithDataTest
 		$response->assertJson(['ids' => [$this->photo1->id]]);
 	}
 
+	/**
+	 * `BaseSmartAlbum::photos()` left-joins `photo_album` without any
+	 * `album_id` restriction - a photo belonging to more than one regular
+	 * album must still appear exactly once here, not once per membership
+	 * (see `ResolvesPhotoSource::resolvePhotoQuery()`'s `whereIn`
+	 * id-subquery fix for this exact fan-out).
+	 */
+	public function testSmartAlbumDeduplicatesPhotoBelongingToMultipleAlbums(): void
+	{
+		$this->photo1->is_highlighted = true;
+		$this->photo1->save();
+		// photo1 already belongs to album1 (base fixture) - attach it to a
+		// second, same-owner album too.
+		$this->photo1->albums()->attach($this->subAlbum1->id);
+
+		$response = $this->actingAs($this->userMayUpload1)->getJsonV3('Albums/highlighted/Photos');
+		$this->assertOk($response);
+		$json = $response->json();
+		$this->assertSame([$this->photo1->id], $json['ids']);
+	}
+
 	public function testPersonAlbumIdSucceeds(): void
 	{
 		Configs::set('ai_vision_enabled', '1');

--- a/tests/Unit/Listeners/ManagedCachePhotoListingInvalidatorTest.php
+++ b/tests/Unit/Listeners/ManagedCachePhotoListingInvalidatorTest.php
@@ -21,11 +21,16 @@ namespace Tests\Unit\Listeners;
 use App\Events\AlbumPhotoSortingChanged;
 use App\Events\PhotoBucketsRecomputed;
 use App\Events\PhotoDeleted;
+use App\Events\PhotoHighlightToggled;
 use App\Events\PhotoMoved;
+use App\Events\PhotoRatingChanged;
 use App\Events\PhotoSaved;
+use App\Events\PhotoTagsChanged;
 use App\Listeners\ManagedCachePhotoListingInvalidator;
 use App\Models\Album;
 use App\Models\Photo;
+use App\Models\Tag;
+use App\Models\TagAlbum;
 use App\Models\User;
 use App\Repositories\ConfigManager;
 use App\Services\Cache\CacheKeyProvider;
@@ -190,5 +195,59 @@ class ManagedCachePhotoListingInvalidatorTest extends AbstractTestCase
 		$this->seedCache('k:x', ['some-tag']);
 		$this->listener->handlePhotoBucketsRecomputed(new PhotoBucketsRecomputed([]));
 		$this->assertNotEvicted('k:x');
+	}
+
+	// ── PhotoTagsChanged ────────────────────────────────────────────
+
+	public function testPhotoTagsChangedEvictsOnlyTagAlbumsWhoseTagSetOverlaps(): void
+	{
+		$user = User::factory()->create();
+		$tag_a = Tag::factory()->create();
+		$tag_b = Tag::factory()->create();
+		$tag_album_a = TagAlbum::factory()->owned_by($user)->of_tags([$tag_a])->create();
+		$tag_album_b = TagAlbum::factory()->owned_by($user)->of_tags([$tag_b])->create();
+
+		$this->seedCache('k:a', [$this->cache_key_provider->photoListingTag($tag_album_a->id)]);
+		$this->seedCache('k:b', [$this->cache_key_provider->photoListingTag($tag_album_b->id)]);
+
+		$this->listener->handlePhotoTagsChanged(new PhotoTagsChanged(['photo-1'], [$tag_a->id]));
+
+		$this->assertEvicted('k:a');
+		$this->assertNotEvicted('k:b');
+	}
+
+	public function testPhotoTagsChangedWithEmptyTagIdsIsNoOp(): void
+	{
+		$this->seedCache('k:x', ['some-tag']);
+		$this->listener->handlePhotoTagsChanged(new PhotoTagsChanged(['photo-1'], []));
+		$this->assertNotEvicted('k:x');
+	}
+
+	// ── PhotoRatingChanged ──────────────────────────────────────────
+
+	public function testPhotoRatingChangedEvictsEveryRatingDependentSmartAlbum(): void
+	{
+		$this->seedCache('k:five-stars', [$this->cache_key_provider->photoListingTag('five_stars')]);
+		$this->seedCache('k:unrated', [$this->cache_key_provider->photoListingTag('unrated')]);
+		$this->seedCache('k:unrelated', [$this->cache_key_provider->photoListingTag('highlighted')]);
+
+		$this->listener->handlePhotoRatingChanged(new PhotoRatingChanged('photo-1'));
+
+		$this->assertEvicted('k:five-stars');
+		$this->assertEvicted('k:unrated');
+		$this->assertNotEvicted('k:unrelated');
+	}
+
+	// ── PhotoHighlightToggled ───────────────────────────────────────
+
+	public function testPhotoHighlightToggledEvictsOnlyTheHighlightedSmartAlbum(): void
+	{
+		$this->seedCache('k:highlighted', [$this->cache_key_provider->photoListingTag('highlighted')]);
+		$this->seedCache('k:unrelated', [$this->cache_key_provider->photoListingTag('five_stars')]);
+
+		$this->listener->handlePhotoHighlightToggled(new PhotoHighlightToggled(['photo-1']));
+
+		$this->assertEvicted('k:highlighted');
+		$this->assertNotEvicted('k:unrelated');
 	}
 }

--- a/tests/Unit/Listeners/ManagedCachePhotoListingInvalidatorTest.php
+++ b/tests/Unit/Listeners/ManagedCachePhotoListingInvalidatorTest.php
@@ -18,6 +18,7 @@
 
 namespace Tests\Unit\Listeners;
 
+use App\Enum\SmartAlbumType;
 use App\Events\AlbumPhotoSortingChanged;
 use App\Events\PhotoBucketsRecomputed;
 use App\Events\PhotoDeleted;
@@ -214,6 +215,20 @@ class ManagedCachePhotoListingInvalidatorTest extends AbstractTestCase
 
 		$this->assertEvicted('k:a');
 		$this->assertNotEvicted('k:b');
+	}
+
+	public function testPhotoTagsChangedEvictsUntaggedSmartAlbum(): void
+	{
+		$user = User::factory()->create();
+		$tag_a = Tag::factory()->create();
+		$tag_album_a = TagAlbum::factory()->owned_by($user)->of_tags([$tag_a])->create();
+
+		$this->seedCache('k:untagged', [$this->cache_key_provider->photoListingTag(SmartAlbumType::UNTAGGED->value)]);
+		$this->seedCache('k:unrelated', [$this->cache_key_provider->photoListingTag($tag_album_a->id)]);
+
+		$this->listener->handlePhotoTagsChanged(new PhotoTagsChanged(['photo-1'], [$tag_a->id]));
+
+		$this->assertEvicted('k:untagged');
 	}
 
 	public function testPhotoTagsChangedWithEmptyTagIdsIsNoOp(): void


### PR DESCRIPTION
<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Photo buckets, details, and ratios now support tag, person, and smart albums.
  - Photo listings provide live bucket information across supported album types.
  - Photo assets automatically fall back to the next available smaller size when needed.

- **Bug Fixes**
  - Improved album resolution, validation, deduplication, and cache handling.
  - Listing caches now update when photo tags, people, ratings, or highlighted status change.

- **Tests**
  - Added coverage for album types, asset fallback, deduplication, and cache invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->