### PR TITLE
Fix display in non-timeline mode

### DIFF
--- a/resources/js/v8/components/gallery/albumModule/Virtualized/AlbumListViewVirtual.vue
+++ b/resources/js/v8/components/gallery/albumModule/Virtualized/AlbumListViewVirtual.vue
@@ -101,7 +101,9 @@ const uiHeaderHeightPx = resolveCssLengthPx("var(--ui-header-height)");
 // bucketability — a non-timeline album must render one continuous list.
 const showHeaders = computed(() => albumStore.bucketableV3 && (albumStore.config?.is_album_timeline_enabled ?? false));
 const boundaries = computed(() =>
-	albumStore.boundariesV3 !== null ? albumStore.boundariesV3 : [{ bucketId: "all", label: "", startIndex: 0, count: albumsStore.albums.length }],
+	showHeaders.value && albumStore.boundariesV3 !== null
+		? albumStore.boundariesV3
+		: [{ bucketId: "all", label: "", startIndex: 0, count: albumsStore.albums.length }],
 );
 
 // NSFW-hidden tiles are dropped before row-chunking (not per-tile in the

--- a/resources/js/v8/components/gallery/albumModule/Virtualized/AlbumRootGridVirtual.vue
+++ b/resources/js/v8/components/gallery/albumModule/Virtualized/AlbumRootGridVirtual.vue
@@ -139,7 +139,7 @@ const showHeaders = computed(
 );
 const boundaries = computed(() => {
 	const b = props.scope === "own" ? albumsStore.ownBoundariesV3 : albumsStore.sharedBoundariesV3;
-	return b !== null ? b : [{ bucketId: "all", label: "", startIndex: 0, count: tiles.value.length }];
+	return showHeaders.value && b !== null ? b : [{ bucketId: "all", label: "", startIndex: 0, count: tiles.value.length }];
 });
 
 // NSFW-hidden tiles, and (for `shared` scope in `separate_shared_only` mode)

--- a/resources/js/v8/components/gallery/albumModule/Virtualized/AlbumRootListViewVirtual.vue
+++ b/resources/js/v8/components/gallery/albumModule/Virtualized/AlbumRootListViewVirtual.vue
@@ -102,7 +102,7 @@ const showHeaders = computed(
 );
 const boundaries = computed(() => {
 	const b = props.scope === "own" ? albumsStore.ownBoundariesV3 : albumsStore.sharedBoundariesV3;
-	return b !== null ? b : [{ bucketId: "all", label: "", startIndex: 0, count: tiles.value.length }];
+	return showHeaders.value && b !== null ? b : [{ bucketId: "all", label: "", startIndex: 0, count: tiles.value.length }];
 });
 
 // NSFW-hidden tiles, and (for `shared` scope in `separate_shared_only` mode)

--- a/resources/js/v8/components/gallery/albumModule/Virtualized/AlbumThumbGridVirtual.vue
+++ b/resources/js/v8/components/gallery/albumModule/Virtualized/AlbumThumbGridVirtual.vue
@@ -142,7 +142,9 @@ const aspectRatioNumber = computed(() => aspectRatioCssToNumber(albumStore.confi
 // buildVirtualAlbumRows() already documents for the other cases.
 const showHeaders = computed(() => albumStore.bucketableV3 && (albumStore.config?.is_album_timeline_enabled ?? false));
 const boundaries = computed(() =>
-	albumStore.boundariesV3 !== null ? albumStore.boundariesV3 : [{ bucketId: "all", label: "", startIndex: 0, count: albumsStore.albums.length }],
+	showHeaders.value && albumStore.boundariesV3 !== null
+		? albumStore.boundariesV3
+		: [{ bucketId: "all", label: "", startIndex: 0, count: albumsStore.albums.length }],
 );
 
 // NSFW-hidden tiles are dropped before row-chunking (not per-tile in the


### PR DESCRIPTION
<!--
Thank you for contributing to Lychee! We only accept PR to the master branch.

In addition, please describe the benefit to end users; the reasons it does not break any existing features, etc.

If you're pushing a Feature:
- Title it: "This new feature"
- Describe what the new feature enables
- Add tests to test the new feature.
- Ensure it doesn't break any existing features.

If you're pushing a Fix:
- Title it: "Fixes the bug name"
- If it is a fix an an existing issue start the description with `fixes #xxxx` where xxxx is the issue number.
- Describe how it fixes in a few words.
- Add a test that triggered the bug before fixing it.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP. 
Ensure your tests pass or your PR may be taken down.

Additionally you can run `make phpstan` and `make formatting` on your own machine as they will be required to pass for your PR to be accepted.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Album grid and list views now consistently hide timeline header rows when timeline headers are disabled.
  - Albums display as a single flat section when timeline grouping is unavailable or turned off.
  - Existing grouped sections remain visible when timeline headers are enabled.
  - Drag-and-select behavior now remains consistent between grouped timeline sections and a single flat section.
  - Public albums are excluded from drag-selection areas when shared albums are displayed separately, improving selection accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->